### PR TITLE
fix: unit suite 220/220 green (#538) + check_style_guide encoding crash

### DIFF
--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -13,6 +13,7 @@ var papers: float = 0.0
 var reputation: float = 50.0
 var doom: float = 50.0  # 0-100, lose at 100
 var action_points: int = 3
+var max_action_points: int = 3  # Per-turn AP cap; difficulty modifiers adjust this (game_manager._apply_difficulty_settings)
 var stationery: float = 100.0  # Office supplies, depletes with staff usage
 
 # Technical Debt System (Issue #416)
@@ -48,6 +49,7 @@ var turn: int = 0
 var game_over: bool = false
 var victory: bool = false
 var game_seed_str: String = ""  # Renamed from 'seed' to avoid shadowing built-in function
+static var _empty_seed_counter: int = 0  # Keeps empty ("random") seeds unique within the same instant (#538)
 
 # Lab mascot 🐱
 var has_cat: bool = false
@@ -107,7 +109,13 @@ var attended_conferences: Array[String] = []  # Conference IDs attended this gam
 var conference_year: int = 2017  # Track which year for conference attendance reset
 
 func _init(game_seed: String = ""):
-	game_seed_str = game_seed if game_seed != "" else str(Time.get_ticks_msec())
+	if game_seed != "":
+		game_seed_str = game_seed
+	else:
+		# Empty = random new game. Combine high-res time with a static counter so two
+		# games created in the same instant (tests, rapid restarts) get unique seeds (#538).
+		_empty_seed_counter += 1
+		game_seed_str = "%d-%d" % [Time.get_ticks_usec(), _empty_seed_counter]
 
 	# Initialize deterministic RNG from seed
 	rng = RandomNumberGenerator.new()

--- a/godot/tests/unit/test_game_manager.gd
+++ b/godot/tests/unit/test_game_manager.gd
@@ -92,15 +92,17 @@ func test_select_action_queues_action():
 		"Correct action should be queued")
 
 func test_select_action_deducts_action_points():
-	# Test that selecting an action deducts AP immediately
+	# Selecting an action commits AP (committed_ap); available AP drops immediately.
+	# state.action_points itself only decrements at execution (end_turn).
 	game_manager.start_new_game("test_seed")
-	var initial_ap = game_manager.state.action_points
+	game_manager.state.research = 100  # safety_research costs 10 research + 1 AP
+	var initial_available = game_manager.state.get_available_ap()
 
 	game_manager.select_action("buy_compute")  # Costs 0 AP in current impl
 	game_manager.select_action("safety_research")  # Costs 1 AP
 
-	assert_lt(game_manager.state.action_points, initial_ap,
-		"Action points should decrease after action selection")
+	assert_lt(game_manager.state.get_available_ap(), initial_available,
+		"Available action points should decrease after committing actions")
 
 func test_select_action_validates_affordability():
 	# Test that actions are validated before queueing
@@ -245,14 +247,15 @@ func test_start_next_turn_increments_turn_counter():
 func test_start_next_turn_resets_action_points():
 	# Test that AP is reset on new turn
 	game_manager.start_new_game("test_seed")
-	game_manager.select_action("safety_research")  # Uses 1 AP
-	var ap_before_turn_end = game_manager.state.action_points
+	game_manager.state.research = 100  # safety_research costs 10 research + 1 AP
+	game_manager.select_action("safety_research")  # Commits 1 AP
+	var available_before_turn_end = game_manager.state.get_available_ap()
 
 	game_manager.end_turn()
 	await wait_seconds(0.6)
 
-	assert_gt(game_manager.state.action_points, ap_before_turn_end,
-		"Action points should be reset on new turn")
+	assert_gt(game_manager.state.get_available_ap(), available_before_turn_end,
+		"Available action points should be reset (higher) on a new turn")
 
 func test_start_next_turn_emits_actions_available_when_no_events():
 	# FIX #418: Test that actions are available if no events
@@ -275,6 +278,8 @@ func test_start_next_turn_emits_actions_available_when_no_events():
 func test_resolve_event_updates_state():
 	# Test that event resolution affects game state
 	game_manager.start_new_game("test_seed")
