### PR TITLE
Refactoring events and game_state for accounting software logic

### DIFF
--- a/events.py
+++ b/events.py
@@ -1,5 +1,15 @@
 import random
-
+def buy_accounting_software(gs):
+    """
+    Custom event effect function for buying accounting software.
+    Deducts $500, sets flag, enables balance change display and monthly costs.
+    """
+    if gs.money >= 500:
+        gs.money -= 500
+        gs.accounting_software_bought = True
+        gs.messages.append("You bought accounting software! Balance change details enabled, monthly costs always visible.")
+    else:
+        gs.messages.append("Not enough money to buy accounting software.")
 EVENTS = [
     {
         "name": "Lab Breakthrough",
@@ -19,4 +29,11 @@ EVENTS = [
         "trigger": lambda gs: gs.staff > 6 and gs.money < gs.staff * gs.staff_maintenance and random.random() < 0.2,
         "effect": lambda gs: gs._add('staff', -random.randint(1, 2))
     }
+    {
+        "name": "Buy Accounting Software",
+        "desc": "Purchased accounting software for $500. Balance change details now available.",
+        # Trigger: After turn 3, and only if not already bought
+        "trigger": lambda gs: gs.turn >= 3 and not getattr(gs, "accounting_software_bought", False),
+        "effect": buy_accounting_software
+    },
 ]

--- a/game_state.py
+++ b/game_state.py
@@ -8,6 +8,33 @@ from events import EVENTS
 SCORE_FILE = "local_highscore.json"
 
 class GameState:
+    def _add(self, attr, val):
+    """
+    Adds val to the given attribute, clamping where appropriate.
+    Also records last_balance_change for 'money' for use in UI,
+    if accounting software has been purchased.
+    """
+    if attr == 'money':
+        # Only record balance change if accounting software is bought
+        if hasattr(self, "accounting_software_bought") and self.accounting_software_bought:
+            self.last_balance_change = val
+        self.money = max(self.money + val, 0)
+    elif attr == 'doom':
+        self.doom = min(max(self.doom + val, 0), self.max_doom)
+    elif attr == 'reputation':
+        self.reputation = max(self.reputation + val, 0)
+    elif attr == 'staff':
+        self.staff = max(self.staff + val, 0)
+    return None
+
+# Ensure last_balance_change gets set on any direct subtraction/addition to money:
+# For example, in end_turn, after maintenance:
+# self._add('money', -maintenance_cost)
+# (Replace raw self.money -= maintenance_cost with self._add('money', -maintenance_cost))
+
+# In __init__, initialize:
+self.last_balance_change = 0
+self.accounting_software_bought = False  # So the flag always exists
     def __init__(self, seed):
         # Core resources
         self.money = 300


### PR DESCRIPTION
Changed 2 files with suggestions from chatgpt to add both the ui interface changes for when the accounting software event is activated and also the details about the event itself in the event library.