### PR TITLE
fix: sustainable salary cadence + bankruptcy warning (#573)

### DIFF
--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -140,11 +140,11 @@ func start_turn() -> Dictionary:
 	var staff_salaries = 0.0
 	if state.researchers.size() > 0:
 		for researcher in state.researchers:
-			staff_salaries += researcher.current_salary / 12.0  # Monthly salary per turn
-		staff_salaries += state.managers * 5000  # Managers still use flat rate
+			staff_salaries += researcher.current_salary / 260.0  # Per-workday salary (turn = 1 workday, ~260 workdays/yr). Was /12 — a full month billed every day, causing the turn-7 cash crash (#573). Magnitude tunable (workshop #2 / payroll depth #574).
+		staff_salaries += state.managers * (60000.0 / 260.0)  # Managers ~$60k/yr, per-workday (#573; was $5000 flat = a month's pay per day)
 	else:
 		# Legacy fallback
-		staff_salaries = total_staff * 5000
+		staff_salaries = total_staff * (60000.0 / 260.0)  # per-workday (#573)
 
 	if staff_salaries > 0:
 		state.add_resources({"money": -staff_salaries})
@@ -295,6 +295,16 @@ func start_turn() -> Dictionary:
 
 	if staff_salaries > 0:
 		messages.append("Paid %s in staff salaries" % GameConfig.format_money(staff_salaries))
+
+		# Low-cash / bankruptcy warning (#573) — surface cash danger BEFORE a silent defeat
+		var ledger_due_soon: float = 0.0
+		if state.ledger and state.ledger.soonest_fuse() >= 0 and state.ledger.soonest_fuse() <= 1:
+			ledger_due_soon = state.ledger.outstanding()
+		var next_turn_bills: float = staff_salaries + ledger_due_soon
+		if state.money < next_turn_bills:
+			messages.append("CRITICAL: Cash (%s) won't cover next turn's bills (%s) — bankruptcy imminent!" % [GameConfig.format_money(state.money), GameConfig.format_money(next_turn_bills)])
+		elif state.money < staff_salaries * 3.0:
+			messages.append("WARNING: Low cash — about %d turn(s) of payroll left (%s)." % [int(state.money / staff_salaries), GameConfig.format_money(state.money)])
 
 	if research_from_employees > 0:
 		messages.append("Generated %.1f research from %d productive researchers" % [research_from_employees, productive_count])

--- a/godot/tests/unit/test_salary_cadence.gd
+++ b/godot/tests/unit/test_salary_cadence.gd
@@ -1,0 +1,34 @@
+extends GutTest
+## Salary cadence + low-cash warning regression (#573).
+## The bug: annual salary (current_salary, ~$60k) was billed as annual/12 (a MONTH's pay)
+## every day-turn ("Day 1/5"), craterng cash by ~turn 7 with no warning. Fixed to per-workday
+## (annual/260) + a bankruptcy warning before a cash defeat.
+
+func test_salary_per_turn_is_small_fraction_of_annual():
+	var state = GameState.new("salary_cadence_seed")
+	var r = Researcher.new()
+	r.current_salary = 60000.0
+	r.specialization = "safety"
+	state.researchers.append(r)
+	var money_before: float = state.money
+	var tm = TurnManager.new(state)
+	tm.start_turn()
+	var per_turn_cost: float = money_before - state.money
+	# Old bug: annual/12 ~= $5000 billed every day. Fixed: annual/260 ~= $231/workday.
+	assert_gt(per_turn_cost, 0.0, "Salary should still be charged each turn")
+	assert_lt(per_turn_cost, 500.0, "Per-turn salary must be a small fraction of annual (regression guard vs the /12 crash)")
+	assert_almost_eq(per_turn_cost, 60000.0 / 260.0, 60.0, "Per-turn salary ~= annual/260 (per workday)")
+
+func test_low_cash_warning_fires_before_cash_defeat():
+	var state = GameState.new("low_cash_seed")
+	var r = Researcher.new()
+	r.current_salary = 60000.0
+	state.researchers.append(r)
+	state.money = 100.0  # cannot cover next turn's payroll
+	var tm = TurnManager.new(state)
+	var result: Dictionary = tm.start_turn()
+	var joined: String = "\n".join(result.get("messages", []))
+	assert_true(
+		joined.contains("CRITICAL") or joined.contains("Low cash") or joined.contains("bankruptcy"),
+		"A low-cash/bankruptcy warning must surface when cash can't cover the next turn's bills"
+	)


### PR DESCRIPTION
Fixes #573. Salaries billed at annual/12 (a month) every day-turn -> ~$5,000/turn/hire -> turn-7 cash crash, no warning. Now annual/260 (per workday, ~$231/turn) + low-cash/bankruptcy warning. Regression test; --quick green. Magnitudes placeholder (#574/workshop-2). Sibling #566.