### PR TITLE
fix: standardize Python 3.11 baseline + repair PEP 701 f-strings

### DIFF
--- a/.github/workflows/dev-blog-automation.yml
+++ b/.github/workflows/dev-blog-automation.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |
@@ -168,7 +168,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Create development blog entry
       run: |
@@ -295,7 +295,7 @@ This automated entry captures the current development state. Manual entries may 
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Regenerate blog index
       run: |

--- a/.github/workflows/enhanced-cicd-pipeline.yml
+++ b/.github/workflows/enhanced-cicd-pipeline.yml
@@ -39,30 +39,30 @@ jobs:
     name: "Stage 1: Basic Validation"
     runs-on: ubuntu-latest
     if: github.event_name != 'schedule' || github.event.inputs.pipeline_stage == 'full' || github.event.inputs.pipeline_stage == 'quality-only'
-    
+
     outputs:
       validation-passed: ${{ steps.validation.outputs.passed }}
-      
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          
+
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-          
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          
+
       - name: ASCII Compliance Check
         id: ascii-check
         run: |
@@ -74,7 +74,7 @@ jobs:
             echo "ERROR ASCII compliance: FAILED"
             exit 1
           fi
-          
+
       - name: Import Structure Validation
         id: import-check
         run: |
@@ -82,7 +82,7 @@ jobs:
           echo "INFO  Project migrated to Godot - Python import checks skipped"
           echo "SUCCESS Using Godot GDScript instead of Python modules"
           echo "SUCCESS Import structure: SKIPPED (Godot project)"
-          
+
       - name: Version Consistency Check
         id: version-check
         run: |
@@ -96,7 +96,7 @@ jobs:
             echo "WARNING Version not found in godot/project.godot"
             echo "SUCCESS Version consistency: PASSED (non-blocking)"
           fi
-          
+
       - name: File Structure Validation
         id: structure-check
         run: |
@@ -117,7 +117,7 @@ jobs:
           done
 
           echo "SUCCESS SUCCESS File structure: PASSED"
-          
+
       - name: Set validation status
         id: validation
         run: |
@@ -130,56 +130,56 @@ jobs:
     runs-on: ubuntu-latest
     needs: basic-validation
     if: needs.basic-validation.outputs.validation-passed == 'true'
-    
+
     outputs:
       quality-score: ${{ steps.quality-metrics.outputs.score }}
       health-score: ${{ steps.health-check.outputs.health-score }}
-      
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          
+
       - name: Restore dependencies cache
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
-          
+
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-          
+
       - name: Development Standards Check
         run: |
           echo "CLIPBOARD Running comprehensive standards enforcement..."
           python scripts/enforce_standards.py --check-all || echo "WARNING  Standards check warnings (non-blocking during Godot migration)"
-          
+
       - name: Import Cleanup Check
         run: |
           echo "INFO  Project migrated to Godot - autoflake import checks skipped"
           echo "SUCCESS Import cleanup handled by GDScript"
-          
+
       - name: Type Annotation Coverage
         id: type-coverage
         run: |
           echo "🏷 Checking type annotation coverage..."
           # TODO: Implement type annotation coverage checker
           echo "type_coverage=85" >> $GITHUB_OUTPUT
-          
+
       - name: Code Quality Metrics
         id: quality-metrics
         run: |
           echo "METRICS Collecting quality metrics..."
-          
+
           # Calculate overall quality score
           type_coverage=${{ steps.type-coverage.outputs.type_coverage }}
-          
+
           if [ "$type_coverage" -ge 80 ]; then
             quality_score="HIGH"
           elif [ "$type_coverage" -ge 60 ]; then
@@ -187,7 +187,7 @@ jobs:
           else
             quality_score="LOW"
           fi
-          
+
           echo "score=$quality_score" >> $GITHUB_OUTPUT
           echo "SUCCESS Quality score: $quality_score (Type coverage: $type_coverage%)"
 
@@ -195,31 +195,31 @@ jobs:
         id: health-check
         run: |
           echo "HEALTH Running comprehensive project health assessment..."
-          
+
           # Run health check and capture output
           python scripts/project_health.py --ci-mode --output health_report.json
-          
+
           # Get machine-readable CI/CD metrics
           health_output=$(python scripts/health_tracker.py --show-trends --format ci)
-          
+
           # Extract key metrics for GitHub Actions
           health_score=$(echo "$health_output" | grep "CICD_HEALTH_SCORE=" | cut -d= -f2)
           health_status=$(echo "$health_output" | grep "CICD_HEALTH_STATUS=" | cut -d= -f2)
           health_trend=$(echo "$health_output" | grep "CICD_HEALTH_TREND_PERCENTAGE=" | cut -d= -f2)
-          
+
           # Set GitHub Actions environment variables
           echo "HEALTH_SCORE=$health_score" >> $GITHUB_ENV
           echo "HEALTH_STATUS=$health_status" >> $GITHUB_ENV
           echo "HEALTH_TREND=$health_trend" >> $GITHUB_ENV
-          
+
           # Set outputs for dependent jobs
           echo "health-score=$health_score" >> $GITHUB_OUTPUT
           echo "health-status=$health_status" >> $GITHUB_OUTPUT
           echo "health-trend=$health_trend" >> $GITHUB_OUTPUT
-          
+
           # Display health summary
           echo "SUMMARY Project Health: $health_score/100 ($health_status, trend: $health_trend%)"
-          
+
       - name: Health Gate Check
         run: |
           echo "GATE Running automated health gate check..."
@@ -228,7 +228,7 @@ jobs:
           python scripts/ci_health_integration.py --gate-check || echo "WARNING  Health gate warnings (non-blocking during migration - linting issues in legacy Python files)"
 
           echo "Health gate assessment: COMPLETED"
-          
+
       - name: Upload Health Report
         uses: actions/upload-artifact@v4
         with:
@@ -242,25 +242,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: code-quality
     if: needs.code-quality.outputs.quality-score != 'LOW' && (needs.code-quality.outputs.health-score >= 70 || needs.code-quality.outputs.health-score == '')
-    
+
     strategy:
       matrix:
-        python-version: ['3.9', '3.11', '3.12']
-        
+        python-version: ['3.11']
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          
+
       - name: Run Test Suite
         id: test-suite
         run: |
@@ -296,32 +296,32 @@ jobs:
     name: "Stage 4: Automated Sync"
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event.inputs.pipeline_stage == 'full' || github.event.inputs.pipeline_stage == 'sync-only'
-    
+
     permissions:
       issues: write
       contents: write
       pull-requests: write
-      
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          
+
       - name: Install GitHub CLI
         run: |
           sudo apt-get update
           sudo apt-get install gh
-          
+
       - name: Authenticate GitHub CLI
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-          
+
       - name: Bidirectional Issue Sync
         run: |
           echo "REFRESH Running bidirectional issue sync..."
@@ -331,14 +331,14 @@ jobs:
           else
             dry_run_flag="--live"
           fi
-          
+
           python scripts/issue_sync_bidirectional.py $dry_run_flag --sync-all
-          
+
       - name: Branch Status Report
         run: |
           echo "METRICS Generating branch status report..."
           python scripts/branch_manager.py --report
-          
+
       - name: Auto-merge Ready PRs
         if: github.event.inputs.dry_run != 'true'
         run: |
@@ -350,30 +350,30 @@ jobs:
     name: "Stage 5: Automated Cleanup"
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event.inputs.pipeline_stage == 'cleanup-only'
-    
+
     permissions:
       contents: write
-      
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          
+
       - name: Install GitHub CLI
         run: |
           sudo apt-get update
           sudo apt-get install gh
-          
+
       - name: Authenticate GitHub CLI
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-          
+
       - name: Clean up stale branches
         run: |
           echo "🧹 Cleaning up stale branches..."
@@ -383,7 +383,7 @@ jobs:
           else
             dry_run_flag="--live"
           fi
-          
+
           python scripts/branch_manager.py $dry_run_flag --cleanup-all --stale-days 30
 
   # Special: Nuclear Option for Develop Branch
@@ -391,40 +391,40 @@ jobs:
     name: "Nuclear: Reset Develop Branch"
     runs-on: ubuntu-latest
     if: github.event.inputs.pipeline_stage == 'nuke-develop'
-    
+
     permissions:
       contents: write
-      
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0  # Need full history for branch operations
-          
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          
+
       - name: Configure Git
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-          
+
       - name: Nuclear Reset of Develop Branch
         run: |
           echo "💥 NUCLEAR OPTION: Resetting develop branch..."
           dry_run_flag=""
           confirm_flag=""
-          
+
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
             dry_run_flag="--dry-run"
           else
             dry_run_flag="--live"
             confirm_flag="--confirm"
           fi
-          
+
           python scripts/branch_manager.py $dry_run_flag --nuke-develop $confirm_flag
 
   # Quality Dashboard Update
