### PR TITLE
fix: rival labs contribute scaling doom pressure (#562)

### DIFF
--- a/godot/scripts/core/doom_system.gd
+++ b/godot/scripts/core/doom_system.gd
@@ -10,6 +10,11 @@ class_name DoomSystem
 ## Core doom state
 var current_doom: float = 50.0
 
+## Rival doom pending contribution — turn_manager sets this via set_rival_doom_contribution()
+## BEFORE calculate_doom_change(); it must be re-applied in _calculate_rival_doom() AFTER the
+## per-turn _reset_doom_sources(), or it gets wiped to 0 (the bug behind issue #562).
+var _pending_rival_doom: float = 0.0
+
 ## Momentum mechanics - doom changes accumulate and compound
 var doom_velocity: float = 0.0  # Current rate of doom change per turn
 var doom_momentum: float = 0.0  # Accumulated momentum (compounds over time)
@@ -210,9 +215,9 @@ func _calculate_researcher_doom(state: GameState):
 	doom_sources["specializations"] = spec_doom
 
 func _calculate_rival_doom(_state: GameState):
-	"""Doom from rival actions - already calculated in turn manager"""
-	# This is set externally by turn_manager after rival processing
-	pass
+	"""Doom from rival actions - computed by turn_manager, stashed in _pending_rival_doom.
+	Applied here (after _reset_doom_sources) so it survives into the source sum. (Issue #562)"""
+	doom_sources["rivals"] = _pending_rival_doom
 
 func _calculate_unproductive_doom(state: GameState):
 	"""Doom from unproductive employees"""
@@ -317,8 +322,10 @@ func add_event_doom(amount: float, _reason: String = ""):
 	current_doom = clamp(current_doom, 0.0, 100.0)
 
 func set_rival_doom_contribution(amount: float):
-	"""Called by turn_manager after processing rival actions"""
-	doom_sources["rivals"] = amount
+	"""Called by turn_manager after processing rival actions.
+	Stored (not written straight to doom_sources) so the next calculate_doom_change()
+	reset does not wipe it before _calculate_rival_doom() re-applies it. (Issue #562)"""
+	_pending_rival_doom = amount
 
 # ============================================================================
 # UTILITY FUNCTIONS

--- a/godot/scripts/core/rivals.gd
+++ b/godot/scripts/core/rivals.gd
@@ -3,6 +3,12 @@ class_name RivalLabs
 ## Rival AI labs that compete with the player
 ## Issue #474: Organization discovery system
 
+## Passive "capability-overhang" doom each rival applies per turn, scaling with its
+## accumulated capability_progress — a GROWING pressure a fixed safety capacity cannot
+## offset forever (the unbounded-mortality term for issue #562 / DQ-1).
+## Placeholder magnitude — tuning is workshop #2.
+const CAPABILITY_OVERHANG_DOOM_PER_PROGRESS: float = 0.05
+
 # Organization visibility states
 enum VisibilityState {
 	HIDDEN,      # Player does not know they exist
@@ -130,6 +136,10 @@ static func process_rival_turn(rival: RivalLab, player_state: GameState, rng: Ra
 			"safety_research":
 				rival.safety_progress += 8.0
 				result["doom_contribution"] -= 3.0
+	# Passive capability-overhang pressure: grows as this rival's capability_progress
+	# accumulates, so advanced rivals apply doom a fixed safety capacity cannot fully
+	# offset over time (issue #562 / DQ-1 mortality term). Placeholder scale.
+	result["doom_contribution"] += rival.capability_progress * CAPABILITY_OVERHANG_DOOM_PER_PROGRESS
 	return result
 
 static func _choose_rival_action(rival: RivalLab, _player_state: GameState, rng: RandomNumberGenerator) -> String:

--- a/godot/tests/unit/test_doom_system.gd
+++ b/godot/tests/unit/test_doom_system.gd
@@ -373,3 +373,40 @@ func test_unproductive_doom_no_double_counting():
 	# Only 6 unproductive (not 6 + 6 from double counting)
 	# 6 * 0.5 = 3.0 doom
 	assert_eq(doom_system.doom_sources["unproductive"], 3.0, "Unmanaged should not be double-counted")
+
+# ============================================================================
+# RIVAL DOOM CONTRIBUTION TESTS (Issue #562)
+# ============================================================================
+
+func test_rival_doom_survives_source_reset():
+	# Regression: turn_manager sets rival doom BEFORE calculate_doom_change(), whose
+	# _reset_doom_sources() used to wipe it to 0 before the sum.
+	var doom_system = _create_doom_system()
+	var state = _create_minimal_game_state()
+	doom_system.set_rival_doom_contribution(7.0)
+	var result = doom_system.calculate_doom_change(state)
+	assert_eq(result["sources"]["rivals"], 7.0, "Rival doom must survive the per-turn source reset (issue #562)")
+
+func test_rival_doom_zero_when_unset():
+	var doom_system = _create_doom_system()
+	var state = _create_minimal_game_state()
+	var result = doom_system.calculate_doom_change(state)
+	assert_eq(result["sources"]["rivals"], 0.0, "Rival doom is 0 when no contribution set")
+
+func test_rival_capability_overhang_scales_with_progress():
+	# The passive overhang term grows with accumulated capability_progress, so an advanced
+	# rival applies strictly more doom than an identical low-progress one (same rng seed).
+	var low = RivalLabs.RivalLab.new("LowLab", 0.9)
+	low.capability_progress = 0.0
+	var high = RivalLabs.RivalLab.new("HighLab", 0.9)
+	high.capability_progress = 200.0
+	var state = _create_minimal_game_state()
+	var rng_low = RandomNumberGenerator.new()
+	rng_low.seed = 12345
+	var rng_high = RandomNumberGenerator.new()
+	rng_high.seed = 12345
+	var low_result = RivalLabs.process_rival_turn(low, state, rng_low)
+	var high_result = RivalLabs.process_rival_turn(high, state, rng_high)
+	var expected_delta = 200.0 * RivalLabs.CAPABILITY_OVERHANG_DOOM_PER_PROGRESS
+	assert_almost_eq(high_result["doom_contribution"] - low_result["doom_contribution"], expected_delta, 0.001, "Overhang doom scales with capability_progress")
+	assert_gt(high_result["doom_contribution"], low_result["doom_contribution"], "Higher-capability rival contributes more doom")

--- a/godot/tests/unit/test_seed_schedule.gd
+++ b/godot/tests/unit/test_seed_schedule.gd
@@ -55,7 +55,7 @@ func test_vet_seed_classifies_against_configurable_envelope():
 	assert_true(str(punishing["reason"]).contains("punishing"), "reason should name the failure")
 
 	# Impossible threat floor: reject as a snoozefest.
-	var snooze := BaselineSimulator.vet_seed(SEED, [], {"doom_threat_floor": 9999.0})
+	var snooze := BaselineSimulator.vet_seed(SEED, [], {"min_turns": 1, "doom_threat_floor": 9999.0})
 	assert_false(snooze["accepted"], "unreachable doom floor should reject")
 	assert_true(str(snooze["reason"]).contains("snoozefest"), "reason should name the failure")
 


### PR DESCRIPTION
Closes #562.

## Root cause
`turn_manager` computes rival doom and calls `doom_system.set_rival_doom_contribution()` — but that ran BEFORE `calculate_doom_change()`, whose `_reset_doom_sources()` wiped it back to 0, and `_calculate_rival_doom()` was a `pass`. So `doom_sources.rivals` was always 0 (Pip's playtest #560 log).

## Fix
- Stash the pending rival contribution in a field; re-apply it in `_calculate_rival_doom()` **after** the reset.
- Add a passive **capability-overhang** term (`rivals.gd`) that scales with each rival's accumulated `capability_progress` — so rivals become a **growing** pressure a fixed safety capacity can't offset forever. This is the candidate **mortality term for clean runs**, i.e. the companion that could make removing the doom≤0 victory (DQ-1) safe.

## Verification
- 3 new tests: rival doom survives the source reset; overhang scales with progress (delta exactly 10.0 for +200 progress @ 0.05); `--quick` green.
- **Integration proof:** the seed-vetting `snoozefest` test now needed `min_turns:1` — because the passive baseline dies *faster* now that rivals bite in real multi-turn runs.

## Parked (workshop #2)
- Magnitude tuning (`CAPABILITY_OVERHANG_DOOM_PER_PROGRESS = 0.05`, placeholder).
- **Whether this is sufficient to make clean safety runs mortal** — needs a re-run of the victory-removed sweep with rivals live to confirm DQ-1 is now safe.