### PR TITLE
feat(ledger-ui): BL-1 player-facing ledger — actions + screen + compact summary (+BL-2 exposure)

### DIFF
--- a/godot/scripts/core/actions.gd
+++ b/godot/scripts/core/actions.gd
@@ -197,6 +197,15 @@ static func get_all_actions() -> Array[Dictionary]:
 			"category": "research",
 			"is_submenu": true,
 			"unlock_conditions": {"papers_min": 1}  # Need at least 1 paper to unlock
+		},
+		# Financing submenu — the Liability Ledger (ADR-0003): every fix is a loan
+		{
+			"id": "financing",
+			"name": "Financing",
+			"description": "Loans, funding-with-strings, and desperation levers - every mitigation is a loan",
+			"costs": {},  # No cost to open menu
+			"category": "influence",
+			"is_submenu": true
 		}
 	]
 
@@ -222,6 +231,9 @@ static func get_action_by_id(action_id: String) -> Dictionary:
 		if action["id"] == action_id:
 			return action
 	for action in get_operations_options():
+		if action["id"] == action_id:
+			return action
+	for action in get_financing_options():
 		if action["id"] == action_id:
 			return action
 	# Special pass action (not in any submenu)
@@ -266,6 +278,41 @@ static func get_hiring_options() -> Array[Dictionary]:
 			"description": "Add philosophical perspective to research (+5 reputation)",
 			"costs": {"money": 70000, "action_points": 1},
 			"category": "hiring"
+		}
+	]
+
+static func get_financing_options() -> Array[Dictionary]:
+	"""Liability Ledger trades (ADR-0003). The caller (execute_action) applies the
+	immediate benefit and adds the future bill via the Ledger factories. Immediate
+	amounts and balance constants are PLACEHOLDERS - tuning parked (DQ-8, workshop #2)."""
+	return [
+		{
+			"id": "take_loan",
+			"name": "Take Loan",
+			"description": "+$50k now; a balloon repayment (~$60k) bills in 4 turns and compounds until paid.",
+			"costs": {"action_points": 1},
+			"category": "financing"
+		},
+		{
+			"id": "funding_strings",
+			"name": "Funding (Strings)",
+			"description": "+$40k now; a governance obligation bills in 6 turns.",
+			"costs": {"action_points": 1},
+			"category": "financing"
+		},
+		{
+			"id": "desperation_lever",
+			"name": "Desperation Lever",
+			"description": "Suppress doom now; plants a SECRET, compounding governance liability that rivals can expose.",
+			"costs": {"action_points": 1},
+			"category": "financing"
+		},
+		{
+			"id": "staff_rider",
+			"name": "Contractor",
+			"description": "+2 action points now; a small governance rider bills later.",
+			"costs": {"money": 15000, "action_points": 1},
+			"category": "financing"
 		}
 	]
 
@@ -562,6 +609,37 @@ static func execute_action(action_id: String, state: GameState) -> Dictionary:
 			# Submenu action - opens operations menu
 			result["message"] = "Opening operations menu..."
 			result["open_submenu"] = "operations"
+
+		"financing":
+			# Submenu action - opens the Liability Ledger financing menu (ADR-0003)
+			result["message"] = "Opening financing menu..."
+			result["open_submenu"] = "financing"
+
+		# --- Liability Ledger trades (ADR-0003): apply the immediate benefit here,
+		# add the future bill via the Ledger factories. Balance parked (DQ-8). ---
+		"take_loan":
+			state.add_resources({"money": 50000})
+			if state.ledger:
+				state.ledger.add(Ledger.loan(50000.0))
+			result["message"] = "Took a $50k loan (repayment bills in ~4 turns, compounding)"
+
+		"funding_strings":
+			state.add_resources({"money": 40000})
+			if state.ledger:
+				state.ledger.add(Ledger.funding_with_strings(40000.0))
+			result["message"] = "Accepted funding with strings (+$40k; a governance obligation bills later)"
+
+		"desperation_lever":
+			state.add_resources({"doom": -10.0})
+			if state.ledger:
+				state.ledger.add(Ledger.desperation_payroll(state.rng))
+			result["message"] = "Pulled a desperation lever (-10 doom now; a SECRET liability is planted)"
+
+		"staff_rider":
+			state.action_points += 2
+			if state.ledger:
+				state.ledger.add(Ledger.staff_rider("Contractor"))
+			result["message"] = "Brought on a contractor (+2 AP; a governance rider bills later)"
 
 		"submit_paper":
 			# Paper submission action (Issue #468)

