### PR TITLE
feat(replay): WS-B canonical input-string replay artifact (ADR-0006)

### DIFF
--- a/godot/autoload/verification_tracker.gd
+++ b/godot/autoload/verification_tracker.gd
@@ -42,6 +42,12 @@ var game_version: String = ""
 # Debug mode (enables verbose logging)
 var debug_mode: bool = false
 
+# Ordered replayable input sequence (ADR-0006: the input string is the canonical run
+# artifact — anti-cheat, share format, and bug-repro in one). The hash chain above is
+# demoted to a cheap fingerprint; only re-simulating this log proves a run is legal.
+# Entries: {"t": turn, "k": "a", "id": action_id} | {"t": turn, "k": "r", "ev": event_id, "ch": choice_id}
+var replay_log: Array = []
+
 
 func start_tracking(seed: String, version: String = "unknown"):
 	"""
@@ -54,6 +60,7 @@ func start_tracking(seed: String, version: String = "unknown"):
 	game_seed = seed
 	game_version = version
 	tracking_enabled = true
+	replay_log.clear()
 
 	# Initialize from seed
 	verification_hash = seed.sha256_text()
@@ -96,6 +103,9 @@ func record_action(action_id: String, state: GameState):
 	var data = "%s|action:%s|%s" % [verification_hash, action_id, snapshot]
 	verification_hash = data.sha256_text()
 
+	# Canonical replay artifact: append the player input in execution order.
+	replay_log.append({"t": state.turn, "k": "a", "id": action_id})
+
 	if debug_mode:
 		print("[VerificationTracker] Action: %s → %s..." % [action_id, verification_hash.substr(0, 16)])
 
@@ -133,6 +143,9 @@ func record_event_response(event_id: String, response_id: String, turn: int):
 
 	var data = "%s|response:%s->%s|t%d" % [verification_hash, event_id, response_id, turn]
 	verification_hash = data.sha256_text()
+
+	# Canonical replay artifact: event responses are player inputs too.
+	replay_log.append({"t": turn, "k": "r", "ev": event_id, "ch": response_id})
 
 	if debug_mode:
 		print("[VerificationTracker] Response: %s → %s → %s..." % [event_id, response_id, verification_hash.substr(0, 16)])
@@ -216,6 +229,55 @@ func is_tracking() -> bool:
 	return tracking_enabled
 
 
+func get_replay() -> Dictionary:
+	"""
+	The canonical run artifact: seed + version + ordered input log (ADR-0006).
+	This is what a verifier re-simulates; the hash is only a cheap fingerprint.
+	"""
+	return {
+		"format": "pdoom1-replay-v1",
+		"seed": game_seed,
+		"version": game_version,
+		"log": replay_log.duplicate(true)
+	}
+
+
+func serialize_replay() -> String:
+	"""Serialize the replay artifact to shareable, forum-postable text (the 'PGN')."""
+	return JSON.stringify(get_replay())
+
+
+static func deserialize_replay(text: String) -> Dictionary:
+	"""Parse a serialized replay artifact. Returns {} on malformed input."""
+	var json = JSON.new()
+	if json.parse(text) != OK:
+		return {}
+	var data = json.data
+	if typeof(data) != TYPE_DICTIONARY:
+		return {}
+	return data
+
+
+func snapshot() -> Dictionary:
+	"""Capture tracker state so a headless replay can run without disturbing a live game."""
+	return {
+		"tracking_enabled": tracking_enabled,
+		"verification_hash": verification_hash,
+		"game_seed": game_seed,
+		"game_version": game_version,
+		"replay_log": replay_log.duplicate(true)
+	}
+
+
+func restore(snap: Dictionary) -> void:
+	"""Restore tracker state captured by snapshot()."""
+	tracking_enabled = snap.get("tracking_enabled", false)
+	verification_hash = snap.get("verification_hash", "")
+	game_seed = snap.get("game_seed", "")
+	game_version = snap.get("game_version", "")
+	replay_log = (snap.get("replay_log", []) as Array).duplicate(true)
+
+
 func _create_state_snapshot(state: GameState) -> String:
 	"""
 	Create deterministic snapshot of game state.
@@ -279,6 +341,7 @@ func export_for_submission(final_state: Dictionary) -> Dictionary:
 		"seed": game_seed,
 		"game_version": game_version,
 		"final_state": final_state,
+		"replay": serialize_replay(),  # ADR-0006: canonical artifact travels with the submission
 		"timestamp": Time.get_unix_time_from_system()
 	}
 

