### PR TITLE
feat(ledger): WS-1 Liability Ledger — flagship mechanic (ADR-0003)

### DIFF
--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -20,6 +20,15 @@ var action_points: int = 3
 var max_action_points: int = 3  # Per-turn AP cap; difficulty modifiers adjust this (game_manager._apply_difficulty_settings)
 var stationery: float = 100.0  # Office supplies, depletes with staff usage
 
+# Governance: institutional legitimacy the Liability Ledger bills against (ADR-0003).
+# Added as an engine resource this lane; its full player-facing design is parked for
+# workshop #2 (kickoff "governance is currently a name, not a system").
+var governance: float = 50.0
+
+# The Liability Ledger (ADR-0003): every mitigation is a loan. Instance state, rebuilt
+# per game in reset(); compounding payables are the mortality guarantee (ADR-0002).
+var ledger: Ledger
+
 # Technical Debt System (Issue #416)
 # Accumulates from rushed research, increases failure risk, affects doom
 var technical_debt: float = 0.0  # 0-100 scale
@@ -160,6 +169,8 @@ func reset():
 	doom = 50.0
 	action_points = 3
 	stationery = 100.0
+	governance = 50.0
+	ledger = Ledger.new()  # ADR-0003: fresh ledger per game
 	technical_debt = 0.0  # Reset tech debt (Issue #416)
 	research_quality_mode = DEFAULT_RESEARCH_QUALITY  # Issue #500
 
@@ -782,6 +793,8 @@ func to_dict() -> Dictionary:
 		"research_quality_mode": research_quality_mode,  # Issue #500
 		"papers": papers,
 		"reputation": reputation,
+		"governance": governance,
+		"ledger": ledger.to_dict() if ledger else {},
 		"doom": doom,
 		"doom_history": doom_history.duplicate(),  # #512 trend graph
 		"doom_system": doom_data,

