### PR TITLE
fix: defeat screen reports real cause + ledger attribution + fits on screen (#580)

### DIFF
--- a/godot/scenes/ui/game_over_screen.tscn
+++ b/godot/scenes/ui/game_over_screen.tscn
@@ -30,19 +30,19 @@ grow_horizontal = 2
 grow_vertical = 2
 
 [node name="PanelContainer" type="PanelContainer" parent="CenterContainer"]
-custom_minimum_size = Vector2(600, 500)
+custom_minimum_size = Vector2(780, 460)
 layout_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="CenterContainer/PanelContainer"]
 layout_mode = 2
-theme_override_constants/margin_left = 30
-theme_override_constants/margin_top = 30
-theme_override_constants/margin_right = 30
-theme_override_constants/margin_bottom = 30
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 20
 
 [node name="VBox" type="VBoxContainer" parent="CenterContainer/PanelContainer/MarginContainer"]
 layout_mode = 2
-theme_override_constants/separation = 20
+theme_override_constants/separation = 12
 
 [node name="TitleLabel" type="Label" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
 layout_mode = 2
@@ -60,13 +60,13 @@ horizontal_alignment = 1
 layout_mode = 2
 
 [node name="StatsLabel" type="RichTextLabel" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
-custom_minimum_size = Vector2(0, 250)
+custom_minimum_size = Vector2(0, 300)
 layout_mode = 2
 size_flags_vertical = 3
 bbcode_enabled = true
 text = "Statistics will appear here"
-fit_content = true
-scroll_active = false
+fit_content = false
+scroll_active = true
 
 [node name="HSeparator2" type="HSeparator" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
 layout_mode = 2

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -189,16 +189,14 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 	else:
 		var reason = _get_defeat_reason(final_state)
 		stats_text += "\n[center][color=red]%s[/color][/center]" % reason
+		var attribution = _get_ledger_attribution_text(final_state)
+		if attribution != "":
+			stats_text += "\n[center][color=orange]%s[/color][/center]" % attribution
 
-	# AI Safety resources call to action
-	stats_text += "\n\n[center][color=gray]───────────────────[/color][/center]\n"
-	stats_text += "\n[center][color=cyan][b]LEARN ABOUT REAL AI SAFETY[/b][/color][/center]\n"
-	stats_text += "[center][color=white]The challenges in this game reflect real concerns.[/color][/center]\n"
-	stats_text += "[center][color=gray]Visit [color=dodger_blue][url=https://aisafety.info]aisafety.info[/url][/color] to learn more.[/color][/center]"
-
-	# Navigation hint
-	stats_text += "\n\n[center][color=gray]───────────────────[/color][/center]\n"
-	stats_text += "\n[center][color=gold][b]⏎ Press ENTER for Leaderboard[/b][/color][/center]"
+	# AI Safety resources call to action (condensed to reduce vertical overflow)
+	stats_text += "\n[center][color=gray]───────────────────[/color][/center]\n"
+	stats_text += "[center][color=cyan]Learn about real AI safety: [url=https://aisafety.info][color=dodger_blue]aisafety.info[/color][/url][/color][/center]\n"
+	stats_text += "[center][color=gold][b]⏎ Press ENTER for Leaderboard[/b][/color][/center]"
 
 	stats_label.text = stats_text
 
@@ -214,15 +212,44 @@ func _get_doom_display_color(doom: float) -> String:
 		return "red"
 
 func _get_defeat_reason(final_state: Dictionary) -> String:
-	"""Generate defeat reason based on final state"""
+	"""Generate defeat reason based on final state.
+	Order mirrors GameState.check_win_lose(): doom >= 100, then reputation <= 0."""
 	var doom = final_state.get("doom", 0)
+	var reputation = final_state.get("reputation", 100)
 
 	if doom >= 100.0:
 		return "Doom reached 100%. The AI became\nunaligned and humanity was lost."
+	elif reputation <= 0.0:
+		return "Your lab lost all credibility —\nreputation hit zero and the doors closed."
 	elif final_state.get("money", 0) < 0:
 		return "Your organization went bankrupt before\nthe mission could be completed."
 	else:
 		return "The experiment ended prematurely."
+
+func _fmt_money(amount: float) -> String:
+	"""Compact money display: 283458 -> $283k."""
+	var a := int(round(amount))
+	if abs(a) >= 1000:
+		return "$%dk" % (a / 1000)
+	return "$%d" % a
+
+func _get_ledger_attribution_text(final_state: Dictionary) -> String:
+	"""Surface the ledger death_attribution already in state, so the player learns what
+	killed them. Returns '' when there's no ledger attribution."""
+	var ledger = final_state.get("ledger", {})
+	var attribution = ledger.get("death_attribution", [])
+	if attribution == null or attribution.is_empty():
+		return ""
+	var total := 0.0
+	var counts := {}
+	for entry in attribution:
+		var src := str(entry.get("source", "debt"))
+		total += float(entry.get("magnitude", 0.0))
+		counts[src] = int(counts.get(src, 0)) + 1
+	var parts := []
+	for src in counts:
+		parts.append("%d %s" % [counts[src], src])
+	return "Your ledger came due: %s — %s in bills you couldn't cover." % [", ".join(parts), _fmt_money(total)]
 
 func _on_play_again_pressed():
 	"""Restart the game"""

--- a/godot/tests/unit/test_game_over_screen.gd
+++ b/godot/tests/unit/test_game_over_screen.gd
@@ -1,0 +1,43 @@
+extends GutTest
+## Defeat-screen legibility tests (#580): the screen must name the REAL cause of death
+## (reputation<=0 was previously falling through to a generic message) and surface the
+## ledger death-attribution that already exists in state.
+
+func test_defeat_reason_reputation_zero_is_named():
+	var s = GameOverScreen.new()
+	var reason = s._get_defeat_reason({"doom": 45.0, "reputation": 0.0, "money": 5000})
+	assert_true(reason.to_lower().contains("reputation") or reason.to_lower().contains("credibility"),
+		"reputation death should be named, got: %s" % reason)
+	assert_false(reason.to_lower().contains("prematurely"),
+		"reputation death should NOT fall through to the generic reason")
+	s.free()
+
+func test_defeat_reason_doom_is_named():
+	var s = GameOverScreen.new()
+	var reason = s._get_defeat_reason({"doom": 100.0, "reputation": 50.0})
+	assert_true(reason.to_lower().contains("doom"), "doom death should be named")
+	s.free()
+
+func test_defeat_reason_generic_fallback():
+	var s = GameOverScreen.new()
+	# No loss condition met -> generic (shouldn't normally happen, but must be safe)
+	var reason = s._get_defeat_reason({"doom": 50.0, "reputation": 50.0, "money": 5000})
+	assert_gt(reason.length(), 0, "always returns a reason string")
+	s.free()
+
+func test_ledger_attribution_shown_when_present():
+	var s = GameOverScreen.new()
+	var state = {"ledger": {"death_attribution": [
+		{"source": "loan", "currency": "money", "magnitude": 115517.0},
+		{"source": "loan", "currency": "money", "magnitude": 167940.0}
+	]}}
+	var txt = s._get_ledger_attribution_text(state)
+	assert_gt(txt.length(), 0, "attribution should be shown when present")
+	assert_true(txt.to_lower().contains("loan"), "should name the source(s)")
+	s.free()
+
+func test_ledger_attribution_empty_when_absent():
+	var s = GameOverScreen.new()
+	assert_eq(s._get_ledger_attribution_text({"ledger": {"death_attribution": []}}), "")
+	assert_eq(s._get_ledger_attribution_text({}), "")
+	s.free()

--- a/godot/tests/unit/test_game_over_screen.gd.uid
+++ b/godot/tests/unit/test_game_over_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dnxd20sj377dr


### PR DESCRIPTION
Fixes #580 (playtest: a turn-23 reputation death the player couldn't understand).

## Changes
- **Real defeat cause.** `_get_defeat_reason` now has the missing **reputation<=0** branch (order mirrors `check_win_lose`: doom>=100, then reputation<=0). Reputation deaths no longer fall through to the generic "the experiment ended prematurely."
- **Ledger attribution surfaced.** New `_get_ledger_attribution_text` reads `final_state.ledger.death_attribution` (already in state) and shows e.g. *"Your ledger came due: 2 loan — $283k in bills you couldn't cover."* — so the player learns what killed them. Hidden cleanly when empty.
- **Layout / overflow.** The screen extended past the top & bottom because `StatsLabel` was `fit_content=true` + `scroll_active=false` (grew unbounded). Now `fit_content=false` + `scroll_active=true`; panel widened 600->780, tighter margins (30->22/20) and VBox separation (20->12); AI-safety CTA condensed.

## Verification
- `run_godot_tests.py --quick` **green**; new `test_game_over_screen.gd` (5 tests) asserts reputation is named (not generic), doom is named, and attribution shows/omits correctly.
- Game boots headless with no script errors. **Visual fit needs a human eye** — the spacing/width values are chosen blind; confirm on screen (esp. that buttons are reachable and stats scroll rather than overflow).

## Out-of-scope note for the orchestrator
Pip mid-task asked that **running out of money should NOT end the game** — instead create escalating problems (unhappy employees, higher quit rate) if bills go unpaid over time. That's an economy/payroll design change (workshop #2, near #573/#574) — flagged, not built here. My change is consistent with it: money is already not a loss condition.