--- a/godot/scripts/core/actions.gd
+++ b/godot/scripts/core/actions.gd
@@ -956,6 +956,10 @@ static func submit_paper_to_conference(state: GameState, conf_id: String, topic:
 
 	# Create paper submission
 	var paper = PaperSubmissions.PaperSubmission.new()
+	# Deterministic id (turn + submission ordinal). The PaperSubmission default id is
+	# wall-clock based, which was leaking into the verification hash label below and
+	# breaking replay reproducibility (ADR-0006); derive it from deterministic state.
+	paper.id = "paper_%d_%d" % [state.turn, state.paper_submissions.size()]
 	paper.target_conference_id = conf_id
 	paper.topic = topic
 	paper.research_invested = research_amount

--- a/godot/scripts/core/replay_simulator.gd
+++ b/godot/scripts/core/replay_simulator.gd
@@ -1,0 +1,108 @@
+extends RefCounted
+class_name ReplaySimulator
+## Re-simulates a game from its canonical input-string artifact (ADR-0006) and checks it
+## reproduces the same final hash and (turns, doom_integral) score.
+##
+## Why re-simulation and not just the hash chain: a hash chain only proves a transcript
+## is internally self-consistent. It does NOT prove the transcript describes a *legal*
+## game. Only replaying the inputs through the real engine does. The input string is
+## therefore the canonical artifact — anti-cheat, share format, and bug-repro in one.
+
+# Mirror of BaselineSimulator.MAX_TURNS — bound runaway/immortal runs.
+const MAX_TURNS: int = 200
+
+
+static func replay(replay_data: Dictionary) -> Dictionary:
+	"""
+	Re-drive a recorded run from its artifact. Returns:
+	  {turns:int, doom_integral:int, hash:String, final_state:Dictionary, replayed:bool}
+
+	Side-effect-free: snapshots and restores the global VerificationTracker so a live
+	game in progress (e.g. computing a comparison at game-over) is left untouched.
+	"""
+	var run_seed: String = str(replay_data.get("seed", ""))
+	var run_version: String = str(replay_data.get("version", "unknown"))
+	var input_log: Array = replay_data.get("log", [])
+
+	# Group inputs by the turn they were recorded under. start_turn() increments turn
+	# first, so a round's event-responses and actions share that post-increment value.
+	var actions_by_turn: Dictionary = {}    # turn -> [action_id, ...] (execution order)
+	var responses_by_turn: Dictionary = {}  # turn -> {event_id: choice_id}
+	for entry in input_log:
+		var t: int = int(entry.get("t", 0))
+		match str(entry.get("k", "")):
+			"a":
+				if not actions_by_turn.has(t):
+					actions_by_turn[t] = []
+				actions_by_turn[t].append(str(entry.get("id", "")))
+			"r":
+				if not responses_by_turn.has(t):
+					responses_by_turn[t] = {}
+				responses_by_turn[t][str(entry.get("ev", ""))] = str(entry.get("ch", ""))
+
+	# Isolate the global tracker for the duration of the replay.
+	var snap: Dictionary = VerificationTracker.snapshot()
+
+	var state: GameState = GameState.new(run_seed)
+	var turn_manager: TurnManager = TurnManager.new(state)
+	VerificationTracker.start_tracking(run_seed, run_version)
+
+	while not state.game_over and state.turn < MAX_TURNS:
+		turn_manager.start_turn()
+		var t: int = state.turn
+
+		# Resolve triggered events with the recorded choices (fall back to first choice
+		# if the artifact is missing one — keeps replay total rather than crashing).
+		var guard: int = 0
+		while state.pending_events.size() > 0 and guard < 128:
+			guard += 1
+			var event: Dictionary = state.pending_events[0]
+			var event_id: String = str(event.get("id", ""))
+			var choices: Array = event.get("choices", [])
+			if choices.size() > 0:
+				var recorded: Dictionary = responses_by_turn.get(t, {})
+				var choice_id: String
+				if recorded.has(event_id):
+					choice_id = str(recorded[event_id])
+				elif typeof(choices[0]) == TYPE_DICTIONARY:
+					choice_id = str(choices[0].get("id", ""))
+				else:
+					choice_id = str(choices[0])
+				turn_manager.resolve_event(event, choice_id)
+			else:
+				state.pending_events.remove_at(0)
+
+		# Queue the recorded actions for this turn, in order.
+		state.queued_actions.clear()
+		for action_id in actions_by_turn.get(t, []):
+			state.queued_actions.append(action_id)
+		turn_manager.execute_turn()
+
+	var final_state: Dictionary = state.to_dict()
+	var score: Array = GameState.score_tuple(final_state)
+	var result: Dictionary = {
+		"turns": score[0],
+		"doom_integral": score[1],
+		"hash": VerificationTracker.get_final_hash(),
+		"final_state": final_state,
+		"replayed": true
+	}
+
+	# Restore the caller's tracker exactly as it was before this replay.
+	VerificationTracker.restore(snap)
+	return result
+
+
+static func verify(replay_data: Dictionary, claimed_turns: int, claimed_integral: int) -> bool:
+	"""
+	True only if re-simulating the artifact reproduces the claimed SCORE (turns, integral).
+	This is the sound anti-cheat property: you cannot claim a score higher than your
+	input sequence actually produces.
+
+	NOTE: the verification *hash* is deliberately NOT compared. It is currently
+	non-deterministic run-to-run (see the WS-B PR / determinism finding), so comparing it
+	would reject legitimate runs. Once the engine is made deterministic, the hash can be
+	re-added here as a cheap fast-path fingerprint (ADR-0006 two-tier verification).
+	"""
+	var r: Dictionary = replay(replay_data)
+	return r["turns"] == claimed_turns and r["doom_integral"] == claimed_integral

--- a/godot/scripts/core/replay_simulator.gd
+++ b/godot/scripts/core/replay_simulator.gd
@@ -93,16 +93,20 @@ static func replay(replay_data: Dictionary) -> Dictionary:
 	return result
 
 
-static func verify(replay_data: Dictionary, claimed_turns: int, claimed_integral: int) -> bool:
+static func verify(replay_data: Dictionary, claimed_turns: int, claimed_integral: int, claimed_hash: String = "") -> bool:
 	"""
-	True only if re-simulating the artifact reproduces the claimed SCORE (turns, integral).
-	This is the sound anti-cheat property: you cannot claim a score higher than your
-	input sequence actually produces.
+	True only if re-simulating the artifact reproduces the claimed SCORE (turns, integral),
+	and — when a claimed_hash is supplied — the claimed verification hash.
 
-	NOTE: the verification *hash* is deliberately NOT compared. It is currently
-	non-deterministic run-to-run (see the WS-B PR / determinism finding), so comparing it
-	would reject legitimate runs. Once the engine is made deterministic, the hash can be
-	re-added here as a cheap fast-path fingerprint (ADR-0006 two-tier verification).
+	The score check is the sound anti-cheat property: you cannot claim a score higher than
+	your input sequence actually produces. The hash is the cheap fast-path fingerprint tier
+	(ADR-0006): now that the engine is deterministic (WS-0), an identical seed+input replay
+	reproduces an identical hash, so a mismatch means the artifact was tampered or the claim
+	forged. Passing "" for claimed_hash skips the fingerprint tier (score-only check).
 	"""
 	var r: Dictionary = replay(replay_data)
-	return r["turns"] == claimed_turns and r["doom_integral"] == claimed_integral
+	if r["turns"] != claimed_turns or r["doom_integral"] != claimed_integral:
+		return false
+	if claimed_hash != "" and str(r["hash"]) != claimed_hash:
+		return false
+	return true

--- a/godot/scripts/core/replay_simulator.gd.uid
+++ b/godot/scripts/core/replay_simulator.gd.uid
@@ -1,0 +1,1 @@
+uid://d028dvon25ip

--- a/godot/tests/unit/test_replay_verification.gd
+++ b/godot/tests/unit/test_replay_verification.gd
@@ -4,11 +4,10 @@ extends GutTest
 ## (turn_manager.execute_turn); these tests exercise that wiring plus the new serialize /
 ## replay / verify path.
 ##
-## SCOPE NOTE: verification is on the SCORE (turns, doom_integral) — the sound anti-cheat
-## property. The verification HASH is NOT asserted here: it is currently non-deterministic
-## run-to-run because of a pre-existing engine bug (rivals/money/candidates diverge for
-## identical seed+inputs). See the WS-B PR body — WS-B is blocked on a determinism fix
-## before the hash-fingerprint tier of ADR-0006 can be trusted.
+## VERIFICATION TIERS (ADR-0006): the SCORE (turns, doom_integral) is the sound anti-cheat
+## property — you cannot claim a score your inputs do not produce. The verification HASH is
+## the cheap fingerprint tier, now asserted too: the engine determinism fix (WS-0) means an
+## identical seed+input replay reproduces an identical hash, so a mismatch = tamper/forgery.
 
 # Drive a real game headless with a per-turn action script, recording via the live
 # VerificationTracker wiring. Returns the exported artifact + the run's score.
@@ -41,7 +40,8 @@ func _play_scripted(seed: String, script: Dictionary, max_turns: int = 40) -> Di
 		"replay": VerificationTracker.serialize_replay(),
 		"export": VerificationTracker.export_for_submission(fs),
 		"turns": sc[0],
-		"integral": sc[1]
+		"integral": sc[1],
+		"hash": VerificationTracker.get_final_hash()
 	}
 	VerificationTracker.stop_tracking()
 	return out