--- a/godot/scripts/core/ledger.gd
+++ b/godot/scripts/core/ledger.gd
@@ -1,0 +1,169 @@
+extends RefCounted
+class_name Ledger
+## The Liability Ledger (ADR-0003): every mitigation is a loan.
+##
+## A two-sided ledger of trades that pay now and bill later. There is NO new
+## player-facing currency (ADR-0003 "no parallel economy"): every entry reads and
+## writes only existing resources — money, reputation, governance, action_points,
+## doom. Compounding interest on payables is the mortality guarantee (ADR-0002):
+## an un-serviced debt grows without bound until a bill it cannot pay ends the run,
+## and the death is attributable to specific entries.
+##
+## First-wave content (ADR-0003): loans, funding-with-strings, desperation levers
+## (payroll coinflip -> secret governance rot), staff riders. Receivables/blackmail
+## chains are modelled at entry level; their full event/UI wiring is parked (see PR).
+
+enum Side { PAYABLE, RECEIVABLE }
+
+## A single liability or asset. Heterogeneous by design (ADR-0003 boundary
+## condition): fuses, currencies and interest profiles vary so the game does not
+## degenerate into an inevitability queue.
+class Entry:
+	var id: String = ""
+	var source: String = ""            # the trade that created it ("loan", "payroll_coinflip", ...)
+	var currency: String = "money"     # money | reputation | governance | doom | action_points
+	var principal: float = 0.0         # current magnitude; grows by `interest` each turn while unsettled
+	var fuse: int = 0                  # turns until it bills (0 = due now)
+	var interest: float = 0.0          # per-turn compounding rate (0.0 = does not grow)
+	var secret: bool = false           # can be exposed by rivals/scheduled causes (ADR-0003)
+	var side: int = Side.PAYABLE
+	var counterparty: String = ""      # per-actor, for receivables (NO global influence stat, ADR-0003)
+	var settled: bool = false          # billed and closed; kept for the post-mortem trail
+
+	func _init(p_source: String, p_currency: String, p_principal: float, p_fuse: int, p_interest: float = 0.0, p_secret: bool = false, p_side: int = Side.PAYABLE, p_counterparty: String = "") -> void:
+		source = p_source
+		currency = p_currency
+		principal = p_principal
+		fuse = p_fuse
+		interest = p_interest
+		secret = p_secret
+		side = p_side
+		counterparty = p_counterparty
+
+	func to_dict() -> Dictionary:
+		return {
+			"source": source, "currency": currency, "principal": principal,
+			"fuse": fuse, "interest": interest, "secret": secret,
+			"side": side, "counterparty": counterparty, "settled": settled,
+		}
+
+# How hard an unpayable money bill converts to doom — the "teeth" that guarantee
+# mortality when a debtor cannot cover a balloon payment. Config, not scattered magic.
+const DOOM_PER_UNPAID_1000: float = 3.5
+const REP_PER_UNPAID_1000: float = 2.0
+
+var entries: Array = []            # Array[Entry] — all entries, incl. settled (post-mortem trail)
+var death_attribution: Array = []  # populated when a bill drives the killing blow
+
+func add(entry: Entry) -> void:
+	entries.append(entry)
+
+# ---- First-wave content factories (ADR-0003). Callers apply the *immediate*
+# benefit (money now / doom suppressed now) and add the returned future bill. ----
+
+## Money now, balloon repayment later with compounding interest. The classic
+## "bill for turn 2" — deep runs are heroic because of what funded them.
+static func loan(amount: float, term: int = 4, rate: float = 0.25) -> Entry:
+	return Entry.new("loan", "money", amount * 1.2, term, rate)
+
+## Money now, an obligation that later bills in reputation/governance (strings).
+static func funding_with_strings(amount: float) -> Entry:
+	return Entry.new("funding_strings", "governance", amount * 0.15, 6, 0.05)
+
+## Desperation lever = catch-up (ADR-0003/0008). Buys doom-suppression NOW but
+## plants a SECRET, compounding governance liability (payroll coinflip -> rot ->
+## exposure -> blackmail chain). Coinflip severity is drawn from state.rng so the
+## run stays deterministic (WS-0).
+static func desperation_payroll(rng: RandomNumberGenerator) -> Entry:
+	var severity := 8000.0 + rng.randf() * 6000.0
+	return Entry.new("payroll_coinflip", "governance", severity, 3, 0.35, true)
+
+## A hire is AP-leverage with a small liability rider (ADR-0008). On departure a
+## caller can flip it to `secret` (a disgruntled ex-researcher).
+static func staff_rider(name: String) -> Entry:
+	return Entry.new("staff:" + name, "governance", 1200.0, 8, 0.02)
+
+# ---- Turn processing: the mortality guarantee lives here ----
+
+## Called once per turn (after WS-C scheduled causes). Compounds interest on live
+## payables, advances fuses, and bills anything due. Unbounded compounding is the
+## mortality guarantee (ADR-0002).
+func tick_and_bill(state) -> void:
+	for e in entries:
+		if e.settled or e.side != Side.PAYABLE:
+			continue
+		if e.interest > 0.0:
+			e.principal *= (1.0 + e.interest)   # unbounded growth -> no immortal runs
+		if e.fuse > 0:
+			e.fuse -= 1
+			continue
+		_bill(e, state)
+		e.settled = true
+
+## Bill a due entry in its own currency. A money bill the debtor cannot cover
+## converts the shortfall into doom + reputation damage and records the entry as a
+## cause of death — this is the escalation that makes debt lethal and traceable.
+func _bill(e: Entry, state) -> void:
+	match e.currency:
+		"money":
+			state.money -= e.principal
+			if state.money < 0.0:
+				var shortfall: float = -state.money
+				state.money = 0.0
+				state.doom += shortfall / 1000.0 * DOOM_PER_UNPAID_1000
+				state.reputation = max(0.0, state.reputation - shortfall / 1000.0 * REP_PER_UNPAID_1000)
+				_attribute(e, shortfall)
+		"reputation":
+			state.reputation = max(0.0, state.reputation - e.principal)
+		"governance":
+			# Governance is a resource the ledger reads/writes (ADR-0003). Its
+			# player-facing design is parked (workshop #2). Below zero, corroded
+			# governance leaks into doom — the bribery/blackmail pressure surface.
+			state.governance -= e.principal
+			if state.governance < 0.0:
+				var deficit: float = -state.governance
+				state.governance = 0.0
+				state.doom += deficit / 1000.0 * DOOM_PER_UNPAID_1000
+				_attribute(e, deficit)
+		"doom":
+			state.doom += e.principal
+			_attribute(e, e.principal)
+		"action_points":
+			state.action_points = max(0, state.action_points - int(e.principal))
+
+func _attribute(e: Entry, magnitude: float) -> void:
+	death_attribution.append({"source": e.source, "currency": e.currency, "magnitude": magnitude})
+
+## Expose a secret entry (rival action / scheduled cause). Converts it to
+## reputation + governance damage, and — the chain continues — may offer a
+## blackmail entry (a new, worse liability). Blackmail is content, not a system.
+func expose(entry: Entry, state, offer_blackmail: bool = true) -> void:
+	if not entry.secret or entry.settled:
+		return
+	entry.secret = false
+	state.reputation = max(0.0, state.reputation - entry.principal / 1000.0 * 4.0)
+	state.governance -= entry.principal * 0.5
+	if offer_blackmail:
+		# A worse liability that keeps the debtor quiet: shorter fuse, steeper rate.
+		add(Entry.new("blackmail:" + entry.source, "money", entry.principal * 1.5, 2, 0.5, true))
+
+# ---- Read helpers ----
+
+func outstanding(side: int = Side.PAYABLE) -> float:
+	var total := 0.0
+	for e in entries:
+		if not e.settled and e.side == side:
+			total += e.principal
+	return total
+
+func secret_entries() -> Array:
+	return entries.filter(func(e): return e.secret and not e.settled)
+
+func to_dict() -> Dictionary:
+	return {
+		"outstanding_payable": outstanding(Side.PAYABLE),
+		"outstanding_receivable": outstanding(Side.RECEIVABLE),
+		"entry_count": entries.size(),
+		"secret_count": secret_entries().size(),
+		"death_attribution": death_attribution.duplicate(true),
+	}