--- a/godot/scripts/core/ledger.gd
+++ b/godot/scripts/core/ledger.gd
@@ -159,11 +159,34 @@ func outstanding(side: int = Side.PAYABLE) -> float:
 func secret_entries() -> Array:
 	return entries.filter(func(e): return e.secret and not e.settled)
 
+## Soonest fuse among live payables (turns until the next bill), -1 if none.
+func soonest_fuse() -> int:
+	var soonest := -1
+	for e in entries:
+		if not e.settled and e.side == Side.PAYABLE:
+			if soonest < 0 or e.fuse < soonest:
+				soonest = e.fuse
+	return soonest
+
+## BL-2: minimal DETERMINISTIC exposure of secret liabilities. Each unsettled secret
+## entry has `chance` (drawn from state.rng, so replay stays deterministic per WS-0) of
+## being exposed this turn -> reputation/governance damage + a blackmail offer. Exact
+## trigger design (rival-driven vs scheduled cause, probability) is PARKED (workshop #2).
+## Returns the entries exposed on this call.
+func check_exposures(state, chance: float) -> Array:
+	var exposed := []
+	for e in secret_entries():
+		if state.rng.randf() < chance:
+			expose(e, state)
+			exposed.append(e)
+	return exposed
+
 func to_dict() -> Dictionary:
 	return {
 		"outstanding_payable": outstanding(Side.PAYABLE),
 		"outstanding_receivable": outstanding(Side.RECEIVABLE),
 		"entry_count": entries.size(),
 		"secret_count": secret_entries().size(),
+		"soonest_fuse": soonest_fuse(),
 		"death_attribution": death_attribution.duplicate(true),
 	}

--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -116,6 +116,9 @@ func start_turn() -> Dictionary:
 	# traceable to specific entries via the ledger's attribution trail.
 	if state.ledger:
 		state.ledger.tick_and_bill(state)
+		# BL-2: secret liabilities have a per-turn chance to surface (deterministic via
+		# state.rng). 0.15 is a placeholder - exposure tuning parked (workshop #2).
+		state.ledger.check_exposures(state, 0.15)
 
 	# Calculate max AP based on staff (base 3 + 0.5 per staff member)
 	var total_staff = state.get_total_staff()

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -42,6 +42,7 @@ var game_manager: Node
 var queued_actions: Array = []
 var research_quality_selector  # Issue #500
 var doom_trend_graph  # #512 doom trend sparkline (script-instantiated)
+var ledger_summary_label: Label  # BL-1 compact Liability Ledger summary (script-instantiated)
 var current_turn_phase: String = "NOT_STARTED"
 
 # Active dialog state for keyboard shortcuts
@@ -82,6 +83,15 @@ func _ready():
 	doom_trend_graph.expand_requested.connect(_show_doom_trend_expanded)
 	right_zones.add_child(doom_trend_graph)
 	right_zones.move_child(doom_trend_graph, doom_meter_zone.get_index() + 1)
+
+	# BL-1: compact Liability Ledger summary just below the doom trend. Kept terse so
+	# the main view stays uncrowded; the full ledger is a switchable screen (Financing).
+	ledger_summary_label = Label.new()
+	ledger_summary_label.add_theme_font_size_override("font_size", 11)
+	ledger_summary_label.add_theme_color_override("font_color", Color(0.6, 0.75, 0.6))
+	ledger_summary_label.text = "Ledger: clean"
+	right_zones.add_child(ledger_summary_label)
+	right_zones.move_child(ledger_summary_label, doom_trend_graph.get_index() + 1)
 
 	# Enable input processing for keyboard shortcuts
 	set_process_input(true)
@@ -523,6 +533,9 @@ func _on_game_state_updated(state: Dictionary):
 	if doom_trend_graph:
 		doom_trend_graph.set_history(state.get("doom_history", []))
 
+	# BL-1: refresh the compact Liability Ledger summary
+	_update_ledger_summary(state.get("ledger", {}))
+
 	# Update office cat for doom level and visibility
 	if office_cat:
 		office_cat.update_doom_level(doom / 100.0)  # Convert percentage to 0.0-1.0
@@ -568,6 +581,24 @@ func _on_game_state_updated(state: Dictionary):
 
 	# Update employee roster display
 	_update_employee_roster(state)
