### PR TITLE
fix: stop unit suite hanging on historical-event flood (#534)

### DIFF
--- a/godot/tests/unit/test_turn_manager.gd
+++ b/godot/tests/unit/test_turn_manager.gd
@@ -3,12 +3,24 @@ extends GutTest
 
 var state: GameState
 var turn_manager: TurnManager
+var _saved_historical_events := []
 
 func before_each():
 	# Create fresh state and turn manager for each test
 	GameEvents.reset_triggered_events()
+	# Test isolation (#534): unit tests must NOT load the live ~1194-event historical
+	# timeline into pending_events. Resolve-all loops over it floods hist_arxiv_* output
+	# and hangs the headless suite. Built-in events (e.g. funding_crisis) still trigger.
+	if EventService:
+		_saved_historical_events = EventService.transformed_events.duplicate()
+		EventService.transformed_events.clear()
 	state = GameState.new("test_seed")
 	turn_manager = TurnManager.new(state)
+
+func after_each():
+	# Restore the historical event deck cleared in before_each (#534)
+	if EventService:
+		EventService.transformed_events = _saved_historical_events
 
 func test_start_turn_increments_turn_counter():
 	# Test that start_turn increases turn number


### PR DESCRIPTION
Closes #534.

## Root cause
`test_turn_manager.gd`'s three resolve-all loops call `start_turn()` (which loads the live **~1194-event** historical timeline into `pending_events`) then loop *resolve ALL pending* — grinding through the whole real dataset, flooding `hist_arxiv_*` output so the headless suite never completes. Sibling tests in the same file already disable EventService for isolation; the `resolve_event` tests didn't.

## Fix
Centralize isolation: clear `EventService.transformed_events` in `before_each`, restore in `after_each`. All turn-manager unit tests become hermetic; built-in events (e.g. funding_crisis) still trigger.

## Verified (ran headless locally)
- `test_turn_manager.gd`: **26/26 pass in ~4s** (was: hang)
- **Full unit suite now COMPLETES in ~79s** (was: never finished) — 220 tests, 187 pass, **33 pre-existing failures now visible** (were masked by the hang; tracked separately, not caused by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)