@@ -433,15 +433,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [basic-validation, code-quality, integration-testing]
     if: always() && (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: Update Quality Metrics
         run: |
           echo "METRICS Updating quality dashboard..."
-          
+
           # Create quality metrics file
           cat > quality_metrics.json << EOF
           {
@@ -453,7 +453,7 @@ jobs:
             "branch": "${{ github.ref_name }}"
           }
           EOF
-          
+
           echo "Quality metrics updated"
 
   # Notification Summary
@@ -462,7 +462,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [basic-validation, code-quality, integration-testing, automated-sync, automated-cleanup]
     if: always()
-    
+
     steps:
       - name: Generate Pipeline Summary
         run: |
@@ -476,9 +476,9 @@ jobs:
           echo "  - Automated Sync: ${{ needs.automated-sync.result }}"
           echo "  - Automated Cleanup: ${{ needs.automated-cleanup.result }}"
           echo ""
-          
-          if [ "${{ needs.basic-validation.result }}" = "success" ] && 
-             [ "${{ needs.code-quality.result }}" = "success" ] && 
+
+          if [ "${{ needs.basic-validation.result }}" = "success" ] &&
+             [ "${{ needs.code-quality.result }}" = "success" ] &&
              [ "${{ needs.integration-testing.result }}" = "success" ]; then
             echo "SUCCESS PIPELINE SUCCESS: All quality gates passed"
             echo "LAUNCH Ready for deployment"
@@ -486,7 +486,7 @@ jobs:
             echo "ERROR PIPELINE FAILURE: Quality gates failed"
             echo "TOOLS Manual intervention required"
           fi
-          
+
           echo ""
           echo "METRICS Quality Metrics:"
           echo "  - Quality Score: ${{ needs.code-quality.outputs.quality-score }}"

--- a/.github/workflows/enhanced-cicd-pipeline.yml
+++ b/.github/workflows/enhanced-cicd-pipeline.yml
@@ -313,6 +313,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
       - name: Install GitHub CLI
         run: |
           sudo apt-get update
@@ -364,6 +369,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Install GitHub CLI
         run: |

--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |
@@ -139,7 +139,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Run Pre-Build Validation
         run: |
@@ -188,7 +188,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -2,9 +2,9 @@ name: Quality Checks
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   quality-checks:
@@ -16,12 +16,19 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+
+    - name: Python syntax gate (3.11 baseline)
+      run: |
+        echo "Compiling automation scripts on the Python 3.11 baseline..."
+        echo "(Guards against modern-only syntax, e.g. PEP 701 f-strings, landing in CI scripts.)"
+        python -m py_compile scripts/*.py
+        echo "SUCCESS All scripts/ compile on the declared baseline"
 
     - name: ASCII Compliance Check
       run: |

--- a/.github/workflows/sync-dev-blog.yml
+++ b/.github/workflows/sync-dev-blog.yml
@@ -19,18 +19,18 @@ jobs:
   sync-dev-blog:
     runs-on: ubuntu-latest
     if: github.repository == 'PipFoweraker/pdoom1'
-    
+
     steps:
       - name: Checkout pdoom1 repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 2  # Need previous commit for diff
-          
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
-          
+          python-version: '3.11'
+
       - name: Validate blog entries
         run: |
           echo "Validating blog entries before sync..."
@@ -40,7 +40,7 @@ jobs:
             exit 1
           fi
           echo "SUCCESS Blog entries validated successfully"
-          
+
       - name: Checkout website repository
         uses: actions/checkout@v4
         with:
@@ -48,7 +48,7 @@ jobs:
           token: ${{ secrets.WEBSITE_SYNC_TOKEN }}
           path: website
           ref: main
-          
+
       - name: Determine changed files
         id: changes
         run: |
@@ -65,16 +65,16 @@ jobs:
               echo "MEMO Changed entries: $changed_files"
             fi
           fi
-          
+
       - name: Sync blog entries to website
         if: steps.changes.outputs.changed_files != ''
         run: |
           echo "LAUNCH Syncing blog entries to website..."
-          
+
           # Ensure blog directory exists
           mkdir -p website/public/blog
           mkdir -p website/public/dev-notes
-          
+
           # Copy changed entries
           for file in ${{ steps.changes.outputs.changed_files }}; do
             if [ -f "$file" ]; then
@@ -83,25 +83,25 @@ jobs:
               cp "$file" "website/public/blog/"
             fi
           done
-          
+
           # Always update the index for navigation
           echo "CLIPBOARD Updating blog index"
           cp dev-blog/index.json website/public/blog/
-          
+
           # Generate website-specific navigation (if needed)
           echo "COMPASS Generating website navigation"
           # Future: Create website-specific navigation from index.json
-          
+
       - name: Commit and push to website
         if: steps.changes.outputs.changed_files != ''
         working-directory: website
         run: |
           git config user.name "Dev Blog Sync Bot"
           git config user.email "dev+blog-sync@pdoom.net"
-          
+
           # Add all blog changes
           git add public/blog/
-          
+
           # Check if there are changes to commit
           if git diff --staged --quiet; then
             echo "INFO No changes to commit"
@@ -111,23 +111,23 @@ jobs:
             if [ "${{ inputs.force_sync }}" == "true" ]; then
               commit_msg="$commit_msg (force sync)"
             fi
-            
+
             echo "SAVE Committing changes: $commit_msg"
             git commit -m "$commit_msg"
-            
+
             echo "LAUNCH Pushing to website repository"
             git push
-            
+
             echo "SUCCESS Blog sync completed successfully"
           fi
-          
+
       - name: Notification
         if: steps.changes.outputs.changed_files != ''
         run: |
           echo "CELEBRATION Dev blog sync completed!"
           echo "METRICS Synced entries: ${{ steps.changes.outputs.changed_files }}"
           echo "GLOBAL Changes will be live on the website shortly"
-          
+
       - name: No changes notification
         if: steps.changes.outputs.changed_files == ''
         run: |

--- a/.github/workflows/sync-documentation.yml
+++ b/.github/workflows/sync-documentation.yml
@@ -31,7 +31,7 @@ jobs:
   sync-documentation:
     runs-on: ubuntu-latest
     if: github.repository == 'PipFoweraker/pdoom1'
-    
+
     strategy:
       matrix:
         target:
@@ -41,28 +41,28 @@ jobs:
           - repo: pdoom-data
             docs_paths: ['shared/', 'data/', 'templates/']
             destination: 'docs/'
-    
+
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 2  # Need for diff detection
-          
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
-          
+          python-version: '3.11'
+
       - name: Install dependencies
         run: |
           pip install pyyaml requests
-          
+
       - name: Skip if not targeting this repository
         if: github.event.inputs.target_repo != '' && github.event.inputs.target_repo != matrix.target.repo
         run: |
           echo "Skipping ${{ matrix.target.repo }} - not the target repository"
           exit 0
-          
+
       - name: Checkout target repository
         uses: actions/checkout@v4
         with:
@@ -70,7 +70,7 @@ jobs:
           token: ${{ secrets.CROSS_REPO_TOKEN }}
           path: target-repo
           ref: main
-          
+
       - name: Detect changed documentation
         id: changes
         run: |
@@ -80,7 +80,7 @@ jobs:
             echo "changed_files=all" >> $GITHUB_OUTPUT
           else
             echo "SEARCH Detecting changed documentation files..."
-            
+
             # Check which documentation directories have changes
             changed_docs=""
             for docs_path in ${{ join(matrix.target.docs_paths, ' ') }}; do
@@ -88,7 +88,7 @@ jobs:
                 changed_docs="$changed_docs docs/$docs_path"
               fi
             done
-            
+
             if [ -n "$changed_docs" ]; then
               echo "MEMO Changed documentation: $changed_docs"
               echo "sync_needed=true" >> $GITHUB_OUTPUT
@@ -98,18 +98,18 @@ jobs:
               echo "sync_needed=false" >> $GITHUB_OUTPUT
             fi
           fi
-          
+
       - name: Sync documentation files
         if: steps.changes.outputs.sync_needed == 'true'
         run: |
           echo "LAUNCH Syncing documentation to ${{ matrix.target.repo }}..."
-          
+
           # Load sync configuration
           if [ ! -f "docs/sync-config.yml" ]; then
             echo "ERROR Sync configuration not found"
             exit 1
           fi
-          
+
           # Create documentation sync script
           cat > sync_docs.py << 'EOF'
           import yaml
@@ -118,37 +118,37 @@ jobs:
           from pathlib import Path
           from datetime import datetime
           import sys
-          
+
           def sync_documentation():
               # Load configuration
               with open('docs/sync-config.yml', 'r') as f:
                   config = yaml.safe_load(f)
-              
+
               target_repo = "${{ matrix.target.repo }}"
               if target_repo not in config['repositories']:
                   print(f"ERROR No configuration found for {target_repo}")
                   return False
-              
+
               repo_config = config['repositories'][target_repo]
               mappings = repo_config['mappings']
               transformations = config.get('transformations', {}).get(target_repo, {})
-              
+
               # Process each mapping
               for source_path, dest_path in mappings.items():
                   source = Path('docs') / source_path
                   destination = Path('target-repo') / dest_path
-                  
+
                   if source.exists():
                       print(f"DOCUMENT Syncing {source}  ->  {destination}")
-                      
+
                       if source.is_file():
                           # Copy single file with processing
                           content = source.read_text(encoding='utf-8')
-                          
+
                           # Apply transformations
                           for pattern, replacement in transformations.items():
                               content = content.replace(pattern, replacement)
-                          
+
                           # Add sync metadata
                           sync_header = f"""<!--
           This file is automatically synced from pdoom1/docs/{source.relative_to(Path('docs'))}
@@ -159,25 +159,25 @@ jobs:
 
           """
                           content = sync_header + content
-                          
+
                           # Write to destination
                           destination.parent.mkdir(parents=True, exist_ok=True)
                           destination.write_text(content, encoding='utf-8')
-                          
+
                       elif source.is_dir():
                           # Copy directory with processing
                           destination.mkdir(parents=True, exist_ok=True)
-                          
+
                           for file_path in source.rglob('*.md'):
                               rel_path = file_path.relative_to(source)
                               dest_file = destination / rel_path
-                              
+
                               content = file_path.read_text(encoding='utf-8')
-                              
+
                               # Apply transformations
                               for pattern, replacement in transformations.items():
                                   content = content.replace(pattern, replacement)
-                              
+
                               # Add sync metadata
                               sync_header = f"""<!--
           This file is automatically synced from pdoom1/docs/{file_path.relative_to(Path('docs'))}
@@ -188,21 +188,21 @@ jobs:
 
           """
                               content = sync_header + content
-                              
+
                               # Write to destination
                               dest_file.parent.mkdir(parents=True, exist_ok=True)
                               dest_file.write_text(content, encoding='utf-8')
-              
+
               return True
-          
+
           if __name__ == "__main__":
               success = sync_documentation()
               sys.exit(0 if success else 1)
           EOF
-          
+
           # Run the sync
           python sync_docs.py
-          
+
       - name: Create sync summary
         if: steps.changes.outputs.sync_needed == 'true'
         working-directory: target-repo
@@ -212,7 +212,7 @@ jobs:
           echo "Source commit: ${{ github.sha }}" >> sync-summary.md
           echo "Sync timestamp: $(date -Iseconds)" >> sync-summary.md
           echo "" >> sync-summary.md
-          
+
           # List changed files
           if [ -n "$(git status --porcelain)" ]; then
             echo "MEMO Files changed:" >> sync-summary.md
@@ -220,45 +220,45 @@ jobs:
           else
             echo "INFO No files changed" >> sync-summary.md
           fi
-          
+
           cat sync-summary.md
-          
+
       - name: Commit and push changes
         if: steps.changes.outputs.sync_needed == 'true'
         working-directory: target-repo
         run: |
           git config user.name "Documentation Sync Bot"
           git config user.email "docs-sync+bot@pdoom.net"
-          
+
           # Check if there are any changes
           if [ -n "$(git status --porcelain)" ]; then
             # Add all changed files
             git add .
-            
+
             # Create commit message
             commit_msg="docs: sync from pdoom1@$(echo ${{ github.sha }} | head -c 7)
 
           Synchronized documentation from pdoom1 repository.
-          
+
           Source commit: ${{ github.sha }}
           Trigger: ${{ github.event_name }}
           Sync timestamp: $(date -Iseconds)
-          
+
           Changed paths: ${{ steps.changes.outputs.changed_files }}
-          
+
           This is an automated commit from the documentation sync workflow."
-            
+
             # Commit changes
             git commit -m "$commit_msg"
-            
+
             # Push to repository
             git push origin main
-            
+
             echo "SUCCESS Successfully synced documentation to ${{ matrix.target.repo }}"
           else
             echo "INFO No documentation changes to commit for ${{ matrix.target.repo }}"
           fi
-          
+
       - name: Report sync status
         if: always()
         run: |
@@ -267,18 +267,18 @@ jobs:
           else
             echo "SKIP Sync skipped for ${{ matrix.target.repo }} (no changes)"
           fi
-          
+
   notify-completion:
     runs-on: ubuntu-latest
     needs: sync-documentation
     if: always() && github.repository == 'PipFoweraker/pdoom1'
-    
+
     steps:
       - name: Notification
         run: |
           echo "TARGET Documentation sync workflow completed"
           echo "Trigger: ${{ github.event_name }}"
           echo "Commit: ${{ github.sha }}"
-          
+
           # Future: Add Discord/Slack notifications here
           # Future: Update documentation dashboard

--- a/.github/workflows/sync-game-version.yml
+++ b/.github/workflows/sync-game-version.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     - name: Extract Version Information
       id: version_info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Welcome! This guide will get you from zero to running the game in under 30 minut
 
 - **Godot 4.5.1** - [Download here](https://godotengine.org/download) (standard, not .NET)
 - **Git** - For cloning the repository
-- **Python 3.9+** - For tooling scripts (optional but recommended)
+- **Python 3.11+** - For tooling scripts (optional but recommended). 3.11 is the supported baseline; see `pyproject.toml`.
 
 ### Clone and Run
 
@@ -121,19 +121,20 @@ python scripts/run_godot_tests.py --quick --ci-mode
 
 ## Branch Workflow
 
-We use a two-branch model:
+We use a single-branch (trunk) model:
 
-- **`main`** - Stable releases only
-- **`develop`** - Active development, all PRs target here
+- **`main`** - The single source of truth. All work branches off `main`, and all PRs target `main`.
+
+> The former `develop` branch was retired in April 2026; everything now flows through `main` via pull requests.
 
 ### Making Changes
 
-1. **Fork** the repository on GitHub
+1. **Fork** the repository on GitHub (external contributors), or branch directly (maintainers)
 
-2. **Create a feature branch from develop:**
+2. **Create a branch from main:**
    ```bash
-   git checkout develop
-   git pull origin develop
+   git checkout main
+   git pull origin main
    git checkout -b feature/your-feature-name
    # or
    git checkout -b fix/issue-123-description
@@ -157,7 +158,7 @@ We use a two-branch model:
    git push origin feature/your-feature-name
    ```
 
-6. **Open a Pull Request** targeting `develop` (not main)
+6. **Open a Pull Request** targeting `main`
 
 ## Contribution Types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+# Authoritative Python baseline for P(Doom) tooling and CI.
+#
+# The game itself is built in Godot / GDScript; Python is used ONLY for
+# automation, CI/CD, and developer tooling under scripts/ and tools/.
+# This file pins the *minimum supported Python* so that modern syntax
+# (e.g. PEP 701 f-strings, valid only on 3.12+) cannot silently land and
+# break CI lanes running an older interpreter.
+#
+# Baseline: Python 3.11  (see CONTRIBUTING.md "Development Setup").
+# Enforced in CI by the "Python syntax gate" step in quality-checks.yml,
+# which compiles scripts/ on the baseline interpreter.
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.black]
+target-version = ["py311"]
+line-length = 100
+
+[tool.isort]
+profile = "black"
+line_length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@
 
 # JSON schema validation
 jsonschema>=4.0.0
+
+# YAML parsing (issue sync, metadata, config files)
+pyyaml>=6.0

--- a/scripts/ascii_compliance_fixer.py
+++ b/scripts/ascii_compliance_fixer.py
@@ -1,197 +1,191 @@
 # !/usr/bin/env python3
-'''
+"""
 ASCII Compliance Fixer for P(Doom) Documentation
 
 This tool systematically finds and replaces Unicode characters with ASCII equivalents
 across all documentation files to ensure cross-platform compatibility.
-'''
+"""
 
-import os
 import glob
+import os
 import re
-from typing import List, Tuple, Dict
+from typing import Dict, List, Tuple
+
 
 class ASCIIComplianceFixer:
     def __init__(self):
         # Common Unicode to ASCII replacements
         self.replacements = {
             # Em and En dashes
-            '\u2013': '-',  # EN DASH
-            '\u2014': '--', # EM DASH
-            '\u2015': '--', # HORIZONTAL BAR
-            
+            "\u2013": "-",  # EN DASH
+            "\u2014": "--",  # EM DASH
+            "\u2015": "--",  # HORIZONTAL BAR
             # Quotation marks
-            '\u201c': ''',  # LEFT DOUBLE QUOTATION MARK
-            '\u201d': ''',  # RIGHT DOUBLE QUOTATION MARK
-            '\u2018': ''',  # LEFT SINGLE QUOTATION MARK  
-            '\u2019': ''',  # RIGHT SINGLE QUOTATION MARK
-            '\u00ab': ''',  # LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-            '\u00bb': ''',  # RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-            
+            "\u201c": """,  # LEFT DOUBLE QUOTATION MARK
+            '\u201d': """,  # RIGHT DOUBLE QUOTATION MARK
+            "\u2018": """,  # LEFT SINGLE QUOTATION MARK
+            '\u2019': """,  # RIGHT SINGLE QUOTATION MARK
+            "\u00ab": """,  # LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+            '\u00bb': """,  # RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
             # Bullets and list markers
-            '\u2022': '*',  # BULLET
-            '\u2023': '*',  # TRIANGULAR BULLET
-            '\u2043': '*',  # HYPHEN BULLET
-            '\u25cf': '*',  # BLACK CIRCLE
-            '\u25cb': 'o',  # WHITE CIRCLE
-            '\u25aa': '*',  # BLACK SMALL SQUARE
-            '\u25ab': '*',  # WHITE SMALL SQUARE
-            
+            "\u2022": "*",  # BULLET
+            "\u2023": "*",  # TRIANGULAR BULLET
+            "\u2043": "*",  # HYPHEN BULLET
+            "\u25cf": "*",  # BLACK CIRCLE
+            "\u25cb": "o",  # WHITE CIRCLE
+            "\u25aa": "*",  # BLACK SMALL SQUARE
+            "\u25ab": "*",  # WHITE SMALL SQUARE
             # Arrows
-            '\u2192': '->',  # RIGHTWARDS ARROW
-            '\u2190': '<-',  # LEFTWARDS ARROW
-            '\u2194': '<->',  # LEFT RIGHT ARROW
-            '\u21d2': '=>',  # RIGHTWARDS DOUBLE ARROW
-            '\u2934': '->',  # ARROW POINTING RIGHTWARDS THEN CURVING UPWARDS
-            '\u2935': '->',  # ARROW POINTING RIGHTWARDS THEN CURVING DOWNWARDS
-            '\u2191': '^',   # UPWARDS ARROW (^)
-            '\u2193': 'v',   # DOWNWARDS ARROW (v)
-            '\u2196': '<-',  # NORTH WEST ARROW
-            '\u2197': '->',  # NORTH EAST ARROW
-            '\u2198': '->',  # SOUTH EAST ARROW
-            '\u2199': '<-',  # SOUTH WEST ARROW
-            
+            "\u2192": "->",  # RIGHTWARDS ARROW
+            "\u2190": "<-",  # LEFTWARDS ARROW
+            "\u2194": "<->",  # LEFT RIGHT ARROW
+            "\u21d2": "=>",  # RIGHTWARDS DOUBLE ARROW
+            "\u2934": "->",  # ARROW POINTING RIGHTWARDS THEN CURVING UPWARDS
+            "\u2935": "->",  # ARROW POINTING RIGHTWARDS THEN CURVING DOWNWARDS
+            "\u2191": "^",  # UPWARDS ARROW (^)
+            "\u2193": "v",  # DOWNWARDS ARROW (v)
+            "\u2196": "<-",  # NORTH WEST ARROW
+            "\u2197": "->",  # NORTH EAST ARROW
+            "\u2198": "->",  # SOUTH EAST ARROW
+            "\u2199": "<-",  # SOUTH WEST ARROW
             # Mathematical symbols
-            '\u2713': 'v',   # CHECK MARK (v)
-            '\u2717': 'x',   # BALLOT X
-            '\u2718': 'x',   # HEAVY BALLOT X
-            '\u2714': 'V',   # HEAVY CHECK MARK
-            '\u2715': 'X',   # MULTIPLICATION X
-            '\u2716': 'X',   # HEAVY MULTIPLICATION X
-            '\u00d7': 'x',   # MULTIPLICATION SIGN
-            '\u00f7': '/',   # DIVISION SIGN
-            '\u2260': '!=',  # NOT EQUAL TO
-            '\u2264': '<=',  # LESS-THAN OR EQUAL TO
-            '\u2265': '>=',  # GREATER-THAN OR EQUAL TO
-            
+            "\u2713": "v",  # CHECK MARK (v)
+            "\u2717": "x",  # BALLOT X
+            "\u2718": "x",  # HEAVY BALLOT X
+            "\u2714": "V",  # HEAVY CHECK MARK
+            "\u2715": "X",  # MULTIPLICATION X
+            "\u2716": "X",  # HEAVY MULTIPLICATION X
+            "\u00d7": "x",  # MULTIPLICATION SIGN
+            "\u00f7": "/",  # DIVISION SIGN
+            "\u2260": "!=",  # NOT EQUAL TO
+            "\u2264": "<=",  # LESS-THAN OR EQUAL TO
+            "\u2265": ">=",  # GREATER-THAN OR EQUAL TO
             # Common punctuation
-            '\u2026': '...',  # HORIZONTAL ELLIPSIS
-            '\u00a0': ' ',    # NON-BREAKING SPACE
-            '\u2007': ' ',    # FIGURE SPACE
-            '\u2008': ' ',    # PUNCTUATION SPACE
-            '\u2009': ' ',    # THIN SPACE
-            '\u200a': ' ',    # HAIR SPACE
-            
+            "\u2026": "...",  # HORIZONTAL ELLIPSIS
+            "\u00a0": " ",  # NON-BREAKING SPACE
+            "\u2007": " ",  # FIGURE SPACE
+            "\u2008": " ",  # PUNCTUATION SPACE
+            "\u2009": " ",  # THIN SPACE
+            "\u200a": " ",  # HAIR SPACE
             # Special characters
-            '\u00a9': '(c)',  # COPYRIGHT SIGN
-            '\u00ae': '(R)',  # REGISTERED SIGN
-            '\u2122': '(TM)', # TRADE MARK SIGN
-            '\u00b0': 'deg',  # DEGREE SIGN
-            '\u00b1': '+/-',  # PLUS-MINUS SIGN
-            '\u00b5': 'u',    # MICRO SIGN
-            '\u2328': '[KEYBOARD]',  # KEYBOARD ([KEYBOARD])
-            '\U0001FA91': '[CHAIR]', # CHAIR ([CHAIR])
-            
+            "\u00a9": "(c)",  # COPYRIGHT SIGN
+            "\u00ae": "(R)",  # REGISTERED SIGN
+            "\u2122": "(TM)",  # TRADE MARK SIGN
+            "\u00b0": "deg",  # DEGREE SIGN
+            "\u00b1": "+/-",  # PLUS-MINUS SIGN
+            "\u00b5": "u",  # MICRO SIGN
+            "\u2328": "[KEYBOARD]",  # KEYBOARD ([KEYBOARD])
+            "\U0001FA91": "[CHAIR]",  # CHAIR ([CHAIR])
             # Fractions
-            '\u00bd': '1/2',  # VULGAR FRACTION ONE HALF
-            '\u00bc': '1/4',  # VULGAR FRACTION ONE QUARTER
-            '\u00be': '3/4',  # VULGAR FRACTION THREE QUARTERS
+            "\u00bd": "1/2",  # VULGAR FRACTION ONE HALF
+            "\u00bc": "1/4",  # VULGAR FRACTION ONE QUARTER
+            "\u00be": "3/4",  # VULGAR FRACTION THREE QUARTERS
         }
-        
+
         # Emoji patterns (remove entirely or replace with text)
         self.emoji_replacements = {
             # Common emojis in documentation
-            '\U0001f4a1': '[IDEA]',      # [IDEA] ELECTRIC LIGHT BULB
-            '\U0001f4dd': '[NOTE]',      # [NOTE] MEMO
-            '\U0001f4cb': '[CHECKLIST]', # [CHECKLIST] CLIPBOARD
-            '\U0001f4ca': '[CHART]',     # [CHART] BAR CHART
-            '\U0001f4c8': '[GRAPH]',     # [GRAPH] CHART WITH UPWARDS TREND
-            '\U0001f4c9': '[GRAPH]',     # [GRAPH] CHART WITH DOWNWARDS TREND
-            '\U0001f4c5': '[CALENDAR]',  # [CALENDAR] CALENDAR
-            '\U0001f4c6': '[DATE]',      # [DATE] TEAR-OFF CALENDAR
-            '\U0001f4e7': '[EMAIL]',     # [EMAIL] E-MAIL SYMBOL
-            '\U0001f4e8': '[INBOX]',     # [INBOX] INCOMING ENVELOPE
-            '\U0001f4f1': '[PHONE]',     # [PHONE] MOBILE PHONE
-            '\U0001f4bb': '[LAPTOP]',    # [LAPTOP] PERSONAL COMPUTER
-            '\U0001f4be': '[DISK]',      # [DISK] FLOPPY DISK
-            '\U0001f4bf': '[DISC]',      # [DISC] OPTICAL DISC
-            '\U0001f4c0': '[DVD]',       # [DVD] DVD
-            '\U0001f50d': '[SEARCH]',    # [SEARCH] LEFT-POINTING MAGNIFYING GLASS
-            '\U0001f512': '[LOCK]',      # [LOCK] LOCK
-            '\U0001f513': '[UNLOCK]',    # [UNLOCK] OPEN LOCK
-            '\U0001f514': '[BELL]',      # [BELL] BELL
-            '\U0001f515': '[SILENT]',    # [SILENT] BELL WITH CANCELLATION STROKE
-            '\U0001f5a5': '[DESKTOP]',   # [DESKTOP][EMOJI] DESKTOP COMPUTER
-            '\U0001f5a8': '[PRINTER]',   # [PRINTER][EMOJI] PRINTER
-            '\U0001f680': '[ROCKET]',    # [ROCKET] ROCKET
-            '\U0001f525': '[FIRE]',      # [FIRE] FIRE
-            '\U0001f4af': '[100]',       # [100] HUNDRED POINTS SYMBOL
-            '\U0001f389': '[PARTY]',     # [PARTY] PARTY POPPER
-            '\U0001f38a': '[CONFETTI]',  # [CONFETTI] CONFETTI BALL
-            '\U0001f44d': '[THUMBS_UP]', # [THUMBS_UP] THUMBS UP SIGN
-            '\U0001f44e': '[THUMBS_DOWN]', # [THUMBS_DOWN] THUMBS DOWN SIGN
-            '\U0001f44f': '[CLAP]',      # [CLAP] CLAPPING HANDS SIGN
-            '\U0001f64f': '[PRAY]',      # [PRAY] PERSON WITH FOLDED HANDS
-            '\U0001f3af': '[TARGET]',    # [TARGET] DIRECT HIT
-            '\U0001f3c6': '[TROPHY]',    # [TROPHY] TROPHY
-            '\U0001f3c5': '[MEDAL]',     # [MEDAL] SPORTS MEDAL
-            '\U0001f451': '[CROWN]',     # [CROWN] CROWN
-            '\U0001f4a5': '[BOOM]',      # [BOOM] COLLISION SYMBOL
-            '\U0001f4a6': '[SPLASH]',    # [SPLASH] SPLASHING SWEAT SYMBOL
-            '\U0001f4a8': '[DASH]',      # [DASH] DASH SYMBOL
-            '\U0001f4ab': '[DIZZY]',     # [DIZZY] DIZZY SYMBOL
-            '\U0001f4ac': '[SPEECH]',    # [SPEECH] SPEECH BALLOON
-            '\U0001f4ad': '[THOUGHT]',   # [THOUGHT] THOUGHT BALLOON
-            '\U0001f590': '[HAND]',      # [HAND][EMOJI] RAISED HAND WITH FINGERS SPLAYED
-            '\U0001f595': '[FINGER]',    # [FINGER] REVERSED HAND WITH MIDDLE FINGER EXTENDED
-            
+            "\U0001f4a1": "[IDEA]",  # [IDEA] ELECTRIC LIGHT BULB
+            "\U0001f4dd": "[NOTE]",  # [NOTE] MEMO
+            "\U0001f4cb": "[CHECKLIST]",  # [CHECKLIST] CLIPBOARD
+            "\U0001f4ca": "[CHART]",  # [CHART] BAR CHART
+            "\U0001f4c8": "[GRAPH]",  # [GRAPH] CHART WITH UPWARDS TREND
+            "\U0001f4c9": "[GRAPH]",  # [GRAPH] CHART WITH DOWNWARDS TREND
+            "\U0001f4c5": "[CALENDAR]",  # [CALENDAR] CALENDAR
+            "\U0001f4c6": "[DATE]",  # [DATE] TEAR-OFF CALENDAR
+            "\U0001f4e7": "[EMAIL]",  # [EMAIL] E-MAIL SYMBOL
+            "\U0001f4e8": "[INBOX]",  # [INBOX] INCOMING ENVELOPE
+            "\U0001f4f1": "[PHONE]",  # [PHONE] MOBILE PHONE
+            "\U0001f4bb": "[LAPTOP]",  # [LAPTOP] PERSONAL COMPUTER
+            "\U0001f4be": "[DISK]",  # [DISK] FLOPPY DISK
+            "\U0001f4bf": "[DISC]",  # [DISC] OPTICAL DISC
+            "\U0001f4c0": "[DVD]",  # [DVD] DVD
+            "\U0001f50d": "[SEARCH]",  # [SEARCH] LEFT-POINTING MAGNIFYING GLASS
+            "\U0001f512": "[LOCK]",  # [LOCK] LOCK
+            "\U0001f513": "[UNLOCK]",  # [UNLOCK] OPEN LOCK
+            "\U0001f514": "[BELL]",  # [BELL] BELL
+            "\U0001f515": "[SILENT]",  # [SILENT] BELL WITH CANCELLATION STROKE
+            "\U0001f5a5": "[DESKTOP]",  # [DESKTOP][EMOJI] DESKTOP COMPUTER
+            "\U0001f5a8": "[PRINTER]",  # [PRINTER][EMOJI] PRINTER
+            "\U0001f680": "[ROCKET]",  # [ROCKET] ROCKET
+            "\U0001f525": "[FIRE]",  # [FIRE] FIRE
+            "\U0001f4af": "[100]",  # [100] HUNDRED POINTS SYMBOL
+            "\U0001f389": "[PARTY]",  # [PARTY] PARTY POPPER
+            "\U0001f38a": "[CONFETTI]",  # [CONFETTI] CONFETTI BALL
+            "\U0001f44d": "[THUMBS_UP]",  # [THUMBS_UP] THUMBS UP SIGN
+            "\U0001f44e": "[THUMBS_DOWN]",  # [THUMBS_DOWN] THUMBS DOWN SIGN
+            "\U0001f44f": "[CLAP]",  # [CLAP] CLAPPING HANDS SIGN
+            "\U0001f64f": "[PRAY]",  # [PRAY] PERSON WITH FOLDED HANDS
+            "\U0001f3af": "[TARGET]",  # [TARGET] DIRECT HIT
+            "\U0001f3c6": "[TROPHY]",  # [TROPHY] TROPHY
+            "\U0001f3c5": "[MEDAL]",  # [MEDAL] SPORTS MEDAL
+            "\U0001f451": "[CROWN]",  # [CROWN] CROWN
+            "\U0001f4a5": "[BOOM]",  # [BOOM] COLLISION SYMBOL
+            "\U0001f4a6": "[SPLASH]",  # [SPLASH] SPLASHING SWEAT SYMBOL
+            "\U0001f4a8": "[DASH]",  # [DASH] DASH SYMBOL
+            "\U0001f4ab": "[DIZZY]",  # [DIZZY] DIZZY SYMBOL
+            "\U0001f4ac": "[SPEECH]",  # [SPEECH] SPEECH BALLOON
+            "\U0001f4ad": "[THOUGHT]",  # [THOUGHT] THOUGHT BALLOON
+            "\U0001f590": "[HAND]",  # [HAND][EMOJI] RAISED HAND WITH FINGERS SPLAYED
+            "\U0001f595": "[FINGER]",  # [FINGER] REVERSED HAND WITH MIDDLE FINGER EXTENDED
             # Weather
-            '\u2600': '[SUN]',           # [SUN][EMOJI] BLACK SUN WITH RAYS
-            '\u2601': '[CLOUD]',         # [CLOUD][EMOJI] CLOUD
-            '\u26c5': '[PARTLY_CLOUDY]', # [PARTLY_CLOUDY] SUN BEHIND CLOUD
-            '\u2614': '[RAIN]',          # [RAIN] UMBRELLA WITH RAIN DROPS
-            '\u26a1': '[LIGHTNING]',     # [LIGHTNING] HIGH VOLTAGE SIGN
-            '\u2744': '[SNOW]',          # [SNOW][EMOJI] SNOWFLAKE
-            
+            "\u2600": "[SUN]",  # [SUN][EMOJI] BLACK SUN WITH RAYS
+            "\u2601": "[CLOUD]",  # [CLOUD][EMOJI] CLOUD
+            "\u26c5": "[PARTLY_CLOUDY]",  # [PARTLY_CLOUDY] SUN BEHIND CLOUD
+            "\u2614": "[RAIN]",  # [RAIN] UMBRELLA WITH RAIN DROPS
+            "\u26a1": "[LIGHTNING]",  # [LIGHTNING] HIGH VOLTAGE SIGN
+            "\u2744": "[SNOW]",  # [SNOW][EMOJI] SNOWFLAKE
             # Symbols
-            '\u2764': '[HEART]',         # [HEART][EMOJI] HEAVY BLACK HEART
-            '\u2665': '[HEART]',         # [HEART] BLACK HEART SUIT
-            '\u2660': '[SPADE]',         # [SPADE] BLACK SPADE SUIT
-            '\u2663': '[CLUB]',          # [CLUB] BLACK CLUB SUIT
-            '\u2666': '[DIAMOND]',       # [DIAMOND] BLACK DIAMOND SUIT
-            '\u2709': '[ENVELOPE]',      # [ENVELOPE][EMOJI] ENVELOPE
-            '\u270f': '[PENCIL]',        # [PENCIL][EMOJI] PENCIL
-            '\u2712': '[NIB]',           # [NIB][EMOJI] BLACK NIB
-            '\u2702': '[SCISSORS]',      # [SCISSORS][EMOJI] BLACK SCISSORS
-            '\u2708': '[PLANE]',         # [PLANE][EMOJI] AIRPLANE
-            '\u26f5': '[SAILBOAT]',      # [SAILBOAT] SAILBOAT
-            '\u26ea': '[CHURCH]',        # [CHURCH] CHURCH
-            '\u26fd': '[FUEL]',          # [FUEL] FUEL PUMP
-            '\u2699': '[GEAR]',          # [GEAR][EMOJI] GEAR
-            '\u269b': '[ATOM]',          # [ATOM][EMOJI] ATOM SYMBOL
-            '\u269c': '[FLEUR]',         # [FLEUR][EMOJI] FLEUR-DE-LIS
-            '\u26a0': '[WARNING]',       # [WARNING][EMOJI] WARNING SIGN
-            '\u26d4': '[NO_ENTRY]',      # [NO_ENTRY] NO ENTRY
-            '\u2753': '[QUESTION]',      # [QUESTION] BLACK QUESTION MARK ORNAMENT
-            '\u2757': '[EXCLAMATION]',   # [EXCLAMATION] HEAVY EXCLAMATION MARK SYMBOL
-            '\u27a1': '[RIGHT_ARROW]',   # [RIGHT_ARROW][EMOJI] BLACK RIGHTWARDS ARROW
-            '\u2b06': '[UP_ARROW]',      # [UP_ARROW][EMOJI] UPWARDS BLACK ARROW
-            '\u2b07': '[DOWN_ARROW]',    # [DOWN_ARROW][EMOJI] DOWNWARDS BLACK ARROW
-            '\u2b05': '[LEFT_ARROW]',    # [LEFT_ARROW][EMOJI] LEFTWARDS BLACK ARROW
-            '\u2934': '[CURVE_RIGHT]',   # ->[EMOJI] ARROW POINTING RIGHTWARDS THEN CURVING UPWARDS
-            '\u2935': '[CURVE_LEFT]',    # ->[EMOJI] ARROW POINTING RIGHTWARDS THEN CURVING DOWNWARDS
+            "\u2764": "[HEART]",  # [HEART][EMOJI] HEAVY BLACK HEART
+            "\u2665": "[HEART]",  # [HEART] BLACK HEART SUIT
+            "\u2660": "[SPADE]",  # [SPADE] BLACK SPADE SUIT
+            "\u2663": "[CLUB]",  # [CLUB] BLACK CLUB SUIT
+            "\u2666": "[DIAMOND]",  # [DIAMOND] BLACK DIAMOND SUIT
+            "\u2709": "[ENVELOPE]",  # [ENVELOPE][EMOJI] ENVELOPE
+            "\u270f": "[PENCIL]",  # [PENCIL][EMOJI] PENCIL
+            "\u2712": "[NIB]",  # [NIB][EMOJI] BLACK NIB
+            "\u2702": "[SCISSORS]",  # [SCISSORS][EMOJI] BLACK SCISSORS
+            "\u2708": "[PLANE]",  # [PLANE][EMOJI] AIRPLANE
+            "\u26f5": "[SAILBOAT]",  # [SAILBOAT] SAILBOAT
+            "\u26ea": "[CHURCH]",  # [CHURCH] CHURCH
+            "\u26fd": "[FUEL]",  # [FUEL] FUEL PUMP
+            "\u2699": "[GEAR]",  # [GEAR][EMOJI] GEAR
+            "\u269b": "[ATOM]",  # [ATOM][EMOJI] ATOM SYMBOL
+            "\u269c": "[FLEUR]",  # [FLEUR][EMOJI] FLEUR-DE-LIS
+            "\u26a0": "[WARNING]",  # [WARNING][EMOJI] WARNING SIGN
+            "\u26d4": "[NO_ENTRY]",  # [NO_ENTRY] NO ENTRY
+            "\u2753": "[QUESTION]",  # [QUESTION] BLACK QUESTION MARK ORNAMENT
+            "\u2757": "[EXCLAMATION]",  # [EXCLAMATION] HEAVY EXCLAMATION MARK SYMBOL
+            "\u27a1": "[RIGHT_ARROW]",  # [RIGHT_ARROW][EMOJI] BLACK RIGHTWARDS ARROW
+            "\u2b06": "[UP_ARROW]",  # [UP_ARROW][EMOJI] UPWARDS BLACK ARROW
+            "\u2b07": "[DOWN_ARROW]",  # [DOWN_ARROW][EMOJI] DOWNWARDS BLACK ARROW
+            "\u2b05": "[LEFT_ARROW]",  # [LEFT_ARROW][EMOJI] LEFTWARDS BLACK ARROW
+            "\u2934": "[CURVE_RIGHT]",  # ->[EMOJI] ARROW POINTING RIGHTWARDS THEN CURVING UPWARDS
+            "\u2935": "[CURVE_LEFT]",  # ->[EMOJI] ARROW POINTING RIGHTWARDS THEN CURVING DOWNWARDS
         }
-        
+
         # Generic emoji pattern for anything we missed
-        self.emoji_pattern = re.compile(r'[\U0001F600-\U0001F64F]|[\U0001F300-\U0001F5FF]|[\U0001F680-\U0001F6FF]|[\U0001F1E0-\U0001F1FF]|[\U00002702-\U000027B0]|[\U000024C2-\U0001F251]')
+        self.emoji_pattern = re.compile(
+            r"[\U0001F600-\U0001F64F]|[\U0001F300-\U0001F5FF]|[\U0001F680-\U0001F6FF]|[\U0001F1E0-\U0001F1FF]|[\U00002702-\U000027B0]|[\U000024C2-\U0001F251]"
+        )
 
     def find_violations(self, file_path: str) -> List[Tuple[int, str, str]]:
-        '''Find all Unicode violations in a file.'''
+        """Find all Unicode violations in a file."""
         violations = []
-        
+
         try:
-            with open(file_path, 'rb') as f:
+            with open(file_path, "rb") as f:
                 content = f.read()
-            
+
             # Try to decode as ASCII
             try:
-                content.decode('ascii')
+                content.decode("ascii")
                 return violations  # No violations
             except UnicodeDecodeError:
                 pass
-            
+
             # Find all violations by checking each character
-            text_content = content.decode('utf-8', errors='replace')
+            text_content = content.decode("utf-8", errors="replace")
             for i, char in enumerate(text_content):
                 if ord(char) > 127:  # Non-ASCII character
                     # Suggest replacement
@@ -200,155 +194,163 @@ class ASCIIComplianceFixer:
                     elif char in self.emoji_replacements:
                         suggestion = self.emoji_replacements[char]
                     elif self.emoji_pattern.match(char):
-                        suggestion = '[EMOJI]'
+                        suggestion = "[EMOJI]"
                     else:
-                        suggestion = f'[U+{ord(char):04X}]'
-                    
+                        suggestion = f"[U+{ord(char):04X}]"
+
                     violations.append((i, char, suggestion))
-        
+
         except Exception as e:
-            print(f'Error processing {file_path}: {e}')
-        
+            print(f"Error processing {file_path}: {e}")
+
         return violations
 
     def fix_file(self, file_path: str, dry_run: bool = False) -> Tuple[bool, int]:
-        '''Fix Unicode violations in a file.'''
+        """Fix Unicode violations in a file."""
         try:
-            with open(file_path, 'r', encoding='utf-8') as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read()
-            
+
             original_content = content
             replacements_made = 0
-            
+
             # Apply character replacements
             for unicode_char, ascii_replacement in self.replacements.items():
                 if unicode_char in content:
                     content = content.replace(unicode_char, ascii_replacement)
-                    replacements_made += content.count(ascii_replacement) - original_content.count(ascii_replacement)
-            
+                    replacements_made += content.count(ascii_replacement) - original_content.count(
+                        ascii_replacement
+                    )
+
             # Apply emoji replacements
             for emoji, replacement in self.emoji_replacements.items():
                 if emoji in content:
                     content = content.replace(emoji, replacement)
                     replacements_made += 1
-            
+
             # Handle any remaining emojis with generic replacement
             remaining_emojis = self.emoji_pattern.findall(content)
             if remaining_emojis:
-                content = self.emoji_pattern.sub('[EMOJI]', content)
+                content = self.emoji_pattern.sub("[EMOJI]", content)
                 replacements_made += len(remaining_emojis)
-            
+
             # Handle any remaining non-ASCII characters
-            import re
+
             remaining_unicode = []
             for i, char in enumerate(content):
                 if ord(char) > 127:
                     remaining_unicode.append(char)
-            
+
             if remaining_unicode:
                 # Replace any remaining Unicode characters with generic markers
                 for char in set(remaining_unicode):
                     if ord(char) > 127:
-                        content = content.replace(char, f'[U+{ord(char):04X}]')
-                        replacements_made += content.count(f'[U+{ord(char):04X}]')
-            
+                        content = content.replace(char, f"[U+{ord(char):04X}]")
+                        replacements_made += content.count(f"[U+{ord(char):04X}]")
+
             # Write back if changes were made and not in dry run mode
             if not dry_run and content != original_content:
-                with open(file_path, 'w', encoding='utf-8') as f:
+                with open(file_path, "w", encoding="utf-8") as f:
                     f.write(content)
                 return True, replacements_made
-            
+
             return content != original_content, replacements_made
-            
+
         except Exception as e:
-            print(f'Error fixing {file_path}: {e}')
+            print(f"Error fixing {file_path}: {e}")
             return False, 0
 
     def process_directory(self, dry_run: bool = False) -> Dict[str, Tuple[bool, int]]:
-        '''Process all documentation files in the repository.'''
+        """Process all documentation files in the repository."""
         results = {}
-        
+
         # File patterns to check
         patterns = [
-            'docs/**/*.md',
-            'dev-blog/**/*.md', 
-            '*.md',
-            'tests/**/*.py',  # Only if they have violations
-            'src/**/*.py'     # Only if they have violations
+            "docs/**/*.md",
+            "dev-blog/**/*.md",
+            "*.md",
+            "tests/**/*.py",  # Only if they have violations
+            "src/**/*.py",  # Only if they have violations
         ]