+
+func _update_ledger_summary(ledger_data: Dictionary) -> void:
+	"""BL-1 compact summary: outstanding owed, soonest due, secret count. Deliberately
+	terse so the main view stays uncrowded; the full ledger is a switchable screen."""
+	if not ledger_summary_label:
+		return
+	var owed: float = float(ledger_data.get("outstanding_payable", 0.0))
+	var soonest: int = int(ledger_data.get("soonest_fuse", -1))
+	var secrets: int = int(ledger_data.get("secret_count", 0))
+	if ledger_data.is_empty() or (owed <= 0.0 and secrets == 0):
+		ledger_summary_label.text = "Ledger: clean"
+		ledger_summary_label.add_theme_color_override("font_color", Color(0.6, 0.75, 0.6))
+		return
+	var due_txt := ("due %dt" % soonest) if soonest >= 0 else "no due"
+	var secret_txt := ("  |  %d secret" % secrets) if secrets > 0 else ""
+	ledger_summary_label.text = "Ledger: %s owed  |  %s%s" % [GameConfig.format_money(owed), due_txt, secret_txt]
+	# Redden as secret liabilities mount (the exposure pressure surface)
+	ledger_summary_label.add_theme_color_override("font_color", Color(0.85, 0.78, 0.55) if secrets == 0 else Color(0.9, 0.55, 0.45))
 
 func _on_turn_phase_changed(phase_name: String):
 	print("[MainUI] Phase changed: ", phase_name)
@@ -871,6 +902,8 @@ func _on_dynamic_action_pressed(action_id: String, action_name: String):
 			_show_travel_submenu()
 		elif action_id == "operations":
 			_show_operations_submenu()
+		elif action_id == "financing":
+			_show_financing_submenu()
 		# Align the submenu to the clicked button + add close affordance (#510)
 		_decorate_active_submenu(_find_action_button(action_id))
 		return
