### PR TITLE
docs(qa): playtest session log + blog seed

### DIFF
--- a/docs/qa/PLAYTEST_SESSION_2026-07-10_ledger-milestone.md
+++ b/docs/qa/PLAYTEST_SESSION_2026-07-10_ledger-milestone.md
@@ -1,0 +1,91 @@
+---
+title: 'Playtest Session — The Ledger Milestone (first play with shape)'
+date: '2026-07-10'
+tags: ['playtest', 'ledger', 'devblog', 'session-log']
+summary: 'First post-Big-Pause play of a build with hiring fixed, rivals biting, no trivial win, and ~47-turn games — session log + blog seed.'
+commit: 'e1cbc26'
+---
+
+# Playtest Session Log — The Ledger Milestone (2026-07-10)
+
+> **Dual-purpose doc.** Left column = a methodical session you work top-to-bottom.
+> Everything you jot here is structured to distill into the **Blog draft** section at the
+> bottom. Pairs with an **OBS capture** — note the timecode for anything worth clipping or
+> writing about, then keep playing; flesh out prose afterward.
+>
+> This is the *feel & story* pass. Hard bugs still go to **F8 / GitHub issues** (and the
+> `QA_PLAYTHROUGH_v0.11.md` checklist covers systematic coverage). Don't stop to write
+> essays mid-run — timecode + a few words is enough.
+
+## Session setup (fill before you hit record)
+- **Build:** `e1cbc26` (`main`) — hiring fixed (#569), rivals bite (#570), no trivial win + softened pacing (#571).
+- **OBS file / start time:** ______________________
+- **Seed(s) played:** ______________________
+- **Difficulty / scenario:** ______________________ *(note: Easy/Hard UI is still broken — #563)*
+- **Today's question (one line):** does the core loop + ledger now create real tension, and does it *read* on video?
+
+## Known-still-broken (so a rough edge doesn't derail the session)
+Difficulty UI (#563), F3 risk-pool overlay (#564), Travel/Conferences menu (#565), loan-billing money/rep crash (#566), event-dialog `r` key (#567), event flood (#568). Being fixed in the background — note if any *block* you, otherwise play around them.
+
+---
+
+## 1 · Running log (timecode → moment)
+Jot as you go. "Clip?" = mark it for the highlight reel / blog.
+
+| OBS time | Turn | What happened | Feel / bug / clip? |
+|----------|------|---------------|--------------------|
+| 0:00 | 1 | game start | |
+|      |    |             | |
+|      |    |             | |
+|      |    |             | |
+|      |    |             | |
+|      |    |             | |
+|      |    |             | |
+|      |    |             | |
+
+## 2 · Highlight reel — moments to clip
+- [ ] `__:__` — ________________________________  *(why it's a good clip)*
+- [ ] `__:__` — ________________________________
+- [ ] `__:__` — ________________________________
+
+## 3 · Feel notes — the spine of the post
+Answer in a sentence as you notice each (they become the blog paragraphs):
+
+- **First tension:** the moment it stopped feeling like admin and started feeling like a race — when? ______________________
+- **First real tradeoff:** the first decision you actually had to *weigh* (take the loan or not? spend on safety or progress?) ______________________
+- **The rivals as a clock:** did you feel opponents driving doom toward you, or was it still abstract? ______________________
+- **The ledger:** legible? Did a bill surprise you? Did a secret get exposed / a blackmail land? Did you ever think "I shouldn't have taken that"? ______________________
+- **Pacing:** where did it drag, where did it spike? Did ~47 turns feel too short / about right / too long? ______________________
+- **"One more turn" pull:** present or absent? ______________________
+- **vs the pre-Big-Pause game:** what's different in your gut? ______________________
+- **The score:** did "I survived N turns" feel like something you'd brag about? ______________________
+
+## 4 · Findings (tag + route)
+| # | Tag | Timecode | What | Route |
+|---|-----|----------|------|-------|
+| 1 |     |          |      |       |
+| 2 |     |          |      |       |
+| 3 |     |          |      |       |
+
+`BUG` → F8 / issue · `BALANCE` → workshop #2 (with the sweep data) · `FEEL` → blog + workshop #2
+
+---
+
+## 5 · Blog draft (distill after the session)
+> Same frontmatter shape as `dev-blog/templates/development-session.md` — drop this into
+> `dev-blog/entries/` when it's ready.
+
+**Working title:** ______________________
+**Hook (one line):** ______________________
+
+**The arc:**
+- *Setup* — hadn't really played since the Big Pause; five mechanic lanes shipped; this is the first run that has *shape* (rivals bite, you can't cheese a win, games last long enough to matter).
+- *What surprised me* — ______________________
+- *The verdict* — ______________________
+
+**Pull quotes / screenshots to grab:** ______________________
+
+**Against the vision** ("cozy competence under existential dread"): how close does this build feel, and what's the next thing that would move it closer? ______________________
+
+---
+*Session doc opened 2026-07-10 on build `e1cbc26`. Feel/story capture; hard bugs → issues.*


### PR DESCRIPTION
OBS-aware session-log doc for the ledger-milestone playtest; distills into a dev-blog entry.