-        
+
         files_to_process = set()
         for pattern in patterns:
             files = glob.glob(pattern, recursive=True)
             for file_path in files:
                 if os.path.isfile(file_path):
                     files_to_process.add(file_path)
-        
+
         total_files = len(files_to_process)
         processed = 0
-        
+
         for file_path in sorted(files_to_process):
             violations = self.find_violations(file_path)
             if violations:
                 if dry_run:
-                    print(f'Would fix {file_path}: {len(violations)} violations')
+                    print(f"Would fix {file_path}: {len(violations)} violations")
                     results[file_path] = (True, len(violations))
                 else:
                     success, count = self.fix_file(file_path)
                     if success:
-                        print(f'Fixed {file_path}: {count} replacements')
+                        print(f"Fixed {file_path}: {count} replacements")
                     else:
-                        print(f'No changes needed: {file_path}')
+                        print(f"No changes needed: {file_path}")
                     results[file_path] = (success, count)
-            
+
             processed += 1
             if processed % 10 == 0:
-                print(f'Progress: {processed}/{total_files} files processed')
-        
+                print(f"Progress: {processed}/{total_files} files processed")
+
         return results
+
 
 def main():
     import argparse
-    
-    parser = argparse.ArgumentParser(description='Fix ASCII compliance issues in P(Doom) documentation')
-    parser.add_argument('--dry-run', action='store_true', help='Show what would be changed without making changes')
-    parser.add_argument('--file', help='Process a specific file instead of all files')
-    
+
+    parser = argparse.ArgumentParser(
+        description="Fix ASCII compliance issues in P(Doom) documentation"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would be changed without making changes"
+    )
+    parser.add_argument("--file", help="Process a specific file instead of all files")
+
     args = parser.parse_args()
-    
+
     fixer = ASCIIComplianceFixer()
-    
+
     if args.file:
         if os.path.exists(args.file):
             violations = fixer.find_violations(args.file)
             if violations:
-                print(f'Found {len(violations)} violations in {args.file}:')
+                print(f"Found {len(violations)} violations in {args.file}:")
                 for pos, char, suggestion in violations[:10]:  # Show first 10
-                    print(f'  Position {pos}: \'{char}\' -> \'{suggestion}\'')
+                    print(f"  Position {pos}: '{char}' -> '{suggestion}'")
                 if len(violations) > 10:
-                    print(f'  ... and {len(violations) - 10} more')
-                
+                    print(f"  ... and {len(violations) - 10} more")
+
                 if not args.dry_run:
                     success, count = fixer.fix_file(args.file)
                     if success:
-                        print(f'Fixed {count} violations in {args.file}')
+                        print(f"Fixed {count} violations in {args.file}")
                     else:
-                        print('No changes made')
+                        print("No changes made")
             else:
-                print(f'No violations found in {args.file}')
+                print(f"No violations found in {args.file}")
         else:
-            print(f'File not found: {args.file}')
+            print(f"File not found: {args.file}")
     else:
-        print('Processing all files...')
+        print("Processing all files...")
         results = fixer.process_directory(dry_run=args.dry_run)
-        
+
         total_files_fixed = sum(1 for success, _ in results.values() if success)
         total_replacements = sum(count for _, count in results.values())
-        
-        print(f'\nSummary:')
-        print(f'Files processed: {len(results)}')
-        print(f'Files {'would be ' if args.dry_run else ''}fixed: {total_files_fixed}')
-        print(f'Total replacements {'would be ' if args.dry_run else ''}made: {total_replacements}')
 
-if __name__ == '__main__':
+        print("\nSummary:")
+        print(f"Files processed: {len(results)}")
+        print(f"Files {'would be ' if args.dry_run else ''}fixed: {total_files_fixed}")
+        print(f"Total replacements {'would be ' if args.dry_run else ''}made: {total_replacements}")
+
+
+if __name__ == "__main__":
     main()

--- a/scripts/branch_manager.py
+++ b/scripts/branch_manager.py
@@ -1,5 +1,5 @@
 # !/usr/bin/env python3
-'''
+"""
 Automated Branch Management System for P(Doom)
 
 This script provides intelligent branch lifecycle management, including:
@@ -13,565 +13,617 @@ Usage:
     python scripts/branch_manager.py --nuke-develop --confirm
     python scripts/branch_manager.py --cleanup-all --dry-run
     python scripts/branch_manager.py --auto-merge-ready
-'''
+"""
 
-import sys
-import json
 import argparse
+import json
 import subprocess
-from pathlib import Path
-from typing import Dict, List, Optional, Any
+import sys
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+
 class BranchInfo:
-    '''Information about a git branch.'''
-    
-    def __init__(self, name: str, last_commit_date: datetime, 
-                 last_commit_hash: str, author: str, is_merged: bool = False):
+    """Information about a git branch."""
+
+    def __init__(
+        self,
+        name: str,
+        last_commit_date: datetime,
+        last_commit_hash: str,
+        author: str,
+        is_merged: bool = False,
+    ):
         self.name = name
         self.last_commit_date = last_commit_date
         self.last_commit_hash = last_commit_hash
         self.author = author
         self.is_merged = is_merged
         self.age_days = (datetime.now() - last_commit_date.replace(tzinfo=None)).days
-    
+
     def __repr__(self):
         return f'BranchInfo(name="{self.name}", age_days={self.age_days}, author="{self.author}")'
 
+
 class GitRepository:
-    '''Interface to git repository operations.'''
-    
+    """Interface to git repository operations."""
+
     def __init__(self, repo_path: Optional[Path] = None):
         self.repo_path = repo_path or PROJECT_ROOT
         self.verify_git_repo()
-    
+
     def verify_git_repo(self) -> None:
-        '''Verify we're in a git repository.'''
-        git_dir = self.repo_path / '.git'
+        """Verify we're in a git repository."""
+        git_dir = self.repo_path / ".git"
         if not git_dir.exists():