@@ -76,6 +76,7 @@ func test_replay_reproduces_score():
 	var r: Dictionary = ReplaySimulator.replay(data)
 	assert_eq(r["turns"], run["turns"], "replay reproduces turns survived")
 	assert_eq(r["doom_integral"], run["integral"], "replay reproduces the doom-integral score")
+	assert_eq(r["hash"], run["hash"], "replay reproduces the verification hash (deterministic engine, WS-0)")
 
 
 func test_replay_is_deterministic():
@@ -99,6 +100,11 @@ func test_verify_accepts_true_score_and_rejects_inflated_claim():
 		"a claim of more turns than the inputs produce is rejected")
 	assert_false(ReplaySimulator.verify(data, run["turns"], run["integral"] + 10000),
 		"a claim of a higher doom-integral than the inputs produce is rejected")
+	# Fingerprint tier (ADR-0006), now that WS-0 made the engine deterministic:
+	assert_true(ReplaySimulator.verify(data, run["turns"], run["integral"], run["hash"]),
+		"an artifact verifies against the score AND hash it actually produces")
+	assert_false(ReplaySimulator.verify(data, run["turns"], run["integral"], "deadbeef_not_the_real_hash"),
+		"a forged verification hash is rejected even when the score matches")
 
 
 func test_malformed_artifact_deserializes_to_empty():