--- a/godot/scripts/core/ledger.gd.uid
+++ b/godot/scripts/core/ledger.gd.uid
@@ -1,0 +1,1 @@
+uid://buweu3reemnav

--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -109,6 +109,14 @@ func start_turn() -> Dictionary:
 	# Causes touch sim inputs only — never doom directly.
 	SeedSchedule.apply_due_causes(state)
 
+	# WS-1 (ADR-0003): the Liability Ledger bills AFTER scheduled causes, so an
+	# exposure cause can land the same turn it fires. Compounding payables are the
+	# mortality guarantee (ADR-0002): an un-serviced debt eventually bills more than
+	# the player can cover, and the resulting bankruptcy escalation is the death —
+	# traceable to specific entries via the ledger's attribution trail.
+	if state.ledger:
+		state.ledger.tick_and_bill(state)
+
 	# Calculate max AP based on staff (base 3 + 0.5 per staff member)
 	var total_staff = state.get_total_staff()
 	var max_ap = 3 + int(total_staff * 0.5)

--- a/godot/tests/unit/test_liability_ledger.gd
+++ b/godot/tests/unit/test_liability_ledger.gd
@@ -1,0 +1,116 @@
+extends GutTest
+## WS-1 (ADR-0003): the Liability Ledger.
+## Verifies entry lifecycle (fuse / compounding interest / billing), the bankruptcy
+## escalation that gives debt teeth, secret exposure -> blackmail chaining, and — the
+## definition-of-done — the ADR-0002 mortality guarantee via a headless soak: a
+## desperation bot buys time then dies of its own ledger (death is attributable);
+## a lean bot dies sooner but clean (no ledger attribution). Both runs are finite.
+
+func _fresh_state(seed_str: String):
+	var s = GameState.new(seed_str)
+	s.doom = 50.0
+	s.money = 245000.0
+	s.governance = 50.0
+	s.reputation = 50.0
+	return s
+
+
+func test_fuse_ticks_and_interest_compounds_before_due():
+	var state = _fresh_state("ledger-lifecycle")
+	var e = Ledger.loan(100000.0, 3, 0.25)  # principal 120k, fuse 3, +25%/turn
+	state.ledger.add(e)
+	var start_money: float = state.money
+
+	state.ledger.tick_and_bill(state)  # compound 120k->150k, fuse 3->2, not due
+	assert_eq(e.fuse, 2, "fuse decrements each turn")
+	assert_almost_eq(e.principal, 150000.0, 1.0, "principal compounds by interest rate")
+	assert_eq(state.money, start_money, "nothing billed before the fuse burns down")
+	assert_false(e.settled, "live entry is not settled")
+
+
+func test_due_entry_bills_its_currency():
+	var state = _fresh_state("ledger-bill")
+	state.ledger.add(Ledger.Entry.new("loan", "money", 50000.0, 0, 0.0))  # due now, no interest
+	var start_money: float = state.money
+	state.ledger.tick_and_bill(state)
+	assert_eq(state.money, start_money - 50000.0, "a due money entry bills in money")
+	assert_eq(state.ledger.entries[0].settled, true, "billed entry settles")
+
+
+func test_unpayable_bill_escalates_to_doom_and_is_attributed():
+	var state = _fresh_state("ledger-bankruptcy")
+	state.money = 5000.0
+	var doom0: float = state.doom
+	state.ledger.add(Ledger.Entry.new("loan", "money", 100000.0, 0, 0.0))
+	state.ledger.tick_and_bill(state)
+	assert_eq(state.money, 0.0, "money floors at zero on an unpayable bill")
+	assert_gt(state.doom, doom0, "the unpayable shortfall escalates into doom (the teeth)")
+	assert_gt(state.ledger.death_attribution.size(), 0, "the killing bill is attributed to its entry")
+
+
+func test_secret_exposure_offers_a_blackmail_entry():
+	var state = _fresh_state("ledger-expose")
+	var secret = Ledger.desperation_payroll(state.rng)  # secret governance liability
+	state.ledger.add(secret)
+	assert_true(secret.secret, "the payroll coinflip plants a secret liability")
+	var before: int = state.ledger.entries.size()
+	state.ledger.expose(secret, state)
+	assert_false(secret.secret, "exposure burns the secrecy flag")
+	assert_gt(state.ledger.entries.size(), before, "exposure offers a new blackmail entry (the chain continues)")
+
+
+# ---- Mortality-guarantee soak (the DoD) ----
+# A controlled structural soak of the ledger mechanic: doom rises each turn; spending
+# money suppresses it. The lean bot spends only clean money; the desperation bot also
+# takes loans to keep suppressing after clean money runs out. (Full-pipeline soak
+# through TurnManager's real doom/rival balance is a follow-up seam — see PR.)
+const _DOOM_RISE := 6.0
+const _SUPPRESS := 8.0
+const _COST := 45000.0
+
+func _soak(desperation: bool) -> Dictionary:
+	var state = _fresh_state("soak-%s" % ("desperation" if desperation else "lean"))
+	var turn := 0
+	while state.doom < 100.0 and turn < 300:
+		turn += 1
+		state.ledger.tick_and_bill(state)          # ledger bills first (may spike doom)
+		if state.doom >= 100.0:
+			break
+		state.doom += _DOOM_RISE
+		var suppressed := false
+		if state.money >= _COST:
+			state.money -= _COST
+			suppressed = true
+		elif desperation:
+			# Desperation lever: borrow to fund another suppression — buys time now,
+			# plants a compounding liability that bills later.
+			state.money += 70000.0
+			state.ledger.add(Ledger.loan(70000.0, 12, 0.10))
+			state.money -= _COST
+			suppressed = true
+		if suppressed:
+			state.doom -= _SUPPRESS
+		state.doom = clamp(state.doom, 0.0, 300.0)
+	return {
+		"turns": turn,
+		"attributed": state.ledger.death_attribution.size(),
+		"final_doom": state.doom,
+	}
+
+
+func test_mortality_guarantee_no_immortal_runs():
+	# Compounding payables guarantee termination: even the doom-suppressing desperation
+	# bot cannot outrun its ledger.
+	var desp := _soak(true)
+	assert_lt(desp["turns"], 300, "a debt-fuelled run must still terminate (no immortal runs)")
+	assert_gt(desp["attributed"], 0, "the desperation death is attributable to ledger entries")
+
+
+func test_desperation_buys_time_then_dies_of_its_own_ledger():
+	var lean := _soak(false)
+	var desp := _soak(true)
+	# Desperation buys time — it survives strictly longer than the clean-hands run...
+	assert_gt(desp["turns"], lean["turns"], "desperation levers buy time (more turns survived)")
+	# ...but at the cost of a spectacular, self-inflicted death.
+	assert_gt(desp["attributed"], 0, "desperation dies of its own ledger (attributed)")
+	assert_eq(lean["attributed"], 0, "the lean run dies clean — no ledger attribution")

