### PR TITLE
fix(engine): WS-0 deterministic RNG — route state-affecting randomness through state.rng

### DIFF
--- a/godot/scripts/core/events.gd
+++ b/godot/scripts/core/events.gd
@@ -2,11 +2,10 @@ extends Node
 class_name GameEvents
 ## Random and triggered events system
 
-# Track which events have already triggered
-static var triggered_events: Array[String] = []
-
-# Track cooldowns for repeatable events (event_id -> last_triggered_turn)
-static var event_cooldowns: Dictionary = {}
+# WS-0 determinism: the event-firing registry (triggered_events / event_cooldowns) now lives
+# as per-game INSTANCE state on GameState, threaded via `state`. As static class vars it
+# persisted across in-process games and replays, desyncing state.rng consumption between
+# otherwise-identical runs (candidate/rival divergence with matching score).
 
 static func get_all_events() -> Array[Dictionary]:
 	"""Return all event definitions"""
@@ -848,7 +847,7 @@ static func check_triggered_events(state: GameState, rng: RandomNumberGenerator)
 	for event in get_all_events():
 		if should_trigger(event, state, rng):
 			to_trigger.append(event)
-			_mark_event_triggered(event, state.turn)
+			_mark_event_triggered(event, state.turn, state)
 
 	# Check scenario-specific events (Issue #483: Mod/Scenario hook)
 	if state.has_meta("scenario_events"):
@@ -856,7 +855,7 @@ static func check_triggered_events(state: GameState, rng: RandomNumberGenerator)
 		for event in scenario_events:
 			if should_trigger(event, state, rng):
 				to_trigger.append(event)
-				_mark_event_triggered(event, state.turn)
+				_mark_event_triggered(event, state.turn, state)
 
 	# Check historical events from EventService (Issue #442: API Event Fetching)
 	# Historical events are real AI safety timeline events transformed into game events
@@ -870,7 +869,7 @@ static func check_triggered_events(state: GameState, rng: RandomNumberGenerator)
 				continue
 			if should_trigger(event, state, rng):
 				to_trigger.append(event)
-				_mark_event_triggered(event, state.turn)
+				_mark_event_triggered(event, state.turn, state)
 
 	return to_trigger
 