-            raise RuntimeError(f'Not a git repository: {self.repo_path}')
-    
-    def run_git_command(self, args: List[str], check: bool = True) -> subprocess.CompletedProcess[str]:
-        '''Run a git command and return the result.'''
-        cmd = ['git'] + args
+            raise RuntimeError(f"Not a git repository: {self.repo_path}")
+
+    def run_git_command(
+        self, args: List[str], check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a git command and return the result."""
+        cmd = ["git"] + args
         try:
-            return subprocess.run(cmd, cwd=self.repo_path, capture_output=True, 
-                                text=True, check=check)
+            return subprocess.run(
+                cmd, cwd=self.repo_path, capture_output=True, text=True, check=check
+            )
         except subprocess.CalledProcessError as e:
             print(f'Git command failed: {" ".join(cmd)}')
-            print(f'Error: {e.stderr}')
+            print(f"Error: {e.stderr}")
             raise
-    
+
     def get_all_branches(self, include_remote: bool = True) -> List[BranchInfo]:
-        '''Get information about all branches.'''
+        """Get information about all branches."""
         branches: List[BranchInfo] = []
-        
+
         # Get local branches
-        cmd_args = ['for-each-ref', '--format=%(refname:short)|%(committerdate:iso)|%(objectname:short)|%(authorname)', 'refs/heads']
+        cmd_args = [
+            "for-each-ref",
+            "--format=%(refname:short)|%(committerdate:iso)|%(objectname:short)|%(authorname)",
+            "refs/heads",
+        ]
         result = self.run_git_command(cmd_args)
-        
-        for line in result.stdout.strip().split('\n'):
+
+        for line in result.stdout.strip().split("\n"):
             if not line:
                 continue
-            parts = line.split('|')
+            parts = line.split("|")
             if len(parts) == 4:
                 name, date_str, commit_hash, author = parts
-                commit_date = datetime.fromisoformat(date_str.replace(' ', 'T'))
-                
+                commit_date = datetime.fromisoformat(date_str.replace(" ", "T"))
+
                 # Check if branch is merged
                 is_merged = self.is_branch_merged(name)
-                
+
                 branches.append(BranchInfo(name, commit_date, commit_hash, author, is_merged))
-        
+
         # Get remote branches if requested
         if include_remote:
-            cmd_args = ['for-each-ref', '--format=%(refname:short)|%(committerdate:iso)|%(objectname:short)|%(authorname)', 'refs/remotes/origin']
+            cmd_args = [
+                "for-each-ref",
+                "--format=%(refname:short)|%(committerdate:iso)|%(objectname:short)|%(authorname)",
+                "refs/remotes/origin",
+            ]
             result = self.run_git_command(cmd_args)
-            
-            for line in result.stdout.strip().split('\n'):
-                if not line or 'origin/HEAD' in line:
+
+            for line in result.stdout.strip().split("\n"):
+                if not line or "origin/HEAD" in line:
                     continue
-                parts = line.split('|')
+                parts = line.split("|")
                 if len(parts) == 4:
                     name, date_str, commit_hash, author = parts
                     # Remove origin/ prefix
-                    local_name = name.replace('origin/', '')
-                    
+                    local_name = name.replace("origin/", "")
+
                     # Skip if we already have the local version
                     if any(b.name == local_name for b in branches):
                         continue
-                    
-                    commit_date = datetime.fromisoformat(date_str.replace(' ', 'T'))
+
+                    commit_date = datetime.fromisoformat(date_str.replace(" ", "T"))
                     branches.append(BranchInfo(name, commit_date, commit_hash, author, False))
-        
+
         return branches
-    
-    def is_branch_merged(self, branch_name: str, target_branch: str = 'main') -> bool:
-        '''Check if a branch has been merged into target branch.'''
+
+    def is_branch_merged(self, branch_name: str, target_branch: str = "main") -> bool:
+        """Check if a branch has been merged into target branch."""
         try:
-            result = self.run_git_command(['merge-base', '--is-ancestor', branch_name, target_branch], check=False)
+            result = self.run_git_command(
+                ["merge-base", "--is-ancestor", branch_name, target_branch], check=False
+            )
             return result.returncode == 0
-        except:
+        except Exception:
             return False
-    
+
     def get_current_branch(self) -> str:
-        '''Get the current branch name.'''
-        result = self.run_git_command(['rev-parse', '--abbrev-ref', 'HEAD'])
+        """Get the current branch name."""
+        result = self.run_git_command(["rev-parse", "--abbrev-ref", "HEAD"])
         return result.stdout.strip()
-    
+
     def delete_branch(self, branch_name: str, force: bool = False) -> bool:
-        '''Delete a local branch.'''
-        flag = '-D' if force else '-d'
+        """Delete a local branch."""
+        flag = "-D" if force else "-d"
         try:
-            self.run_git_command(['branch', flag, branch_name])
-            return True
-        except subprocess.CalledProcessError:
-            return False
-    
-    def delete_remote_branch(self, branch_name: str) -> bool:
-        '''Delete a remote branch.'''
-        try:
-            self.run_git_command(['push', 'origin', '--delete', branch_name])
-            return True
-        except subprocess.CalledProcessError:
-            return False
-    
-    def create_branch(self, branch_name: str, start_point: str = 'main') -> bool:
-        '''Create a new branch from start_point.'''
-        try:
-            self.run_git_command(['checkout', '-b', branch_name, start_point])
-            return True
-        except subprocess.CalledProcessError:
-            return False
-    
-    def reset_branch_to_main(self, branch_name: str, force: bool = False) -> bool:
-        '''Reset a branch to match main branch.'''
-        try:
-            # Fetch latest
-            self.run_git_command(['fetch', 'origin'])
-            
-            # Checkout the branch
-            self.run_git_command(['checkout', branch_name])
-            
-            # Reset to main
-            reset_flag = '--hard' if force else '--mixed'
-            self.run_git_command(['reset', reset_flag, 'origin/main'])
-            
-            # Force push if requested
-            if force:
-                self.run_git_command(['push', 'origin', branch_name, '--force-with-lease'])
-            
+            self.run_git_command(["branch", flag, branch_name])
             return True
         except subprocess.CalledProcessError:
             return False
 
+    def delete_remote_branch(self, branch_name: str) -> bool:
+        """Delete a remote branch."""
+        try:
+            self.run_git_command(["push", "origin", "--delete", branch_name])
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    def create_branch(self, branch_name: str, start_point: str = "main") -> bool:
+        """Create a new branch from start_point."""
+        try:
+            self.run_git_command(["checkout", "-b", branch_name, start_point])
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+    def reset_branch_to_main(self, branch_name: str, force: bool = False) -> bool:
+        """Reset a branch to match main branch."""
+        try:
+            # Fetch latest
+            self.run_git_command(["fetch", "origin"])
+
+            # Checkout the branch
+            self.run_git_command(["checkout", branch_name])
+
+            # Reset to main
+            reset_flag = "--hard" if force else "--mixed"
+            self.run_git_command(["reset", reset_flag, "origin/main"])
+
+            # Force push if requested
+            if force:
+                self.run_git_command(["push", "origin", branch_name, "--force-with-lease"])
+
+            return True
+        except subprocess.CalledProcessError:
+            return False
+
+
 class PullRequestManager:
-    '''Manages GitHub Pull Requests via GitHub CLI.'''
-    
+    """Manages GitHub Pull Requests via GitHub CLI."""
+
     def __init__(self):
         self.verify_gh_cli()
-    
+
     def verify_gh_cli(self) -> None:
-        '''Verify GitHub CLI is available and authenticated.'''
+        """Verify GitHub CLI is available and authenticated."""
         try:
-            result = subprocess.run(['gh', 'auth', 'status'], capture_output=True)
+            result = subprocess.run(["gh", "auth", "status"], capture_output=True)
             if result.returncode != 0:
-                raise RuntimeError('GitHub CLI not authenticated')
+                raise RuntimeError("GitHub CLI not authenticated")
         except FileNotFoundError:
-            raise RuntimeError('GitHub CLI not found')
-    
+            raise RuntimeError("GitHub CLI not found")
+
     def get_all_prs(self) -> List[Dict[str, Any]]:
-        '''Get all pull requests.'''
+        """Get all pull requests."""
         try:
-            cmd = ['gh', 'pr', 'list', '--limit', '100', '--json', 
-                   'number,title,headRefName,baseRefName,state,mergeable,checks']
+            cmd = [
+                "gh",
+                "pr",
+                "list",
+                "--limit",
+                "100",
+                "--json",
+                "number,title,headRefName,baseRefName,state,mergeable,checks",
+            ]
             result = subprocess.run(cmd, capture_output=True, text=True, check=True)
             return json.loads(result.stdout)
         except subprocess.CalledProcessError:
             return []
-    
+
     def get_ready_to_merge_prs(self) -> List[Dict[str, Any]]:
-        '''Get PRs that are ready to be auto-merged.'''
+        """Get PRs that are ready to be auto-merged."""
         all_prs = self.get_all_prs()
         ready_prs: List[Dict[str, Any]] = []
-        
+
         for pr in all_prs:
-            if (pr['state'] == 'OPEN' and 
-                pr.get('mergeable') == 'MERGEABLE' and
-                self._all_checks_passed(pr.get('checks', []))):
+            if (
+                pr["state"] == "OPEN"
+                and pr.get("mergeable") == "MERGEABLE"
+                and self._all_checks_passed(pr.get("checks", []))
+            ):
                 ready_prs.append(pr)
-        
+
         return ready_prs
-    
+
     def _all_checks_passed(self, checks: List[Dict[str, Any]]) -> bool:
-        '''Check if all PR checks have passed.'''
+        """Check if all PR checks have passed."""
         if not checks:
             return False
-        
+
         for check in checks:
-            if check.get('conclusion') != 'SUCCESS':
+            if check.get("conclusion") != "SUCCESS":
                 return False
-        
+
         return True
-    
+
     def auto_merge_pr(self, pr_number: int) -> bool:
-        '''Auto-merge a PR with squash.'''
+        """Auto-merge a PR with squash."""
         try:
-            cmd = ['gh', 'pr', 'merge', str(pr_number), '--squash', '--auto']
+            cmd = ["gh", "pr", "merge", str(pr_number), "--squash", "--auto"]
             subprocess.run(cmd, check=True)
             return True
         except subprocess.CalledProcessError:
             return False
 
+
 class BranchManager:
-    '''Main branch management orchestrator.'''
-    
+    """Main branch management orchestrator."""
+
     def __init__(self, dry_run: bool = True):
         self.dry_run = dry_run
         self.git = GitRepository()
         self.pr_manager = PullRequestManager()
         self.actions_log: List[Dict[str, Any]] = []
-    
-    def detect_stale_branches(self, stale_days: int = 30, 
-                            exclude_branches: Optional[List[str]] = None) -> List[BranchInfo]:
-        '''Detect branches that haven't been updated in stale_days.'''
+
+    def detect_stale_branches(
+        self, stale_days: int = 30, exclude_branches: Optional[List[str]] = None
+    ) -> List[BranchInfo]:
+        """Detect branches that haven't been updated in stale_days."""
         if exclude_branches is None:
-            exclude_branches = ['main', 'develop', 'master']
-        
+            exclude_branches = ["main", "develop", "master"]
+
         all_branches = self.git.get_all_branches()
         stale_branches: List[BranchInfo] = []
-        
+
         for branch in all_branches:
-            if (branch.name not in exclude_branches and 
-                branch.age_days > stale_days and
-                not branch.is_merged):
+            if (
+                branch.name not in exclude_branches
+                and branch.age_days > stale_days
+                and not branch.is_merged
+            ):
                 stale_branches.append(branch)
-        
+
         return stale_branches
-    
-    def cleanup_stale_branches(self, stale_days: int = 30, 
-                              auto_delete_merged: bool = True) -> None:
-        '''Clean up stale branches.'''
-        print(f'SEARCH Detecting stale branches (older than {stale_days} days)...')
-        
+
+    def cleanup_stale_branches(self, stale_days: int = 30, auto_delete_merged: bool = True) -> None:
+        """Clean up stale branches."""
+        print(f"SEARCH Detecting stale branches (older than {stale_days} days)...")
+
         stale_branches = self.detect_stale_branches(stale_days)
         merged_branches = [b for b in stale_branches if b.is_merged]
         unmerged_branches = [b for b in stale_branches if not b.is_merged]
-        
-        print(f'METRICS Found {len(stale_branches)} stale branches:')
-        print(f'   - {len(merged_branches)} merged (safe to delete)')
-        print(f'   - {len(unmerged_branches)} unmerged (require review)')
+
+        print(f"METRICS Found {len(stale_branches)} stale branches:")
+        print(f"   - {len(merged_branches)} merged (safe to delete)")
+        print(f"   - {len(unmerged_branches)} unmerged (require review)")
         print()
-        
+
         # Auto-delete merged branches
         if auto_delete_merged and merged_branches:
-            print('TRASH  Auto-deleting merged branches:')
+            print("TRASH  Auto-deleting merged branches:")
             for branch in merged_branches:
                 self._delete_branch_safely(branch)
-        
+
         # Report unmerged branches for manual review
         if unmerged_branches:
-            print('WARNING  Unmerged stale branches requiring manual review:')
+            print("WARNING  Unmerged stale branches requiring manual review:")
             for branch in unmerged_branches:
-                print(f'   - {branch.name} (age: {branch.age_days} days, author: {branch.author})')
+                print(f"   - {branch.name} (age: {branch.age_days} days, author: {branch.author})")
                 # TODO: Create GitHub issue for manual review
-    
+
     def nuke_develop_branch(self, confirm: bool = False) -> None:
-        '''Reset develop branch to match main (nuclear option).'''
+        """Reset develop branch to match main (nuclear option)."""
         if not confirm:
-            print('ERROR --confirm flag required for develop branch reset')
-            print('   This is a destructive operation that will:')
-            print('   1. Delete the current develop branch')
-            print('   2. Create a new develop branch from main')
-            print('   3. Force push to origin/develop')
+            print("ERROR --confirm flag required for develop branch reset")
+            print("   This is a destructive operation that will:")
+            print("   1. Delete the current develop branch")
+            print("   2. Create a new develop branch from main")
+            print("   3. Force push to origin/develop")
             print()
             print("   Run with --confirm flag if you're sure")
             return
-        
-        print('? NUCLEAR OPTION: Resetting develop branch to match main')
-        print('   This will permanently destroy the current develop branch!')
-        
+
+        print("? NUCLEAR OPTION: Resetting develop branch to match main")
+        print("   This will permanently destroy the current develop branch!")
+
         current_branch = self.git.get_current_branch()
-        
+
         try:
             # Step 1: Switch to main
             if self.dry_run:
-                print('[DRY RUN] Would checkout main branch')
+                print("[DRY RUN] Would checkout main branch")
             else:
-                self.git.run_git_command(['checkout', 'main'])
-                print('SUCCESS Switched to main branch')
-            
+                self.git.run_git_command(["checkout", "main"])
+                print("SUCCESS Switched to main branch")
+
             # Step 2: Fetch latest changes
             if self.dry_run:
-                print('[DRY RUN] Would fetch latest changes')
+                print("[DRY RUN] Would fetch latest changes")
             else:
-                self.git.run_git_command(['fetch', 'origin'])
-                print('SUCCESS Fetched latest changes')
-            
+                self.git.run_git_command(["fetch", "origin"])
+                print("SUCCESS Fetched latest changes")
+
             # Step 3: Delete local develop branch
             if self.dry_run:
-                print('[DRY RUN] Would delete local develop branch')
+                print("[DRY RUN] Would delete local develop branch")
             else:
-                success = self.git.delete_branch('develop', force=True)
+                success = self.git.delete_branch("develop", force=True)
                 if success:
-                    print('SUCCESS Deleted local develop branch')
+                    print("SUCCESS Deleted local develop branch")
                 else:
-                    print('WARNING  Local develop branch not found or already deleted')
-            
+                    print("WARNING  Local develop branch not found or already deleted")
+
             # Step 4: Create new develop branch from main
             if self.dry_run:
-                print('[DRY RUN] Would create new develop branch from main')
+                print("[DRY RUN] Would create new develop branch from main")
             else:
-                success = self.git.create_branch('develop', 'main')
+                success = self.git.create_branch("develop", "main")
                 if success:
-                    print('SUCCESS Created new develop branch from main')
+                    print("SUCCESS Created new develop branch from main")
                 else:
-                    raise RuntimeError('Failed to create new develop branch')
-            
+                    raise RuntimeError("Failed to create new develop branch")
+
             # Step 5: Force push to origin
             if self.dry_run:
-                print('[DRY RUN] Would force push to origin/develop')
+                print("[DRY RUN] Would force push to origin/develop")
             else:
-                self.git.run_git_command(['push', 'origin', 'develop', '--force-with-lease'])
-                print('SUCCESS Force pushed new develop branch to origin')
-            
+                self.git.run_git_command(["push", "origin", "develop", "--force-with-lease"])
+                print("SUCCESS Force pushed new develop branch to origin")
+
             # Step 6: Return to original branch if it still exists
-            if current_branch != 'develop':
+            if current_branch != "develop":
                 if self.dry_run:
-                    print(f'[DRY RUN] Would return to {current_branch} branch')
+                    print(f"[DRY RUN] Would return to {current_branch} branch")
                 else:
                     try:
-                        self.git.run_git_command(['checkout', current_branch])
-                        print(f'SUCCESS Returned to {current_branch} branch')
-                    except:
-                        print(f'WARNING  Could not return to {current_branch}, staying on develop')
-            
+                        self.git.run_git_command(["checkout", current_branch])
+                        print(f"SUCCESS Returned to {current_branch} branch")
+                    except Exception:
+                        print(f"WARNING  Could not return to {current_branch}, staying on develop")
+
             print()
-            print('TARGET Develop branch reset complete!')
-            print('   - develop branch now matches main exactly')
-            print('   - All previous develop commits are lost')
-            print('   - Remote develop branch has been updated')
-            
-            self.actions_log.append({
-                'action': 'nuke_develop',
-                'timestamp': datetime.now().isoformat(),
-                'dry_run': self.dry_run,
-                'success': True
-            })
-            
+            print("TARGET Develop branch reset complete!")
+            print("   - develop branch now matches main exactly")
+            print("   - All previous develop commits are lost")
+            print("   - Remote develop branch has been updated")
+
+            self.actions_log.append(
+                {
+                    "action": "nuke_develop",
+                    "timestamp": datetime.now().isoformat(),
+                    "dry_run": self.dry_run,
+                    "success": True,
+                }
+            )
+
         except Exception as e:
-            print(f'ERROR Error during develop branch reset: {e}')
-            self.actions_log.append({
-                'action': 'nuke_develop',
-                'timestamp': datetime.now().isoformat(),
-                'dry_run': self.dry_run,
-                'success': False,
-                'error': str(e)
-            })
+            print(f"ERROR Error during develop branch reset: {e}")
+            self.actions_log.append(
+                {
+                    "action": "nuke_develop",
+                    "timestamp": datetime.now().isoformat(),
+                    "dry_run": self.dry_run,
+                    "success": False,
+                    "error": str(e),
+                }
+            )
             raise
-    
+
     def auto_merge_ready_prs(self) -> None:
-        '''Automatically merge PRs that are ready.'''
-        print('SEARCH Checking for PRs ready to auto-merge...')
-        
+        """Automatically merge PRs that are ready."""
+        print("SEARCH Checking for PRs ready to auto-merge...")
+
         ready_prs = self.pr_manager.get_ready_to_merge_prs()
-        
+
         if not ready_prs:
-            print('SUCCESS No PRs ready for auto-merge')
+            print("SUCCESS No PRs ready for auto-merge")
             return
-        
-        print(f'LAUNCH Found {len(ready_prs)} PRs ready for auto-merge:')
-        
+
+        print(f"LAUNCH Found {len(ready_prs)} PRs ready for auto-merge:")
+
         for pr in ready_prs:
-            pr_number = pr['number']
-            title = pr['title']
-            branch = pr['headRefName']
-            
+            pr_number = pr["number"]
+            title = pr["title"]
+            branch = pr["headRefName"]
+
             if self.dry_run:
-                print(f'[DRY RUN] Would auto-merge PR #{pr_number}: {title}')
+                print(f"[DRY RUN] Would auto-merge PR #{pr_number}: {title}")
             else:
                 success = self.pr_manager.auto_merge_pr(pr_number)
                 if success:
-                    print(f'SUCCESS Auto-merged PR #{pr_number}: {title}')
-                    
+                    print(f"SUCCESS Auto-merged PR #{pr_number}: {title}")
+
                     # Schedule branch cleanup
                     self._schedule_branch_cleanup(branch)
                 else:
-                    print(f'ERROR Failed to auto-merge PR #{pr_number}: {title}')
-            
-            self.actions_log.append({
-                'action': 'auto_merge_pr',
-                'pr_number': pr_number,
-                'title': title,
-                'branch': branch,
-                'dry_run': self.dry_run
-            })
-    
+                    print(f"ERROR Failed to auto-merge PR #{pr_number}: {title}")
+
+            self.actions_log.append(
+                {
+                    "action": "auto_merge_pr",
+                    "pr_number": pr_number,
+                    "title": title,
+                    "branch": branch,
+                    "dry_run": self.dry_run,
+                }
+            )
+
     def _delete_branch_safely(self, branch: BranchInfo) -> None:
-        '''Safely delete a branch (local and remote).'''
-        branch_name = branch.name.replace('origin/', '')
-        
+        """Safely delete a branch (local and remote)."""
+        branch_name = branch.name.replace("origin/", "")
+
         if self.dry_run:
-            print(f'[DRY RUN] Would delete branch: {branch_name}')
+            print(f"[DRY RUN] Would delete branch: {branch_name}")
             return
-        
+
         # Delete local branch
         local_success = self.git.delete_branch(branch_name, force=True)
-        
+
         # Delete remote branch if it exists
         remote_success = True
-        if branch.name.startswith('origin/'):
+        if branch.name.startswith("origin/"):
             remote_success = self.git.delete_remote_branch(branch_name)
-        
+
         if local_success or remote_success:
-            print(f'SUCCESS Deleted branch: {branch_name}')
+            print(f"SUCCESS Deleted branch: {branch_name}")
         else:
-            print(f'WARNING  Failed to delete branch: {branch_name}')
-        
-        self.actions_log.append({
-            'action': 'delete_branch',
-            'branch_name': branch_name,
-            'age_days': branch.age_days,
-            'author': branch.author,
-            'dry_run': self.dry_run,
-            'success': local_success or remote_success
-        })
-    
+            print(f"WARNING  Failed to delete branch: {branch_name}")
+
+        self.actions_log.append(
+            {
+                "action": "delete_branch",
+                "branch_name": branch_name,
+                "age_days": branch.age_days,
+                "author": branch.author,
+                "dry_run": self.dry_run,
+                "success": local_success or remote_success,
+            }
+        )
+
     def _schedule_branch_cleanup(self, branch_name: str) -> None:
-        '''Schedule a branch for cleanup after PR merge.'''
+        """Schedule a branch for cleanup after PR merge."""
         # Wait a bit for GitHub to process the merge
         import time
+
         time.sleep(2)
-        
+
         if self.dry_run:
-            print(f'[DRY RUN] Would schedule cleanup for branch: {branch_name}')
+            print(f"[DRY RUN] Would schedule cleanup for branch: {branch_name}")
         else:
             success = self.git.delete_branch(branch_name, force=False)
             if success:
-                print(f'? Cleaned up merged branch: {branch_name}')
-    
+                print(f"? Cleaned up merged branch: {branch_name}")
+
     def generate_branch_report(self) -> None:
-        '''Generate a comprehensive branch status report.'''
-        print('METRICS Branch Status Report')
-        print('=' * 50)
-        
+        """Generate a comprehensive branch status report."""
+        print("METRICS Branch Status Report")
+        print("=" * 50)
+
         all_branches = self.git.get_all_branches()
         current_branch = self.git.get_current_branch()
-        
+
         # Categorize branches
         active_branches = [b for b in all_branches if b.age_days <= 7]
         recent_branches = [b for b in all_branches if 7 < b.age_days <= 30]
         stale_branches = [b for b in all_branches if b.age_days > 30]
         merged_branches = [b for b in all_branches if b.is_merged]
-        
-        print(f'Current branch: {current_branch}')
-        print(f'Total branches: {len(all_branches)}')
+
+        print(f"Current branch: {current_branch}")
+        print(f"Total branches: {len(all_branches)}")
         print()
-        
-        print('GROWTH Branch Categories:')
-        print(f'   Active (<=7 days):     {len(active_branches)}')
-        print(f'   Recent (8-30 days):   {len(recent_branches)}')
-        print(f'   Stale (>30 days):     {len(stale_branches)}')
-        print(f'   Merged:               {len(merged_branches)}')
+
+        print("GROWTH Branch Categories:")
+        print(f"   Active (<=7 days):     {len(active_branches)}")
+        print(f"   Recent (8-30 days):   {len(recent_branches)}")
+        print(f"   Stale (>30 days):     {len(stale_branches)}")
+        print(f"   Merged:               {len(merged_branches)}")
         print()
-        
+
         if stale_branches:
-            print('WARNING  Stale Branches (>30 days old):')
+            print("WARNING  Stale Branches (>30 days old):")
             for branch in sorted(stale_branches, key=lambda x: x.age_days, reverse=True):
-                status = 'merged' if branch.is_merged else 'unmerged'
-                print(f'   - {branch.name} ({branch.age_days} days, {status}, {branch.author})')
+                status = "merged" if branch.is_merged else "unmerged"
+                print(f"   - {branch.name} ({branch.age_days} days, {status}, {branch.author})")
             print()
-        
+
         # Check for PRs
         try:
             ready_prs = self.pr_manager.get_ready_to_merge_prs()
             if ready_prs:
-                print(f'LAUNCH PRs Ready for Auto-merge: {len(ready_prs)}')
+                print(f"LAUNCH PRs Ready for Auto-merge: {len(ready_prs)}")
                 for pr in ready_prs:
-                    print(f'   - #{pr['number']}: {pr['title']}')
+                    print(f"   - #{pr['number']}: {pr['title']}")
                 print()
-        except:
-            print('WARNING  Could not fetch PR information (GitHub CLI issue)')
-    
+        except Exception:
+            print("WARNING  Could not fetch PR information (GitHub CLI issue)")
+
     def print_actions_summary(self) -> None:
-        '''Print summary of all actions performed.'''
+        """Print summary of all actions performed."""
         if not self.actions_log:
-            print('MEMO No actions performed')
+            print("MEMO No actions performed")
             return
-        
-        print('\\nMEMO Actions Summary:')
+
+        print("\\nMEMO Actions Summary:")
         for entry in self.actions_log:
-            action = entry['action']
-            dry_run_prefix = '[DRY RUN] ' if entry.get('dry_run') else ''
-            
-            if action == 'delete_branch':
-                print(f'   {dry_run_prefix}Deleted branch: {entry['branch_name']} (age: {entry['age_days']} days)')
-            elif action == 'auto_merge_pr':
-                print(f'   {dry_run_prefix}Auto-merged PR #{entry['pr_number']}: {entry['title']}')
-            elif action == 'nuke_develop':
-                status = 'SUCCESS' if entry['success'] else 'FAILED'
-                print(f'   {dry_run_prefix}Develop branch reset: {status}')
+            action = entry["action"]
+            dry_run_prefix = "[DRY RUN] " if entry.get("dry_run") else ""
+
+            if action == "delete_branch":
+                print(
+                    f"   {dry_run_prefix}Deleted branch: {entry['branch_name']} (age: {entry['age_days']} days)"
+                )
+            elif action == "auto_merge_pr":
+                print(f"   {dry_run_prefix}Auto-merged PR #{entry['pr_number']}: {entry['title']}")
+            elif action == "nuke_develop":
+                status = "SUCCESS" if entry["success"] else "FAILED"
+                print(f"   {dry_run_prefix}Develop branch reset: {status}")
+
 
 def main():
-    parser = argparse.ArgumentParser(description='Automated Branch Management for P(Doom)')
-    parser.add_argument('--dry-run', action='store_true', default=True,
-                       help='Run in dry-run mode (default)')
-    parser.add_argument('--live', action='store_true',
-                       help='Run in live mode (make actual changes)')
-    
+    parser = argparse.ArgumentParser(description="Automated Branch Management for P(Doom)")
+    parser.add_argument(
+        "--dry-run", action="store_true", default=True, help="Run in dry-run mode (default)"
+    )
+    parser.add_argument(
+        "--live", action="store_true", help="Run in live mode (make actual changes)"
+    )
+
     # Action arguments
-    parser.add_argument('--detect-stale', action='store_true',
-                       help='Detect and report stale branches')
-    parser.add_argument('--cleanup-all', action='store_true',
-                       help='Clean up stale and merged branches')
-    parser.add_argument('--nuke-develop', action='store_true',
-                       help='Reset develop branch to match main (destructive!)')
-    parser.add_argument('--confirm', action='store_true',
-                       help='Confirm destructive operations')
-    parser.add_argument('--auto-merge-ready', action='store_true',
-                       help='Auto-merge ready PRs')
-    parser.add_argument('--report', action='store_true',
-                       help='Generate branch status report')
-    
+    parser.add_argument(
+        "--detect-stale", action="store_true", help="Detect and report stale branches"
+    )
+    parser.add_argument(
+        "--cleanup-all", action="store_true", help="Clean up stale and merged branches"
+    )
+    parser.add_argument(
+        "--nuke-develop",
+        action="store_true",
+        help="Reset develop branch to match main (destructive!)",
+    )
+    parser.add_argument("--confirm", action="store_true", help="Confirm destructive operations")
+    parser.add_argument("--auto-merge-ready", action="store_true", help="Auto-merge ready PRs")
+    parser.add_argument("--report", action="store_true", help="Generate branch status report")
+
     # Configuration arguments
-    parser.add_argument('--stale-days', type=int, default=30,
-                       help='Days after which a branch is considered stale')
-    
+    parser.add_argument(
+        "--stale-days", type=int, default=30, help="Days after which a branch is considered stale"
+    )
+
     args = parser.parse_args()
-    
+
     # Determine mode
     dry_run = not args.live
-    
+
     try:
         manager = BranchManager(dry_run=dry_run)
-        
+
         if args.report or len(sys.argv) == 1:
             manager.generate_branch_report()
-        
+
         if args.detect_stale:
             stale_branches = manager.detect_stale_branches(args.stale_days)
-            print(f'Found {len(stale_branches)} stale branches')
+            print(f"Found {len(stale_branches)} stale branches")
             for branch in stale_branches:
-                print(f'  - {branch}')
-        
+                print(f"  - {branch}")
+
         if args.cleanup_all:
             manager.cleanup_stale_branches(args.stale_days)
-        
+
         if args.nuke_develop:
             manager.nuke_develop_branch(args.confirm)
-        
+
         if args.auto_merge_ready:
             manager.auto_merge_ready_prs()
-        
+
         manager.print_actions_summary()
-    
+
     except Exception as e:
-        print(f'ERROR Error: {e}')
+        print(f"ERROR Error: {e}")
         sys.exit(1)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/scripts/issue_sync_bidirectional.py
+++ b/scripts/issue_sync_bidirectional.py
@@ -1,5 +1,5 @@
 # !/usr/bin/env python3
-'''
+"""
 Bidirectional Issue Sync System for P(Doom)
 
 This script provides a data lake-inspired approach to keeping local Markdown issues
@@ -8,7 +8,7 @@ in sync with GitHub Issues, maintaining a single source of truth with audit trai
 Features:
 - Bidirectional synchronization (local  <->  GitHub)
 - Conflict detection and resolution
-- Audit trail for all changes  
+- Audit trail for all changes
 - Dry-run mode for safe testing
 - Automatic linking between local and GitHub issues
 
@@ -16,160 +16,165 @@ Usage:
     python scripts/issue_sync_bidirectional.py --dry-run
     python scripts/issue_sync_bidirectional.py --sync-all
     python scripts/issue_sync_bidirectional.py --resolve-conflicts
-'''
+"""
 
-import sys
-import json
 import argparse
-import subprocess
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Any
-from datetime import datetime
 import hashlib
+import json
 import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
 import yaml
 
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+
 class IssueMetadata:
-    '''Manages metadata for issue tracking and synchronization.'''
-    
-    def __init__(self, github_id: Optional[int] = None, 
-                 last_sync: Optional[str] = None,
-                 local_hash: Optional[str] = None,
-                 github_hash: Optional[str] = None):
+    """Manages metadata for issue tracking and synchronization."""
+
+    def __init__(
+        self,
+        github_id: Optional[int] = None,
+        last_sync: Optional[str] = None,
+        local_hash: Optional[str] = None,
+        github_hash: Optional[str] = None,
+    ):
         self.github_id = github_id
         self.last_sync = last_sync or datetime.now().isoformat()
         self.local_hash = local_hash
         self.github_hash = github_hash
-    
+
     def to_dict(self) -> Dict[str, Any]:
         return {
-            'github_id': self.github_id,
-            'last_sync': self.last_sync,
-            'local_hash': self.local_hash,
-            'github_hash': self.github_hash
+            "github_id": self.github_id,
+            "last_sync": self.last_sync,
+            "local_hash": self.local_hash,
+            "github_hash": self.github_hash,
         }
-    
+
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'IssueMetadata':
+    def from_dict(cls, data: Dict[str, Any]) -> "IssueMetadata":
         return cls(
-            github_id=data.get('github_id'),
-            last_sync=data.get('last_sync'),
-            local_hash=data.get('local_hash'),
-            github_hash=data.get('github_hash')
+            github_id=data.get("github_id"),
+            last_sync=data.get("last_sync"),
+            local_hash=data.get("local_hash"),
+            github_hash=data.get("github_hash"),
         )
 
+
 class LocalIssueManager:
-    '''Manages local Markdown issue files.'''
-    
+    """Manages local Markdown issue files."""
+
     def __init__(self, issues_dir: Optional[Path] = None):
-        self.issues_dir = issues_dir or PROJECT_ROOT / 'issues'
-        self.metadata_file = self.issues_dir / '.sync_metadata.json'
+        self.issues_dir = issues_dir or PROJECT_ROOT / "issues"
+        self.metadata_file = self.issues_dir / ".sync_metadata.json"
         self.load_metadata()
-    
+
     def load_metadata(self) -> None:
-        '''Load sync metadata from file.'''
+        """Load sync metadata from file."""
         if self.metadata_file.exists():
-            with open(self.metadata_file, 'r') as f:
+            with open(self.metadata_file, "r") as f:
                 data = json.load(f)
                 self.metadata = {
-                    filename: IssueMetadata.from_dict(meta)
-                    for filename, meta in data.items()
+                    filename: IssueMetadata.from_dict(meta) for filename, meta in data.items()
                 }
         else:
             self.metadata = {}
-    
+
     def save_metadata(self) -> None:
-        '''Save sync metadata to file.'''
-        data = {
-            filename: meta.to_dict()
-            for filename, meta in self.metadata.items()
-        }
-        with open(self.metadata_file, 'w') as f:
+        """Save sync metadata to file."""
+        data = {filename: meta.to_dict() for filename, meta in self.metadata.items()}
+        with open(self.metadata_file, "w") as f:
             json.dump(data, f, indent=2)
-    
+
     def get_all_issues(self) -> List[Tuple[str, str, IssueMetadata]]:
-        '''Get all local issues with their content and metadata.'''
+        """Get all local issues with their content and metadata."""
         issues: List[Tuple[str, str, IssueMetadata]] = []
-        
-        for issue_file in self.issues_dir.glob('*.md'):
-            if issue_file.name.startswith('.'):
+
+        for issue_file in self.issues_dir.glob("*.md"):
+            if issue_file.name.startswith("."):
                 continue
-                
-            with open(issue_file, 'r', encoding='utf-8') as f:
+
+            with open(issue_file, "r", encoding="utf-8") as f:
                 content = f.read()
-            
+
             filename = issue_file.name
             metadata = self.metadata.get(filename, IssueMetadata())
-            
+
             # Update local hash
             metadata.local_hash = self.calculate_content_hash(content)
             self.metadata[filename] = metadata
-            
+
             issues.append((filename, content, metadata))
-        
+
         return issues
-    
+
     def calculate_content_hash(self, content: str) -> str:
-        '''Calculate hash of issue content for change detection.'''
+        """Calculate hash of issue content for change detection."""
         # Normalize content for hashing (remove metadata section)
-        normalized = re.sub(r'<!--.*?-->', '', content, flags=re.DOTALL)
+        normalized = re.sub(r"<!--.*?-->", "", content, flags=re.DOTALL)
         normalized = normalized.strip()
         return hashlib.sha256(normalized.encode()).hexdigest()[:16]
-    
+
     def create_issue(self, filename: str, content: str, metadata: IssueMetadata) -> None:
-        '''Create a new local issue file.'''
+        """Create a new local issue file."""
         filepath = self.issues_dir / filename
-        with open(filepath, 'w', encoding='utf-8') as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             f.write(content)
-        
+
         metadata.local_hash = self.calculate_content_hash(content)
         self.metadata[filename] = metadata
         self.save_metadata()
-    
+
     def update_issue(self, filename: str, content: str) -> None:
-        '''Update an existing local issue file.'''
+        """Update an existing local issue file."""
         filepath = self.issues_dir / filename
-        with open(filepath, 'w', encoding='utf-8') as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             f.write(content)
-        
+
         if filename in self.metadata:
             self.metadata[filename].local_hash = self.calculate_content_hash(content)
             self.metadata[filename].last_sync = datetime.now().isoformat()
-        
+
         self.save_metadata()
 
+
 class GitHubIssueManager:
-    '''Manages GitHub Issues via GitHub CLI with robust encoding.'''
-    
+    """Manages GitHub Issues via GitHub CLI with robust encoding."""
+
     def __init__(self):
         self.verify_gh_cli()
-    
+
     def verify_gh_cli(self) -> None:
-        '''Verify GitHub CLI is installed and authenticated.'''
+        """Verify GitHub CLI is installed and authenticated."""
         try:
-            result = self._run_command(['gh', 'auth', 'status'])
+            result = self._run_command(["gh", "auth", "status"])
             if result.returncode != 0:
                 raise RuntimeError("GitHub CLI not authenticated. Run 'gh auth login'")
         except FileNotFoundError:
-            raise RuntimeError('GitHub CLI not found. Please install GitHub CLI')
-    
-    def _run_command(self, cmd: List[str], input_text: Optional[str] = None) -> subprocess.CompletedProcess:
-        '''Run subprocess command with robust encoding handling.'''
+            raise RuntimeError("GitHub CLI not found. Please install GitHub CLI")
+
+    def _run_command(
+        self, cmd: List[str], input_text: Optional[str] = None
+    ) -> subprocess.CompletedProcess:
+        """Run subprocess command with robust encoding handling."""
         import platform
-        
+
         # Determine the best encoding for the current platform
-        encoding = 'utf-8'
-        if platform.system() == 'Windows':
+        encoding = "utf-8"
+        if platform.system() == "Windows":
             # Windows can have encoding issues, try multiple fallbacks
             try:
-                encoding = 'utf-8'
-            except:
-                encoding = 'cp1252'  # Windows default
-        
+                encoding = "utf-8"
+            except Exception:
+                encoding = "cp1252"  # Windows default
+
         try:
             result = subprocess.run(
                 cmd,
@@ -177,493 +182,533 @@ class GitHubIssueManager:
                 capture_output=True,
                 text=True,
                 encoding=encoding,
-                errors='replace',  # Replace invalid characters instead of failing
-                cwd=PROJECT_ROOT
+                errors="replace",  # Replace invalid characters instead of failing
+                cwd=PROJECT_ROOT,
             )
             return result
         except UnicodeDecodeError:
             # Fallback to bytes mode if encoding fails
-            print(f'Warning: Encoding issue with command {cmd}, using fallback')
+            print(f"Warning: Encoding issue with command {cmd}, using fallback")
             result = subprocess.run(
                 cmd,
-                input=input_text.encode('utf-8') if input_text else None,
+                input=input_text.encode("utf-8") if input_text else None,
                 capture_output=True,
-                cwd=PROJECT_ROOT
+                cwd=PROJECT_ROOT,
             )
             # Decode manually with error handling
-            result.stdout = result.stdout.decode('utf-8', errors='replace')
-            result.stderr = result.stderr.decode('utf-8', errors='replace')
+            result.stdout = result.stdout.decode("utf-8", errors="replace")
+            result.stderr = result.stderr.decode("utf-8", errors="replace")
             return result
-    
+
     def get_all_issues(self) -> List[Dict[str, Any]]:
-        '''Get all GitHub issues with robust encoding handling.'''
+        """Get all GitHub issues with robust encoding handling."""
         try:
-            cmd = ['gh', 'issue', 'list', '--limit', '1000', '--json', 
-                   'number,title,body,state,labels,createdAt,updatedAt']
+            cmd = [
+                "gh",
+                "issue",
+                "list",
+                "--limit",
+                "1000",
+                "--json",
+                "number,title,body,state,labels,createdAt,updatedAt",
+            ]
             result = self._run_command(cmd)
-            
+
             if result.returncode == 0:
                 return json.loads(result.stdout)
             else:
-                print(f'Error fetching GitHub issues: {result.stderr}')
+                print(f"Error fetching GitHub issues: {result.stderr}")
                 return []
-                
+
         except json.JSONDecodeError as e:
-            print(f'Error parsing GitHub issues JSON: {e}')
+            print(f"Error parsing GitHub issues JSON: {e}")
             return []
         except Exception as e:
-            print(f'Error fetching GitHub issues: {e}')
+            print(f"Error fetching GitHub issues: {e}")
             return []
-    
-    def create_issue(self, title: str, body: str, labels: Optional[List[str]] = None) -> Optional[int]:
-        '''Create a new GitHub issue with robust encoding.'''
-        cmd = ['gh', 'issue', 'create', '--title', title, '--body', body]
+
+    def create_issue(
+        self, title: str, body: str, labels: Optional[List[str]] = None
+    ) -> Optional[int]:
+        """Create a new GitHub issue with robust encoding."""
+        cmd = ["gh", "issue", "create", "--title", title, "--body", body]
         if labels:
-            cmd.extend(['--label', ','.join(labels)])
-        
+            cmd.extend(["--label", ",".join(labels)])
+
         try:
             result = self._run_command(cmd)
             if result.returncode == 0:
                 # Extract issue number from output
-                output_lines = result.stdout.strip().split('\n')
+                output_lines = result.stdout.strip().split("\n")
                 for line in output_lines:
-                    if 'github.com' in line and '/issues/' in line:
-                        issue_number = line.split('/issues/')[-1].split()[0]
+                    if "github.com" in line and "/issues/" in line:
+                        issue_number = line.split("/issues/")[-1].split()[0]
                         return int(issue_number)
                 return None
             else:
-                print(f'Error creating GitHub issue: {result.stderr}')
+                print(f"Error creating GitHub issue: {result.stderr}")
                 return None
         except Exception as e:
-            print(f'Error creating GitHub issue: {e}')
+            print(f"Error creating GitHub issue: {e}")
             return None
-    
-    def update_issue(self, issue_number: int, title: Optional[str] = None, 
-                    body: Optional[str] = None) -> bool:
-        '''Update an existing GitHub issue with robust encoding.'''
-        cmd = ['gh', 'issue', 'edit', str(issue_number)]
+
+    def update_issue(
+        self, issue_number: int, title: Optional[str] = None, body: Optional[str] = None
+    ) -> bool:
+        """Update an existing GitHub issue with robust encoding."""
+        cmd = ["gh", "issue", "edit", str(issue_number)]
         if title:
-            cmd.extend(['--title', title])
+            cmd.extend(["--title", title])
         if body:
-            cmd.extend(['--body', body])
-        
+            cmd.extend(["--body", body])
+
         try:
             result = self._run_command(cmd)
             if result.returncode == 0:
                 return True
             else:
-                print(f'Error updating GitHub issue #{issue_number}: {result.stderr}')
+                print(f"Error updating GitHub issue #{issue_number}: {result.stderr}")
                 return False
         except Exception as e:
-            print(f'Error updating GitHub issue #{issue_number}: {e}')
+            print(f"Error updating GitHub issue #{issue_number}: {e}")
             return False
-            print(f'Error updating GitHub issue #{issue_number}: {e}')
+            print(f"Error updating GitHub issue #{issue_number}: {e}")
             return False
 
+
 class ConflictResolver:
-    '''Resolves conflicts between local and GitHub issues.'''
-    
+    """Resolves conflicts between local and GitHub issues."""
+
     def __init__(self):
         self.resolution_strategies = {
-            'github_newer': self._resolve_github_wins,
-            'local_newer': self._resolve_local_wins,
-            'manual': self._resolve_manual
+            "github_newer": self._resolve_github_wins,
+            "local_newer": self._resolve_local_wins,
+            "manual": self._resolve_manual,
         }
-    
-    def detect_conflicts(self, local_issues: List[Tuple[str, str, IssueMetadata]], 
-                        github_issues: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        '''Detect conflicts between local and GitHub issues.'''
+
+    def detect_conflicts(
+        self,
+        local_issues: List[Tuple[str, str, IssueMetadata]],
+        github_issues: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Detect conflicts between local and GitHub issues."""
         conflicts: List[Dict[str, Any]] = []
-        
+
         # Create lookup for GitHub issues by ID
-        github_by_id = {issue['number']: issue for issue in github_issues}
-        
+        github_by_id = {issue["number"]: issue for issue in github_issues}
+
         for filename, content, metadata in local_issues:
             if metadata.github_id and metadata.github_id in github_by_id:
                 github_issue = github_by_id[metadata.github_id]
-                
+
                 # Calculate GitHub content hash
-                github_content = f'# {github_issue['title']}\n\n{github_issue['body'] or ''}'
+                github_content = f"# {github_issue['title']}\n\n{github_issue['body'] or ''}"
                 github_hash = self._calculate_hash(github_content)
-                
+
                 # Check for conflicts
-                if (metadata.local_hash != metadata.github_hash and 
-                    github_hash != metadata.github_hash):
-                    conflicts.append({
-                        'type': 'content_conflict',
-                        'filename': filename,
-                        'local_content': content,
-                        'github_content': github_content,
-                        'metadata': metadata,
-                        'github_issue': github_issue
-                    })
-        
+                if (
+                    metadata.local_hash != metadata.github_hash
+                    and github_hash != metadata.github_hash
+                ):
+                    conflicts.append(
+                        {
+                            "type": "content_conflict",
+                            "filename": filename,
+                            "local_content": content,
+                            "github_content": github_content,
+                            "metadata": metadata,
+                            "github_issue": github_issue,
+                        }
+                    )
+
         return conflicts
-    
+
     def _calculate_hash(self, content: str) -> str:
-        '''Calculate normalized content hash.'''
-        normalized = re.sub(r'<!--.*?-->', '', content, flags=re.DOTALL)
+        """Calculate normalized content hash."""
+        normalized = re.sub(r"<!--.*?-->", "", content, flags=re.DOTALL)
         normalized = normalized.strip()
         return hashlib.sha256(normalized.encode()).hexdigest()[:16]
-    
+
     def _resolve_github_wins(self, conflict: Dict[str, Any]) -> Dict[str, Any]:
-        '''Resolve conflict by using GitHub version.'''
+        """Resolve conflict by using GitHub version."""
         return {
-            'action': 'update_local',
-            'filename': conflict['filename'],
-            'content': conflict['github_content'],
-            'metadata': conflict['metadata']
-        }
-    
-    def _resolve_local_wins(self, conflict: Dict[str, Any]) -> Dict[str, Any]:
-        '''Resolve conflict by using local version.'''
-        return {
-            'action': 'update_github',
-            'github_issue': conflict['github_issue'],
-            'content': conflict['local_content'],
-            'metadata': conflict['metadata']
-        }
-    
-    def _resolve_manual(self, conflict: Dict[str, Any]) -> Dict[str, Any]:
-        '''Mark conflict for manual resolution.'''
-        return {
-            'action': 'manual_review',
-            'conflict': conflict
+            "action": "update_local",
+            "filename": conflict["filename"],
+            "content": conflict["github_content"],
+            "metadata": conflict["metadata"],
         }
 
+    def _resolve_local_wins(self, conflict: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve conflict by using local version."""
+        return {
+            "action": "update_github",
+            "github_issue": conflict["github_issue"],
+            "content": conflict["local_content"],
+            "metadata": conflict["metadata"],
+        }
+
+    def _resolve_manual(self, conflict: Dict[str, Any]) -> Dict[str, Any]:
+        """Mark conflict for manual resolution."""
+        return {"action": "manual_review", "conflict": conflict}
+
+
 class BidirectionalIssueSync:
-    '''Main orchestrator for bidirectional issue synchronization.'''
-    
+    """Main orchestrator for bidirectional issue synchronization."""
+
     def __init__(self, dry_run: bool = True):
         self.dry_run = dry_run
         self.local_manager = LocalIssueManager()
         self.github_manager = GitHubIssueManager()
         self.conflict_resolver = ConflictResolver()
         self.audit_log: List[Dict[str, Any]] = []
-    
+
     def sync_all(self) -> None:
-        '''Perform complete bidirectional synchronization.'''
-        print('REFRESH Starting bidirectional issue synchronization...')
-        print(f'   Mode: {'DRY RUN' if self.dry_run else 'LIVE SYNC'}')
+        """Perform complete bidirectional synchronization."""
+        print("REFRESH Starting bidirectional issue synchronization...")
+        print(f"   Mode: {'DRY RUN' if self.dry_run else 'LIVE SYNC'}")
         print()
-        
+
         # 1. Load all issues
         local_issues = self.local_manager.get_all_issues()
         github_issues = self.github_manager.get_all_issues()
-        
-        print(f'FOLDER Local issues found: {len(local_issues)}')
-        print(f'? GitHub issues found: {len(github_issues)}')
+
+        print(f"FOLDER Local issues found: {len(local_issues)}")
+        print(f"? GitHub issues found: {len(github_issues)}")
         print()
-        
+
         # 2. Detect conflicts
         conflicts = self.conflict_resolver.detect_conflicts(local_issues, github_issues)
-        
+
         if conflicts:
-            print(f'WARNING  Conflicts detected: {len(conflicts)}')
+            print(f"WARNING  Conflicts detected: {len(conflicts)}")
             self._handle_conflicts(conflicts)
             return
-        
+
         # 3. Sync new local issues to GitHub
         self._sync_local_to_github(local_issues, github_issues)
-        
+
         # 4. Sync new GitHub issues to local
         self._sync_github_to_local(local_issues, github_issues)
-        
+
         # 5. Update existing issues
         self._sync_updates(local_issues, github_issues)
-        
-        print('SUCCESS Synchronization complete!')
+
+        print("SUCCESS Synchronization complete!")
         self._print_audit_summary()
-    
-    def _sync_local_to_github(self, local_issues: List[Tuple[str, str, IssueMetadata]], 
-                             github_issues: List[Dict[str, Any]]) -> None:
-        '''Sync local issues that don't exist on GitHub.'''
-        github_ids = {issue['number'] for issue in github_issues}
-        
+
+    def _sync_local_to_github(
+        self,
+        local_issues: List[Tuple[str, str, IssueMetadata]],
+        github_issues: List[Dict[str, Any]],
+    ) -> None:
+        """Sync local issues that don't exist on GitHub."""
+        github_ids = {issue["number"] for issue in github_issues}
+
         for filename, content, metadata in local_issues:
             if metadata.github_id is None or metadata.github_id not in github_ids:
                 title = self._extract_title_from_content(content)
                 labels = self._extract_labels_from_content(content, filename)
-                
+
                 if self.dry_run:
-                    print(f'[DRY RUN] Would create GitHub issue: {title}')
+                    print(f"[DRY RUN] Would create GitHub issue: {title}")
                 else:
                     github_id = self.github_manager.create_issue(title, content, labels)
                     if github_id:
                         metadata.github_id = github_id
                         metadata.github_hash = metadata.local_hash
                         self.local_manager.save_metadata()
-                        print(f'SUCCESS Created GitHub issue #{github_id}: {title}')
-                
-                self.audit_log.append({
-                    'action': 'create_github_issue',
-                    'filename': filename,
-                    'title': title,
-                    'dry_run': self.dry_run
-                })
-    
-    def _sync_github_to_local(self, local_issues: List[Tuple[str, str, IssueMetadata]], 
-                             github_issues: List[Dict[str, Any]]) -> None:
-        '''Sync GitHub issues that don't exist locally.'''
+                        print(f"SUCCESS Created GitHub issue #{github_id}: {title}")
+
+                self.audit_log.append(
+                    {
+                        "action": "create_github_issue",
+                        "filename": filename,
+                        "title": title,
+                        "dry_run": self.dry_run,
+                    }
+                )
+
+    def _sync_github_to_local(
+        self,
+        local_issues: List[Tuple[str, str, IssueMetadata]],
+        github_issues: List[Dict[str, Any]],
+    ) -> None:
+        """Sync GitHub issues that don't exist locally."""
         local_github_ids = {meta.github_id for _, _, meta in local_issues if meta.github_id}
-        
+
         for github_issue in github_issues:
-            if github_issue['number'] not in local_github_ids:
-                filename = self._generate_filename_from_title(github_issue['title'])
+            if github_issue["number"] not in local_github_ids:
+                filename = self._generate_filename_from_title(github_issue["title"])
                 content = self._format_github_issue_as_markdown(github_issue)
-                
+
                 if self.dry_run:
-                    print(f'[DRY RUN] Would create local issue: {filename}')
+                    print(f"[DRY RUN] Would create local issue: {filename}")
                 else:
                     metadata = IssueMetadata(
-                        github_id=github_issue['number'],
-                        github_hash=self.local_manager.calculate_content_hash(content)
+                        github_id=github_issue["number"],
+                        github_hash=self.local_manager.calculate_content_hash(content),
                     )
                     self.local_manager.create_issue(filename, content, metadata)
-                    print(f'SUCCESS Created local issue: {filename}')
-                
-                self.audit_log.append({
-                    'action': 'create_local_issue',
-                    'filename': filename,
-                    'github_id': github_issue['number'],
-                    'dry_run': self.dry_run
-                })
-    
-    def _sync_updates(self, local_issues: List[Tuple[str, str, IssueMetadata]], 
-                     github_issues: List[Dict[str, Any]]) -> None:
-        '''Sync updates between linked issues.'''
-        github_by_id = {issue['number']: issue for issue in github_issues}
-        
+                    print(f"SUCCESS Created local issue: {filename}")
+
+                self.audit_log.append(
+                    {
+                        "action": "create_local_issue",
+                        "filename": filename,
+                        "github_id": github_issue["number"],
+                        "dry_run": self.dry_run,
+                    }
+                )
+
+    def _sync_updates(
+        self,
+        local_issues: List[Tuple[str, str, IssueMetadata]],
+        github_issues: List[Dict[str, Any]],
+    ) -> None:
+        """Sync updates between linked issues."""
+        github_by_id = {issue["number"]: issue for issue in github_issues}
+
         for filename, content, metadata in local_issues:
             if metadata.github_id and metadata.github_id in github_by_id:
                 github_issue = github_by_id[metadata.github_id]
                 github_content = self._format_github_issue_as_markdown(github_issue)
                 github_hash = self.local_manager.calculate_content_hash(github_content)
-                
+
                 # Local changed, GitHub unchanged
-                if (metadata.local_hash != metadata.github_hash and 
-                    github_hash == metadata.github_hash):
+                if (
+                    metadata.local_hash != metadata.github_hash
+                    and github_hash == metadata.github_hash
+                ):
                     title = self._extract_title_from_content(content)
                     body = self._extract_body_from_content(content)
-                    
+
                     if self.dry_run:
-                        print(f'[DRY RUN] Would update GitHub issue #{metadata.github_id}')
+                        print(f"[DRY RUN] Would update GitHub issue #{metadata.github_id}")
                     else:
-                        success = self.github_manager.update_issue(
-                            metadata.github_id, title, body)
+                        success = self.github_manager.update_issue(metadata.github_id, title, body)
                         if success:
                             metadata.github_hash = metadata.local_hash
                             self.local_manager.save_metadata()
-                            print(f'SUCCESS Updated GitHub issue #{metadata.github_id}')
-                
+                            print(f"SUCCESS Updated GitHub issue #{metadata.github_id}")
+
                 # GitHub changed, local unchanged
-                elif (github_hash != metadata.github_hash and 
-                      metadata.local_hash == metadata.github_hash):
-                    
+                elif (
+                    github_hash != metadata.github_hash
+                    and metadata.local_hash == metadata.github_hash
+                ):
+
                     if self.dry_run:
-                        print(f'[DRY RUN] Would update local issue: {filename}')
+                        print(f"[DRY RUN] Would update local issue: {filename}")
                     else:
                         self.local_manager.update_issue(filename, github_content)
                         metadata.github_hash = github_hash
                         metadata.local_hash = github_hash
                         self.local_manager.save_metadata()
-                        print(f'SUCCESS Updated local issue: {filename}')
-    
+                        print(f"SUCCESS Updated local issue: {filename}")
+
     def _handle_conflicts(self, conflicts: List[Dict[str, Any]]) -> None:
-        '''Handle detected conflicts.'''
-        print('WARNING  Conflicts require manual resolution:')
+        """Handle detected conflicts."""
+        print("WARNING  Conflicts require manual resolution:")
         for i, conflict in enumerate(conflicts, 1):
-            print(f'   {i}. {conflict['filename']}  <->  GitHub #{conflict['github_issue']['number']}')
-        
-        print('\\nRun with --resolve-conflicts to handle these interactively')
-    
+            print(
+                f"   {i}. {conflict['filename']}  <->  GitHub #{conflict['github_issue']['number']}"
+            )
+
+        print("\\nRun with --resolve-conflicts to handle these interactively")
+
     def _parse_frontmatter(self, content: str) -> Tuple[Dict[str, Any], str]:
-        '''Parse YAML frontmatter from markdown content.
-        
+        """Parse YAML frontmatter from markdown content.
+
         Returns:
             Tuple of (frontmatter_dict, content_without_frontmatter)
-        '''
-        if not content.strip().startswith('---'):
+        """
+        if not content.strip().startswith("---"):
             return {}, content
-        
-        lines = content.split('\n')
+
+        lines = content.split("\n")
         if len(lines) < 3:
             return {}, content
-        
-        # Find the closing --- 
+
+        # Find the closing ---
         end_index = -1
         for i in range(1, len(lines)):
-            if lines[i].strip() == '---':
+            if lines[i].strip() == "---":
                 end_index = i
                 break
-        
+
         if end_index == -1:
             return {}, content
-        
+
         # Extract frontmatter (include empty lines - YAML can handle them)
         frontmatter_lines = lines[1:end_index]
-        frontmatter_text = '\n'.join(frontmatter_lines)
-        
+        frontmatter_text = "\n".join(frontmatter_lines)
+
         try:
             frontmatter = yaml.safe_load(frontmatter_text) or {}
         except yaml.YAMLError as e:
-            print(f'WARNING: Failed to parse YAML frontmatter: {e}')
+            print(f"WARNING: Failed to parse YAML frontmatter: {e}")
             return {}, content
-        
+
         # Extract content without frontmatter
-        content_lines = lines[end_index + 1:]
-        content_without_frontmatter = '\n'.join(content_lines).strip()
-        
+        content_lines = lines[end_index + 1 :]
+        content_without_frontmatter = "\n".join(content_lines).strip()
+
         return frontmatter, content_without_frontmatter
-    
+
     def _extract_title_from_content(self, content: str) -> str:
-        '''Extract title from Markdown content, checking YAML frontmatter first.'''
+        """Extract title from Markdown content, checking YAML frontmatter first."""
         # Parse frontmatter first
         frontmatter, content_body = self._parse_frontmatter(content)
-        
+
         # Check for title in frontmatter
-        if 'title' in frontmatter and frontmatter['title']:
-            return str(frontmatter['title']).strip('\'"')
-        
+        if "title" in frontmatter and frontmatter["title"]:
+            return str(frontmatter["title"]).strip("'\"")
+
         # Check for name in frontmatter (GitHub issue template format)
-        if 'name' in frontmatter and frontmatter['name']:
-            return str(frontmatter['name']).strip('\'"')
-        
+        if "name" in frontmatter and frontmatter["name"]:
+            return str(frontmatter["name"]).strip("'\"")
+
         # Fallback to markdown header
-        lines = content_body.split('\n')
+        lines = content_body.split("\n")
         for line in lines:
-            if line.startswith('# '):
+            if line.startswith("# "):
                 return line[2:].strip()
-        
+
         # Final fallback
-        return 'Untitled Issue'
-    
+        return "Untitled Issue"
+
     def _extract_body_from_content(self, content: str) -> str:
-        '''Extract body from Markdown content, skipping YAML frontmatter.'''
+        """Extract body from Markdown content, skipping YAML frontmatter."""
         # Parse frontmatter and get clean content
         frontmatter, content_body = self._parse_frontmatter(content)
-        
+
         # Skip first H1 title if present
-        lines = content_body.split('\n')
+        lines = content_body.split("\n")
         body_lines: List[str] = []
         found_title = False
-        
+
         for line in lines:
-            if line.startswith('# ') and not found_title:
+            if line.startswith("# ") and not found_title:
                 found_title = True
                 continue
             body_lines.append(line)
-        
-        return '\n'.join(body_lines).strip()
-    
+
+        return "\n".join(body_lines).strip()
+
     def _extract_labels_from_content(self, content: str, filename: str) -> List[str]:
-        '''Extract labels from YAML frontmatter and filename patterns.'''
+        """Extract labels from YAML frontmatter and filename patterns."""
         labels: List[str] = []
-        
+
         # Parse frontmatter for labels
         frontmatter, _ = self._parse_frontmatter(content)
-        
+
         # Extract from frontmatter labels field
-        if 'labels' in frontmatter:
-            fm_labels = frontmatter['labels']
+        if "labels" in frontmatter:
+            fm_labels = frontmatter["labels"]
             if isinstance(fm_labels, str):
                 # Handle comma-separated string
-                labels.extend([label.strip() for label in fm_labels.split(',')])
+                labels.extend([label.strip() for label in fm_labels.split(",")])
             elif isinstance(fm_labels, list):
                 # Handle list format
                 labels.extend([str(label).strip() for label in fm_labels])
-        
+
         # Fallback to filename-based label extraction
         filename_labels = self._extract_labels_from_filename(filename)
         labels.extend(filename_labels)
-        
+
         # Remove duplicates and empty labels
         return list(set(label for label in labels if label.strip()))
-    
+
     def _extract_labels_from_filename(self, filename: str) -> List[str]:
-        '''Extract labels from filename patterns.'''
+        """Extract labels from filename patterns."""
         labels: List[str] = []
-        name = filename.replace('.md', '').lower()
-        
-        if 'bug' in name or 'fix' in name:
-            labels.append('bug')
-        if 'feature' in name or 'enhancement' in name:
-            labels.append('enhancement')
-        if 'docs' in name or 'documentation' in name:
-            labels.append('documentation')
-        if 'test' in name:
-            labels.append('testing')
-        
+        name = filename.replace(".md", "").lower()
+
+        if "bug" in name or "fix" in name:
+            labels.append("bug")
+        if "feature" in name or "enhancement" in name:
+            labels.append("enhancement")
+        if "docs" in name or "documentation" in name:
+            labels.append("documentation")
+        if "test" in name:
+            labels.append("testing")
+
         return labels
-    
+
     def _generate_filename_from_title(self, title: str) -> str:
-        '''Generate filename from issue title.'''
+        """Generate filename from issue title."""
         # Convert to lowercase, replace spaces with hyphens, remove special chars
-        filename = re.sub(r'[^a-zA-Z0-9\\s-]', '', title.lower())
-        filename = re.sub(r'\\s+', '-', filename)
-        filename = re.sub(r'-+', '-', filename)
-        filename = filename.strip('-')
-        
-        return f'{filename}.md'
-    
+        filename = re.sub(r"[^a-zA-Z0-9\\s-]", "", title.lower())
+        filename = re.sub(r"\\s+", "-", filename)
+        filename = re.sub(r"-+", "-", filename)
+        filename = filename.strip("-")
+
+        return f"{filename}.md"
+
     def _format_github_issue_as_markdown(self, github_issue: Dict[str, Any]) -> str:
-        '''Format GitHub issue as Markdown.'''
-        content = f'# {github_issue['title']}\\n\\n'
-        
-        if github_issue.get('body'):
-            content += github_issue['body']
-        
+        """Format GitHub issue as Markdown."""
+        content = f"# {github_issue['title']}\\n\\n"
+
+        if github_issue.get("body"):
+            content += github_issue["body"]
+
         # Add metadata comment
-        content += f'\\n\\n<!-- GitHub Issue #{github_issue['number']} -->'
-        
+        content += f"\\n\\n<!-- GitHub Issue #{github_issue['number']} -->"
+
         return content
-    
+
     def _print_audit_summary(self) -> None:
-        '''Print summary of all actions performed.'''
+        """Print summary of all actions performed."""
         if not self.audit_log:
-            print('MEMO No changes made')
+            print("MEMO No changes made")
             return
-        
-        print('\\nMEMO Audit Summary:')
+
+        print("\\nMEMO Audit Summary:")
         for entry in self.audit_log:
-            action = entry['action']
-            if action == 'create_github_issue':
-                status = '[DRY RUN] ' if entry['dry_run'] else ''
-                print(f'   {status}Created GitHub issue for {entry['filename']}')
-            elif action == 'create_local_issue':
-                status = '[DRY RUN] ' if entry['dry_run'] else ''
-                print(f'   {status}Created local issue {entry['filename']} from GitHub #{entry['github_id']}')
+            action = entry["action"]
+            if action == "create_github_issue":
+                status = "[DRY RUN] " if entry["dry_run"] else ""
+                print(f"   {status}Created GitHub issue for {entry['filename']}")
+            elif action == "create_local_issue":
+                status = "[DRY RUN] " if entry["dry_run"] else ""
+                print(
+                    f"   {status}Created local issue {entry['filename']} from GitHub #{entry['github_id']}"
+                )
+
 
 def main():
-    parser = argparse.ArgumentParser(description='Bidirectional Issue Sync for P(Doom)')
-    parser.add_argument('--dry-run', action='store_true', default=True,
-                       help='Run in dry-run mode (default)')
-    parser.add_argument('--live', action='store_true', 
-                       help='Run in live mode (make actual changes)')
-    parser.add_argument('--sync-all', action='store_true',
-                       help='Perform complete synchronization')
-    parser.add_argument('--resolve-conflicts', action='store_true',
-                       help='Interactively resolve conflicts')
-    
+    parser = argparse.ArgumentParser(description="Bidirectional Issue Sync for P(Doom)")
+    parser.add_argument(
+        "--dry-run", action="store_true", default=True, help="Run in dry-run mode (default)"
+    )
+    parser.add_argument(
+        "--live", action="store_true", help="Run in live mode (make actual changes)"
+    )
+    parser.add_argument("--sync-all", action="store_true", help="Perform complete synchronization")
+    parser.add_argument(
+        "--resolve-conflicts", action="store_true", help="Interactively resolve conflicts"
+    )
+
     args = parser.parse_args()
-    
+
     # Determine mode
     dry_run = not args.live
-    
+
     try:
         sync = BidirectionalIssueSync(dry_run=dry_run)
-        
+
         if args.sync_all or len(sys.argv) == 1:
             sync.sync_all()
         elif args.resolve_conflicts:
-            print('Interactive conflict resolution not yet implemented')
+            print("Interactive conflict resolution not yet implemented")
             sys.exit(1)
         else:
             parser.print_help()
-    
+
     except Exception as e:
-        print(f'ERROR Error: {e}')
+        print(f"ERROR Error: {e}")
         sys.exit(1)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/scripts/logging_system.py
+++ b/scripts/logging_system.py
@@ -1,5 +1,5 @@
 # !/usr/bin/env python3
-'''
+"""
 P(Doom) Centralized Logging System
 
 Provides structured logging for all development tools, CI/CD workflows,
@@ -12,60 +12,66 @@ Features:
 - File rotation and retention
 - Integration with GitHub Actions
 - Debug/verbose modes
-'''
+"""
 
+import json
 import logging
 import logging.handlers
-import json
-import sys
 import os
+import sys
 from datetime import datetime
-from pathlib import Path
-from typing import Dict, Any, Optional, Union
 from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
 
 class LogLevel(Enum):
-    '''Standard log levels with industrial naming.'''
-    CRITICAL = 'CRITICAL'
-    ERROR = 'ERROR' 
-    WARNING = 'WARNING'
-    INFO = 'INFO'
-    DEBUG = 'DEBUG'
-    TRACE = 'TRACE'
+    """Standard log levels with industrial naming."""
+
+    CRITICAL = "CRITICAL"
+    ERROR = "ERROR"
+    WARNING = "WARNING"
+    INFO = "INFO"
+    DEBUG = "DEBUG"
+    TRACE = "TRACE"
+
 
 class LogCategory(Enum):
-    '''Categorized logging for different subsystems.
-    
+    """Categorized logging for different subsystems.
+
     Logging Directory Structure:
     - logs/quality/   : QUALITY, ASCII, STANDARDS (code quality enforcement)
-    - logs/release/   : VERSION, BUILD (release and deployment processes)  
+    - logs/release/   : VERSION, BUILD (release and deployment processes)
     - logs/testing/   : TESTS (test execution and validation)
     - logs/docs/      : DOCS (documentation generation and processing)
     - logs/dev/       : GENERAL (general development activities)
-    '''
-    QUALITY = 'QUALITY'      # Quality checks and enforcement
-    ASCII = 'ASCII'          # ASCII compliance tools
-    STANDARDS = 'STANDARDS'  # Development standards
-    VERSION = 'VERSION'      # Version management
-    TESTS = 'TESTS'          # Test execution
-    BUILD = 'BUILD'          # Build and deployment
-    DOCS = 'DOCS'            # Documentation processing
-    GENERAL = 'GENERAL'      # General purpose
+    """
+
+    QUALITY = "QUALITY"  # Quality checks and enforcement
+    ASCII = "ASCII"  # ASCII compliance tools
+    STANDARDS = "STANDARDS"  # Development standards
+    VERSION = "VERSION"  # Version management
+    TESTS = "TESTS"  # Test execution
+    BUILD = "BUILD"  # Build and deployment
+    DOCS = "DOCS"  # Documentation processing
+    GENERAL = "GENERAL"  # General purpose
 
 
 class PDoomLogger:
-    '''Centralized logger for P(Doom) development tools.'''
-    
-    def __init__(self, 
-                 tool_name: str,
-                 category: LogCategory = LogCategory.GENERAL,
-                 log_level: LogLevel = LogLevel.INFO,
-                 log_to_file: bool = True,
-                 log_directory: Optional[Path] = None,
-                 structured_output: bool = False):
-        '''
+    """Centralized logger for P(Doom) development tools."""
+
+    def __init__(
+        self,
+        tool_name: str,
+        category: LogCategory = LogCategory.GENERAL,
+        log_level: LogLevel = LogLevel.INFO,
+        log_to_file: bool = True,
+        log_directory: Optional[Path] = None,
+        structured_output: bool = False,
+    ):
+        """
         Initialize P(Doom) logger.
-        
+
         Args:
             tool_name: Name of the tool using this logger
             category: Log category for filtering/routing
@@ -73,45 +79,45 @@ class PDoomLogger:
             log_to_file: Whether to write to log files
             log_directory: Directory for log files (default: project_root/logs)
             structured_output: Use JSON structured logging
-        '''
+        """
         self.tool_name = tool_name
         self.category = category
         self.structured_output = structured_output
-        self.session_id = datetime.now().strftime('%Y%m%d_%H%M%S')
-        
+        self.session_id = datetime.now().strftime("%Y%m%d_%H%M%S")
+
         # Detect project root
         self.project_root = self._find_project_root()
-        
+
         # Set up log directory with category-based subdirectories
         if log_directory is None:
-            log_directory = self.project_root / 'logs'
-        
+            log_directory = self.project_root / "logs"
+
         # Create category-specific subdirectories for organized logging
         if category in [LogCategory.QUALITY, LogCategory.ASCII, LogCategory.STANDARDS]:
             # Quality enforcement tools
-            log_directory = log_directory / 'quality'
+            log_directory = log_directory / "quality"
         elif category in [LogCategory.VERSION, LogCategory.BUILD]:
             # Release and deployment processes
-            log_directory = log_directory / 'release'
+            log_directory = log_directory / "release"
         elif category == LogCategory.TESTS:
             # Test execution and validation
-            log_directory = log_directory / 'testing'
+            log_directory = log_directory / "testing"
         elif category == LogCategory.DOCS:
             # Documentation generation and processing
-            log_directory = log_directory / 'docs'
+            log_directory = log_directory / "docs"
         else:
             # General development logs
-            log_directory = log_directory / 'dev'
-        
+            log_directory = log_directory / "dev"
+
         log_directory.mkdir(parents=True, exist_ok=True)
-        
+
         # Configure logging
-        self.logger = logging.getLogger(f'pdoom.{tool_name}')
+        self.logger = logging.getLogger(f"pdoom.{tool_name}")
         self.logger.setLevel(getattr(logging, log_level.value))
-        
+
         # Clear any existing handlers
         self.logger.handlers.clear()
-        
+
         # Console handler with custom formatting
         console_handler = logging.StreamHandler(sys.stdout)
         if structured_output:
@@ -119,346 +125,366 @@ class PDoomLogger:
         else:
             console_handler.setFormatter(self._get_console_formatter())
         self.logger.addHandler(console_handler)
-        
+
         # File handler with rotation
         if log_to_file:
-            log_file = log_directory / f'{tool_name}_{self.session_id}.log'
+            log_file = log_directory / f"{tool_name}_{self.session_id}.log"
             file_handler = logging.handlers.RotatingFileHandler(
-                log_file, maxBytes=10*1024*1024, backupCount=5  # 10MB files, keep 5
+                log_file, maxBytes=10 * 1024 * 1024, backupCount=5  # 10MB files, keep 5
             )
             file_handler.setFormatter(self._get_json_formatter())
             self.logger.addHandler(file_handler)
-            
+
             # Also create a daily log for aggregation
-            daily_log = log_directory / f'daily_{datetime.now().strftime('%Y%m%d')}.log'
+            daily_log = log_directory / f"daily_{datetime.now().strftime('%Y%m%d')}.log"
             daily_handler = logging.handlers.RotatingFileHandler(
-                daily_log, maxBytes=50*1024*1024, backupCount=30  # 50MB daily files
+                daily_log, maxBytes=50 * 1024 * 1024, backupCount=30  # 50MB daily files
             )
             daily_handler.setFormatter(self._get_json_formatter())
             self.logger.addHandler(daily_handler)
-        
+
         # Log session start
         self._log_session_start()
-    
+
     def _find_project_root(self) -> Path:
-        '''Find the project root directory.'''
+        """Find the project root directory."""
         current = Path(__file__).parent
         while current != current.parent:
-            if (current / '.git').exists() or (current / 'main.py').exists():
+            if (current / ".git").exists() or (current / "main.py").exists():
                 return current
             current = current.parent
         return Path.cwd()
-    
+
     def _get_console_formatter(self) -> logging.Formatter:
-        '''Get human-readable console formatter.'''
+        """Get human-readable console formatter."""
         return logging.Formatter(
-            fmt='[%(asctime)s] %(levelname)-8s [%(name)s] %(message)s',
-            datefmt='%H:%M:%S'
+            fmt="[%(asctime)s] %(levelname)-8s [%(name)s] %(message)s", datefmt="%H:%M:%S"
         )
-    
+
     def _get_json_formatter(self) -> logging.Formatter:
-        '''Get structured JSON formatter for file output.'''
+        """Get structured JSON formatter for file output."""
+
         class JsonFormatter(logging.Formatter):
             def __init__(self, category, session_id):
                 super().__init__()
                 self.category = category
                 self.session_id = session_id
-            
+
             def format(self, record):
                 log_entry = {
-                    'timestamp': datetime.fromtimestamp(record.created).isoformat(),
-                    'level': record.levelname,
-                    'tool': record.name,
-                    'category': self.category.value,
-                    'session_id': self.session_id,
-                    'message': record.getMessage(),
-                    'module': record.module,
-                    'function': record.funcName,
-                    'line': record.lineno
+                    "timestamp": datetime.fromtimestamp(record.created).isoformat(),
+                    "level": record.levelname,
+                    "tool": record.name,
+                    "category": self.category.value,
+                    "session_id": self.session_id,
+                    "message": record.getMessage(),
+                    "module": record.module,
+                    "function": record.funcName,
+                    "line": record.lineno,
                 }
-                
+
                 # Add exception info if present
                 if record.exc_info:
-                    log_entry['exception'] = self.formatException(record.exc_info)
-                
+                    log_entry["exception"] = self.formatException(record.exc_info)
+
                 # Add extra fields if present
-                if hasattr(record, 'extra_data'):
-                    log_entry['extra'] = record.extra_data
-                
+                if hasattr(record, "extra_data"):
+                    log_entry["extra"] = record.extra_data
+
                 return json.dumps(log_entry)
-        
+
         return JsonFormatter(self.category, self.session_id)
-    
+
     def _log_session_start(self):
-        '''Log session initialization.'''
-        self.info('Logging session started', extra_data={
-            'tool_name': self.tool_name,
-            'category': self.category.value,
-            'session_id': self.session_id,
-            'project_root': str(self.project_root),
-            'python_version': sys.version,
-            'platform': sys.platform
-        })
-    
+        """Log session initialization."""
+        self.info(
+            "Logging session started",
+            extra_data={
+                "tool_name": self.tool_name,
+                "category": self.category.value,
+                "session_id": self.session_id,
+                "project_root": str(self.project_root),
+                "python_version": sys.version,
+                "platform": sys.platform,
+            },
+        )
+
     # Standard logging methods with extra context
     def critical(self, message: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log critical error.'''
+        """Log critical error."""
         self._log_with_extra(logging.CRITICAL, message, extra_data)
-    
+
     def error(self, message: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log error.'''
+        """Log error."""
         self._log_with_extra(logging.ERROR, message, extra_data)
-    
+
     def warning(self, message: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log warning.'''
+        """Log warning."""
         self._log_with_extra(logging.WARNING, message, extra_data)
-    
+
     def info(self, message: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log info.'''
+        """Log info."""
         self._log_with_extra(logging.INFO, message, extra_data)
-    
+
     def debug(self, message: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log debug.'''
+        """Log debug."""
         self._log_with_extra(logging.DEBUG, message, extra_data)
-    
+
     def trace(self, message: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log trace (debug level with trace marker).'''
-        message = f'[TRACE] {message}'
+        """Log trace (debug level with trace marker)."""
+        message = f"[TRACE] {message}"
         self._log_with_extra(logging.DEBUG, message, extra_data)
-    
+
     def _log_with_extra(self, level: int, message: str, extra_data: Optional[Dict[str, Any]]):
-        '''Internal method to log with extra data.'''
+        """Internal method to log with extra data."""
         if extra_data:
             # Create a LogRecord with extra data
-            record = self.logger.makeRecord(
-                self.logger.name, level, __file__, 0, message, (), None
-            )
+            record = self.logger.makeRecord(self.logger.name, level, __file__, 0, message, (), None)
             record.extra_data = extra_data
             self.logger.handle(record)
         else:
             self.logger.log(level, message)
-    
+
     # Specialized logging methods for common CI/CD scenarios
     def step_start(self, step_name: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log the start of a processing step.'''
-        extra = {'step_name': step_name, 'step_status': 'STARTED'}
+        """Log the start of a processing step."""
+        extra = {"step_name": step_name, "step_status": "STARTED"}
         if extra_data:
             extra.update(extra_data)
-        self.info(f'STEP START: {step_name}', extra_data=extra)
-    
+        self.info(f"STEP START: {step_name}", extra_data=extra)
+
     def step_success(self, step_name: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log successful step completion.'''
-        extra = {'step_name': step_name, 'step_status': 'SUCCESS'}
+        """Log successful step completion."""
+        extra = {"step_name": step_name, "step_status": "SUCCESS"}
         if extra_data:
             extra.update(extra_data)
-        self.info(f'STEP SUCCESS: {step_name}', extra_data=extra)
-    
+        self.info(f"STEP SUCCESS: {step_name}", extra_data=extra)
+
     def step_failure(self, step_name: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log step failure.'''
-        extra = {'step_name': step_name, 'step_status': 'FAILURE'}
+        """Log step failure."""
+        extra = {"step_name": step_name, "step_status": "FAILURE"}
         if extra_data:
             extra.update(extra_data)
-        self.error(f'STEP FAILURE: {step_name}', extra_data=extra)
-    
-    def metrics(self, metric_name: str, value: Union[int, float, str], 
-                unit: Optional[str] = None, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log metrics for monitoring.'''
+        self.error(f"STEP FAILURE: {step_name}", extra_data=extra)
+
+    def metrics(
+        self,
+        metric_name: str,
+        value: Union[int, float, str],
+        unit: Optional[str] = None,
+        extra_data: Optional[Dict[str, Any]] = None,
+    ):
+        """Log metrics for monitoring."""
         metric_data = {
-            'metric_name': metric_name,
-            'metric_value': value,
-            'metric_unit': unit or 'count'
+            "metric_name": metric_name,
+            "metric_value": value,
+            "metric_unit": unit or "count",
         }
         if extra_data:
             metric_data.update(extra_data)
-        
-        self.info(f'METRIC: {metric_name} = {value} {unit or ''}', extra_data=metric_data)
-    
-    def performance(self, operation: str, duration_ms: float, 
-                   extra_data: Optional[Dict[str, Any]] = None):
-        '''Log performance data.'''
+
+        self.info(f"METRIC: {metric_name} = {value} {unit or ''}", extra_data=metric_data)
+
+    def performance(
+        self, operation: str, duration_ms: float, extra_data: Optional[Dict[str, Any]] = None
+    ):
+        """Log performance data."""
         perf_data = {
-            'operation': operation,
-            'duration_ms': duration_ms,
-            'performance_category': 'timing'
+            "operation": operation,
+            "duration_ms": duration_ms,
+            "performance_category": "timing",
         }
         if extra_data:
             perf_data.update(extra_data)
-        
-        self.info(f'PERFORMANCE: {operation} took {duration_ms:.2f}ms', extra_data=perf_data)
-    
+
+        self.info(f"PERFORMANCE: {operation} took {duration_ms:.2f}ms", extra_data=perf_data)
+
     def command_start(self, command: str, args: Optional[Dict[str, Any]] = None):
-        '''Log command execution start.'''
-        cmd_data = {'command': command, 'command_status': 'STARTED'}
+        """Log command execution start."""
+        cmd_data = {"command": command, "command_status": "STARTED"}
         if args:
-            cmd_data['command_args'] = args
-        self.info(f'COMMAND START: {command}', extra_data=cmd_data)
-    
-    def command_result(self, command: str, exit_code: int, 
-                      stdout: Optional[str] = None, stderr: Optional[str] = None):
-        '''Log command execution result.'''
+            cmd_data["command_args"] = args
+        self.info(f"COMMAND START: {command}", extra_data=cmd_data)
+
+    def command_result(
+        self,
+        command: str,
+        exit_code: int,
+        stdout: Optional[str] = None,
+        stderr: Optional[str] = None,
+    ):
+        """Log command execution result."""
         cmd_data = {
-            'command': command,
-            'exit_code': exit_code,
-            'command_status': 'SUCCESS' if exit_code == 0 else 'FAILURE'
+            "command": command,
+            "exit_code": exit_code,
+            "command_status": "SUCCESS" if exit_code == 0 else "FAILURE",
         }
-        
+
         if stdout:
-            cmd_data['stdout'] = stdout[-1000:]  # Last 1000 chars
+            cmd_data["stdout"] = stdout[-1000:]  # Last 1000 chars
         if stderr:
-            cmd_data['stderr'] = stderr[-1000:]  # Last 1000 chars
-        
+            cmd_data["stderr"] = stderr[-1000:]  # Last 1000 chars
+
         if exit_code == 0:
-            self.info(f'COMMAND SUCCESS: {command}', extra_data=cmd_data)
+            self.info(f"COMMAND SUCCESS: {command}", extra_data=cmd_data)
         else:
-            self.error(f'COMMAND FAILURE: {command} (exit code {exit_code})', extra_data=cmd_data)
-    
-    def file_operation(self, operation: str, file_path: str, 
-                      result: str, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log file operations.'''
+            self.error(f"COMMAND FAILURE: {command} (exit code {exit_code})", extra_data=cmd_data)
+
+    def file_operation(
+        self,
+        operation: str,
+        file_path: str,
+        result: str,
+        extra_data: Optional[Dict[str, Any]] = None,
+    ):
+        """Log file operations."""
         file_data = {
-            'file_operation': operation,
-            'file_path': file_path,
-            'operation_result': result
+            "file_operation": operation,
+            "file_path": file_path,
+            "operation_result": result,
         }
         if extra_data:
             file_data.update(extra_data)
-        
-        self.info(f'FILE {operation.upper()}: {file_path} - {result}', extra_data=file_data)
-    
+
+        self.info(f"FILE {operation.upper()}: {file_path} - {result}", extra_data=file_data)
+
     def github_action_output(self, name: str, value: str):
-        '''Output GitHub Actions workflow variables.'''
+        """Output GitHub Actions workflow variables."""
         # GitHub Actions output format
-        print(f'::set-output name={name}::{value}')
-        
+        print(f"::set-output name={name}::{value}")
+
         # Also log normally
-        self.info(f'GitHub Action Output: {name} = {value}', extra_data={
-            'github_output_name': name,
-            'github_output_value': value
-        })
-    
-    def github_action_error(self, message: str, file_path: Optional[str] = None, 
-                           line: Optional[int] = None):
-        '''Output GitHub Actions error annotation.'''
-        annotation = f'::error'
+        self.info(
+            f"GitHub Action Output: {name} = {value}",
+            extra_data={"github_output_name": name, "github_output_value": value},
+        )
+
+    def github_action_error(
+        self, message: str, file_path: Optional[str] = None, line: Optional[int] = None
+    ):
+        """Output GitHub Actions error annotation."""
+        annotation = "::error"
         if file_path:
-            annotation += f' file={file_path}'
+            annotation += f" file={file_path}"
         if line:
-            annotation += f',line={line}'
-        annotation += f'::{message}'
-        
+            annotation += f",line={line}"
+        annotation += f"::{message}"
+
         print(annotation)
-        self.error(f'GitHub Action Error: {message}', extra_data={
-            'github_annotation': True,
-            'file_path': file_path,
-            'line_number': line
-        })
-    
-    def github_action_warning(self, message: str, file_path: Optional[str] = None, 
-                             line: Optional[int] = None):
-        '''Output GitHub Actions warning annotation.'''
-        annotation = f'::warning'
+        self.error(
+            f"GitHub Action Error: {message}",
+            extra_data={"github_annotation": True, "file_path": file_path, "line_number": line},
+        )
+
+    def github_action_warning(
+        self, message: str, file_path: Optional[str] = None, line: Optional[int] = None
+    ):
+        """Output GitHub Actions warning annotation."""
+        annotation = "::warning"
         if file_path:
-            annotation += f' file={file_path}'
+            annotation += f" file={file_path}"
         if line:
-            annotation += f',line={line}'
-        annotation += f'::{message}'
-        
+            annotation += f",line={line}"
+        annotation += f"::{message}"
+
         print(annotation)
-        self.warning(f'GitHub Action Warning: {message}', extra_data={
-            'github_annotation': True,
-            'file_path': file_path,
-            'line_number': line
-        })
-    
+        self.warning(
+            f"GitHub Action Warning: {message}",
+            extra_data={"github_annotation": True, "file_path": file_path, "line_number": line},
+        )
+
     def session_summary(self, success: bool, extra_data: Optional[Dict[str, Any]] = None):
-        '''Log session completion summary.'''
+        """Log session completion summary."""
         session_data = {
-            'session_success': success,
-            'session_id': self.session_id,
-            'session_duration': 'calculated_by_log_parser'  # Post-processing
+            "session_success": success,
+            "session_id": self.session_id,
+            "session_duration": "calculated_by_log_parser",  # Post-processing
         }
         if extra_data:
             session_data.update(extra_data)
-        
+
         if success:
-            self.info('Session completed successfully', extra_data=session_data)
+            self.info("Session completed successfully", extra_data=session_data)
         else:
-            self.error('Session completed with failures', extra_data=session_data)
+            self.error("Session completed with failures", extra_data=session_data)
 
 
-def get_logger(tool_name: str, 
-               category: LogCategory = LogCategory.GENERAL,
-               verbose: bool = False,
-               structured: bool = False) -> PDoomLogger:
-    '''
+def get_logger(
+    tool_name: str,
+    category: LogCategory = LogCategory.GENERAL,
+    verbose: bool = False,
+    structured: bool = False,
+) -> PDoomLogger:
+    """
     Convenience function to get a configured logger.
-    
+
     Args:
         tool_name: Name of the tool requesting the logger
         category: Category for log filtering
         verbose: Enable debug/trace logging
         structured: Use JSON structured output to console
-    
+
     Returns:
         Configured PDoomLogger instance
-    '''
+    """
     log_level = LogLevel.DEBUG if verbose else LogLevel.INFO
-    
+
     # Check for CI environment
-    is_ci = os.getenv('CI') == 'true' or os.getenv('GITHUB_ACTIONS') == 'true'
+    is_ci = os.getenv("CI") == "true" or os.getenv("GITHUB_ACTIONS") == "true"
     if is_ci:
         structured = True  # Force structured logging in CI
-    
+
     return PDoomLogger(
-        tool_name=tool_name,
-        category=category,
-        log_level=log_level,
-        structured_output=structured
+        tool_name=tool_name, category=category, log_level=log_level, structured_output=structured
     )
 
 
 # Context manager for timed operations
 class TimedOperation:
-    '''Context manager for timing operations with automatic logging.'''
-    
-    def __init__(self, logger: PDoomLogger, operation_name: str, 
-                 extra_data: Optional[Dict[str, Any]] = None):
+    """Context manager for timing operations with automatic logging."""
+
+    def __init__(
+        self, logger: PDoomLogger, operation_name: str, extra_data: Optional[Dict[str, Any]] = None
+    ):
         self.logger = logger
         self.operation_name = operation_name
         self.extra_data = extra_data or {}
         self.start_time = None
-    
+
     def __enter__(self):
         import time
+
         self.start_time = time.time()
         self.logger.step_start(self.operation_name, self.extra_data)
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         import time
+
         duration_ms = (time.time() - self.start_time) * 1000
-        
-        result_data = {**self.extra_data, 'duration_ms': duration_ms}
-        
+
+        result_data = {**self.extra_data, "duration_ms": duration_ms}
+
         if exc_type is None:
             self.logger.step_success(self.operation_name, result_data)
             self.logger.performance(self.operation_name, duration_ms)
         else:
-            result_data['exception_type'] = exc_type.__name__ if exc_type else None
-            result_data['exception_message'] = str(exc_val) if exc_val else None
+            result_data["exception_type"] = exc_type.__name__ if exc_type else None
+            result_data["exception_message"] = str(exc_val) if exc_val else None
             self.logger.step_failure(self.operation_name, result_data)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Test the logging system
-    logger = get_logger('test_logging', LogCategory.QUALITY, verbose=True)
-    
-    logger.info('Testing P(Doom) logging system')
-    
-    with TimedOperation(logger, 'test_operation'):
+    logger = get_logger("test_logging", LogCategory.QUALITY, verbose=True)
+
+    logger.info("Testing P(Doom) logging system")
+
+    with TimedOperation(logger, "test_operation"):
         import time
+
         time.sleep(0.1)  # Simulate work
-    
-    logger.metrics('test_metric', 42, 'items')
-    logger.performance('test_perf', 123.45)
-    logger.session_summary(True, {'tests_run': 10, 'tests_passed': 10})
+
+    logger.metrics("test_metric", 42, "items")
+    logger.performance("test_perf", 123.45)
+    logger.session_summary(True, {"tests_run": 10, "tests_passed": 10})

--- a/scripts/pre_version_bump.py
+++ b/scripts/pre_version_bump.py
@@ -1,5 +1,5 @@
 # !/usr/bin/env python3
-'''
+"""
 Pre-Version Bump Quality Checks for P(Doom)
 
 Runs comprehensive quality checks before version increments to ensure
@@ -10,263 +10,279 @@ Usage:
     python scripts/pre_version_bump.py --target-version v0.10.1
     python scripts/pre_version_bump.py --auto-fix
     python scripts/pre_version_bump.py --check-only
-'''
+"""
 
-import sys
-import subprocess
 import argparse
+import subprocess
+import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
-from datetime import datetime
 
 # Project root detection
 PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+
 class PreVersionBumpChecker:
-    '''Comprehensive quality checks for version increments.'''
-    
+    """Comprehensive quality checks for version increments."""
+
     def __init__(self, auto_fix: bool = False):
         self.auto_fix = auto_fix
         self.project_root = PROJECT_ROOT
         self.issues_found = []
         self.fixes_applied = []
-        
+
     def run_all_checks(self, target_version: Optional[str] = None) -> bool:
-        '''Run all pre-version-bump checks.'''
-        print('=' * 60)
-        print('P(DOOM) PRE-VERSION BUMP QUALITY CHECKS')
-        print('=' * 60)
-        
+        """Run all pre-version-bump checks."""
+        print("=" * 60)
+        print("P(DOOM) PRE-VERSION BUMP QUALITY CHECKS")
+        print("=" * 60)
+
         if target_version:
-            print(f'Target Version: {target_version}')
-        print(f'Auto-fix Mode: {'ENABLED' if self.auto_fix else 'DISABLED'}')
-        print(f'Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}')
+            print(f"Target Version: {target_version}")
+        print(f"Auto-fix Mode: {'ENABLED' if self.auto_fix else 'DISABLED'}")
+        print(f"Timestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
         print()
-        
+
         success = True
-        
+
         # 1. ASCII Compliance Check
         success &= self._check_ascii_compliance()
-        
+
         # 2. Development Standards Check
         success &= self._check_development_standards()
-        
+
         # 3. Test Suite Validation
         success &= self._check_test_suite()
-        
+
         # 4. Documentation Consistency
         success &= self._check_documentation()
-        
+
         # 5. Version Consistency Check
         if target_version:
             success &= self._check_version_consistency(target_version)
-        
+
         # Print summary
         self._print_summary(success)
-        
+
         return success
-    
+
     def _check_ascii_compliance(self) -> bool:
-        '''Check and optionally fix ASCII compliance.'''
-        print('STEP 1: ASCII Compliance Check')
-        print('-' * 30)
-        
+        """Check and optionally fix ASCII compliance."""
+        print("STEP 1: ASCII Compliance Check")
+        print("-" * 30)
+
         try:
-            converter_path = self.project_root / 'scripts' / 'intelligent_ascii_converter.py'
-            
+            converter_path = self.project_root / "scripts" / "intelligent_ascii_converter.py"
+
             # Run dry-run first
-            result = subprocess.run([
-                sys.executable, str(converter_path), '--dry-run'
-            ], capture_output=True, text=True, cwd=self.project_root)
-            
+            result = subprocess.run(
+                [sys.executable, str(converter_path), "--dry-run"],
+                capture_output=True,
+                text=True,
+                cwd=self.project_root,
+            )
+
             if result.returncode == 0:
-                if 'All files are ASCII compliant' in result.stdout:
-                    print('SUCCESS All files are ASCII compliant')
+                if "All files are ASCII compliant" in result.stdout:
+                    print("SUCCESS All files are ASCII compliant")
                     return True
                 else:
-                    print('WARNING Unicode characters found')
-                    self.issues_found.append('Unicode characters detected')
-                    
+                    print("WARNING Unicode characters found")
+                    self.issues_found.append("Unicode characters detected")
+
                     if self.auto_fix:
-                        print('INFO Applying automatic ASCII fixes...')
-                        fix_result = subprocess.run([
-                            sys.executable, str(converter_path)
-                        ], capture_output=True, text=True, cwd=self.project_root)
-                        
+                        print("INFO Applying automatic ASCII fixes...")
+                        fix_result = subprocess.run(
+                            [sys.executable, str(converter_path)],
+                            capture_output=True,
+                            text=True,
+                            cwd=self.project_root,
+                        )
+
                         if fix_result.returncode == 0:
-                            print('SUCCESS ASCII fixes applied successfully')
-                            self.fixes_applied.append('ASCII compliance auto-fixed')
+                            print("SUCCESS ASCII fixes applied successfully")
+                            self.fixes_applied.append("ASCII compliance auto-fixed")
                             return True
                         else:
-                            print(f'ERROR ASCII fix failed: {fix_result.stderr}')
+                            print(f"ERROR ASCII fix failed: {fix_result.stderr}")
                             return False
                     else:
-                        print('ACTION Run: python scripts/intelligent_ascii_converter.py')
+                        print("ACTION Run: python scripts/intelligent_ascii_converter.py")
                         return False
             else:
-                print(f'ERROR ASCII check failed: {result.stderr}')
+                print(f"ERROR ASCII check failed: {result.stderr}")
                 return False
-                
+
         except Exception as e:
-            print(f'ERROR ASCII compliance check failed: {e}')
+            print(f"ERROR ASCII compliance check failed: {e}")
             return False
-    
+
     def _check_development_standards(self) -> bool:
-        '''Check development standards compliance.'''
-        print('\nSTEP 2: Development Standards Check')
-        print('-' * 35)
-        
+        """Check development standards compliance."""
+        print("\nSTEP 2: Development Standards Check")
+        print("-" * 35)
+
         try:
-            standards_path = self.project_root / 'scripts' / 'enforce_standards.py'
-            
-            result = subprocess.run([
-                sys.executable, str(standards_path), '--check-all'
-            ], capture_output=True, text=True, cwd=self.project_root)
-            
+            standards_path = self.project_root / "scripts" / "enforce_standards.py"
+
+            result = subprocess.run(
+                [sys.executable, str(standards_path), "--check-all"],
+                capture_output=True,
+                text=True,
+                cwd=self.project_root,
+            )
+
             if result.returncode == 0:
-                print('SUCCESS All development standards met')
+                print("SUCCESS All development standards met")
                 return True
             else:
-                print('WARNING Standards violations detected')
-                print('Details:')
+                print("WARNING Standards violations detected")
+                print("Details:")
                 print(result.stdout)
-                self.issues_found.append('Development standards violations')
+                self.issues_found.append("Development standards violations")
                 return False
-                
+
         except Exception as e:
-            print(f'ERROR Standards check failed: {e}')
+            print(f"ERROR Standards check failed: {e}")
             return False
-    
+
     def _check_test_suite(self) -> bool:
-        '''Validate test suite execution.'''
-        print('\nSTEP 3: Test Suite Validation')
-        print('-' * 26)
-        
+        """Validate test suite execution."""
+        print("\nSTEP 3: Test Suite Validation")
+        print("-" * 26)
+
         try:
             # Run a quick test to ensure test suite is functional
-            result = subprocess.run([
-                sys.executable, '-m', 'unittest', 'discover', 'tests', '-v', '--failfast'
-            ], capture_output=True, text=True, cwd=self.project_root, timeout=120)
-            
+            result = subprocess.run(
+                [sys.executable, "-m", "unittest", "discover", "tests", "-v", "--failfast"],
+                capture_output=True,
+                text=True,
+                cwd=self.project_root,
+                timeout=120,
+            )
+
             if result.returncode == 0:
-                print('SUCCESS Test suite passed')
+                print("SUCCESS Test suite passed")
                 return True
             else:
-                print('ERROR Test suite failures detected')
-                print('Details:')
+                print("ERROR Test suite failures detected")
+                print("Details:")
                 print(result.stdout[-1000:])  # Last 1000 chars
-                self.issues_found.append('Test suite failures')
+                self.issues_found.append("Test suite failures")
                 return False
-                
+
         except subprocess.TimeoutExpired:
-            print('WARNING Test suite timeout (>120s)')
-            self.issues_found.append('Test suite performance issue')
+            print("WARNING Test suite timeout (>120s)")
+            self.issues_found.append("Test suite performance issue")
             return False
         except Exception as e:
-            print(f'ERROR Test suite check failed: {e}')
+            print(f"ERROR Test suite check failed: {e}")
             return False
-    
+
     def _check_documentation(self) -> bool:
-        '''Check documentation consistency.'''
-        print('\nSTEP 4: Documentation Consistency')
-        print('-' * 30)
-        
+        """Check documentation consistency."""
+        print("\nSTEP 4: Documentation Consistency")
+        print("-" * 30)
+
         # Basic checks for key documentation files
         required_docs = [
-            'README.md',
-            'docs/DEVELOPERGUIDE.md', 
-            'docs/PLAYERGUIDE.md',
-            'CHANGELOG.md'
+            "README.md",
+            "docs/DEVELOPERGUIDE.md",
+            "docs/PLAYERGUIDE.md",
+            "CHANGELOG.md",
         ]
-        
+
         missing_docs = []
         for doc in required_docs:
             doc_path = self.project_root / doc
             if not doc_path.exists():
                 missing_docs.append(doc)
-        
+
         if missing_docs:
-            print(f'ERROR Missing documentation: {', '.join(missing_docs)}')
-            self.issues_found.append(f'Missing docs: {missing_docs}')
+            print(f"ERROR Missing documentation: {', '.join(missing_docs)}")
+            self.issues_found.append(f"Missing docs: {missing_docs}")
             return False
-        
-        print('SUCCESS Core documentation files present')
+
+        print("SUCCESS Core documentation files present")
         return True
-    
+
     def _check_version_consistency(self, target_version: str) -> bool:
-        '''Check version consistency across files.'''
-        print(f'\nSTEP 5: Version Consistency Check')
-        print('-' * 29)
-        
+        """Check version consistency across files."""
+        print("\nSTEP 5: Version Consistency Check")
+        print("-" * 29)
+
         try:
             # Check current version
             from scripts.lib.services.version import get_display_version
+
             current_version = get_display_version()
-            
-            print(f'Current Version: {current_version}')
-            print(f'Target Version:  {target_version}')
-            
+
+            print(f"Current Version: {current_version}")
+            print(f"Target Version:  {target_version}")
+
             # Basic validation that target version is different
             if current_version == target_version:
-                print('WARNING Target version same as current version')
-                self.issues_found.append('Version not incremented')
+                print("WARNING Target version same as current version")
+                self.issues_found.append("Version not incremented")
                 return False
-            
-            print('SUCCESS Version increment planned')
+
+            print("SUCCESS Version increment planned")
             return True
-            
+
         except Exception as e:
-            print(f'ERROR Version check failed: {e}')
+            print(f"ERROR Version check failed: {e}")
             return False
-    
+
     def _print_summary(self, success: bool) -> None:
-        '''Print final summary.'''
-        print('\n' + '=' * 60)
-        print('QUALITY CHECK SUMMARY')
-        print('=' * 60)
-        
+        """Print final summary."""
+        print("\n" + "=" * 60)
+        print("QUALITY CHECK SUMMARY")
+        print("=" * 60)
+
         if success:
-            print('SUCCESS All quality checks passed')
+            print("SUCCESS All quality checks passed")
             if self.fixes_applied:
-                print('\nFixes Applied:')
+                print("\nFixes Applied:")
                 for fix in self.fixes_applied:
-                    print(f'  - {fix}')
-            print('\nREADY for version increment')
+                    print(f"  - {fix}")
+            print("\nREADY for version increment")
         else:
-            print('ERROR Quality checks failed')
+            print("ERROR Quality checks failed")
             if self.issues_found:
-                print('\nIssues Found:')
+                print("\nIssues Found:")
                 for issue in self.issues_found:
-                    print(f'  - {issue}')
-            print('\nNOT READY for version increment')
-        
-        print(f'\nTimestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}')
+                    print(f"  - {issue}")
+            print("\nNOT READY for version increment")
+
+        print(f"\nTimestamp: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Pre-version bump quality checks for P(Doom)',
-        formatter_class=argparse.RawDescriptionHelpFormatter
+        description="Pre-version bump quality checks for P(Doom)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
-    parser.add_argument('--target-version', 
-                       help='Target version for increment (e.g., v0.10.1)')
-    parser.add_argument('--auto-fix', action='store_true',
-                       help='Automatically fix issues where possible')
-    parser.add_argument('--check-only', action='store_true',
-                       help='Only check, never fix (overrides --auto-fix)')
-    
+
+    parser.add_argument("--target-version", help="Target version for increment (e.g., v0.10.1)")
+    parser.add_argument(
+        "--auto-fix", action="store_true", help="Automatically fix issues where possible"
+    )
+    parser.add_argument(
+        "--check-only", action="store_true", help="Only check, never fix (overrides --auto-fix)"
+    )
+
     args = parser.parse_args()
-    
+
     # Override auto-fix if check-only is specified
     auto_fix = args.auto_fix and not args.check_only
-    
+
     checker = PreVersionBumpChecker(auto_fix=auto_fix)
     success = checker.run_all_checks(args.target_version)
-    
+
     return 0 if success else 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     exit(main())


### PR DESCRIPTION
## Why

The **daily scheduled CI** (Enhanced CI/CD Pipeline, Stages 4 & 5) has failed for **10+ days straight** with:

```
SyntaxError: f-string: unmatched '['
```

Root cause: several `scripts/` files use **PEP 701 nested-same-quote f-strings** (e.g. `f'{d['k']}'`), which are valid only on **Python 3.12+** and a hard `SyntaxError` on the **3.11** CI runner. The dev machine runs 3.13, so the breakage only ever surfaced in the scheduled lane (it doesn't run on PRs).

Underlying issue: there was **no authoritative Python baseline** anywhere (no `pyproject.toml`/`setup.py`), and workflow Python pins were scattered across 3.9 / 3.10 / 3.11 / 3.12.

## What

- **Repair all PEP 701 f-strings** in `scripts/` (flip the outer quote to `"`); the result is legal on **every Python 3.9+** — `ascii_compliance_fixer`, `branch_manager`, `issue_sync_bidirectional`, `logging_system`, `pre_version_bump`.
- **Add `pyproject.toml`** declaring **Python 3.11** as the baseline (ruff/black/isort `target-version`). This is the missing source of truth.
- **Add a CI gate** — a `Python syntax gate (3.11 baseline)` step in `quality-checks.yml` that `py_compile`s `scripts/` on PRs, so modern-only syntax can't land silently again. (The broken stages only run on `schedule`, so this gate is what actually guards PRs.)
- **Standardize** stray workflow Python pins to 3.11; drop `3.9` from the integration-test matrix.
- Point `quality-checks` triggers at `main` only (the `develop` branch was retired in April 2026).
- **`CONTRIBUTING.md`**: `Python 3.9+` → `3.11+`; two-branch model → single-branch (`main`).
- Narrow 4 pre-existing bare `except:` → `except Exception:` (ruff `E722`, required by the commit hook on the touched files).

## Note on diff size

Most of the +1609/-1437 is **`black` reformatting** whole script files that weren't previously black-clean (applied automatically by the repo's own pre-commit hooks). The substantive logic changes are small.

## Verification

- All `scripts/` compile under Python 3.10 (a PEP 701-strict stand-in for the 3.11 floor): **0 broken**.
- Pre-commit (black/isort/ruff/enforce-standards) passes.
- After merge, the scheduled Stages 4 & 5 should be confirmed green via a manual `workflow_dispatch` run.

## Out of scope (separate decision)

A broader scan found **~28 files in root `tests/` and `tools/`** with **genuine** syntax errors on *all* Python versions (pygame-era migration debris, currently masked by a non-blocking CI step). Deliberately left out — that's an archive-vs-fix call to make separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
