### PR TITLE
feat(seeds): WS-C seed schedules + headless vetting harness (ADR-0005)

### DIFF
--- a/godot/scripts/core/baseline_simulator.gd
+++ b/godot/scripts/core/baseline_simulator.gd
@@ -28,6 +28,16 @@ class_name BaselineSimulator
 # Maximum turns to simulate (prevents infinite loops)
 const MAX_TURNS: int = 200
 
+# WS-C (ADR-0005): default seed-vetting playability envelope. These are the CONFIG a curator
+# tunes (or overrides per-call / from league config), not thresholds baked into the
+# classification logic. A seed is rejected if it falls outside this envelope.
+const DEFAULT_VETTING_ENVELOPE := {
+	"min_turns": 5,             # reject if even the cautious (passive) line dies before this
+	"doom_threat_floor": 70.0,  # reject if even the careless (reckless) line never makes doom
+	                            #   this dangerous — a snoozefest with no threat
+	"max_turns": MAX_TURNS,     # simulation cap
+}
+
 # Computation modes
 enum Mode {
 	PRECOMPUTED,  # Baseline already computed (weekly league)
@@ -173,15 +183,19 @@ static func _run_deferred_simulation(game_seed: String):
 ## SIMULATION LOGIC
 ## ============================================================================
 
-static func _run_baseline_simulation(game_seed: String) -> Dictionary:
+static func _run_baseline_simulation(game_seed: String, schedule: Array = [], choice_policy: String = "passive") -> Dictionary:
 	"""
 	Run a headless game with no player actions.
 	The game proceeds with only passive effects (doom, staff productivity, etc.)
-	"""
-	print("[BaselineSimulator] Running baseline simulation for seed: %s" % game_seed)
 
-	# Create game state with the same seed
-	var state = GameState.new(game_seed)
+	WS-C (ADR-0005): `schedule` seeds the run's scheduled causes; `choice_policy` selects the
+	event-response heuristic ("passive" = first/safest choice, "reckless" = last choice) so
+	seed vetting can bracket a seed between a cautious and a careless line.
+	"""
+	print("[BaselineSimulator] Running baseline simulation for seed: %s (policy: %s)" % [game_seed, choice_policy])
+
+	# Create game state with the same seed + schedule
+	var state = GameState.new(game_seed, schedule)
 	var turn_manager = TurnManager.new(state)
 
 	var simulation_start = Time.get_ticks_msec()
@@ -196,8 +210,8 @@ static func _run_baseline_simulation(game_seed: String) -> Dictionary:
 			var event = state.pending_events[0]
 			var choices = event.get("choices", [])
 			if choices.size() > 0:
-				# Use baseline strategy to pick choice
-				var choice_id = _get_event_choice_for_baseline(event, choices)
+				# Pick a choice per the active policy (passive = safest-first, reckless = last)
+				var choice_id = _choice_for_policy(event, choices, choice_policy)
 				turn_manager.resolve_event(event, choice_id)
 			else:
 				# No choices available, remove event
@@ -214,12 +228,17 @@ static func _run_baseline_simulation(game_seed: String) -> Dictionary:
 	# sim — no separate formula. Engine is the sole scoring authority.
 	var final_state = state.to_dict()
 
+	var peak_doom: float = state.doom
+	if state.doom_history.size() > 0:
+		peak_doom = state.doom_history.max()
+
 	return {
 		"turns": state.turn,
 		"doom_integral": int(round(state.doom_integral)),
 		"final_state": final_state,
 		"victory": state.victory,
 		"doom": state.doom,
+		"max_doom": peak_doom,
 		"simulation_time_ms": simulation_time
 	}
 
@@ -269,8 +288,80 @@ static func get_comparison_text(player_turns: int, player_integral: int, baselin
 	}
 
 ## ============================================================================
+## SEED VETTING (WS-C / ADR-0005)
+## ============================================================================
+
+static func vet_seed(game_seed: String, schedule: Array = [], envelope: Dictionary = {}) -> Dictionary:
+	"""
+	Classify a candidate seed (RNG seed + schedule) against a playability envelope by
+	running it headless between a cautious line (passive event choices) and a careless line
+	(reckless event choices). Deterministic given (seed, schedule) — WS-0 guarantees it.
+
+	Returns: {seed, accepted: bool, reason, passive_turns, reckless_turns, peak_doom, envelope}
+
+	This is the curation tool that replaces authored waves: run a batch, publish only seeds
+	inside the envelope. `envelope` overrides DEFAULT_VETTING_ENVELOPE key-by-key.
+	"""
+	var env: Dictionary = DEFAULT_VETTING_ENVELOPE.duplicate(true)
+	for k in envelope:
+		env[k] = envelope[k]
+
+	var passive: Dictionary = _run_baseline_simulation(game_seed, schedule, "passive")
+	var reckless: Dictionary = _run_baseline_simulation(game_seed, schedule, "reckless")
+
+	var passive_turns: int = int(passive["turns"])
+	var peak_doom: float = maxf(float(passive["max_doom"]), float(reckless["max_doom"]))
+
+	var accepted: bool = true
+	var reason: String
+	if passive_turns < int(env["min_turns"]):
+		accepted = false
+		reason = "too punishing: cautious line dies at turn %d (< min %d)" % [passive_turns, int(env["min_turns"])]
+	elif peak_doom < float(env["doom_threat_floor"]):
+		accepted = false
+		reason = "snoozefest: peak doom %.1f never reached threat floor %.1f" % [peak_doom, float(env["doom_threat_floor"])]
+	else:
+		reason = "playable: cautious line survives %d turns, peak doom %.1f" % [passive_turns, peak_doom]
+
+	return {
+		"seed": game_seed,
+		"accepted": accepted,
+		"reason": reason,
+		"passive_turns": passive_turns,
+		"reckless_turns": int(reckless["turns"]),
+		"peak_doom": peak_doom,
+		"envelope": env,
+	}
+
+static func vet_seed_batch(candidates: Array, envelope: Dictionary = {}) -> Array:
+	"""
+	Vet a batch of candidates. Each candidate is either a seed String or a
+	{seed: String, schedule: Array} Dictionary. Returns one vet_seed result per candidate.
+	"""
+	var results: Array = []
+	for c in candidates:
+		if typeof(c) == TYPE_DICTIONARY:
+			results.append(vet_seed(str(c.get("seed", "")), c.get("schedule", []), envelope))
+		else:
+			results.append(vet_seed(str(c), [], envelope))
+	return results
+
+## ============================================================================
 ## EVENT STRATEGY
 ## ============================================================================
+
+static func _choice_for_policy(event: Dictionary, choices: Array, policy: String) -> String:
+	"""
+	Map an event's choices to an id under a vetting policy.
+	  passive  -> the safest-first choice (index 0), the existing baseline behaviour
+	  reckless -> the last choice (typically the most aggressive/risky option)
+	"""
+	if policy == "reckless" and choices.size() > 0:
+		var last = choices[choices.size() - 1]
+		if typeof(last) == TYPE_DICTIONARY:
+			return str(last.get("id", ""))
+		return str(last)
+	return _get_event_choice_for_baseline(event, choices)
 
 static func _get_event_choice_for_baseline(event: Dictionary, choices: Array) -> String:
 	"""

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -105,6 +105,11 @@ var queued_actions: Array[String] = []
 # Rival labs
 var rival_labs: Array = []  # Array of RivalLabs.RivalLab
 
+# WS-C (ADR-0005): a seed = RNG seed + event schedule. Ordered list of scheduled causes
+# ({turn, cause, target, magnitude}) applied per-turn by SeedSchedule. Causes touch sim
+# INPUTS only, never doom. Part of the seed's identity, so it survives reset().
+var event_schedule: Array = []
+
 # Doom system (modular, extensible)
 var doom_system: DoomSystem
 
@@ -117,7 +122,10 @@ var paper_submissions: Array = []  # Array of PaperSubmissions.PaperSubmission
 var attended_conferences: Array[String] = []  # Conference IDs attended this game year
 var conference_year: int = 2017  # Track which year for conference attendance reset
 
-func _init(game_seed: String = ""):
+func _init(game_seed: String = "", schedule: Array = []):
+	# WS-C (ADR-0005): schedule is part of seed identity; duplicated so external mutation
+	# can't alias it, and deliberately NOT cleared by reset().
+	event_schedule = schedule.duplicate(true)
 	if game_seed != "":
 		game_seed_str = game_seed
 	else:

--- a/godot/scripts/core/replay_simulator.gd
+++ b/godot/scripts/core/replay_simulator.gd
@@ -23,6 +23,9 @@ static func replay(replay_data: Dictionary) -> Dictionary:
 	var run_seed: String = str(replay_data.get("seed", ""))
 	var run_version: String = str(replay_data.get("version", "unknown"))
 	var input_log: Array = replay_data.get("log", [])
+	# WS-C (ADR-0005): the event schedule is part of the run's identity, so it must be
+	# replayed alongside seed+version or a scheduled run won't reproduce.
+	var run_schedule: Array = replay_data.get("schedule", [])
 
 	# Group inputs by the turn they were recorded under. start_turn() increments turn
 	# first, so a round's event-responses and actions share that post-increment value.
@@ -43,7 +46,7 @@ static func replay(replay_data: Dictionary) -> Dictionary:
 	# Isolate the global tracker for the duration of the replay.
 	var snap: Dictionary = VerificationTracker.snapshot()
 
-	var state: GameState = GameState.new(run_seed)
+	var state: GameState = GameState.new(run_seed, run_schedule)
 	var turn_manager: TurnManager = TurnManager.new(state)
 	VerificationTracker.start_tracking(run_seed, run_version)
 

--- a/godot/scripts/core/seed_schedule.gd
+++ b/godot/scripts/core/seed_schedule.gd
@@ -1,0 +1,67 @@
+extends RefCounted
+class_name SeedSchedule
+## ADR-0005 — a seed = RNG seed + event schedule.
+##
+## A schedule is an ordered list of "scheduled causes": the designer's thumb on the scale.
+## HARD INVARIANT (ADR-0005 "author causes, never outcomes"): a cause may only touch sim
+## INPUTS — rival funding, rival aggression, an injected event id — never the doom variable
+## or any other outcome directly. The wave that reaches the player is whatever the sim does
+## with the cause given opponent state and the player's ledger. This keeps every spike
+## attributable (SA content for free), replay deterministic, and the meta rotatable by
+## rotating schedules instead of nerfing numbers.
+##
+## Cause shape: {"turn": int, "cause": String, "target": String, "magnitude": float}
+## Extensible seam: pdoom-data timeline entries become causes (content, not engine code).
+
+# Recognised cause types. Add new INPUT-only handlers here; the invariant test guards that
+# none of this file writes an outcome.
+const CAUSE_TYPES := ["rival_funding_wave", "rival_aggression_shift", "inject_event"]
+
+
+static func apply_due_causes(state) -> Array:
+	## Apply every scheduled cause whose `turn` equals the current turn. Deterministic and
+	## fired exactly once per turn (start_turn runs once per turn). Returns human-readable
+	## summaries of what fired — these are legible SA content, not side effects.
+	var applied: Array = []
+	for cause in state.event_schedule:
+		if int(cause.get("turn", -1)) != state.turn:
+			continue
+		var summary: String = _apply_cause(state, cause)
+		if summary != "":
+			applied.append(summary)
+	return applied
+
+
+static func _apply_cause(state, cause: Dictionary) -> String:
+	var kind: String = str(cause.get("cause", ""))
+	var target: String = str(cause.get("target", ""))
+	var magnitude: float = float(cause.get("magnitude", 0.0))
+	match kind:
+		"rival_funding_wave":
+			# INPUT: rivals decide their number of actions from funding; more funding => more
+			# capability/safety moves => an emergent doom wave next, produced by the sim.
+			var rival = _find_rival(state, target)
+			if rival != null:
+				rival.funding += magnitude
+				return "%s received a $%.0fk funding wave" % [rival.name, magnitude / 1000.0]
+		"rival_aggression_shift":
+			# INPUT: shifts a rival's capability-vs-safety bias.
+			var rival = _find_rival(state, target)
+			if rival != null:
+				rival.aggression = clampf(rival.aggression + magnitude, 0.0, 1.0)
+				return "%s shifted its research posture" % rival.name
+		"inject_event":
+			# INPUT: queue an event id for this turn's normal resolution. Any outcome the
+			# event carries runs through the event pipeline (the sim), never here.
+			state.pending_events.append({"id": target, "scheduled": true})
+			return "Scheduled development: %s" % target
+		_:
+			push_warning("[SeedSchedule] Unknown cause type: %s" % kind)
+	return ""
+
+
+static func _find_rival(state, rival_id: String):
+	for rival in state.rival_labs:
+		if rival.id == rival_id or rival.name.to_lower().replace(" ", "_") == rival_id:
+			return rival
+	return null

--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -104,6 +104,11 @@ func start_turn() -> Dictionary:
 	state.queued_actions.clear()
 	state.can_end_turn = false
 
+	# WS-C (ADR-0005): apply any scheduled causes due this turn BEFORE events/rivals react,
+	# so the authored cause (e.g. a rival funding wave) shapes this turn's emergent outcome.
+	# Causes touch sim inputs only — never doom directly.
+	SeedSchedule.apply_due_causes(state)
+
 	# Calculate max AP based on staff (base 3 + 0.5 per staff member)
 	var total_staff = state.get_total_staff()
 	var max_ap = 3 + int(total_staff * 0.5)

--- a/godot/tests/unit/test_seed_schedule.gd
+++ b/godot/tests/unit/test_seed_schedule.gd
@@ -1,0 +1,89 @@
+extends GutTest
+## WS-C (ADR-0005): seed schedules + headless vetting harness.
+## Verifies: a seed = RNG seed + event schedule; scheduled causes change the run
+## deterministically; the schedule path never writes an outcome; the vetting harness
+## classifies seeds against a configurable envelope; scheduled runs are replay-verifiable.
+
+const SEED := "ws-c-vet-seed"
+
+# A schedule that leans hard on the scale: fund + inflame CapabiliCorp early so it drives
+# an emergent doom wave. (Inputs only — the wave itself is the sim's doing.)
+func _heavy_schedule() -> Array:
+	return [
+		{"turn": 1, "cause": "rival_funding_wave", "target": "capabilicorp", "magnitude": 5000000.0},
+		{"turn": 1, "cause": "rival_aggression_shift", "target": "capabilicorp", "magnitude": 0.5},
+		{"turn": 3, "cause": "rival_funding_wave", "target": "capabilicorp", "magnitude": 5000000.0},
+	]
+
+func _final_json(run: Dictionary) -> String:
+	return JSON.stringify(run["final_state"])
+
+
+func test_schedule_changes_run_and_is_deterministic():
+	var sched := _heavy_schedule()
+	var with_a := BaselineSimulator._run_baseline_simulation(SEED, sched)
+	var with_a_again := BaselineSimulator._run_baseline_simulation(SEED, sched)
+	var without := BaselineSimulator._run_baseline_simulation(SEED, [])
+
+	# Deterministic: identical seed + identical schedule => byte-identical final state.
+	assert_eq(_final_json(with_a), _final_json(with_a_again),
+		"same seed + same schedule must reproduce identical state")
+	# The schedule actually shapes the run: same RNG seed, different schedule => different run.
+	assert_ne(_final_json(with_a), _final_json(without),
+		"a scheduled cause must change the run outcome")
+
+
+func test_schedule_path_never_writes_an_outcome():
+	# ADR-0005 hard invariant: the schedule application code touches inputs only, never the
+	# doom variable (or any outcome). Enforced structurally by grepping the source.
+	var f := FileAccess.open("res://scripts/core/seed_schedule.gd", FileAccess.READ)
+	assert_not_null(f, "seed_schedule.gd must exist")
+	var src := f.get_as_text()
+	f.close()
+	assert_false(src.contains(".doom"), "schedule code must not read or write .doom")
+	assert_false(src.contains("state.technical_debt"), "schedule code must not write outcomes")
+
+
+func test_vet_seed_classifies_against_configurable_envelope():
+	# Lax envelope: always playable.
+	var lax := BaselineSimulator.vet_seed(SEED, [], {"min_turns": 1, "doom_threat_floor": 0.0})
+	assert_true(lax["accepted"], "a lax envelope should accept: %s" % lax["reason"])
+
+	# Punishing floor: reject because the cautious line can't survive an impossible min.
+	var punishing := BaselineSimulator.vet_seed(SEED, [], {"min_turns": 9999})
+	assert_false(punishing["accepted"], "impossible min_turns should reject")
+	assert_true(str(punishing["reason"]).contains("punishing"), "reason should name the failure")
+
+	# Impossible threat floor: reject as a snoozefest.
+	var snooze := BaselineSimulator.vet_seed(SEED, [], {"doom_threat_floor": 9999.0})
+	assert_false(snooze["accepted"], "unreachable doom floor should reject")
+	assert_true(str(snooze["reason"]).contains("snoozefest"), "reason should name the failure")
+
+
+func test_vet_seed_batch_classifies_each():
+	var batch := [SEED, {"seed": SEED, "schedule": _heavy_schedule()}]
+	var results := BaselineSimulator.vet_seed_batch(batch, {"min_turns": 1, "doom_threat_floor": 0.0})
+	assert_eq(results.size(), 2, "one result per candidate")
+	for r in results:
+		assert_true(r.has("accepted"), "each result carries a verdict")
+
+
+func test_scheduled_run_is_replay_verifiable():
+	var sched := _heavy_schedule()
+	var data_a := {"seed": "ws-c-replay", "version": "t", "log": [], "schedule": sched}
+	var data_empty := {"seed": "ws-c-replay", "version": "t", "log": [], "schedule": []}
+
+	var a := ReplaySimulator.replay(data_a)
+	var empty := ReplaySimulator.replay(data_empty)
+
+	# The schedule is part of the run's identity: replaying with it vs without diverges.
+	assert_ne(JSON.stringify(a["final_state"]), JSON.stringify(empty["final_state"]),
+		"the schedule must be part of what replay reproduces")
+
+	# Round-trip: re-simulating the artifact reproduces its claimed score AND hash.
+	assert_true(ReplaySimulator.verify(data_a, a["turns"], a["doom_integral"], a["hash"]),
+		"a scheduled run must verify against its own artifact")
+
+	# Anti-cheat: a forged (too-high) score is rejected.
+	assert_false(ReplaySimulator.verify(data_a, a["turns"] + 1, a["doom_integral"]),
+		"a forged turn count must fail verification")


### PR DESCRIPTION
Implements **WS-C** from `IMPLEMENTATION_KICKOFF.md`, per **ADR-0005**. Builds on WS-0 (determinism) + WS-B (replay).

## What changed
A **seed = RNG seed + event schedule**. A schedule is an ordered list of *scheduled causes* `{turn, cause, target, magnitude}` — the designer's thumb on the scale.

- **`seed_schedule.gd` (new)** — `SeedSchedule.apply_due_causes(state)`. Cause handlers touch **sim inputs only**: `rival_funding_wave` (+funding), `rival_aggression_shift` (bias), `inject_event` (queues an event id for normal resolution). The wave that reaches the player is whatever the sim does with the cause.
- **`game_state.gd`** — `event_schedule` field; part of the seed's identity, duplicated in `_init(seed, schedule)`, survives `reset()`.
- **`turn_manager.gd`** — applies due causes in `start_turn` right after the turn increment, before events/rivals react.
- **`baseline_simulator.gd`** — `_run_baseline_simulation` takes a schedule + event-choice policy (`passive` = safest-first, `reckless` = last); **`vet_seed` / `vet_seed_batch`** classify a seed by bracketing it between a cautious and a careless headless line against a **configurable playability envelope** (`DEFAULT_VETTING_ENVELOPE`, overridable per-call).
- **`replay_simulator.gd`** — schedule threaded into replay (`replay_data.schedule` → `GameState.new(seed, schedule)`), so scheduled runs are replay-verifiable.

## Definition of done
- [x] Seed = RNG seed + event schedule.
- [x] Two seeds, identical RNG, different schedules → different, deterministic, replay-verifiable runs (`test_schedule_changes_run_and_is_deterministic`, `test_scheduled_run_is_replay_verifiable`).
- [x] Vetting harness classifies a batch vs a **configurable** envelope (`test_vet_seed_*`).
- [x] **Hard invariant — schedule path never writes an outcome:** `grep -E '\.doom\s*[-+]?=' seed_schedule.gd` → **CLEAN**; also enforced by `test_schedule_path_never_writes_an_outcome` (source assertion).
- [x] GUT green: new suite **5/5, 16 asserts**; full `run_godot_tests.py --quick` **exit 0**, no regressions (WS-0 determinism + WS-B replay still pass).

## Questions for the next design workshop (parked — add to WORKSHOP_2_BACKLOG.md)
1. **Schedule provenance in the replay artifact.** Replay now accepts a schedule, but the live-game artifact export doesn't yet *carry* it — a shared replay of a scheduled seed needs the schedule to travel with the run OR be recoverable from `(seed, version)` via a seed registry. Decide which. (Connects to WS-B artifact format + backlog EE-2 serialization.)
2. **Vetting bots.** Currently brackets by *event-choice* policy (passive vs reckless) — no action-taking bots, so no action ids are guessed (safe/deterministic). Action-taking heuristic bots (greedy-safety, capability-rush) are a seam, deferred.
3. **Envelope config source.** Thresholds are a passable dict (default provided); wiring to a JSON/league config file is a seam.
4. **Schedule content pipeline.** ADR-0005 names `pdoom-data` as feedstock (real timeline → causes); the content pipeline is explicitly out of WS-C scope — mechanism only, seam left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)