### PR TITLE
feat: remove doom<=0 victory (DQ-1, ADR-0002) + soften rival pressure

### DIFF
--- a/docs/game-design/WORKSHOP_2_BACKLOG.md
+++ b/docs/game-design/WORKSHOP_2_BACKLOG.md
@@ -15,10 +15,11 @@
 
 ## Design questions — for Fable workshop #2
 
-- **DQ-1 · Victory condition removal** *(#550, ADR-0002)* — `check_win_lose()` still ends
-  with `victory=true` at doom ≤ 0, contradicting ADR-0002. Removal was gated on a mortality
-  guarantee — **which WS-1 now provides** (compounding ledger interest), so this is
-  unblocked to decide. Remove the doom≤0 victory branch?
+- **DQ-1 · Victory condition removal — RESOLVED** *(#550, ADR-0002)* — the doom≤0 victory
+  branch is **removed**. Proven safe by the exploit sweep: with rival labs contributing
+  scaling doom (#562), a clean safety run is now *finite* (dies of doom, no immortal runs),
+  so removing the win no longer creates an immortal-run exploit. The game is now unwinnable
+  by design (ADR-0002 thesis: you can only buy time).
 - **DQ-2 · Baseline yardstick** *(#550)* — is the no-action baseline still the right
   reference under turns-survived scoring?
 - **DQ-3 · Cross-version leaderboard UX** *(#550)* — `(seed, game_version)` boards show as
@@ -36,8 +37,10 @@
 - **DQ-7 · Governance player-facing design** *(#555)* — `governance` added as an engine
   `float` (a ledger currency per ADR-0003), but its scale, starting value, how the player
   raises/spends it, and its UI are **undesigned**.
-- **DQ-8 · Ledger balance constants** *(#555)* — escalation rates (`DOOM_PER_UNPAID_1000`,
-  interest, loan multiple) are **placeholders**, not tuned. Likely a playtest-driven pass.
+- **DQ-8 · Balance constants** *(#555, #562)* — ledger escalation rates
+  (`DOOM_PER_UNPAID_1000`, interest, loan multiple) and rival doom pressure are
+  **placeholders**. Rival magnitude softened `0.05 → 0.025` as a first step toward longer
+  games; full tuning (game length, sink pricing) still open — a playtest-driven pass.
 - **DQ-9 · Receivables / counterparty content** *(#555)* — the `Entry` model supports the
   receivable (favor/pledge) side, but content is unbuilt and **overlaps ADR-0007 alliances**
   (WS-3). Design together?

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -428,9 +428,6 @@ func check_win_lose():
 	elif reputation <= 0.0:
 		game_over = true
 		victory = false
-	elif doom <= 0.0:
-		game_over = true
-		victory = true
 
 func get_total_staff() -> int:
 	# Count individual researchers if using new system

--- a/godot/scripts/core/rivals.gd
+++ b/godot/scripts/core/rivals.gd
@@ -7,7 +7,7 @@ class_name RivalLabs
 ## accumulated capability_progress — a GROWING pressure a fixed safety capacity cannot
 ## offset forever (the unbounded-mortality term for issue #562 / DQ-1).
 ## Placeholder magnitude — tuning is workshop #2.
-const CAPABILITY_OVERHANG_DOOM_PER_PROGRESS: float = 0.05
+const CAPABILITY_OVERHANG_DOOM_PER_PROGRESS: float = 0.025
 
 # Organization visibility states
 enum VisibilityState {

--- a/godot/tests/unit/test_game_state.gd
+++ b/godot/tests/unit/test_game_state.gd
@@ -94,8 +94,8 @@ func test_get_total_staff_counts_all_types():
 
 	assert_eq(state.get_total_staff(), 9, "Total staff should be 9")
 
-func test_check_win_lose_doom_victory():
-	# Test victory when doom reaches 0
+func test_check_win_lose_doom_zero_no_victory():
+	# DQ-1 / ADR-0002: there is NO victory condition. doom<=0 must NOT end the game.
 	var state = GameState.new("test_seed")
 	state.doom = 0.0
 	# Must also set doom_system since check_win_lose syncs from it
@@ -104,8 +104,8 @@ func test_check_win_lose_doom_victory():
 
 	state.check_win_lose()
 
-	assert_true(state.game_over, "Game should be over")
-	assert_true(state.victory, "Should be victorious")
+	assert_false(state.game_over, "doom<=0 must not end the game (no victory condition)")
+	assert_false(state.victory, "There is no victory condition (ADR-0002)")
 
 func test_check_win_lose_doom_defeat():
 	# Test defeat when doom reaches 100


### PR DESCRIPTION
Resolves **DQ-1** (backlog) and softens rival doom magnitude — the pacing pass Pip approved.

## Changes
- **Removed the doom<=0 victory branch** from `check_win_lose()` (`game_state.gd`). ADR-0002 mandates no victory condition; the game is now unwinnable by design.
- **Softened** `CAPABILITY_OVERHANG_DOOM_PER_PROGRESS` `0.05 -> 0.025` (`rivals.gd`) for longer, more testable games. Placeholder — full tuning is DQ-8/workshop #2.
- Updated `test_game_state.gd`: `doom<=0` now asserts **no** game-over / **no** victory (new contract, not deleted coverage).
- `WORKSHOP_2_BACKLOG.md`: DQ-1 marked **RESOLVED**, DQ-8 notes the rival softening.

## Why it's safe (exploit sweep, 20 seeds x 5 policies, real turn loop)
Removing the victory alone made clean safety runs immortal; rival scaling doom (#562) is the unbounded pressure that fixes it.

| policy (safety_lean) | wins | immortal | median | max |
|---|---|---|---|---|
| 0.05 rivals, no victory | 0 | **no** | 16 | 32 |
| **0.025 rivals, no victory (this PR)** | 0 | **no** | **47** | **62** |

All policies: **0 wins**, **every run terminates before turn 300** (mortality holds), and games are **longer** (safety_lean 16->47 median). `run_godot_tests.py --quick` green.