### PR TITLE
feat(scoring): WS-A lexicographic turns-survived scoring (ADR-0002)

### DIFF
--- a/godot/scripts/core/baseline_simulator.gd
+++ b/godot/scripts/core/baseline_simulator.gd
@@ -62,7 +62,7 @@ static func set_precomputed_baseline(game_seed: String, baseline_data: Dictionar
 	_precomputed_baselines[game_seed] = baseline_data
 	_baseline_cache[game_seed] = baseline_data
 	_current_mode = Mode.PRECOMPUTED
-	print("[BaselineSimulator] Precomputed baseline set for seed %s: %d points" % [game_seed, baseline_data.get("score", 0)])
+	print("[BaselineSimulator] Precomputed baseline set for seed %s: Turn %d" % [game_seed, baseline_data.get("turns", 0)])
 
 static func start_background_simulation(game_seed: String):
 	"""
@@ -210,107 +210,62 @@ static func _run_baseline_simulation(game_seed: String) -> Dictionary:
 	var simulation_time = Time.get_ticks_msec() - simulation_start
 	print("[BaselineSimulator] Simulation complete: %d turns, %.2fs" % [state.turn, simulation_time / 1000.0])
 
-	# Calculate final score using same formula as game over screen
+	# ADR-0002: score is the (turns, doom_integral) tuple accrued in-engine during the
+	# sim — no separate formula. Engine is the sole scoring authority.
 	var final_state = state.to_dict()
-	var score = _calculate_score(final_state)
 
 	return {
-		"score": score,
-		"final_state": final_state,
 		"turns": state.turn,
+		"doom_integral": int(round(state.doom_integral)),
+		"final_state": final_state,
 		"victory": state.victory,
 		"doom": state.doom,
 		"simulation_time_ms": simulation_time
 	}
 
-static func _calculate_score(state: Dictionary) -> int:
+static func get_comparison_text(player_turns: int, player_integral: int, baseline_turns: int, baseline_integral: int) -> Dictionary:
 	"""
-	Calculate score using same formula as GameOverScreen.calculate_final_score()
-	Must stay in sync with that function!
+	Compare the player's (turns, doom_integral) score against the no-action baseline
+	using ADR-0002 lexicographic ordering (turns dominant, doom-integral tiebreak).
+	Returns: {text: String, color: Color, cmp: int}
 	"""
-	var score = 0
-
-	var doom = state.get("doom", 0.0)
-	var papers = state.get("papers", 0)
-	var turn = state.get("turn", 0)
-	var money = state.get("money", 0)
-
-	# Count total researchers (all types)
-	var researchers = 0
-	researchers += state.get("safety_researchers", 0)
-	researchers += state.get("capability_researchers", 0)
-	researchers += state.get("compute_engineers", 0)
-
-	# 1. Safety Achievement (40-50% of total score)
-	var safety_score = (100 - doom) * 1000
-	score += safety_score
-
-	# 2. Research Output (20-30% of total score)
-	var paper_score = papers * 5000
-	score += paper_score
-
-	# 3. Team Excellence (10-15% of total score)
-	var team_score = researchers * 2000
-	score += team_score
-
-	# 4. Survival Duration (10-15% of total score)
-	var survival_score = turn * 500
-	score += survival_score
-
-	# 5. Financial Success (5-10% of total score)
-	var financial_score = money * 0.1
-	score += financial_score
-
-	# 6. Victory Bonus (unlocks at doom < 20%)
-	if doom < 20.0:
-		score += 50000  # Victory bonus
-
-	return int(score)
-
-static func get_comparison_text(player_score: int, baseline_score: int) -> Dictionary:
-	"""
-	Generate comparison text for displaying player vs baseline performance.
-	Returns: {text: String, color: Color, percentage: float}
-	"""
-	if baseline_score <= 0:
+	if baseline_turns <= 0:
 		return {
 			"text": "No baseline available",
 			"color": Color.GRAY,
-			"percentage": 0.0
+			"cmp": 0
 		}
 
-	var difference = player_score - baseline_score
-	var percentage = (float(player_score) / float(baseline_score) - 1.0) * 100.0
+	var cmp = GameState.compare_score(player_turns, player_integral, baseline_turns, baseline_integral)
 
 	var text: String
 	var color: Color
 
-	if difference > 0:
-		if percentage >= 100:
-			text = "+%d points (%.0f%% better than baseline!)" % [difference, percentage]
+	if cmp > 0:
+		var turn_diff = player_turns - baseline_turns
+		if turn_diff > 0:
+			text = "%d turn%s longer than baseline!" % [turn_diff, "s" if turn_diff != 1 else ""]
 			color = Color(0.2, 1.0, 0.2)  # Bright green
-		elif percentage >= 50:
-			text = "+%d points (%.0f%% better)" % [difference, percentage]
-			color = Color(0.4, 1.0, 0.4)  # Green
 		else:
-			text = "+%d points (%.0f%% better)" % [difference, percentage]
+			# Same survival length, better stewardship (lower doom along the way)
+			text = "Same survival, +%d stewardship over baseline" % (player_integral - baseline_integral)
 			color = Color(0.6, 1.0, 0.6)  # Light green
-	elif difference < 0:
-		if percentage <= -50:
-			text = "%d points (%.0f%% below baseline)" % [difference, abs(percentage)]
+	elif cmp < 0:
+		var turn_diff = baseline_turns - player_turns
+		if turn_diff > 0:
+			text = "%d turn%s shorter than baseline" % [turn_diff, "s" if turn_diff != 1 else ""]
 			color = Color(1.0, 0.3, 0.3)  # Red
 		else:
-			text = "%d points (%.0f%% below baseline)" % [difference, abs(percentage)]
+			text = "Same survival, %d stewardship below baseline" % (baseline_integral - player_integral)
 			color = Color(1.0, 0.6, 0.4)  # Orange
 	else:
-		text = "Matched baseline exactly!"
+		text = "Matched baseline exactly"
 		color = Color(1.0, 1.0, 0.4)  # Yellow
 
 	return {
 		"text": text,
 		"color": color,
-		"percentage": percentage,
-		"difference": difference
+		"cmp": cmp
 	}
 
 ## ============================================================================

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -13,6 +13,9 @@ var papers: float = 0.0
 var reputation: float = 50.0
 var doom: float = 50.0  # 0-100, lose at 100
 var doom_history: Array[float] = []  # Per-turn doom snapshots for the trend graph (#512)
+# ADR-0002: area under the survival curve — sum of (100 - doom) over turns actually
+# survived. The lexicographic score tiebreaker ("doom-years averted"); accrues in-engine.
+var doom_integral: float = 0.0
 var action_points: int = 3
 var max_action_points: int = 3  # Per-turn AP cap; difficulty modifiers adjust this (game_manager._apply_difficulty_settings)
 var stationery: float = 100.0  # Office supplies, depletes with staff usage
@@ -161,6 +164,7 @@ func reset():
 	_populate_initial_candidates()
 
 	turn = 0
+	doom_integral = 0.0  # ADR-0002: reset the survival-curve accumulator
 	game_over = false
 	victory = false
 	queued_actions.clear()
@@ -684,6 +688,35 @@ func record_doom_history() -> void:
 	doom_history.append(doom)
 
 
+func accrue_survival_credit() -> void:
+	"""ADR-0002: credit this survived turn to the doom-integral score tiebreaker.
+	Call only for turns the player actually survived (game not over); a turn that
+	ended the game earns no stewardship credit."""
+	doom_integral += 100.0 - doom
+
+
+# --- Scoring (ADR-0002) --------------------------------------------------------
+# The engine is the sole scoring authority. Score is the tuple
+# (turns_survived, doom_integral), compared lexicographically: turns strictly
+# dominant, doom-integral as tiebreak. FLOWS ONLY — no stock the player holds at
+# death (money, papers, staff, reputation) may ever affect the score.
+static func score_tuple(state: Dictionary) -> Array:
+	return [int(state.get("turn", 0)), int(round(state.get("doom_integral", 0.0)))]
+
+
+static func compare_score(a_turns: int, a_integral: int, b_turns: int, b_integral: int) -> int:
+	"""Lexicographic compare. Returns 1 if A ranks above B, -1 if below, 0 if equal."""
+	if a_turns != b_turns:
+		return 1 if a_turns > b_turns else -1
+	if a_integral != b_integral:
+		return 1 if a_integral > b_integral else -1
+	return 0
+
+
+static func format_score(turns: int, integral: int) -> String:
+	return "Turn %d · %d" % [turns, integral]
+
+
 func to_dict() -> Dictionary:
 	"""Serialize state for UI"""
 	var rival_summaries = []
@@ -759,7 +792,8 @@ func to_dict() -> Dictionary:
 		"management_capacity": get_management_capacity(),
 		"unmanaged_count": get_unmanaged_count(),
 		"turn": turn,
-		"turn_display": get_turn_display(),
+		"doom_integral": doom_integral,
+			"turn_display": get_turn_display(),
 		"calendar": get_current_date(),
 		"game_over": game_over,
 		"victory": victory,
@@ -800,6 +834,7 @@ func from_dict(data: Dictionary) -> void:
 
 	# Game state
 	turn = data.get("turn", 0)
+	doom_integral = data.get("doom_integral", 0.0)
 	game_over = data.get("game_over", false)
 	victory = data.get("victory", false)
 	has_cat = data.get("has_cat", false)

--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -552,6 +552,11 @@ func execute_turn() -> Dictionary:
 	# Check win/lose
 	state.check_win_lose()
 
+	# ADR-0002: accrue this turn's survival credit into the doom-integral score
+	# tiebreaker. A turn that ended the game earns no stewardship credit.
+	if not state.game_over:
+		state.accrue_survival_credit()
+
 	if state.game_over:
 		if state.victory:
 			results.append({"success": true, "message": "VICTORY! p(doom) reached 0!"})

--- a/godot/scripts/leaderboard.gd
+++ b/godot/scripts/leaderboard.gd
@@ -7,17 +7,24 @@ class_name Leaderboard
 
 # Score entry data structure
 class ScoreEntry:
+	# ADR-0002: the score is the tuple (score, doom_integral) where `score` is
+	# turns-survived (primary, dominant metric) and `doom_integral` is the
+	# area-under-the-survival-curve tiebreak. `score` is named for back-compat with
+	# the UI, which already treats it as turns.
 	var score: int  # Turns survived (primary metric)
+	var doom_integral: int  # Doom-integral tiebreak (ADR-0002)
 	var player_name: String  # Lab name
 	var date: String  # ISO timestamp
-	var level_reached: int  # Final turn number
-	var game_mode: String  # e.g., "Bootstrap_v0.4.1"
+	var level_reached: int  # Final turn number (== score; kept for back-compat)
+	var game_mode: String  # Game version, e.g. "v0.11.0"
 	var duration_seconds: float  # Game duration
 	var entry_uuid: String  # Unique identifier
-	var baseline_score: int  # Baseline (no-action) score for comparison (Issue #372)
+	var baseline_score: int  # Baseline (no-action) turns survived for comparison (Issue #372)
+	var baseline_doom_integral: int  # Baseline doom-integral tiebreak
 
-	func _init(p_score: int, p_player_name: String, p_level: int, p_mode: String, p_duration: float, p_baseline: int = 0):
+	func _init(p_score: int, p_player_name: String, p_level: int, p_mode: String, p_duration: float, p_baseline: int = 0, p_doom_integral: int = 0, p_baseline_integral: int = 0):
 		score = p_score
+		doom_integral = p_doom_integral
 		player_name = p_player_name
 		date = Time.get_datetime_string_from_system()
 		level_reached = p_level
@@ -25,17 +32,20 @@ class ScoreEntry:
 		duration_seconds = p_duration
 		entry_uuid = generate_uuid()
 		baseline_score = p_baseline
+		baseline_doom_integral = p_baseline_integral
 
 	func to_dict() -> Dictionary:
 		return {
 			"score": score,
+			"doom_integral": doom_integral,
 			"player_name": player_name,
 			"date": date,
 			"level_reached": level_reached,
 			"game_mode": game_mode,
 			"duration_seconds": duration_seconds,
 			"entry_uuid": entry_uuid,
-			"baseline_score": baseline_score
+			"baseline_score": baseline_score,
+			"baseline_doom_integral": baseline_doom_integral
 		}
 
 	static func from_dict(data: Dictionary) -> ScoreEntry:
@@ -45,7 +55,9 @@ class ScoreEntry:
 			data.get("level_reached", 0),
 			data.get("game_mode", "Unknown"),
 			data.get("duration_seconds", 0.0),
-			data.get("baseline_score", 0)  # Issue #372
+			data.get("baseline_score", 0),  # Issue #372
+			data.get("doom_integral", 0),
+			data.get("baseline_doom_integral", 0)
 		)
 		entry.date = data.get("date", "")
 		entry.entry_uuid = data.get("entry_uuid", "")
@@ -65,12 +77,20 @@ var version: String = "1.0.0"
 var max_entries: int = 50
 var entries: Array[ScoreEntry] = []
 var game_seed: String = ""  # Renamed from 'seed' to avoid shadowing built-in function
+var game_version: String = ""  # ADR-0002 #5: boards are keyed by (seed, game_version)
 var leaderboard_dir: String = "user://leaderboards"
 var file_path: String = ""
 
-func _init(p_seed: String = "default"):
+func _init(p_seed: String = "default", p_version: String = ""):
 	game_seed = p_seed
-	file_path = "%s/leaderboard_%s.json" % [leaderboard_dir, game_seed]
+	game_version = p_version
+	# ADR-0002 #5: version-scope the board so balance patches rotate the meta and old
+	# scores never rank against the current game. Legacy callers (no version) keep the
+	# old per-seed filename. Delimiter is '__' to survive hyphens/underscores in seeds.
+	if game_version != "":
+		file_path = "%s/leaderboard_%s__%s.json" % [leaderboard_dir, game_seed, game_version]
+	else:
+		file_path = "%s/leaderboard_%s.json" % [leaderboard_dir, game_seed]
 	_ensure_directory_exists()
 	_load_leaderboard()
 
@@ -90,8 +110,8 @@ func add_score(entry: ScoreEntry) -> Dictionary:
 	# Add entry
 	entries.append(entry)
 
-	# Sort by score (highest first)
-	entries.sort_custom(func(a, b): return a.score > b.score)
+	# Sort lexicographically (ADR-0002): turns dominant, doom-integral tiebreak.
+	entries.sort_custom(func(a, b): return GameState.compare_score(a.score, a.doom_integral, b.score, b.doom_integral) > 0)
 
 	# Find rank (1-based)
 	var rank = 0
@@ -146,6 +166,7 @@ func _save_leaderboard():
 		"created": Time.get_datetime_string_from_system(),
 		"max_entries": max_entries,
 		"seed": game_seed,
+		"game_version": game_version,  # ADR-0002 #5
 		"entries": []
 	}
 

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -8,8 +8,10 @@ class_name GameOverScreen
 @onready var stats_label = $CenterContainer/PanelContainer/MarginContainer/VBox/StatsLabel
 
 var game_manager: Node
-var final_score: int = 0
-var baseline_score: int = 0
+var final_turns: int = 0
+var final_doom_integral: int = 0
+var baseline_turns: int = 0
+var baseline_doom_integral: int = 0
 var baseline_result: Dictionary = {}
 var leaderboard_entry_uuid: String = ""
 var game_start_time: float = 0.0
@@ -58,15 +60,19 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 		MusicManager.play_context(MusicManager.MusicContext.DEFEAT)
 
 
-	# Calculate final score
-	final_score = calculate_final_score(final_state)
-	print("[GameOverScreen] Final score: %d" % final_score)
+	# ADR-0002: the engine is the scoring authority — read the (turns, doom_integral)
+	# tuple straight off final_state; no formula here.
+	var st = GameState.score_tuple(final_state)
+	final_turns = st[0]
+	final_doom_integral = st[1]
+	print("[GameOverScreen] Final score: %s" % GameState.format_score(final_turns, final_doom_integral))
 
-	# Get baseline score for comparison (Issue #372)
+	# Get baseline (no-action) score for comparison (Issue #372)
 	var game_seed = GameConfig.get_display_seed()
 	baseline_result = BaselineSimulator.get_baseline_score(game_seed)
-	baseline_score = baseline_result.get("score", 0)
-	print("[GameOverScreen] Baseline score: %d" % baseline_score)
+	baseline_turns = int(baseline_result.get("turns", 0))
+	baseline_doom_integral = int(round(baseline_result.get("doom_integral", 0.0)))
+	print("[GameOverScreen] Baseline: %s" % GameState.format_score(baseline_turns, baseline_doom_integral))
 
 	# Stop verification tracking and get final hash
 	VerificationTracker.stop_tracking()
@@ -74,23 +80,26 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 
 	# Export verification data for submission (future leaderboard integration)
 	var verification_data = VerificationTracker.export_for_submission(final_state)
-	verification_data["score"] = final_score  # Include calculated score
+	verification_data["turns_survived"] = final_turns  # ADR-0002 score tuple
+	verification_data["doom_integral"] = final_doom_integral
 	print("[GameOverScreen] Game ended - Verification hash: %s..." % final_hash.substr(0, 16))
-	print("[GameOverScreen] Score: %d" % final_score)
+	print("[GameOverScreen] Score: %s" % GameState.format_score(final_turns, final_doom_integral))
 	print("[GameOverScreen] Full verification data ready for submission")
 
 
 	# Save score to leaderboard (game_seed already obtained for baseline)
-	var leaderboard = Leaderboard.new(game_seed)
+	var leaderboard = Leaderboard.new(game_seed, "v" + GameConfig.CURRENT_VERSION)
 	var duration = Time.get_ticks_msec() / 1000.0 - game_start_time
 
 	var entry = Leaderboard.ScoreEntry.new(
-		final_score,
+		final_turns,
 		GameConfig.lab_name,
 		final_state.get("turn", 0),
 		"v" + GameConfig.CURRENT_VERSION,  # Game version from GameConfig
 		duration,
-		baseline_score  # Baseline score for comparison (Issue #372)
+		baseline_turns,  # Baseline turns for comparison (Issue #372)
+		final_doom_integral,  # ADR-0002 tiebreak
+		baseline_doom_integral
 	)
 
 	var result = leaderboard.add_score(entry)
@@ -119,14 +128,14 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 
 	# Final Score (prominent display)
 	stats_text += "[center][color=gold]★ FINAL SCORE ★[/color][/center]\n"
-	stats_text += "[center][b][color=yellow]%d[/color][/b] points[/center]\n" % final_score
+	stats_text += "[center][b][color=yellow]%s[/color][/b][/center]\n" % GameState.format_score(final_turns, final_doom_integral)
 
 	# Baseline comparison (Issue #372)
-	if baseline_score > 0:
-		var comparison = BaselineSimulator.get_comparison_text(final_score, baseline_score)
+	if baseline_turns > 0:
+		var comparison = BaselineSimulator.get_comparison_text(final_turns, final_doom_integral, baseline_turns, baseline_doom_integral)
 		var comparison_color = comparison["color"].to_html(false)
 		stats_text += "[center][color=%s]%s[/color][/center]\n" % [comparison_color, comparison["text"]]
-		stats_text += "[center][color=gray](Baseline: %d points with no actions)[/color][/center]\n\n" % baseline_score
+		stats_text += "[center][color=gray](Baseline: %s with no actions)[/color][/center]\n\n" % GameState.format_score(baseline_turns, baseline_doom_integral)
 	else:
 		stats_text += "\n"
 
@@ -235,63 +244,6 @@ func _on_meta_clicked(meta):
 	"""Handle URL clicks in the stats label"""
 	print("[GameOverScreen] Opening URL: %s" % meta)
 	OS.shell_open(str(meta))
-
-func calculate_final_score(state: Dictionary) -> int:
-	"""
-	Calculate final score from game state.
-
-	CRITICAL: This formula must match the server-side calculation in
-	pdoom1-website/scripts/verification_logic.py exactly!
-
-	Components:
-	- Safety Achievement: (100 - doom) * 1000    [Max: 100,000]
-	- Research Output:    papers * 5000          [~5-10 papers = 25k-50k]
-	- Team Excellence:    researchers * 2000     [~5-10 researchers = 10k-20k]
-	- Survival Duration:  turn * 500             [50 turns = 25k]
-	- Financial Success:  money * 0.1            [125k money = 12.5k]
-	- Victory Bonus:      +50000 if doom < 20%   [50k bonus]
-
-	Typical Range: 50k-250k (good game), 300k+ (excellent)
-	"""
-	var score = 0
-
-	# Extract values with defaults
-	var doom = state.get("doom", 0.0)
-	var papers = state.get("papers", 0)
-	var turn = state.get("turn", 0)
-	var money = state.get("money", 0)
-
-	# Count total researchers (all types)
-	var researchers = 0
-	researchers += state.get("safety_researchers", 0)
-	researchers += state.get("capability_researchers", 0)
-	researchers += state.get("compute_engineers", 0)
-
-	# 1. Safety Achievement (40-50% of total score)
-	var safety_score = (100 - doom) * 1000
-	score += safety_score
-
-	# 2. Research Output (20-30% of total score)
-	var paper_score = papers * 5000
-	score += paper_score
-
-	# 3. Team Excellence (10-15% of total score)
-	var team_score = researchers * 2000
-	score += team_score
-
-	# 4. Survival Duration (10-15% of total score)
-	var survival_score = turn * 500
-	score += survival_score
-
-	# 5. Financial Success (5-10% of total score)
-	var financial_score = money * 0.1
-	score += financial_score
-
-	# 6. Victory Bonus (unlocks at doom < 20%)
-	if doom < 20.0:
-		score += 50000  # Victory bonus
-
-	return int(score)
 
 func _continue_to_leaderboard():
 	"""Navigate to leaderboard screen to show saved score"""

--- a/godot/scripts/ui/leaderboard_screen.gd
+++ b/godot/scripts/ui/leaderboard_screen.gd
@@ -47,12 +47,22 @@ func _load_all_leaderboards():
 
 	while file_name != "":
 		if file_name.ends_with(".json") and file_name.begins_with("leaderboard_"):
-			# Extract seed from filename: "leaderboard_SEED.json"
-			var lb_seed = file_name.substr(12, file_name.length() - 17)  # Remove "leaderboard_" and ".json"
+			# Parse "leaderboard_SEED.json" or the version-keyed
+			# "leaderboard_SEED__VERSION.json" (ADR-0002 #5). '__' delimiter survives
+			# hyphens/underscores in seeds.
+			var base_name = file_name.trim_prefix("leaderboard_").trim_suffix(".json")
+			var lb_seed = base_name
+			var lb_version = ""
+			if base_name.contains("__"):
+				var parts = base_name.rsplit("__", true, 1)
+				lb_seed = parts[0]
+				lb_version = parts[1]
 
-			# Load this leaderboard
-			var leaderboard = LeaderboardClass.new(lb_seed)
-			all_leaderboards[lb_seed] = leaderboard
+			# Reconstruct with the same (seed, version) so file_path matches on load.
+			var leaderboard = LeaderboardClass.new(lb_seed, lb_version)
+			# Key by full identity so same-seed/different-version boards don't collide.
+			var board_key = lb_seed if lb_version == "" else "%s (%s)" % [lb_seed, lb_version]
+			all_leaderboards[board_key] = leaderboard
 
 			# Add entries to combined list
 			for entry in leaderboard.entries:
@@ -61,15 +71,15 @@ func _load_all_leaderboards():
 			ErrorHandler.info(
 				ErrorHandler.Category.SAVE_LOAD,
 				"Loaded leaderboard",
-				{"seed": lb_seed, "entries": leaderboard.entries.size()}
+				{"seed": lb_seed, "version": lb_version, "entries": leaderboard.entries.size()}
 			)
 
 		file_name = dir.get_next()
 
 	dir.list_dir_end()
 
-	# Sort all entries by score (highest first)
-	all_entries.sort_custom(func(a, b): return a.score > b.score)
+	# Sort lexicographically (ADR-0002): turns dominant, doom-integral tiebreak.
+	all_entries.sort_custom(func(a, b): return GameState.compare_score(a.score, a.doom_integral, b.score, b.doom_integral) > 0)
 
 	ErrorHandler.info(
 		ErrorHandler.Category.SAVE_LOAD,

--- a/godot/tests/unit/test_scoring_formula.gd
+++ b/godot/tests/unit/test_scoring_formula.gd
@@ -1,279 +1,80 @@
-extends Node
-## Scoring Formula Test Suite
-## Verifies scoring calculation matches expected values from SCORING_SYSTEM_PROPOSAL.md
+extends GutTest
+## Scoring tests (ADR-0002): the score is the lexicographic tuple
+## (turns_survived, doom_integral) — turns strictly dominant, doom-integral tiebreak —
+## accrued in-engine, flows-only, with the engine as the sole scoring authority.
 ##
-## Usage:
-##   godot --headless --script tests/unit/test_scoring_formula.gd
+## This replaces the old composite-formula test. There is deliberately NO score formula
+## outside the engine to duplicate here.
 
-# Import the GameOverScreen to access calculate_final_score
-# Since we can't directly import, we'll duplicate the function here for testing
-# CRITICAL: This must match game_over_screen.gd exactly!
+func test_format_score_display():
+	assert_eq(GameState.format_score(14, 862), "Turn 14 · 862", "Display is 'Turn N · integral'")
 
-func calculate_final_score(state: Dictionary) -> int:
-	"""
-	Calculate final score from game state.
-	DUPLICATE of game_over_screen.gd for testing purposes.
-	"""
-	var score = 0
+func test_score_tuple_from_state():
+	var st = GameState.score_tuple({"turn": 14, "doom_integral": 862.4})
+	assert_eq(st[0], 14, "First element is turns survived")
+	assert_eq(st[1], 862, "Second element is the rounded doom-integral")
 
-	# Extract values with defaults
-	var doom = state.get("doom", 0.0)
-	var papers = state.get("papers", 0)
-	var turn = state.get("turn", 0)
-	var money = state.get("money", 0)
+func test_score_tuple_defaults_to_zero():
+	assert_eq(GameState.score_tuple({}), [0, 0], "Missing fields default to zero")
 
-	# Count total researchers (all types)
-	var researchers = 0
-	researchers += state.get("safety_researchers", 0)
-	researchers += state.get("capability_researchers", 0)
-	researchers += state.get("compute_engineers", 0)
+func test_lexicographic_turns_dominate():
+	# More turns beats fewer no matter how large the loser's tiebreak.
+	assert_true(GameState.compare_score(14, 0, 13, 999999) > 0, "14 turns beats 13 turns")
+	assert_true(GameState.compare_score(13, 999999, 14, 0) < 0, "13 turns loses to 14 turns")
 
-	# 1. Safety Achievement (40-50% of total score)
-	var safety_score = (100 - doom) * 1000
-	score += safety_score
+func test_lexicographic_integral_tiebreak():
+	# Equal turns -> higher doom-integral wins.
+	assert_true(GameState.compare_score(14, 900, 14, 800) > 0, "Higher integral wins the tie")
+	assert_true(GameState.compare_score(14, 800, 14, 900) < 0, "Lower integral loses the tie")
+	assert_eq(GameState.compare_score(14, 800, 14, 800), 0, "Identical tuples compare equal")
 
-	# 2. Research Output (20-30% of total score)
-	var paper_score = papers * 5000
-	score += paper_score
+func test_flows_only_score_ignores_stocks():
+	# ADR-0002 #3: no stock the player holds at death may affect the score. Two states
+	# with identical (turn, doom_integral) but wildly different money/papers/staff/
+	# reputation must score identically.
+	var lean = {"turn": 20, "doom_integral": 1200.0, "money": 0, "papers": 0,
+		"safety_researchers": 0, "capability_researchers": 0, "reputation": 0}
+	var hoard = {"turn": 20, "doom_integral": 1200.0, "money": 9999999, "papers": 99,
+		"safety_researchers": 50, "capability_researchers": 50, "reputation": 100}
+	assert_eq(GameState.score_tuple(lean), GameState.score_tuple(hoard),
+		"Stocks held at death must not change the score")
+	assert_eq(GameState.compare_score(20, 1200, 20, 1200), 0, "and they rank equal")
 
-	# 3. Team Excellence (10-15% of total score)
-	var team_score = researchers * 2000
-	score += team_score
+func test_accrue_survival_credit():
+	var state = GameState.new("accrual_seed")
+	state.doom = 40.0
+	state.accrue_survival_credit()
+	state.accrue_survival_credit()
+	assert_almost_eq(state.doom_integral, 120.0, 0.001, "Two survived turns at doom 40 -> 2*(100-40)")
 
-	# 4. Survival Duration (10-15% of total score)
-	var survival_score = turn * 500
-	score += survival_score
+func test_reset_clears_integral():
+	var state = GameState.new("reset_seed")
+	state.doom_integral = 555.0
+	state.reset()
+	assert_eq(state.doom_integral, 0.0, "reset() zeroes the survival-curve accumulator")
 
-	# 5. Financial Success (5-10% of total score)
-	var financial_score = money * 0.1
-	score += financial_score
+func test_to_dict_roundtrips_integral():
+	var state = GameState.new("roundtrip_seed")
+	state.doom_integral = 321.0
+	state.turn = 7
+	var d = state.to_dict()
+	assert_eq(d.get("doom_integral"), 321.0, "to_dict emits doom_integral")
+	assert_eq(GameState.score_tuple(d), [7, 321], "score_tuple reads it back")
 
-	# 6. Victory Bonus (unlocks at doom < 20%)
-	if doom < 20.0:
-		score += 50000  # Victory bonus
+func test_baseline_sim_is_deterministic():
+	# Same seed -> identical accrued (turns, doom_integral). Engine is the authority and
+	# a headless replay recomputes the score for free (ADR-0002 #4).
+	BaselineSimulator.clear_cache()
+	var r1 = BaselineSimulator.get_baseline_score("determinism_seed_A")
+	BaselineSimulator.clear_cache()
+	var r2 = BaselineSimulator.get_baseline_score("determinism_seed_A")
+	assert_eq(r1["turns"], r2["turns"], "Turns survived is deterministic for a seed")
+	assert_eq(r1["doom_integral"], r2["doom_integral"], "Doom-integral is deterministic for a seed")
 
-	return int(score)
-
-func _ready():
-	print("\n============================================================")
-	print("SCORING FORMULA TEST SUITE")
-	print("============================================================\n")
-
-	var tests_passed = 0
-	var tests_failed = 0
-
-	# Test Scenario 1: Safety-Focused Win
-	print("[TEST 1] Safety-Focused Win")
-	var state1 = {
-		"turn": 50,
-		"doom": 15.0,
-		"papers": 8,
-		"safety_researchers": 6,
-		"capability_researchers": 0,
-		"compute_engineers": 0,
-		"money": 150000
-	}
-	var expected1 = 227000
-	var actual1 = calculate_final_score(state1)
-
-	print("  Expected: %d" % expected1)
-	print("  Actual:   %d" % actual1)
-
-	if actual1 == expected1:
-		print("  ✅ PASS")
-		tests_passed += 1
-	else:
-		print("  ❌ FAIL (difference: %d)" % (actual1 - expected1))
-		tests_failed += 1
-	print("")
-
-	# Test Scenario 2: Long Survival (No Victory)
-	print("[TEST 2] Long Survival (No Victory)")
-	var state2 = {
-		"turn": 80,
-		"doom": 55.0,
-		"papers": 12,
-		"safety_researchers": 5,
-		"capability_researchers": 3,
-		"compute_engineers": 2,
-		"money": 80000
-	}
-	var expected2 = 173000
-	var actual2 = calculate_final_score(state2)
-
-	print("  Expected: %d" % expected2)
-	print("  Actual:   %d" % actual2)
-
-	if actual2 == expected2:
-		print("  ✅ PASS")
-		tests_passed += 1
-	else:
-		print("  ❌ FAIL (difference: %d)" % (actual2 - expected2))
-		tests_failed += 1
-	print("")
-
-	# Test Scenario 3: Early Loss (Typical)
-	print("[TEST 3] Early Loss (Typical)")
-	var state3 = {
-		"turn": 20,
-		"doom": 100.0,
-		"papers": 3,
-		"safety_researchers": 2,
-		"capability_researchers": 1,
-		"compute_engineers": 1,
-		"money": 50000
-	}
-	var expected3 = 38000
-	var actual3 = calculate_final_score(state3)
-
-	print("  Expected: %d" % expected3)
-	print("  Actual:   %d" % actual3)
-
-	if actual3 == expected3:
-		print("  ✅ PASS")
-		tests_passed += 1
-	else:
-		print("  ❌ FAIL (difference: %d)" % (actual3 - expected3))
-		tests_failed += 1
-	print("")
-
-	# Test Scenario 4: Capability Rush (Risky)
-	print("[TEST 4] Capability Rush (Risky)")
-	var state4 = {
-		"turn": 35,
-		"doom": 75.0,
-		"papers": 15,
-		"safety_researchers": 2,
-		"capability_researchers": 5,
-		"compute_engineers": 1,
-		"money": 200000
-	}
-	var expected4 = 153500
-	var actual4 = calculate_final_score(state4)
-
-	print("  Expected: %d" % expected4)
-	print("  Actual:   %d" % actual4)
-
-	if actual4 == expected4:
-		print("  ✅ PASS")
-		tests_passed += 1
-	else:
-		print("  ❌ FAIL (difference: %d)" % (actual4 - expected4))
-		tests_failed += 1
-	print("")
-
-	# Test Edge Case: Perfect Safety Win
-	print("[TEST 5] Perfect Safety Win (Edge Case)")
-	var state5 = {
-		"turn": 60,
-		"doom": 5.0,
-		"papers": 10,
-		"safety_researchers": 10,
-		"capability_researchers": 0,
-		"compute_engineers": 0,
-		"money": 200000
-	}
-	# Calculation:
-	# Safety: (100-5)*1000 = 95,000
-	# Papers: 10*5000 = 50,000
-	# Team: 10*2000 = 20,000
-	# Survival: 60*500 = 30,000
-	# Financial: 200000*0.1 = 20,000
-	# Victory: +50,000 (doom < 20)
-	# Total: 265,000
-	var expected5 = 265000
-	var actual5 = calculate_final_score(state5)
-
-	print("  Expected: %d" % expected5)
-	print("  Actual:   %d" % actual5)
-
-	if actual5 == expected5:
-		print("  ✅ PASS")
-		tests_passed += 1
-	else:
-		print("  ❌ FAIL (difference: %d)" % (actual5 - expected5))
-		tests_failed += 1
-	print("")
-
-	# Test Edge Case: Victory Threshold (19.9% doom)
-	print("[TEST 6] Victory Threshold Test (19.9% doom)")
-	var state6 = {
-		"turn": 30,
-		"doom": 19.9,
-		"papers": 5,
-		"safety_researchers": 3,
-		"capability_researchers": 0,
-		"compute_engineers": 0,
-		"money": 100000
-	}
-	# Calculation:
-	# Safety: (100-19.9)*1000 = 80,100
-	# Papers: 5*5000 = 25,000
-	# Team: 3*2000 = 6,000
-	# Survival: 30*500 = 15,000
-	# Financial: 100000*0.1 = 10,000
-	# Victory: +50,000 (doom < 20)
-	# Total: 186,100
-	var expected6 = 186100
-	var actual6 = calculate_final_score(state6)
-
-	print("  Expected: %d" % expected6)
-	print("  Actual:   %d" % actual6)
-
-	if actual6 == expected6:
-		print("  ✅ PASS")
-		tests_passed += 1
-	else:
-		print("  ❌ FAIL (difference: %d)" % (actual6 - expected6))
-		tests_failed += 1
-	print("")
-
-	# Test Edge Case: No Victory Threshold (20.1% doom)
-	print("[TEST 7] No Victory Threshold (20.1% doom)")
-	var state7 = {
-		"turn": 30,
-		"doom": 20.1,
-		"papers": 5,
-		"safety_researchers": 3,
-		"capability_researchers": 0,
-		"compute_engineers": 0,
-		"money": 100000
-	}
-	# Same as above BUT no victory bonus (doom >= 20)
-	# Total: 136,100 (without 50k bonus)
-	var expected7 = 136100
-	var actual7 = calculate_final_score(state7)
-
-	print("  Expected: %d" % expected7)
-	print("  Actual:   %d" % actual7)
-
-	if actual7 == expected7:
-		print("  ✅ PASS")
-		tests_passed += 1
-	else:
-		print("  ❌ FAIL (difference: %d)" % (actual7 - expected7))
-		tests_failed += 1
-	print("")
-
-	# Results Summary
-	print("============================================================")
-	print("TEST RESULTS")
-	print("============================================================")
-	print("Tests Passed: %d" % tests_passed)
-	print("Tests Failed: %d" % tests_failed)
-	print("")
-
-	if tests_failed == 0:
-		print("✅ ALL TESTS PASSED!")
-		print("\nScoring formula is working correctly and matches")
-		print("the expected values from SCORING_SYSTEM_PROPOSAL.md")
-	else:
-		print("❌ SOME TESTS FAILED!")
-		print("\nCheck the scoring formula in game_over_screen.gd")
-		print("to ensure it matches the specification.")
-
-	print("============================================================\n")
-
-	# Exit after test
-	await get_tree().create_timer(1.0).timeout
-	get_tree().quit()
+func test_baseline_sim_accrues_bounded_integral():
+	BaselineSimulator.clear_cache()
+	var r = BaselineSimulator.get_baseline_score("bounds_seed")
+	assert_true(r["turns"] > 0, "Baseline survives at least one turn")
+	assert_true(r["doom_integral"] >= 0, "Integral is non-negative")
+	# Each survived turn contributes at most 100 (doom >= 0), so integral <= turns*100.
+	assert_true(r["doom_integral"] <= r["turns"] * 100, "Integral is bounded by turns*100")

--- a/godot/tests/unit/test_scoring_formula.tscn
+++ b/godot/tests/unit/test_scoring_formula.tscn
@@ -1,6 +1,0 @@
-[gd_scene load_steps=2 format=3 uid="uid://scoring_formula_test"]
-
-[ext_resource type="Script" path="res://tests/unit/test_scoring_formula.gd" id="1"]
-
-[node name="ScoringFormulaTest" type="Node"]
-script = ExtResource("1")


### PR DESCRIPTION
Implements **WS-A (Scoring rewire)** from `docs/game-design/IMPLEMENTATION_KICKOFF.md`, per **ADR-0002**. First lane off Fable workshop #1.

## What changed
The composite score formula (`(100-doom)*1000 + papers*5000 + researchers*2000 + turn*500 + money*0.1 + 50k victory bonus`) is **deleted** and replaced with the engine-authoritative tuple **`(turns_survived, doom_integral)`**, compared lexicographically — turns strictly dominant, doom-integral (area under the survival curve) as tiebreak. Display: **`Turn 14 · 862`**.

- **Engine = sole scoring authority.** `GameState` gains `doom_integral`, accrued `+= 100 - doom` per *survived* turn in `turn_manager.execute_turn()` (after `check_win_lose`; a turn that ends the game earns no credit). One place holds the "formula": `GameState.score_tuple/compare_score/format_score` (static).
- **Duplicates removed.** `GameOverScreen.calculate_final_score` and `BaselineSimulator._calculate_score` deleted; `baseline_simulator` returns the accrued `{turns, doom_integral}` (score recomputed for free on replay). The test's inline formula copy is gone too.
- **Flows only (ADR-0002 #3).** Score can't value any stock held at death — money/papers/staff/reputation. Enforced by construction + a test.
- **No victory *bonus*.** The +50k is gone. (The victory *condition* is a separate mechanics change — **parked**, see below.)
- **Boards keyed by `(seed, game_version)` (ADR-0002 #5).** `Leaderboard._init(seed, version)` → `leaderboard_{seed}__{version}.json`; `leaderboard_screen` parses the version-keyed filename (legacy per-seed files still load).
- **`ScoreEntry.score` now canonically means turns-survived** (which the leaderboard/end-game UI already assumed — `game_over_screen` had been feeding the composite in, a latent bug this fixes), plus a new `doom_integral` tiebreak field. New fields are optional trailing constructor params, so the legacy `game_controller` 5-arg call is unaffected.
- **Test rewritten as a real GUT suite.** The old `test_scoring_formula.gd` was `extends Node`/`_ready` — a standalone script *outside* the GUT gate. Now `extends GutTest` with accrual, lexicographic-order, flows-only, and determinism tests. Dead `test_scoring_formula.tscn` removed.

## Definition of done
- [x] No score formula outside engine core — grep confirms `calculate_final_score`/`_calculate_score`/`final_score`/victory-bonus all gone; only `GameState` holds `score_tuple/compare_score/format_score`.
- [x] No stock affects score — `(turns, doom_integral)` are both flows; `test_flows_only_score_ignores_stocks` passes.
- [x] GUT passes headless — full unit suite `run_godot_tests.py --quick` exits 0; scoring file **11/11 tests, 20 asserts** green.
- [x] Boards keyed by `(seed, game_version)`.
- [x] Determinism — same seed → identical `(turns, doom_integral)` (`test_baseline_sim_is_deterministic`).

## Follow-up (NOT in this PR — cross-repo)
- `pdoom1-website/scripts/verification_logic.py` still holds the old composite formula. Per ADR-0002 #4 it is **deleted, not synced** — separate repo/PR. The in-game submission payload now carries `turns_survived` + `doom_integral` instead of `score` (WS-B replay artifact will formalize the submission format).

## Questions for the next design workshop (parked — not freelanced)
1. **Victory condition.** ADR-0002 says "there is no victory condition," but `check_win_lose()` still ends the game with `victory=true` at doom ≤ 0, and `test_game_state.gd` asserts that behavior. Removing it is a *mechanics* change that interacts with the **mortality guarantee (WS-1 ledger interest)** — without that guarantee, a doom-pinned-at-0 run could become immortal, which ADR-0002 itself warns against. I removed the victory *bonus from scoring* only and left the condition intact. **Should the doom≤0 victory branch be removed, and must WS-1 land first?**
2. **Baseline yardstick.** The "vs no-action baseline" comparison now compares tuples. Is the no-action baseline still the right reference under turns-survived scoring, or does it want rethinking?
3. **Leaderboard browser, cross-version.** Version-keyed boards now display as separate `seed (version)` entries in the browser. Desired UX, or should it aggregate/filter by version explicitly?
4. **Legacy `game_controller`/`end_game_screen` path.** Still constructs `ScoreEntry` with `doom_integral` defaulting to 0 (no accrual wired) and an unversioned board. Appears superseded by the `game_manager`/`game_over_screen`/`main_ui` path. Remove it, or wire it to the new scoring? (Left alone — out of WS-A scope, low risk.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