@@ -1567,6 +1600,190 @@ func _on_fundraising_option_selected(action_id: String, action_name: String, dia
 
 	print("[MainUI] Calling game_manager.select_action(%s)" % action_id)
 	game_manager.select_action(action_id)
+
+func _show_financing_submenu():
+	"""BL-1: the Liability Ledger financing menu (ADR-0003) - lists the ledger trades
+	plus a button that opens the full switchable ledger screen."""
+	if active_dialog != null and is_instance_valid(active_dialog):
+		active_dialog.queue_free()
+		active_dialog = null
+		active_dialog_buttons = []
+
+	var dialog = Panel.new()
+	dialog.custom_minimum_size = Vector2(440, 330)
+	dialog.size = Vector2(440, 330)
+	dialog.position = Vector2(90, 80)
+
+	var margin = MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 15)
+	margin.add_theme_constant_override("margin_right", 15)
+	margin.add_theme_constant_override("margin_top", 15)
+	margin.add_theme_constant_override("margin_bottom", 15)
+	dialog.add_child(margin)
+
+	var main_vbox = VBoxContainer.new()
+	main_vbox.add_theme_constant_override("separation", 6)
+	margin.add_child(main_vbox)
+
+	var title = Label.new()
+	title.text = "FINANCING - every fix is a loan"
+	title.add_theme_font_size_override("font_size", 13)
+	title.add_theme_color_override("font_color", Color(0.85, 0.78, 0.55))
+	main_vbox.add_child(title)
+
+	var current_state = game_manager.get_game_state()
+	var buttons = []
+	var key_labels = ["Q", "W", "E", "R"]
+	var idx = 0
+	for option in GameActions.get_financing_options():
+		var opt_id = option.get("id", "")
+		var opt_name = option.get("name", "")
+		var opt_costs = option.get("costs", {})
+		var btn = Button.new()
+		btn.focus_mode = Control.FOCUS_NONE
+		btn.custom_minimum_size = Vector2(0, 44)
+		var key = key_labels[idx] if idx < key_labels.size() else ""
+		var cost_bits = []
+		if opt_costs.get("action_points", 0) > 0:
+			cost_bits.append("%d AP" % opt_costs["action_points"])
+		if opt_costs.get("money", 0) > 0:
+			cost_bits.append(GameConfig.format_money(opt_costs["money"]))
+		var cost_txt = (" (%s)" % ", ".join(cost_bits)) if cost_bits.size() > 0 else ""
+		btn.text = "[%s]  %s%s" % [key, opt_name, cost_txt]
+		btn.tooltip_text = option.get("description", "")
+		var can_afford = true
+		for res in opt_costs.keys():
+			if res == "action_points":
+				continue
+			if current_state.get(res, 0) < opt_costs[res]:
+				can_afford = false
+		if not can_afford:
+			btn.disabled = true
+			btn.modulate = Color(0.5, 0.5, 0.5)
+		btn.pressed.connect(func(): _on_financing_option_selected(opt_id, opt_name, dialog))
+		main_vbox.add_child(btn)
+		buttons.append(btn)
+		idx += 1
+
+	var view_btn = Button.new()
+	view_btn.focus_mode = Control.FOCUS_NONE
+	view_btn.custom_minimum_size = Vector2(0, 34)
+	view_btn.text = "View Ledger  >>"
+	view_btn.add_theme_color_override("font_color", Color(0.7, 0.85, 0.9))
+	view_btn.pressed.connect(func(): _show_ledger_screen())
+	main_vbox.add_child(view_btn)
+
+	active_dialog = dialog
+	active_dialog_buttons = buttons
+	tab_manager.add_child(dialog)
+	dialog.visible = true
+	dialog.z_index = 1000
+	dialog.z_as_relative = false
+
+func _on_financing_option_selected(action_id: String, action_name: String, dialog: Control):
+	"""Queue a ledger trade (mirrors fundraising selection)."""
+	dialog.queue_free()
+	active_dialog = null
+	active_dialog_buttons = []
+
+	var action_def = _get_action_by_id(action_id)
+	var ap_cost = action_def.get("costs", {}).get("action_points", 0)
+	var available_ap = game_manager.state.get_available_ap()
+	if available_ap < ap_cost:
+		log_message("[color=red]Not enough AP: need %d, have %d[/color]" % [ap_cost, available_ap])
+		return
+	if not game_manager.state.can_afford(action_def.get("costs", {})):
+		log_message("[color=red]Cannot afford: %s[/color]" % action_name)
+		return
+	log_message("[color=cyan]Financing: %s[/color]" % action_name)
+	queued_actions.append({"id": action_id, "name": action_name})
+	update_queued_actions_display()
+	game_manager.select_action(action_id)
+
+func _show_ledger_screen():
+	"""BL-1: the full Liability Ledger screen - a switchable CRT viewport listing every
+	live entry (source, currency, principal, fuse, secrecy) plus death attribution."""
+	if active_dialog != null and is_instance_valid(active_dialog):
+		active_dialog.queue_free()
+		active_dialog = null
+		active_dialog_buttons = []
+
+	var dialog = Panel.new()
+	dialog.custom_minimum_size = Vector2(560, 460)
+	dialog.size = Vector2(560, 460)
+	dialog.position = Vector2(90, 60)
+
+	var margin = MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 16)
+	margin.add_theme_constant_override("margin_right", 16)
+	margin.add_theme_constant_override("margin_top", 16)
+	margin.add_theme_constant_override("margin_bottom", 16)
+	dialog.add_child(margin)
+	var vbox = VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 4)
+	margin.add_child(vbox)
+
+	var ledger = game_manager.state.ledger if (game_manager and game_manager.state) else null
+
+	var title = Label.new()
+	title.text = "LIABILITY LEDGER"
+	title.add_theme_font_size_override("font_size", 15)
+	title.add_theme_color_override("font_color", Color(0.85, 0.78, 0.55))
+	vbox.add_child(title)
+
+	if ledger == null:
+		var none = Label.new()
+		none.text = "(no ledger)"
+		vbox.add_child(none)
+	else:
+		var summary = Label.new()
+		summary.text = "Owed: %s    Favors: %s    Secrets: %d" % [
+			GameConfig.format_money(ledger.outstanding(Ledger.Side.PAYABLE)),
+			GameConfig.format_money(ledger.outstanding(Ledger.Side.RECEIVABLE)),
+			ledger.secret_entries().size()]
+		summary.add_theme_font_size_override("font_size", 12)
+		summary.add_theme_color_override("font_color", Color(0.8, 0.8, 0.8))
+		vbox.add_child(summary)
+
+		var scroll = ScrollContainer.new()
+		scroll.custom_minimum_size = Vector2(0, 320)
+		scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		vbox.add_child(scroll)
+		var list = VBoxContainer.new()
+		list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		scroll.add_child(list)
+
+		var live = ledger.entries.filter(func(e): return not e.settled)
+		if live.is_empty():
+			var clean = Label.new()
+			clean.text = "Clean books. Every mitigation you take will show up here as a bill."
+			clean.add_theme_color_override("font_color", Color(0.6, 0.75, 0.6))
+			list.add_child(clean)
+		for e in live:
+			var row = Label.new()
+			var side_txt = "owe" if e.side == Ledger.Side.PAYABLE else "owed"
+			var secret_txt = "   [SECRET]" if e.secret else ""
+			var interest_txt = ("  @%.0f%%/t" % (e.interest * 100.0)) if e.interest > 0.0 else ""
+			row.text = "%s   %s %.0f %s  |  due %dt%s%s" % [
+				e.source, side_txt, e.principal, e.currency, e.fuse, interest_txt, secret_txt]
+			row.add_theme_font_size_override("font_size", 11)
+			if e.secret:
+				row.add_theme_color_override("font_color", Color(0.9, 0.6, 0.5))
+			list.add_child(row)
+
+		if ledger.death_attribution.size() > 0:
+			var att = Label.new()
+			att.text = "\nAttributed damage: %d billed shortfalls" % ledger.death_attribution.size()
+			att.add_theme_color_override("font_color", Color(0.9, 0.5, 0.5))
+			vbox.add_child(att)
+
+	active_dialog = dialog
+	active_dialog_buttons = []
+	tab_manager.add_child(dialog)
+	dialog.visible = true
+	dialog.z_index = 1000
+	dialog.z_as_relative = false
+	_decorate_active_submenu()
 
 func _show_publicity_submenu():
 	"""Show popup dialog with publicity/influence options with keyboard support - icon grid layout"""

