### PR TITLE
feat: Add in-game What's New / Patch Notes modal (Issue #481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.11.0] - 2025-12-08 - 'Travel & Conferences System'
 
 ### Added
+- **What's New Modal** (#481): In-game patch notes display
+  - Shows "What's New" modal automatically on first launch after an update
+  - "What's New" button in main menu to view patch notes anytime
+  - Patch notes stored in JSON file for easy updates without code changes
+  - Tracks last-seen version in user preferences
+  - Colored formatting for Added/Fixed/Changed sections
+
 - **Academic Conference System** (#468): Submit papers to major AI conferences
   - 9 conferences: NeurIPS, ICML, ICLR, AAAI, FAccT, AIES, MATS, ILIAD, Safety Retreat
   - Conference timing based on real-world calendar (game starts July 3, 2017)
@@ -53,8 +60,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Event Popup AP Display** (#453): Shows correct available AP for event options
 
 ### Technical
-- New files: `conferences.gd`, `paper_submissions.gd`
-- Modified: `game_state.gd`, `actions.gd`, `turn_manager.gd`, `main_ui.gd`, `events.gd`, `researcher.gd`
+- New files: `whats_new_modal.gd`, `whats_new_modal.tscn`, `patch_notes.json`, `conferences.gd`, `paper_submissions.gd`
+- Modified: `game_config.gd`, `welcome_screen.gd`, `welcome.tscn`, `game_manager.gd`, `game_state.gd`, `actions.gd`, `turn_manager.gd`, `main_ui.gd`, `events.gd`, `researcher.gd`
 - Engine: Godot 4.5.1 stable
 
 ---

--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -22,6 +22,10 @@ var current_game_active: bool = false
 var games_played: int = 0
 var config_mode: String = "default"  # "default" = weekly seed (locked), "custom" = user configured
 
+# Version tracking for What's New feature
+var last_seen_version: String = ""  # Empty = never seen patch notes
+const CURRENT_VERSION: String = "0.11.0"
+
 # Leaderboard State (transient, not saved)
 var latest_leaderboard_entry: String = ""  # UUID of most recent score entry
 
@@ -54,6 +58,7 @@ func save_config() -> void:
 	# Game section
 	config.set_value("game", "difficulty", difficulty)
 	config.set_value("game", "last_seed", game_seed)
+	config.set_value("game", "last_seen_version", last_seen_version)
 
 	# Audio section
 	config.set_value("audio", "master_volume", master_volume)
@@ -91,6 +96,7 @@ func load_config() -> void:
 	# Load game settings
 	difficulty = config.get_value("game", "difficulty", difficulty)
 	game_seed = config.get_value("game", "last_seed", game_seed)
+	last_seen_version = config.get_value("game", "last_seen_version", last_seen_version)
 
 	# Load audio settings
 	master_volume = config.get_value("audio", "master_volume", master_volume)
@@ -273,6 +279,22 @@ func format_money(amount: float) -> String:
 
 	return formatted
 
+## Check if there are unseen patch notes (new version since last seen)
+func has_unseen_patch_notes() -> bool:
+	if last_seen_version.is_empty():
+		return true  # Never seen any patch notes
+	return last_seen_version != CURRENT_VERSION
+
+## Mark current version's patch notes as seen
+func mark_patch_notes_seen() -> void:
+	last_seen_version = CURRENT_VERSION
+	save_config()
+	print("[GameConfig] Patch notes marked as seen for version %s" % CURRENT_VERSION)
+
+## Get the current game version
+func get_current_version() -> String:
+	return CURRENT_VERSION
+
 ## Debug print current configuration
 func print_config() -> void:
 	print("[GameConfig] === Current Configuration ===")
@@ -286,4 +308,6 @@ func print_config() -> void:
 	print("  Graphics: %s" % get_graphics_quality_string())
 	print("  Fullscreen: %s" % fullscreen)
 	print("  Games Played: %d" % games_played)
+	print("  Last Seen Version: %s" % last_seen_version)
+	print("  Current Version: %s" % CURRENT_VERSION)
 	print("========================================")

--- a/godot/data/patch_notes.json
+++ b/godot/data/patch_notes.json
@@ -1,0 +1,82 @@
+{
+  "versions": [
+    {
+      "version": "0.11.0",
+      "date": "2025-12-08",
+      "title": "Travel & Conferences System",
+      "highlights": [
+        "What's New Modal - See patch notes on first launch after updates",
+        "Academic Conference System - Submit papers to NeurIPS, ICML, ICLR, and more",
+        "Travel Cost System - Realistic flight and accommodation costs",
+        "Jet Lag Mechanics - Travel class affects researcher productivity"
+      ],
+      "sections": {
+        "added": [
+          "What's New modal showing patch notes on first launch after updates",
+          "What's New button in main menu to view patch notes anytime",
+          "Academic Conference System with 9 real-world AI conferences",
+          "Travel submenu with paper submission and conference attendance",
+          "Paper review process with multi-turn decision cycles",
+          "Three travel classes: Economy, Business, First Class",
+          "Jet lag affecting researcher productivity based on travel class",
+          "Public opinion meter affecting fundraising and events",
+          "Responsive UI layout adapting to screen sizes"
+        ],
+        "fixed": [
+          "AP Double-Spend Bug - Actions no longer deduct AP twice",
+          "Poaching Event Infinite Loop - Now respects probability",
+          "Manager Threshold - First 9 researchers now founder-managed",
+          "Hiring Queue - Support for multiple hires per turn",
+          "Event Popup AP Display - Shows correct available AP"
+        ],
+        "changed": []
+      }
+    },
+    {
+      "version": "0.10.3",
+      "date": "2025-11-17",
+      "title": "Playtesting Fixes & Turn Philosophy",
+      "highlights": [
+        "Bug Reporter Integration - In-game bug reporting with F8",
+        "Turn Philosophy Reframe - 'Monday Planning' metaphor",
+        "Event Dialog UX Improvements - Better visibility and interaction"
+      ],
+      "sections": {
+        "added": [
+          "In-game bug reporting system (F8 or backslash)",
+          "Cat contributor recognition system",
+          "Comprehensive turn sequence documentation"
+        ],
+        "fixed": [
+          "Turn advancement with empty action queue now works",
+          "Event AP Logic uses available AP correctly",
+          "Employee screen display renders correctly"
+        ],
+        "changed": [
+          "Turn Philosophy: 'Skip Turn' renamed to 'Commit Plan & Reserve AP'",
+          "Event dialog background improved for visibility"
+        ]
+      }
+    },
+    {
+      "version": "0.10.2",
+      "date": "2025-11-08",
+      "title": "Multi-Platform Release & Enhanced CI/CD",
+      "highlights": [
+        "Multi-Platform Build Support - Windows, Linux, and macOS",
+        "Enhanced CI/CD Pipeline - Automated validation and releases",
+        "Employee Management Screen - Tab-based interface"
+      ],
+      "sections": {
+        "added": [
+          "Automated builds for Windows, Linux, and macOS",
+          "Linux/X11 and macOS export presets",
+          "Release metadata generation (JSON + RSS feeds)",
+          "Employee Management Screen with progressive warnings"
+        ],
+        "fixed": [],
+        "changed": []
+      }
+    }
+  ]
+}

--- a/godot/scenes/ui/whats_new_modal.tscn
+++ b/godot/scenes/ui/whats_new_modal.tscn
@@ -1,0 +1,119 @@
+[gd_scene load_steps=4 format=3 uid="uid://whatsnew481"]
+
+[ext_resource type="Script" path="res://scripts/ui/whats_new_modal.gd" id="1_whatsnew"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.1, 0.12, 0.15, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.3, 0.5, 0.7, 1)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_button"]
+bg_color = Color(0.2, 0.35, 0.5, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.4, 0.6, 0.8, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="WhatsNewModal" type="Control"]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("1_whatsnew")
+
+[node name="Overlay" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 0
+color = Color(0, 0, 0, 0.75)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="CenterContainer"]
+custom_minimum_size = Vector2(600, 500)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="MarginContainer" type="MarginContainer" parent="CenterContainer/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 30
+theme_override_constants/margin_top = 25
+theme_override_constants/margin_right = 30
+theme_override_constants/margin_bottom = 25
+
+[node name="VBox" type="VBoxContainer" parent="CenterContainer/PanelContainer/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 15
+
+[node name="TitleLabel" type="Label" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
+theme_override_font_sizes/font_size = 36
+text = "What's New"
+horizontal_alignment = 1
+
+[node name="VersionLabel" type="Label" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 0.75, 0.9, 1)
+theme_override_font_sizes/font_size = 18
+text = "Version 0.11.0 - Travel & Conferences"
+horizontal_alignment = 1
+
+[node name="HSeparator" type="HSeparator" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+layout_mode = 2
+
+[node name="ContentScroll" type="ScrollContainer" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+custom_minimum_size = Vector2(0, 300)
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+
+[node name="ContentLabel" type="RichTextLabel" parent="CenterContainer/PanelContainer/MarginContainer/VBox/ContentScroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_colors/default_color = Color(0.85, 0.88, 0.92, 1)
+theme_override_font_sizes/normal_font_size = 16
+bbcode_enabled = true
+text = "Loading patch notes..."
+fit_content = true
+scroll_active = false
+
+[node name="HSeparator2" type="HSeparator" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+layout_mode = 2
+
+[node name="CloseButton" type="Button" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+custom_minimum_size = Vector2(200, 45)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 18
+theme_override_styles/normal = SubResource("StyleBoxFlat_button")
+text = "Got it!"

--- a/godot/scenes/welcome.tscn
+++ b/godot/scenes/welcome.tscn
@@ -195,6 +195,19 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_pressed")
 theme_override_styles/focus = SubResource("StyleBoxFlat_focus")
 text = "🏆 Leaderboard"
 
+[node name="WhatsNewButton" type="Button" parent="VBox/MenuContainer"]
+custom_minimum_size = Vector2(400, 50)
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 0.85, 1, 1)
+theme_override_colors/font_hover_color = Color(0.8, 0.95, 1, 1)
+theme_override_colors/font_pressed_color = Color(0.5, 0.75, 1, 1)
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover = SubResource("StyleBoxFlat_hover")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_pressed")
+theme_override_styles/focus = SubResource("StyleBoxFlat_focus")
+text = "What's New"
+
 [node name="AISafetyButton" type="Button" parent="VBox/MenuContainer"]
 custom_minimum_size = Vector2(400, 50)
 layout_mode = 2

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -37,7 +37,7 @@ func start_new_game(game_seed: String = ""):
 	is_initialized = true
 
 	# Start verification tracking
-	var game_version = "0.11.0"  # TODO: Get from GameConfig or version constant
+	var game_version = GameConfig.CURRENT_VERSION
 	VerificationTracker.enable_debug()  # Enable verbose logging
 	VerificationTracker.start_tracking(game_seed, game_version)
 	print("[GameManager] Verification tracking enabled (debug mode: ON)")

--- a/godot/scripts/ui/whats_new_modal.gd
+++ b/godot/scripts/ui/whats_new_modal.gd
@@ -1,0 +1,206 @@
+extends Control
+## What's New Modal - Shows patch notes for new versions
+##
+## Displays patch notes on first launch after an update.
+## Can also be opened manually from the welcome screen menu.
+
+signal closed
+
+# UI References
+@onready var panel_container: PanelContainer = $CenterContainer/PanelContainer
+@onready var title_label: Label = $CenterContainer/PanelContainer/MarginContainer/VBox/TitleLabel
+@onready var version_label: Label = $CenterContainer/PanelContainer/MarginContainer/VBox/VersionLabel
+@onready var content_scroll: ScrollContainer = $CenterContainer/PanelContainer/MarginContainer/VBox/ContentScroll
+@onready var content_label: RichTextLabel = $CenterContainer/PanelContainer/MarginContainer/VBox/ContentScroll/ContentLabel
+@onready var close_button: Button = $CenterContainer/PanelContainer/MarginContainer/VBox/CloseButton
+
+# Patch notes data
+var patch_notes_data: Dictionary = {}
+var current_version_data: Dictionary = {}
+
+const PATCH_NOTES_PATH = "res://data/patch_notes.json"
+
+func _ready():
+	# Hide by default
+	visible = false
+
+	# Connect signals
+	close_button.pressed.connect(_on_close_pressed)
+
+	# Load patch notes data
+	_load_patch_notes()
+
+func _input(event: InputEvent):
+	# Only handle input if modal is visible
+	if not visible:
+		return
+
+	# Handle keyboard shortcuts to close
+	if event is InputEventKey and event.pressed and not event.echo:
+		if event.keycode == KEY_ESCAPE or event.keycode == KEY_ENTER or event.keycode == KEY_SPACE:
+			_on_close_pressed()
+			get_viewport().set_input_as_handled()
+
+## Load patch notes from JSON file
+func _load_patch_notes() -> void:
+	if not FileAccess.file_exists(PATCH_NOTES_PATH):
+		print("[WhatsNewModal] ERROR: Patch notes file not found at %s" % PATCH_NOTES_PATH)
+		return
+
+	var file = FileAccess.open(PATCH_NOTES_PATH, FileAccess.READ)
+	if not file:
+		print("[WhatsNewModal] ERROR: Could not open patch notes file")
+		return
+
+	var json_text = file.get_as_text()
+	file.close()
+
+	var json = JSON.new()
+	var error = json.parse(json_text)
+	if error != OK:
+		print("[WhatsNewModal] ERROR: Failed to parse patch notes JSON: %s" % json.get_error_message())
+		return
+
+	patch_notes_data = json.get_data()
+	print("[WhatsNewModal] Loaded patch notes with %d versions" % patch_notes_data.get("versions", []).size())
+
+## Show the modal with patch notes for current version
+func show_modal(mark_as_seen: bool = true) -> void:
+	if patch_notes_data.is_empty():
+		_load_patch_notes()
+
+	# Find current version's patch notes
+	var current_version = GameConfig.get_current_version()
+	current_version_data = _get_version_data(current_version)
+
+	if current_version_data.is_empty():
+		print("[WhatsNewModal] No patch notes found for version %s" % current_version)
+		# Still show something
+		_display_fallback_notes(current_version)
+	else:
+		_display_version_notes(current_version_data)
+
+	visible = true
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	close_button.grab_focus()
+
+	if mark_as_seen:
+		GameConfig.mark_patch_notes_seen()
+
+## Show the modal with all recent patch notes
+func show_all_notes() -> void:
+	if patch_notes_data.is_empty():
+		_load_patch_notes()
+
+	_display_all_notes()
+
+	visible = true
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	close_button.grab_focus()
+
+## Hide the modal
+func hide_modal() -> void:
+	visible = false
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	closed.emit()
+
+## Get patch notes data for a specific version
+func _get_version_data(version: String) -> Dictionary:
+	var versions = patch_notes_data.get("versions", [])
+	for v in versions:
+		if v.get("version", "") == version:
+			return v
+	return {}
+
+## Display patch notes for a specific version
+func _display_version_notes(version_data: Dictionary) -> void:
+	var version = version_data.get("version", "Unknown")
+	var title = version_data.get("title", "")
+	var date = version_data.get("date", "")
+
+	title_label.text = "What's New"
+	version_label.text = "Version %s - %s" % [version, title]
+	if not date.is_empty():
+		version_label.text += " (%s)" % date
+
+	# Build content
+	var content = ""
+
+	# Highlights section
+	var highlights = version_data.get("highlights", [])
+	if highlights.size() > 0:
+		content += "[b][color=#88ccff]Highlights:[/color][/b]\n"
+		for highlight in highlights:
+			content += "  [color=#aaffaa]*[/color] %s\n" % highlight
+		content += "\n"
+
+	# Sections
+	var sections = version_data.get("sections", {})
+
+	# Added
+	var added = sections.get("added", [])
+	if added.size() > 0:
+		content += "[b][color=#88ff88]Added:[/color][/b]\n"
+		for item in added:
+			content += "  [color=#88ff88]+[/color] %s\n" % item
+		content += "\n"
+
+	# Fixed
+	var fixed = sections.get("fixed", [])
+	if fixed.size() > 0:
+		content += "[b][color=#ffcc88]Fixed:[/color][/b]\n"
+		for item in fixed:
+			content += "  [color=#ffcc88]*[/color] %s\n" % item
+		content += "\n"
+
+	# Changed
+	var changed = sections.get("changed", [])
+	if changed.size() > 0:
+		content += "[b][color=#ccccff]Changed:[/color][/b]\n"
+		for item in changed:
+			content += "  [color=#ccccff]~[/color] %s\n" % item
+		content += "\n"
+
+	content_label.bbcode_enabled = true
+	content_label.text = content
+
+## Display all patch notes
+func _display_all_notes() -> void:
+	title_label.text = "Patch Notes"
+	version_label.text = "Recent Updates"
+
+	var content = ""
+	var versions = patch_notes_data.get("versions", [])
+
+	for i in range(mini(versions.size(), 3)):  # Show last 3 versions
+		var version_data = versions[i]
+		var version = version_data.get("version", "Unknown")
+		var title = version_data.get("title", "")
+		var date = version_data.get("date", "")
+
+		content += "[b][color=#ffffff]v%s - %s[/color][/b]" % [version, title]
+		if not date.is_empty():
+			content += " [color=#888888](%s)[/color]" % date
+		content += "\n"
+
+		# Highlights only for all notes view
+		var highlights = version_data.get("highlights", [])
+		for highlight in highlights:
+			content += "  [color=#aaffaa]*[/color] %s\n" % highlight
+
+		content += "\n"
+
+	content_label.bbcode_enabled = true
+	content_label.text = content
+
+## Display fallback when no patch notes found
+func _display_fallback_notes(version: String) -> void:
+	title_label.text = "What's New"
+	version_label.text = "Version %s" % version
+
+	content_label.bbcode_enabled = true
+	content_label.text = "[color=#aaaaaa]No detailed patch notes available for this version.\n\nCheck the CHANGELOG.md file for the latest updates.[/color]"
+
+## Handle close button
+func _on_close_pressed() -> void:
+	hide_modal()


### PR DESCRIPTION
## Summary
- Adds a "What's New" modal that shows patch notes on first launch after an update
- Adds a "What's New" button in the main menu for manual viewing
- Stores patch notes in JSON file for easy updates without code changes
- Tracks last-seen version in user preferences

## Changes
**New Files:**
- `godot/scripts/ui/whats_new_modal.gd` - Modal script with BBCode formatting
- `godot/scenes/ui/whats_new_modal.tscn` - Modal scene with styled UI
- `godot/data/patch_notes.json` - Patch notes data (easy to update per release)

**Modified Files:**
- `godot/autoload/game_config.gd` - Added `CURRENT_VERSION` constant and `last_seen_version` tracking
- `godot/scripts/ui/welcome_screen.gd` - Added modal trigger and menu button
- `godot/scenes/welcome.tscn` - Added "What's New" button
- `godot/scripts/game_manager.gd` - Use `GameConfig.CURRENT_VERSION` instead of hardcoded value
- `CHANGELOG.md` - Documented the feature

## Features
- Auto-shows on first launch after update (checks `last_seen_version` vs `CURRENT_VERSION`)
- Color-coded formatting: green for Added, orange for Fixed, purple for Changed
- Keyboard support: Escape, Enter, or Space to close
- Shows highlights and detailed sections
- Dark modal overlay for focus

## How to update patch notes
1. Edit `godot/data/patch_notes.json`
2. Update `CURRENT_VERSION` in `godot/autoload/game_config.gd`
3. Update `version.txt` for consistency

## Test plan
- [ ] First launch shows What's New modal automatically
- [ ] Closing modal marks version as seen (doesn't show again)
- [ ] "What's New" button in menu opens modal
- [ ] Modal displays patch notes with proper formatting
- [ ] Keyboard shortcuts (Escape/Enter/Space) close modal
- [ ] Deleting config.cfg triggers modal on next launch

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)