--- a/godot/tests/unit/test_liability_ledger.gd.uid
+++ b/godot/tests/unit/test_liability_ledger.gd.uid
@@ -1,0 +1,1 @@
+uid://bg8awbx28mxxk


### PR DESCRIPTION
## The flagship (ADR-0003): every mitigation is a loan

A two-sided ledger of trades that **pay now and bill later**. **No new player-facing currency** (ADR-0003 "no parallel economy") — every entry reads/writes only existing resources: money, reputation, governance, action_points, doom. **Compounding interest is the ADR-0002 mortality guarantee**: an un-serviced debt eventually bills more than the player can cover, and the bankruptcy escalation that follows is the death — *traceable to specific entries*.

This is a **checkpoint lane opened for review, not auto-merged.** It is a faithful, well-tested **first wave of the engine + the soak proof**; player-facing action/UI wiring and content breadth are deliberately deferred (see Parked).

## Architecture

- **`ledger.gd` (new)** — `Entry` (source, currency, fuse, interest, secret, side, counterparty); `tick_and_bill()` (compound → advance fuse → bill due; an unpayable **money**/**governance** bill escalates the shortfall into **doom** + records **attribution**); `expose()` (secret → reputation/governance damage → **offers a blackmail entry**, the chain continues); first-wave content factories: `loan`, `funding_with_strings`, `desperation_payroll` (secret governance rot, coinflip via `state.rng` — deterministic), `staff_rider`.
- **`game_state.gd`** — `governance` resource added (the ledger bills against it; **player-facing design parked**); per-game `ledger` instance rebuilt in `reset()`; both serialized in `to_dict`.
- **`turn_manager.gd`** — `ledger.tick_and_bill()` in `start_turn`, **after** WS-C scheduled causes (so an exposure cause can land same-turn).

## DoD — the soak test is the proof
- [x] **Mortality guarantee:** a debt-fuelled desperation bot still terminates (no immortal runs) — compounding wins.
- [x] **Desperation buys time then dies of its own ledger:** desperation bot survives **strictly more turns** than the lean bot, and its death is **attributed** to ledger entries.
- [x] **Lean path survives cleanly:** the clean-hands run dies sooner but with **zero ledger attribution** (ADR-0003 boundary: the lean ledger must be viable).
- [x] Entry lifecycle, bankruptcy escalation, secret→blackmail all unit-tested — **6/6, 17 asserts**.
- [x] `run_godot_tests.py --quick` **green, no regressions** (WS-0 determinism, WS-B replay, WS-C schedule all still pass).

## ADR conflicts
None. `governance` is added as an engine resource because ADR-0003 explicitly names it a ledger currency; its player-facing design was already an open question (kickoff) and is parked, not invented.

## Questions for the next design workshop (parked — not freelanced)
1. **Governance design** — added as a `float` resource; its scale, starting value, how the player *raises/spends* it, and UI are undesigned.
2. **Balance constants** — escalation rates (`DOOM_PER_UNPAID_1000`, interest, loan multiple) are placeholders, not tuned.
3. **Player-facing action wiring** — content factories exist but aren't yet clickable actions in `actions.gd`/UI. This wave is engine + soak; the action/UI slice is next.
4. **Exposure trigger** — `expose()` is built + tested but not yet fired by a WS-C scheduled cause or rival action (no `expose_liability` cause handler yet).
5. **Receivables / counterparty depth** — the `Entry` model supports the receivable side, but favor/pledge content is unbuilt (overlaps ADR-0007 alliances).
6. **Staff riders** — factory exists but hiring/departure don't yet create/flip entries.
7. **Soak fidelity** — the soak uses a controlled doom model in the test, not the full TurnManager rival/doom pipeline; a full-pipeline soak is a follow-up.
8. **Ledger save/load serialization** — `to_dict` emits a summary; `from_dict` doesn't rebuild entries (replay reconstructs from turn 0, same bucket as EE-2).
9. **Inward-SA / ledger visibility** — no UI; ADR notes the ledger's own visibility may be partial (inward-SA deferral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)