### PR TITLE
fix: difficulty selectable in UI + apply modifiers (#563)

### DIFF
--- a/godot/scenes/pregame_setup.tscn
+++ b/godot/scenes/pregame_setup.tscn
@@ -222,22 +222,14 @@ theme_override_constants/separation = 10
 
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/DifficultyRow/LabelRow"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.5, 0.5, 0.6, 1)
+theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
 theme_override_font_sizes/font_size = 18
 text = "Research Intensity:"
-
-[node name="ComingSoon" type="Label" parent="Panel/VBox/FieldsContainer/DifficultyRow/LabelRow"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.7, 0.7, 0.3, 0.8)
-theme_override_font_sizes/font_size = 14
-text = "(Coming Soon)"
 
 [node name="OptionButton" type="OptionButton" parent="Panel/VBox/FieldsContainer/DifficultyRow"]
 custom_minimum_size = Vector2(0, 45)
 layout_mode = 2
 theme_override_font_sizes/font_size = 20
-disabled = true
-modulate = Color(0.5, 0.5, 0.5, 0.7)
 selected = 1
 item_count = 3
 popup/item_0/text = "Easy (Conservative)"

--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -120,9 +120,11 @@ func start_turn() -> Dictionary:
 		# state.rng). 0.15 is a placeholder - exposure tuning parked (workshop #2).
 		state.ledger.check_exposures(state, 0.15)
 
-	# Calculate max AP based on staff (base 3 + 0.5 per staff member)
+	# Calculate max AP based on difficulty base + staff (0.5 per staff member).
+	# FIX #541: use state.max_action_points (set by difficulty: Easy=4, Standard=3,
+	# Hard=2) as the base instead of a hardcoded 3, so difficulty actually changes AP.
 	var total_staff = state.get_total_staff()
-	var max_ap = 3 + int(total_staff * 0.5)
+	var max_ap = state.max_action_points + int(total_staff * 0.5)
 	state.action_points = max_ap
 
 	# Reset AP tracking for new turn (reserve system)

--- a/godot/tests/unit/test_game_manager.gd
+++ b/godot/tests/unit/test_game_manager.gd
@@ -4,6 +4,7 @@ extends GutTest
 
 var game_manager: GameManager
 var _saved_historical_events: Array = []
+var _saved_difficulty: int = 1
 
 func before_each():
 	# GameManager extends Node (autoload) — can't call .new() on the singleton
@@ -18,6 +19,9 @@ func before_each():
 		EventService.transformed_events.clear()
 	GameEvents.reset_triggered_events()
 
+	# Preserve difficulty (autoload singleton) so difficulty tests don't leak
+	_saved_difficulty = GameConfig.difficulty
+
 	# Watch all signals
 	watch_signals(game_manager)
 
@@ -25,6 +29,8 @@ func after_each():
 	# Restore historical events
 	if EventService:
 		EventService.transformed_events = _saved_historical_events
+	# Restore difficulty
+	GameConfig.difficulty = _saved_difficulty
 	# Clean up
 	if game_manager:
 		game_manager.queue_free()
@@ -437,3 +443,44 @@ func test_multiple_actions_single_turn():
 
 	assert_eq(game_manager.state.queued_actions.size(), 0,
 		"All actions should be processed")
+
+# === DIFFICULTY TESTS (Issue #563 / #541) ===
+
+const _BASE_MONEY := 245000.0  # GameState starting money (issue #436)
+
+func test_easy_difficulty_grants_more_starting_money():
+	# Issue #563: Easy = +50% starting money
+	GameConfig.difficulty = 0  # Easy
+	game_manager.start_new_game("difficulty_seed")
+	assert_almost_eq(game_manager.state.money, _BASE_MONEY * 1.5, 0.01,
+		"Easy should grant 50% more starting money")
+
+func test_hard_difficulty_reduces_starting_money():
+	# Issue #563: Hard = -25% starting money
+	GameConfig.difficulty = 2  # Hard
+	game_manager.start_new_game("difficulty_seed")
+	assert_almost_eq(game_manager.state.money, _BASE_MONEY * 0.75, 0.01,
+		"Hard should reduce starting money by 25%")
+
+func test_standard_difficulty_uses_base_money():
+	GameConfig.difficulty = 1  # Standard
+	game_manager.start_new_game("difficulty_seed")
+	assert_almost_eq(game_manager.state.money, _BASE_MONEY, 0.01,
+		"Standard should use unmodified base money")
+
+func test_difficulty_changes_turn1_action_points():
+	# Issue #541: max_action_points (set by difficulty) must feed start_turn's AP.
+	# Staff scaling is identical across difficulties, so Easy base (4) must exceed
+	# Hard base (2) by exactly 2 on turn 1.
+	GameConfig.difficulty = 0  # Easy
+	game_manager.start_new_game("difficulty_seed")
+	var easy_ap = game_manager.state.action_points
+
+	GameConfig.difficulty = 2  # Hard
+	game_manager.start_new_game("difficulty_seed")
+	var hard_ap = game_manager.state.action_points
+
+	assert_gt(easy_ap, hard_ap,
+		"Easy should grant more turn-1 AP than Hard (#541)")
+	assert_eq(easy_ap - hard_ap, 2,
+		"Easy base AP (4) minus Hard base AP (2) should be 2 on turn 1")


### PR DESCRIPTION
## What was broken

Playtester report (#563): "there are no easy and hard versions of the game according to the actual UI." The Research Intensity (difficulty) `OptionButton` in `pregame_setup.tscn` was shipped `disabled = true`, greyed out via `modulate`, with a greyed label and a **"(Coming Soon)"** tag. The selection handler (`_on_difficulty_selected`), the signal wiring, and the difficulty modifiers in `game_manager._apply_difficulty_settings()` all already existed — only the control itself was locked, so Easy/Standard/Hard could never be chosen.

## What this changes

- **UI**: Enable the difficulty `OptionButton`, restore its active label styling, and remove the "(Coming Soon)" affordance. Easy / Standard / Hard are now selectable in pre-game setup.
- **Modifiers confirmed** (base starting money $245,000):
  - Easy = +50% -> **$367,500**
  - Standard = **$245,000**
  - Hard = -25% -> **$183,750**
- **Fixes #541**: `TurnManager.start_turn()` hardcoded the base AP at `3`, ignoring `state.max_action_points` (which difficulty sets to Easy=4 / Standard=3 / Hard=2). It now uses `state.max_action_points` as the base, preserving the existing `+0.5 per staff` scaling. Turn-1 AP now reflects difficulty: **Easy gets 2 more AP than Hard**.

## Tests

Added GUT tests in `test_game_manager.gd` demonstrating the deltas:
- Easy / Standard / Hard starting-money values
- Easy turn-1 AP > Hard turn-1 AP (exactly +2)

Difficulty is saved/restored around each test so the `GameConfig` singleton isn't polluted.

Full unit suite: **189/189 passing, 2002 asserts** (`python scripts/run_godot_tests.py --quick` green). Pregame scene boot-checked to instantiate without script errors (OptionButton now `disabled=false`, `item_count=3`).

Closes #563. Closes #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)