@@ -879,13 +878,13 @@ static func should_trigger(event: Dictionary, state: GameState, rng: RandomNumbe
 	var event_id = event.get("id", "")
 
 	# Don't trigger if already triggered (unless repeatable)
-	if event_id in triggered_events and not event.get("repeatable", false):
+	if event_id in state.triggered_events and not event.get("repeatable", false):
 		return false
 
 	# Check cooldown for repeatable events (cooldown_turns = minimum turns between triggers)
 	var cooldown_turns = event.get("cooldown_turns", 0)
-	if cooldown_turns > 0 and event_cooldowns.has(event_id):
-		var last_triggered = event_cooldowns[event_id]
+	if cooldown_turns > 0 and state.event_cooldowns.has(event_id):
+		var last_triggered = state.event_cooldowns[event_id]
 		if state.turn - last_triggered < cooldown_turns:
 			return false
 
@@ -1090,14 +1089,14 @@ static func execute_event_choice(event: Dictionary, choice_id: String, state: Ga
 	var message = chosen_option.get("message", "Event resolved")
 	return {"success": true, "message": message}
 
-static func _mark_event_triggered(event: Dictionary, turn: int):
+static func _mark_event_triggered(event: Dictionary, turn: int, state: GameState):
 	"""Mark an event as triggered, handling both one-time and cooldown tracking"""
 	var event_id = event.get("id", "")
 	if not event.get("repeatable", false):
-		triggered_events.append(event_id)
+		state.triggered_events.append(event_id)
 	# Always record cooldown for repeatable events with cooldown_turns
 	if event.get("cooldown_turns", 0) > 0:
-		event_cooldowns[event_id] = turn
+		state.event_cooldowns[event_id] = turn
 
 static func _calculate_salary_disparity(state: GameState) -> float:
 	"""Calculate salary disparity as coefficient of variation (percentage).
@@ -1435,7 +1434,5 @@ static func get_risk_event_for_pool(pool_name: String, severity: String, rng: Ra
 	var idx = rng.randi() % severity_events.size()
 	return severity_events[idx]
 
-static func reset_triggered_events():
-	"""Clear triggered events (for new game)"""
-	triggered_events.clear()
-	event_cooldowns.clear()
+# WS-0: reset_triggered_events() removed — the registry is now per-GameState instance state,
+# so it resets automatically with each new GameState. No global reset is needed.

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -94,6 +94,11 @@ var can_end_turn: bool = false
 # Deterministic RNG for events
 var rng: RandomNumberGenerator
 
+# WS-0 determinism: per-game event-firing registry (was static in events.gd, which leaked
+# across in-process games/replays and desynced state.rng). Fresh per GameState instance.
+var triggered_events: Array[String] = []
+var event_cooldowns: Dictionary = {}
+
 # Queued actions for this turn
 var queued_actions: Array[String] = []
 

--- a/godot/scripts/core/media_story.gd
+++ b/godot/scripts/core/media_story.gd
@@ -200,7 +200,15 @@ static func from_dict(data: Dictionary) -> MediaStory:
 
 ## Preset story templates for common scenarios
 
-static func create_breakthrough_story(lab_name: String, reputation_gain: float) -> MediaStory:
+## WS-0 determinism: select an option via the seeded rng when provided. Falls back to
+## global randi only for legacy/no-rng callers (headline text is cosmetic, but seeding it
+## keeps replay byte-identical).
+static func _pick(options: Array, rng: RandomNumberGenerator):
+	var idx: int = (rng.randi() if rng != null else randi()) % options.size()
+	return options[idx]
+
+
+static func create_breakthrough_story(lab_name: String, reputation_gain: float, rng: RandomNumberGenerator = null) -> MediaStory:
 	"""Create a positive breakthrough story"""
 	var headlines = [
 		"%s Achieves Major AI Safety Milestone" % lab_name,
@@ -212,7 +220,7 @@ static func create_breakthrough_story(lab_name: String, reputation_gain: float) 
 	var intensity = clamp(reputation_gain / 3.0, 0.5, 2.0)  # Scale with reputation
 
 	return MediaStory.new(
-		headlines[randi() % headlines.size()],
+		_pick(headlines, rng),
 		StoryType.BREAKTHROUGH,
 		3,  # duration
 		intensity * 3.0,  # sentiment
@@ -223,7 +231,7 @@ static func create_breakthrough_story(lab_name: String, reputation_gain: float) 
 	)
 
 
-static func create_scandal_story(lab_name: String, severity: float = 1.0) -> MediaStory:
+static func create_scandal_story(lab_name: String, severity: float = 1.0, rng: RandomNumberGenerator = null) -> MediaStory:
 	"""Create a negative scandal story"""
 	var headlines = [
 		"Safety Concerns Raised About %s Practices" % lab_name,
@@ -233,7 +241,7 @@ static func create_scandal_story(lab_name: String, severity: float = 1.0) -> Med
 	]
 
 	return MediaStory.new(
-		headlines[randi() % headlines.size()],
+		_pick(headlines, rng),
 		StoryType.SCANDAL,
 		4,  # longer duration
 		-severity * 5.0,  # sentiment
@@ -244,7 +252,7 @@ static func create_scandal_story(lab_name: String, severity: float = 1.0) -> Med
 	)
 
 
-static func create_safety_concern_story() -> MediaStory:
+static func create_safety_concern_story(rng: RandomNumberGenerator = null) -> MediaStory:
 	"""Create a general AI safety concern story"""
 	var headlines = [
 		"Experts Warn of AI Alignment Challenges",
@@ -254,7 +262,7 @@ static func create_safety_concern_story() -> MediaStory:
 	]
 
 	return MediaStory.new(
-		headlines[randi() % headlines.size()],
+		_pick(headlines, rng),
 		StoryType.SAFETY_CONCERN,
 		3,
 		-2.0,  # slight negative sentiment
@@ -265,7 +273,7 @@ static func create_safety_concern_story() -> MediaStory:
 	)
 
 
-static func create_competitor_story(competitor_name: String, positive: bool) -> MediaStory:
+static func create_competitor_story(competitor_name: String, positive: bool, rng: RandomNumberGenerator = null) -> MediaStory:
 	"""Create a story about a competitor"""
 	var headlines_positive = [
 		"%s Secures Major Funding Round" % competitor_name,
@@ -282,7 +290,7 @@ static func create_competitor_story(competitor_name: String, positive: bool) -> 
 	var headlines = headlines_positive if positive else headlines_negative
 
 	return MediaStory.new(
-		headlines[randi() % headlines.size()],
+		_pick(headlines, rng),
 		StoryType.COMPETITOR,
 		2,  # shorter duration
 		-1.0 if positive else 1.0,  # negative if competitor succeeds

--- a/godot/scripts/core/media_system.gd
+++ b/godot/scripts/core/media_system.gd
@@ -77,12 +77,12 @@ func generate_random_story() -> bool:
 
 	if story_type_roll < 0.3:
 		# Safety concern story (30% chance)
-		add_story(MediaStory.create_safety_concern_story())
+		add_story(MediaStory.create_safety_concern_story(rng))
 		return true
 	elif story_type_roll < 0.5:
 		# Competitor story (20% chance)
 		var positive = rng.randf() < 0.5
-		add_story(MediaStory.create_competitor_story("Rival Lab", positive))
+		add_story(MediaStory.create_competitor_story("Rival Lab", positive, rng))
 		return true
 	elif story_type_roll < 0.7:
 		# Policy/industry news (20% chance)
@@ -151,7 +151,7 @@ func check_for_action_story(action_type: String, reputation_gain: float, lab_nam
 	var story_prob = 0.3 + (public_opinion.media_attention / 200.0)  # 30-80% chance
 
 	if rng.randf() < story_prob:
-		add_story(MediaStory.create_breakthrough_story(lab_name, reputation_gain))
+		add_story(MediaStory.create_breakthrough_story(lab_name, reputation_gain, rng))
 		return true
 
 	return false
@@ -433,7 +433,7 @@ func execute_investigative_tip(game_state, target_lab_name: String) -> Dictionar
 		}
 	else:
 		# Success: competitor gets negative story
-		add_story(MediaStory.create_scandal_story(target_lab_name, 0.8))
+		add_story(MediaStory.create_scandal_story(target_lab_name, 0.8, rng))
 		# Small trust boost from competitor problems
 		public_opinion.update_opinion("lab_trust", 2.0, "Competitor Scrutiny")
 

--- a/godot/scripts/core/researcher.gd
+++ b/godot/scripts/core/researcher.gd
@@ -125,21 +125,19 @@ const NEGATIVE_TRAITS = {
 
 func _init(spec: String = "safety", name: String = ""):
 	specialization = spec
-	researcher_name = name if name != "" else _generate_name()
+	# WS-0 determinism: no global RNG in _init. Seeded creation calls generate_random(rng);
+	# deserialization calls from_dict. Both overwrite these deterministic defaults.
+	researcher_name = name if name != "" else "New Researcher"
 
 	# Set base salary from specialization
 	if SPECIALIZATIONS.has(spec):
 		salary_expectation = SPECIALIZATIONS[spec]["base_cost"]
 		current_salary = salary_expectation
 
-	# Random skill level (3-7 for new hires, can grow)
-	skill_level = randi_range(3, 7)
-
-	# Base productivity from skill
-	base_productivity = 0.5 + (skill_level * 0.1)  # 0.8 to 1.2 for skill 3-7
-
-	# Random loyalty (40-70 for new hires)
-	loyalty = randi_range(40, 70)
+	# Deterministic mid-range defaults; variation is applied only via generate_random(rng)
+	skill_level = 5
+	base_productivity = 0.5 + (skill_level * 0.1)  # 1.0
+	loyalty = 55
 
 func generate_random(rng: RandomNumberGenerator):
 	"""Generate random attributes using provided RNG for determinism"""
@@ -355,8 +353,8 @@ func process_turn(rng: RandomNumberGenerator = null):
 	recover_jet_lag()
 
 	# Skill growth (very slow - 1 point per ~20 turns)
-	# Use provided RNG for determinism, fallback to global for tests
-	var skill_roll = rng.randf() if rng else randf()
+	# WS-0 determinism: use provided seeded RNG only; no global-RNG fallback (1.0 => no growth)
+	var skill_roll: float = rng.randf() if rng != null else 1.0
 	if skill_roll < 0.05:  # 5% chance per turn
 		skill_level = min(skill_level + 1, 10)
 		base_productivity = 0.5 + (skill_level * 0.1)
@@ -371,21 +369,6 @@ func process_turn(rng: RandomNumberGenerator = null):
 # ============================================================================
 # UTILITY FUNCTIONS
 # ============================================================================
-
-func _generate_name() -> String:
-	"""Generate a random researcher name"""
-	const FIRST_NAMES = [
-		"Alex", "Blake", "Casey", "Drew", "Ellis", "Finley", "Gray", "Harper",
-		"Iris", "Jordan", "Kelly", "Lane", "Morgan", "Noel", "Owen", "Parker",
-		"Quinn", "Riley", "Sage", "Taylor"
-	]
-	const LAST_NAMES = [
-		"Chen", "Kumar", "O'Brien", "Patel", "Rodriguez", "Smith", "Williams",
-		"Zhang", "Anderson", "Martinez", "Thompson", "Garcia", "Lee", "Wilson",
-		"Moore", "Taylor", "Brown", "Davis", "Miller", "Johnson"
-	]
-
-	return FIRST_NAMES[randi() % FIRST_NAMES.size()] + " " + LAST_NAMES[randi() % LAST_NAMES.size()]
 
 func get_summary() -> String:
 	"""Get one-line summary of researcher"""

--- a/godot/tests/unit/test_engine_determinism.gd
+++ b/godot/tests/unit/test_engine_determinism.gd
@@ -1,0 +1,40 @@
+extends GutTest
+## WS-0 — engine determinism guard.
+##
+## Same seed + same (baseline, no-action) inputs must produce a BYTE-IDENTICAL final
+## state across two runs in the same process. This is the invariant that ADR-0002/0006
+## (replay recomputes score/hash), ADR-0005 (seed vetting) and ADR-0003 (mortality soak
+## tests) all silently depend on. The old test_deterministic_rng.gd only checked the raw
+## rng stream and skipped the real turn loop, so it masked global-RNG leaks into state.
+
+const SEEDS := ["ws0-determinism-probe", "aardvark-7", "turn-fourteen"]
+
+func _final_state_json(game_seed: String) -> String:
+	BaselineSimulator.clear_cache()
+	var result: Dictionary = BaselineSimulator._run_baseline_simulation(game_seed)
+	return JSON.stringify(result.get("final_state", {}))
+
+func _report_divergence(a_json: String, b_json: String) -> void:
+	var a: Dictionary = JSON.parse_string(a_json)
+	var b: Dictionary = JSON.parse_string(b_json)
+	for k in a.keys():
+		var va := JSON.stringify(a[k])
+		var vb := JSON.stringify(b.get(k))
+		if va != vb:
+			gut.p("  DIVERGES [%s]\n    run1=%s\n    run2=%s" % [k, va, vb])
+
+func test_engine_deterministic_same_seed_same_inputs():
+	for game_seed in SEEDS:
+		var run1 := _final_state_json(game_seed)
+		var run2 := _final_state_json(game_seed)
+		if run1 != run2:
+			gut.p("Determinism FAILED for seed '%s':" % game_seed)
+			_report_divergence(run1, run2)
+		assert_eq(run1, run2,
+			"engine must be deterministic for seed '%s' (same seed+inputs -> identical state)" % game_seed)
+
+func test_different_seeds_actually_differ():
+	# Guard against a degenerate "everything constant" pass: distinct seeds should diverge.
+	var a := _final_state_json(SEEDS[0])
+	var b := _final_state_json(SEEDS[1])
+	assert_ne(a, b, "distinct seeds should produce distinct runs (else determinism test is vacuous)")


### PR DESCRIPTION
## WS-0 — engine determinism hardening

**Critical-path bugfix.** Same seed + same inputs now produce **byte-identical** game state across in-process runs — the invariant that ADR-0002/0006 (replay recomputes score/hash), ADR-0005 (seed vetting / WS-C) and ADR-0003 (mortality soak tests / WS-1) all silently depend on. WS-B (#551) surfaced the non-determinism; this fixes it at the engine.

### Root cause (the big one)
`events.gd` held the fired-event registry in **static (process-global) vars** — `triggered_events` / `event_cooldowns` — and `reset_triggered_events()` was **never called**. So a second game in the same process inherited the first's registry → different event eligibility → a different number of `state.rng` draws → downstream `state.rng` desync. Fixed by moving the registry to **per-game instance state on `GameState`**, threaded via `state`. (Also fixes a real bug: events wrongly persisting across game restarts within one process.)

Two secondary global-RNG leaks into state, also fixed:
- **`researcher.gd`** — `_init` rolled skill/loyalty/name from **global** `randi`; `process_turn` fell back to global `randf`. Now deterministic mid-range defaults; randomization only via the seeded `generate_random(rng)`.
- **`media_story.gd` / `media_system.gd`** — story-headline selection used global `randi`; now threads the seeded `rng`.

### RNG audit (all `*.gd`)
| Call site | Affects game state? | Action |
|---|---|---|
| `events.gd` static `triggered_events`/`event_cooldowns` | **Yes** (event eligibility → rng order) | **Fixed** → instance state on GameState |
| `researcher.gd` `_init` skill/loyalty/name (global) | **Yes** (productivity→research→doom) | **Fixed** → deterministic defaults |
| `researcher.gd` `process_turn` global-randf fallback | **Yes** (skill growth) | **Fixed** → seeded-only |
| `media_story.gd` headlines ×4 (global) | Yes (story text in state) | **Fixed** → seeded `rng` |
| `leaderboard.gd:70` UUID | No (cosmetic id) | left |
| `music_manager.gd:104` track pick | No (audio) | left |
| `office_cat.gd:41` cat image | No (visual) | left |
| `pregame_setup.gd:152-163` lab-name suggestion | No (pre-sim UI, user-editable) | left |
| `contributor_manager.gd:93` random contributor | No (credits display) | left |

### Test
Adds `tests/unit/test_engine_determinism.gd`: runs the **real baseline turn loop twice** per seed and asserts **byte-identical `to_dict()`**, plus a distinct-seeds-differ guard so it can't pass vacuously. Before the event-registry fix it failed with matching score/money/doom but diverging `candidate_pool[3+]` and `rival_labs` funding — exactly a `state.rng`-order desync. After: **2/2 pass**. Full `run_godot_tests.py --quick` green, no regressions.

### Questions for the next design workshop
- **Character-creation re-roll within a seed:** ruling applied is *same seed → same starting staff* (seed-keyed leaderboards + replay demand it). Whether a future character-creation screen lets you re-roll *within* a seed is deferred — not implemented, not precluded.
- **Empty-seed path:** `GameState._init` still derives a `Time.get_ticks_usec()` seed when the seed string is empty — i.e. only *explicitly-seeded* games are replayable/deterministic (empty = intentionally random). Confirm that's the intended contract.
- **Serialization:** `triggered_events`/`event_cooldowns` are not in `to_dict`/`from_dict`. Replay rebuilds them from turn 0 so replay/score is unaffected, but a mid-game save/load would forget event history (pre-existing behavior). Flag for the save/load pass.

### Follow-up
**WS-B #551** can now rebase onto this and re-add the hash comparison to `replay_simulator.verify()` (currently score-only pending this).

Do not merge without review — opened for Pip.