--- a/godot/tests/unit/test_replay_verification.gd
+++ b/godot/tests/unit/test_replay_verification.gd
@@ -1,0 +1,125 @@
+extends GutTest
+## Replay artifact tests (ADR-0006, WS-B): the ordered input string is the canonical run
+## artifact. record_action was already wired into the live pipeline
+## (turn_manager.execute_turn); these tests exercise that wiring plus the new serialize /
+## replay / verify path.
+##
+## SCOPE NOTE: verification is on the SCORE (turns, doom_integral) — the sound anti-cheat
+## property. The verification HASH is NOT asserted here: it is currently non-deterministic
+## run-to-run because of a pre-existing engine bug (rivals/money/candidates diverge for
+## identical seed+inputs). See the WS-B PR body — WS-B is blocked on a determinism fix
+## before the hash-fingerprint tier of ADR-0006 can be trusted.
+
+# Drive a real game headless with a per-turn action script, recording via the live
+# VerificationTracker wiring. Returns the exported artifact + the run's score.
+func _play_scripted(seed: String, script: Dictionary, max_turns: int = 40) -> Dictionary:
+	var state: GameState = GameState.new(seed)
+	var tm: TurnManager = TurnManager.new(state)
+	VerificationTracker.start_tracking(seed, "test-vB")
+
+	while not state.game_over and state.turn < max_turns:
+		tm.start_turn()
+		var t: int = state.turn
+		var guard: int = 0
+		while state.pending_events.size() > 0 and guard < 128:
+			guard += 1
+			var event: Dictionary = state.pending_events[0]
+			var choices: Array = event.get("choices", [])
+			if choices.size() > 0:
+				var choice_id: String = str(choices[0].get("id", "")) if typeof(choices[0]) == TYPE_DICTIONARY else str(choices[0])
+				tm.resolve_event(event, choice_id)
+			else:
+				state.pending_events.remove_at(0)
+		state.queued_actions.clear()
+		for action_id in script.get(t, []):
+			state.queued_actions.append(action_id)
+		tm.execute_turn()
+
+	var fs: Dictionary = state.to_dict()
+	var sc: Array = GameState.score_tuple(fs)
+	var out: Dictionary = {
+		"replay": VerificationTracker.serialize_replay(),
+		"export": VerificationTracker.export_for_submission(fs),
+		"turns": sc[0],
+		"integral": sc[1]
+	}
+	VerificationTracker.stop_tracking()
+	return out
+
+
+func test_live_pipeline_records_inputs_into_log():
+	# The queued action must show up in the artifact — proof record_action is wired live.
+	var run: Dictionary = _play_scripted("replay_seed_W", {1: ["buy_compute"]})
+	var data: Dictionary = VerificationTracker.deserialize_replay(run["replay"])
+	var found: bool = false
+	for entry in data.get("log", []):
+		if str(entry.get("k", "")) == "a" and str(entry.get("id", "")) == "buy_compute":
+			found = true
+	assert_true(found, "the live turn pipeline recorded the queued action into the replay log")
+
+
+func test_export_carries_replay_artifact():
+	var run: Dictionary = _play_scripted("replay_seed_E", {1: ["fundraise_small"]})
+	assert_true(run["export"].has("replay"), "game-over export carries the replay artifact")
+	var data: Dictionary = VerificationTracker.deserialize_replay(run["export"]["replay"])
+	assert_eq(data.get("seed", ""), "replay_seed_E", "artifact records its seed")
+	assert_eq(data.get("format", ""), "pdoom1-replay-v1", "artifact is tagged with its format version")
+	assert_true((data.get("log", []) as Array).size() > 0, "artifact records a non-empty input log")
+
+
+func test_replay_reproduces_score():
+	# Re-simulating the recorded input sequence reproduces the run's score.
+	var run: Dictionary = _play_scripted("replay_seed_A", {1: ["fundraise_small"], 2: ["buy_compute"], 3: ["publish_paper"]})
+	var data: Dictionary = VerificationTracker.deserialize_replay(run["replay"])
+	assert_false(data.is_empty(), "artifact deserializes")
+
+	var r: Dictionary = ReplaySimulator.replay(data)
+	assert_eq(r["turns"], run["turns"], "replay reproduces turns survived")
+	assert_eq(r["doom_integral"], run["integral"], "replay reproduces the doom-integral score")
+
+
+func test_replay_is_deterministic():
+	# Replaying the SAME artifact twice yields the same result (the harness itself is stable).
+	var run: Dictionary = _play_scripted("replay_seed_D", {1: ["buy_compute"], 2: ["fundraise_small"]})
+	var data: Dictionary = VerificationTracker.deserialize_replay(run["replay"])
+	var r1: Dictionary = ReplaySimulator.replay(data)
+	var r2: Dictionary = ReplaySimulator.replay(data)
+	assert_eq(r1["turns"], r2["turns"], "same artifact replays to same turns")
+	assert_eq(r1["doom_integral"], r2["doom_integral"], "same artifact replays to same integral")
+	assert_eq(r1["hash"], r2["hash"], "same artifact replays to same hash (replay path is internally stable)")
+
+
+func test_verify_accepts_true_score_and_rejects_inflated_claim():
+	# The sound anti-cheat property: you cannot claim a score your inputs do not produce.
+	var run: Dictionary = _play_scripted("replay_seed_V", {1: ["fundraise_small"], 2: ["buy_compute"]})
+	var data: Dictionary = VerificationTracker.deserialize_replay(run["replay"])
+	assert_true(ReplaySimulator.verify(data, run["turns"], run["integral"]),
+		"an artifact verifies against the score it actually produces")
+	assert_false(ReplaySimulator.verify(data, run["turns"] + 5, run["integral"]),
+		"a claim of more turns than the inputs produce is rejected")
+	assert_false(ReplaySimulator.verify(data, run["turns"], run["integral"] + 10000),
+		"a claim of a higher doom-integral than the inputs produce is rejected")
+
+
+func test_malformed_artifact_deserializes_to_empty():
+	assert_true(VerificationTracker.deserialize_replay("not json {{{").is_empty(),
+		"malformed replay text yields an empty dict, not a crash")
+	assert_true(VerificationTracker.deserialize_replay("[1,2,3]").is_empty(),
+		"a non-object JSON payload is rejected")
+
+
+func test_replay_does_not_disturb_live_tracker():
+	# A live game is mid-flight; replaying a different run must leave the live hash intact.
+	VerificationTracker.start_tracking("live_seed", "test-vB")
+	VerificationTracker.record_action("buy_compute", GameState.new("live_seed"))
+	var live_hash: String = VerificationTracker.get_final_hash()
+	var live_log_size: int = VerificationTracker.replay_log.size()
+
+	var other: Dictionary = _play_scripted("other_seed", {1: ["fundraise_small"]})
+	VerificationTracker.start_tracking("live_seed", "test-vB")  # restore the live context
+	VerificationTracker.record_action("buy_compute", GameState.new("live_seed"))
+
+	ReplaySimulator.replay(VerificationTracker.deserialize_replay(other["replay"]))
+	assert_eq(VerificationTracker.get_final_hash(), live_hash, "replay restored the live hash")
+	assert_eq(VerificationTracker.replay_log.size(), live_log_size, "replay restored the live input log")
+	VerificationTracker.stop_tracking()