--- a/godot/tests/unit/test_actions.gd
+++ b/godot/tests/unit/test_actions.gd
@@ -19,7 +19,7 @@ func test_all_actions_have_required_fields():
 func test_action_count():
 	# Test that we have expected number of actions
 	var actions = GameActions.get_all_actions()
-	assert_eq(actions.size(), 12, "Should have 12 main actions")
+	assert_eq(actions.size(), 13, "Should have 13 main actions (incl. BL-1 Financing submenu)")
 
 func test_hiring_options_exist():
 	# Test that hiring submenu has 5 options (safety, capability, compute, manager, ethicist)

--- a/godot/tests/unit/test_ledger_actions.gd
+++ b/godot/tests/unit/test_ledger_actions.gd
@@ -1,0 +1,68 @@
+extends GutTest
+## BL-1: player-facing Liability Ledger trades (via GameActions.execute_action) +
+## the BL-2 deterministic exposure trigger. Engine-level; UI is exercised by the boot check.
+
+func _fresh_state(seed_str: String = "bl1-test") -> GameState:
+	var s = GameState.new(seed_str)
+	s.money = 200000
+	s.action_points = 5
+	return s
+
+func test_take_loan_pays_out_and_adds_bill():
+	var s = _fresh_state()
+	var before = s.money
+	GameActions.execute_action("take_loan", s)
+	assert_eq(s.money, before + 50000, "loan pays out immediately")
+	assert_eq(s.ledger.entries.size(), 1, "loan adds one ledger entry")
+	assert_gt(s.ledger.outstanding(Ledger.Side.PAYABLE), 0.0, "loan creates a payable liability")
+
+func test_funding_strings_bills_governance():
+	var s = _fresh_state()
+	var before = s.money
+	GameActions.execute_action("funding_strings", s)
+	assert_eq(s.money, before + 40000, "funding pays out")
+	assert_eq(s.ledger.entries[0].currency, "governance", "strings bill in governance")
+
+func test_desperation_lever_suppresses_doom_and_plants_secret():
+	var s = _fresh_state()
+	var before_doom = s.doom
+	GameActions.execute_action("desperation_lever", s)
+	assert_lt(s.doom, before_doom, "desperation suppresses doom now")
+	assert_eq(s.ledger.secret_entries().size(), 1, "desperation plants a SECRET liability")
+
+func test_staff_rider_grants_ap_and_rider():
+	var s = _fresh_state()
+	var before_ap = s.action_points
+	GameActions.execute_action("staff_rider", s)
+	assert_eq(s.action_points, before_ap + 2, "contractor grants +2 AP now")
+	assert_eq(s.ledger.entries.size(), 1, "staff rider adds a ledger entry")
+
+func test_exposure_fires_and_chains():
+	var s = _fresh_state()
+	GameActions.execute_action("desperation_lever", s)
+	assert_eq(s.ledger.secret_entries().size(), 1, "one secret before exposure")
+	var before_entries = s.ledger.entries.size()
+	var exposed = s.ledger.check_exposures(s, 1.0)  # chance 1.0 -> deterministic expose
+	assert_eq(exposed.size(), 1, "the secret entry is exposed")
+	assert_false(exposed[0].secret, "the exposed entry is no longer secret")
+	assert_gt(s.ledger.entries.size(), before_entries, "exposure offers a blackmail entry (chain continues)")
+	var has_blackmail := false
+	for e in s.ledger.entries:
+		if e.source.begins_with("blackmail:"):
+			has_blackmail = true
+	assert_true(has_blackmail, "exposure creates a blackmail entry (itself a new secret liability)")
+
+func test_soonest_fuse_is_nearest_bill():
+	var s = _fresh_state()
+	GameActions.execute_action("take_loan", s)          # fuse 4
+	GameActions.execute_action("desperation_lever", s)  # fuse 3
+	assert_eq(s.ledger.soonest_fuse(), 3, "soonest fuse is the nearest upcoming bill")
+
+func test_trade_stays_seed_deterministic():
+	# WS-0 invariant: same seed + same trade -> identical ledger outcome.
+	var a = _fresh_state("det-seed")
+	GameActions.execute_action("desperation_lever", a)
+	var b = _fresh_state("det-seed")
+	GameActions.execute_action("desperation_lever", b)
+	assert_eq(a.ledger.entries[0].principal, b.ledger.entries[0].principal,
+		"desperation severity (rng-drawn) is identical for identical seeds")