+	# resolve_event requires TURN_START phase (FIX #418); set it for this isolated event
+	game_manager.state.current_phase = GameState.TurnPhase.TURN_START
 
 	# Create a test event
 	var test_event = {
@@ -301,6 +306,8 @@ func test_resolve_event_updates_state():
 func test_resolve_event_emits_game_state_updated():
 	# Test that event resolution emits state update
 	game_manager.start_new_game("test_seed")
+	# resolve_event requires TURN_START phase (FIX #418)
+	game_manager.state.current_phase = GameState.TurnPhase.TURN_START
 
 	var test_event = {
 		"id": "test_event",

--- a/godot/tests/unit/test_upgrades.gd
+++ b/godot/tests/unit/test_upgrades.gd
@@ -10,20 +10,21 @@ func test_initial_state_has_no_upgrades():
 	assert_eq(state.purchased_upgrades.size(), 0, "Should start with no upgrades")
 
 func test_can_purchase_upgrade():
-	state.money = 1000.0
-	state.purchase_upgrade("upgrade_computers")
-	assert_true(state.has_upgrade("upgrade_computers"), "Should have purchased upgrade")
+	state.money = 300000.0
+	GameUpgrades.purchase_upgrade("upgrade_computer", state)
+	assert_true(state.has_upgrade("upgrade_computer"), "Should have purchased upgrade")
 	assert_eq(state.purchased_upgrades.size(), 1, "Should have 1 upgrade")
 
 func test_cannot_purchase_same_upgrade_twice():
-	state.money = 1000.0
-	state.purchase_upgrade("upgrade_computers")
+	state.money = 300000.0
+	GameUpgrades.purchase_upgrade("upgrade_computer", state)
 	var before_size = state.purchased_upgrades.size()
-	state.purchase_upgrade("upgrade_computers")
+	GameUpgrades.purchase_upgrade("upgrade_computer", state)
 	assert_eq(state.purchased_upgrades.size(), before_size, "Should not purchase same upgrade twice")
 
 func test_to_dict_includes_upgrades():
-	state.purchase_upgrade("upgrade_computers")
+	state.money = 300000.0
+	GameUpgrades.purchase_upgrade("upgrade_computer", state)
 	var dict = state.to_dict()
 	assert_true(dict.has("purchased_upgrades"), "State dict should include purchased_upgrades")
 	assert_eq(dict["purchased_upgrades"].size(), 1, "Should have 1 upgrade in dict")

--- a/scripts/check_style_guide.py
+++ b/scripts/check_style_guide.py
@@ -21,14 +21,12 @@ Skip this check:
 import os
 import subprocess
 import sys
-from pathlib import Path
 
 # Files/patterns that should trigger style guide update reminders
 STYLE_SENSITIVE_PATTERNS = [
     # Theme and styling
     "godot/autoload/theme_manager.gd",
     "godot/theme/",
-
     # UI scenes with styling
     "godot/scenes/welcome.tscn",
     "godot/scenes/settings_menu.tscn",
@@ -36,11 +34,9 @@ STYLE_SENSITIVE_PATTERNS = [
     "godot/scenes/leaderboard_screen.tscn",
     "godot/scenes/end_game_screen.tscn",
     "godot/scenes/main.tscn",
-
     # Asset additions
     "godot/assets/textures/",
     "godot/assets/ui/",
-
     # Color/style definitions in GDScript
     "Color(",  # When new colors are added
 ]
@@ -55,9 +51,11 @@ def get_staged_files():
             ["git", "diff", "--cached", "--name-only"],
             capture_output=True,
             text=True,
-            check=True
+            encoding="utf-8",
+            errors="replace",
+            check=True,
         )
-        return result.stdout.strip().split('\n') if result.stdout.strip() else []
+        return result.stdout.strip().split("\n") if result.stdout.strip() else []
     except subprocess.CalledProcessError:
         return []
 
@@ -65,17 +63,19 @@ def get_staged_files():
 def check_for_color_additions(files):
     """Check if any GDScript files have new Color() definitions."""
     for file in files:
-        if file.endswith('.gd'):
+        if file.endswith(".gd"):
             try:
                 result = subprocess.run(
                     ["git", "diff", "--cached", file],
                     capture_output=True,
                     text=True,
-                    check=True
+                    encoding="utf-8",
+                    errors="replace",
+                    check=True,
                 )
                 # Check for added lines with Color(
-                for line in result.stdout.split('\n'):
-                    if line.startswith('+') and 'Color(' in line and not line.startswith('+++'):
+                for line in result.stdout.split("\n"):
+                    if line.startswith("+") and "Color(" in line and not line.startswith("+++"):
                         return True
             except subprocess.CalledProcessError:
                 pass
@@ -119,11 +119,11 @@ def check_style_guide_update(files):
 
 def main():
     # Check for skip environment variable
-    if os.environ.get('SKIP_STYLE_GUIDE_CHECK', '').lower() in ('1', 'true', 'yes'):
+    if os.environ.get("SKIP_STYLE_GUIDE_CHECK", "").lower() in ("1", "true", "yes"):
         print("[STYLE GUIDE] Check skipped via SKIP_STYLE_GUIDE_CHECK environment variable")
         return 0
 
-    strict_mode = '--strict' in sys.argv
+    strict_mode = "--strict" in sys.argv
 
     files = get_staged_files()
     if not files:


### PR DESCRIPTION
Closes #538.

## Result
Full unit suite: **220/220 passing in ~73s** (was 33 failing, and before #537 it hung forever).

## The 33 failures → 4 root causes
1. **🔴 Real bug** — `GameState` was missing `max_action_points`, which `game_manager` assigns on **Easy/Hard difficulty** → start-game crash on those difficulties (Standard skips it). Added the property (default 3). *Note: `start_turn` still ignores it, so the difficulty AP modifier remains a no-op — wiring it is a separate balance decision, left to you.*
2. **Stale test** — `test_upgrades` called a removed `GameState.purchase_upgrade()` with the wrong id (`upgrade_computers` vs `upgrade_computer`) and too little money (cost 200k vs 1k). Repointed to `GameUpgrades.purchase_upgrade(id, state)`.
3. **Flaky test** — empty-seed RNG used `Time.get_ticks_msec()` and collided sub-millisecond. Now collision-proof via a static counter + `get_ticks_usec()`.
4. **Stale tests** (revealed by fixing #1) — 4 `game_manager` tests didn't set `TURN_START` phase for `resolve_event` (FIX #418), and the AP tests checked `state.action_points` instead of the commit-at-select `get_available_ap()` model (and lacked the research to afford `safety_research`).

## Plus: pre-commit hook fix
`scripts/check_style_guide.py` ran `git diff` with `text=True` but no encoding → on Windows it decoded UTF-8 diff output (emoji/em-dashes in `.gd` files) as cp1252 and crashed, **blocking commits** of any non-ASCII `.gd` change. Added `encoding='utf-8', errors='replace'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)