### PR TITLE
fix: player-facing consistency - bug-report keybind + canonical domain

### DIFF
--- a/godot/data/patch_notes.json
+++ b/godot/data/patch_notes.json
@@ -37,13 +37,13 @@
       "date": "2025-11-17",
       "title": "Playtesting Fixes & Turn Philosophy",
       "highlights": [
-        "Bug Reporter Integration - In-game bug reporting with F8",
+        "Bug Reporter Integration - In-game bug reporting with backslash or N key",
         "Turn Philosophy Reframe - 'Monday Planning' metaphor",
         "Event Dialog UX Improvements - Better visibility and interaction"
       ],
       "sections": {
         "added": [
-          "In-game bug reporting system (F8 or backslash)",
+          "In-game bug reporting system (backslash or N)",
           "Cat contributor recognition system",
           "Comprehensive turn sequence documentation"
         ],

--- a/godot/scripts/ui/bug_report_panel.gd
+++ b/godot/scripts/ui/bug_report_panel.gd
@@ -46,8 +46,8 @@ func _ready():
 	# Set privacy notice
 	privacy_label.bbcode_enabled = true
 	privacy_label.text = "[center][color=gray]Your privacy is important to us. Reports are saved locally on your device by default. " + \
-		"We collect only essential technical information. See [url=https://pdoom.net/privacy]Privacy Policy[/url] for details." + \
-		"\n\nBy including your name, you may be recognized in our [url=https://pdoom.net/contributors]Contributors[/url] program![/color][/center]"
+		"We collect only essential technical information. See [url=https://pdoom1.com/privacy]Privacy Policy[/url] for details." + \
+		"\n\nBy including your name, you may be recognized in our [url=https://pdoom1.com/contributors]Contributors[/url] program![/color][/center]"
 
 	# Initially disable attribution fields
 	name_input.editable = false


### PR DESCRIPTION
Decision **H** from the consistency audit (PR #543 review). Fixes drifted player-facing constants:

- **`godot/scripts/ui/bug_report_panel.gd`**: the in-panel privacy + contributors links pointed at `pdoom.net`; corrected to the canonical **`pdoom1.com`** (confirmed 2026-06).
- **`godot/data/patch_notes.json`**: the What's New entries claimed bug reporting via **F8** — but there's no `F8` input action in `project.godot`; the reporter actually opens on **`\` (backslash) or `N`** (`main_ui.gd:204`). Corrected.

## Notes
- These files live in `godot/` — the area your `feat/ui-player-experience` branch touches. Pip confirmed not mid-QA; kept edits minimal (link/string only) to keep any future merge trivial. Based on current `main` (`c4d289f`, incl. your #546 QA checklist).
- **Prevention (follow-up, not in this PR):** the root pattern is player-facing constants (keybind, domain, version) hardcoded in many places. Tracked for (a) a drift-linter that flags stale keybind/domain claims, and (b) centralizing these into a single constants source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)