--- a/godot/tests/unit/test_ledger_actions.gd.uid
+++ b/godot/tests/unit/test_ledger_actions.gd.uid
@@ -1,0 +1,1 @@
+uid://b2bul416lgmij


### PR DESCRIPTION
Makes the WS-1 Liability Ledger (ADR-0003, #555) **player-facing** — the piece that turns the merged ledger engine into something you can actually play and playtest.

## What's now player-interactable
- **Financing submenu** (new top-level action) with four ledger trades, each wired through the existing action pipeline (affordability → queue → `execute_action`):
  - **Take Loan** — +$50k now; ~$60k balloon bills in 4 turns, compounding.
  - **Funding (Strings)** — +$40k now; a governance obligation bills in 6 turns.
  - **Desperation Lever** — suppresses doom now; plants a **secret** compounding governance liability.
  - **Contractor** — +2 AP now; a small governance rider bills later.
  Each applies its immediate benefit and adds the future bill via the `Ledger` factories.
- **Switchable Liability Ledger screen** (reached via Financing → "View Ledger") — a CRT-style viewport listing every live entry (source, currency, principal, `due Nt`, interest, secrecy, side) + outstanding totals + death attribution. Built on the existing submenu/dialog idiom.
- **Compact main-UI summary** below the doom trend: `Ledger: $X owed | due Nt | Y secret`, reddening as secrets mount. Kept terse to avoid crowding (per direction).

## BL-2 (bundled — the loop needs it)
`expose()` existed but nothing fired it, so desperation levers had no downside. Added a **minimal deterministic** per-turn exposure check (`Ledger.check_exposures`, drawn from `state.rng`) in the turn loop, so secret liabilities surface → reputation/governance damage → blackmail chain. Exact trigger tuning is parked.

## Verification
- **183/183 unit tests green** (7 new `test_ledger_actions.gd` covering the four trades, exposure+chain, soonest-fuse, seed-determinism; no regressions — WS-0/WS-1/WS-B/WS-C all pass). Updated `test_action_count` 12→13 for the new submenu.
- **Boot check:** `scenes/main.tscn` loads headless, `MainUI._ready()` + the ledger widget instantiate and refresh with **zero script errors**; ledger state flows into the UI.
- Caveat: the click-only dialog builders (Financing submenu, Ledger screen) are parse-valid and copy the proven fundraising-dialog pattern, but were **not** click-exercised headlessly — worth a click-through during playtest.

## Parked (workshop #2 / balance)
- **DQ-7 Governance UX** — governance is billed against but has no player-facing raise/spend/UI design.
- **DQ-8 Balance** — all immediate amounts, loan terms, and the 0.15 exposure chance are placeholders, untuned.
- **Exposure trigger design** — rival-driven vs scheduled-cause vs per-turn probability; currently a flat per-turn rng check.
- **BL-3 staff-rider hire/departure** auto-wiring still parked (the Contractor action is standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)