--- a/godot/tests/unit/test_replay_verification.gd.uid
+++ b/godot/tests/unit/test_replay_verification.gd.uid
@@ -1,0 +1,1 @@
+uid://cibgverr7x0t2


### PR DESCRIPTION
> **Draft / do not merge.** The replay machinery is built and tested, but building it surfaced a **foundational engine non-determinism bug** that blocks sound completion of WS-B. Opened as a draft to preserve the work and put the finding in front of a design decision.

## What this builds (ADR-0006)

The input-string replay is the canonical run artifact — anti-cheat, share format ("PGN"), and bug-repro in one. A hash chain only proves a transcript is self-consistent; only re-simulating the inputs proves the transcript describes a *legal* game.

- **`verification_tracker.gd`** — accumulates the ordered `replay_log` (player actions + event responses) alongside the existing hash; `serialize_replay`/`deserialize_replay`, `snapshot`/`restore`, and the artifact now travels in `export_for_submission`.
- **`replay_simulator.gd` (new)** — re-drives a fresh game from an artifact, isolated from any live tracker (snapshot/restore), and `verify()`s a claimed **score**.
- **`actions.gd`** — conference paper submissions now get a deterministic id (was `"paper_%d" % Time.get_ticks_msec()`, which leaked wall-clock into a verification-hash label).

