### PR TITLE
fix: F3 toggles risk-pool debug overlay (#564)

### DIFF
--- a/godot/autoload/keybind_manager.gd
+++ b/godot/autoload/keybind_manager.gd
@@ -18,7 +18,7 @@ var keybinds: Dictionary = {
 	"export_log": {"key": KEY_BACKSLASH, "category": Category.ADMIN, "description": "Export Game Log"},
 
 	# Debug & Admin
-	"debug_overlay": {"key": KEY_ASCIITILDE, "category": Category.DEBUG, "description": "Toggle Debug Overlay (User)"},
+	"debug_overlay": {"key": KEY_F3, "category": Category.DEBUG, "description": "Toggle Debug Overlay (User)"},
 	"admin_mode": {"key": KEY_BRACKETRIGHT, "category": Category.ADMIN, "description": "Toggle Admin Mode"},
 
 	# Gameplay
@@ -62,6 +62,7 @@ var profiles: Dictionary = {}  # profile_name -> keybind dict
 
 # Config file
 const CONFIG_PATH = "user://keybinds.cfg"
+const KEYBINDS_CONFIG_VERSION = 2  # bump when default binds change; stale saved configs refresh to defaults
 var config = ConfigFile.new()
 
 # Signals
@@ -81,6 +82,21 @@ func load_keybinds():
 	var err = config.load(CONFIG_PATH)
 
 	if err == OK:
+		# Defaults changed since this config was written? Refresh from defaults. Otherwise a
+		# stale saved bind silently overrides the new default (e.g. the F3 debug overlay was
+		# stuck on the old '~' bind — issue #564). In beta this resets custom rebinds on a
+		# default change; the alternative is defaults that never take effect.
+		var saved_version = config.get_value("settings", "config_version", 1)
+		if saved_version < KEYBINDS_CONFIG_VERSION:
+			current_profile = config.get_value("settings", "current_profile", "default")
+			var stale_profiles = config.get_value("settings", "profiles", ["default"])
+			for profile in stale_profiles:
+				profiles[profile] = keybinds.duplicate(true)
+			if not profiles.has(current_profile):
+				profiles[current_profile] = keybinds.duplicate(true)
+			apply_profile(current_profile)  # applies defaults + saves with the new version
+			return
+
 		# Load current profile
 		current_profile = config.get_value("settings", "current_profile", "default")
 
@@ -112,6 +128,7 @@ func load_keybinds():
 
 ## Save keybinds to config file
 func save_keybinds():
+	config.set_value("settings", "config_version", KEYBINDS_CONFIG_VERSION)
 	config.set_value("settings", "current_profile", current_profile)
 	config.set_value("settings", "profiles", profiles.keys())
 

--- a/godot/scenes/main.tscn
+++ b/godot/scenes/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://bvqxj8x5p6h8c"]
+[gd_scene load_steps=10 format=3 uid="uid://bvqxj8x5p6h8c"]
 
 [ext_resource type="Script" path="res://scripts/game_manager.gd" id="1_main_gm"]
 [ext_resource type="Script" path="res://scripts/ui/main_ui.gd" id="2_main_ui"]
@@ -10,6 +10,7 @@
 [ext_resource type="PackedScene" uid="uid://bugreport123456" path="res://scenes/ui/bug_report_panel.tscn" id="8_bugreport"]
 [ext_resource type="PackedScene" uid="uid://officecat123456" path="res://scenes/ui/office_cat.tscn" id="9_officecat"]
 [ext_resource type="PackedScene" uid="uid://cnj8yk4x5oopm" path="res://scenes/pause_menu.tscn" id="10_pausemenu"]
+[ext_resource type="PackedScene" uid="uid://dqc4gxtx62j3s" path="res://scenes/debug_overlay.tscn" id="11_debugoverlay"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_TurnCounter"]
 bg_color = Color(0.15, 0.15, 0.2, 0.8)
@@ -460,6 +461,8 @@ layout_mode = 1
 
 [node name="PauseMenu" parent="." instance=ExtResource("10_pausemenu")]
 layout_mode = 1
+
+[node name="DebugOverlay" parent="." instance=ExtResource("11_debugoverlay")]
 
 [connection signal="pressed" from="TabManager/MainUI/BottomBar/ControlButtons/InitButton" to="TabManager/MainUI" method="_on_init_button_pressed"]
 [connection signal="pressed" from="TabManager/MainUI/BottomBar/ControlButtons/TestActionButton" to="TabManager/MainUI" method="_on_test_action_button_pressed"]


### PR DESCRIPTION
Closes #564. Two root causes: (1) `debug_overlay.tscn` was never instantiated in `main.tscn` (its `_ready()` never ran, so nothing listened for the toggle signal); (2) the default bind was `~` (KEY_ASCIITILDE) not F3, and a persisted `user://keybinds.cfg` overrode the default. Fixes: instance DebugOverlay at main-scene root; default -> KEY_F3; `KEYBINDS_CONFIG_VERSION` bump so stale saved configs refresh to defaults (beta note: resets custom rebinds on a default change). Verified headless: boots with '[DebugOverlay] Ready - Press F3 to toggle', no errors; --quick green. Visual (actual F3 keypress showing the 6 pools) needs a human eye.