Note: the kickoff said `record_action` was "tests-only" — **stale**. It was already wired into `turn_manager.execute_turn` (`:363`). The gap was the ordered-input artifact + re-simulator, which this adds.

## 🚩 The blocker (headline)

**The engine is non-deterministic run-to-run.** Two runs with *identical seed and inputs* produce divergent state:

```
STATE DIFFS: money 253173 vs 254086
             rival_labs DeepSafety $175k/135rep vs $305k/140rep   <-- large
             candidate_pool differs
```

Doom/turns/integral matched in tested seeds (so the *score* reproduced), but that is **not guaranteed** — rivals feed doom, so score determinism is coincidental, not structural.

- Rivals start deterministic (hardcoded funding) and use the seeded `state.rng`, yet diverge → `state.rng` is being consumed in a different order between runs.
- The only non-seeded consumer I found in the gameplay path is `Researcher._init` (process-global `randi()` for skill/loyalty/name), whose state carries over between in-process runs. It's *usually* overwritten by `generate_random(state.rng)`, so I could not pin the exact surviving path in the budget I gave it.
- The **old `test_verification_determinism.gd` gave false confidence** — it uses a simplified harness that skips `start_turn`/events/rivals, so it never exercised the divergent path.

This undercuts more than WS-B: ADR-0002's "headless replay recomputes the score for free", ADR-0005's seed-vetting envelope, and ADR-0006's hash-fingerprint tier all assume determinism.

## Consequence for this PR

`verify()` is **score-only** (the sound anti-cheat property: you can't claim a score your inputs don't produce). The hash is **not** asserted anywhere — comparing a non-deterministic hash would reject legitimate runs. Tests assert only robustly-true properties (artifact plumbing, replay-vs-replay stability, score reproduction, inflated-claim rejection, live-tracker isolation). `run_godot_tests.py --quick` is green (replay suite 7/7, 18 asserts; nothing else regressed).

## Recommended follow-up (a determinism-hardening lane, before trusting verification)

1. Thread `state.rng` through **all** researcher creation (or make `Researcher._init` use fixed, non-global defaults) — **design call: should per-seed starting-staff variety be deterministic?** (parked for Fable workshop #2).
2. Audit for any other non-seeded branch (global `randi`/`randf`, `Time`, object-id ordering) in the turn path.
3. Replace the misleading `test_verification_determinism.gd` with a full-turn-loop determinism test (two identical runs → identical hash *and* full state).
4. Once deterministic, re-add hash comparison to `verify()` as the cheap fingerprint tier.

## Questions for the next design workshop

- Determinism vs. per-seed variety for starting staff / candidate attributes (blocks the fix above).
- Website static-JSON board wiring for the exported artifact is **out of scope** (separate `pdoom1-website` repo) — deferred, same as WS-A's `verification_logic.py`.
