### PR TITLE
feat(assets): migrate pipeline to gpt-image-1.5 + dormant Nano Banana backend + hero banner YAML

### DIFF
--- a/art_prompts/hero_banners.yaml
+++ b/art_prompts/hero_banners.yaml
@@ -1,0 +1,81 @@
+schema_version: '1.0'
+asset_type: hero_banners
+# Landscape hero banners. gpt-image-1.5 caps landscape at 1536x1024.
+default_size: 1536x1024
+# Widths only; each downscale preserves the 3:2 master aspect ratio.
+output_sizes:
+- 1536
+- 768
+styles:
+  banner_scene_base: 'wide 1536x1024 landscape hero banner, a full illustrative
+    SCENE with real environmental depth and atmosphere (NOT a single symbol on a
+    vignette), lush StarCraft 2 / XCOM digital matte-painting, cinematic
+    composition with foreground, midground and background layers, volumetric
+    haze and soft god-rays, dramatic but restrained key lighting, high dynamic
+    range, painterly rendered detail, room to overlay a title in the upper-left
+    negative space, no text, no logos, no watermarks, no UI, no human faces in
+    close-up'
+  surface_tarkov: 'Tarkov-style worn metal, scuffed brushed aluminium, chipped
+    paint, dust, fingerprints and grime on every surface, lived-in industrial
+    props, exposed cable runs and cheap office furniture that has seen years of
+    use'
+  mood_cozy_dread: 'tone of cozy competence under existential dread, quiet and
+    intimate yet quietly ominous, the warmth of late-night focus haunted by
+    something larger looming just off-frame'
+themes:
+  base_corporate:
+    style_overrides:
+    - banner_scene_base
+    - surface_tarkov
+    - mood_cozy_dread
+    color_bias: 'heavily desaturated palette of teal and olive with muted slate
+      greys, warm amber CRT/monitor glow as the only saturated accent, deep
+      shadow, low overall saturation'
+assets:
+- id: banner_title_hero
+  category: title
+  display_name: Title Screen Hero
+  status: pending
+  theme: base_corporate
+  prompt_tail: 'a dim near-future AI-safety lab and open-plan office at night, seen
+    from a low three-quarter angle across a cluttered desk in the foreground;
+    banks of chunky CRT-style terminals and modern flat panels cast a soft amber
+    and teal glow across worn desks, coffee-stained mugs, sticky notes and a
+    tangle of cables; a lone empty ergonomic chair, a whiteboard covered in faint
+    equations in the midground; tall server racks blink faintly in the shadowed
+    background; a single window shows a cold blue city skyline under heavy cloud;
+    the room feels warm and focused up close but the darkness at the edges is
+    quietly ominous, as if the work being done here matters more than anyone in
+    the room can quite admit'
+- id: banner_doom_rising
+  category: event
+  display_name: Doom Rising
+  status: pending
+  theme: base_corporate
+  prompt_tail: 'the same near-future AI-safety lab and office, but dread is
+    escalating for a doom-spike moment: the amber terminal glow has soured toward
+    a harsh red, warning strobes and status lights flare across the server racks,
+    long ominous shadows stretch across the worn desks; papers and a knocked-over
+    mug scattered as if people left in a hurry; a wall of monitors shows a single
+    rising red curve climbing off the top of its chart; smoke or thick haze
+    creeps low across the floor, cables sparking faintly; through the window the
+    city skyline is darker and redder; still painterly and cinematic, still the
+    desaturated teal-and-olive world underneath, but now suffused with quiet
+    catastrophe and the sense that a threshold is being crossed'
+- id: fanfare_strategic_moves
+  category: fanfare
+  display_name: Strategic Moves Granted
+  status: pending
+  theme: base_corporate
+  prompt_tail: 'a ceremonial moment: a shadowed boardroom or council chamber where
+    a governing board grants the player new authority; a long worn-metal
+    conference table catches a warm shaft of light from above, seated
+    silhouetted board members (backs and shoulders, no close-up faces) turned
+    toward a single illuminated seat at the head of the table; a sleek folder,
+    an official seal and a glowing tablet slide into that pool of light as if
+    handed over; faint teal holographic org-charts and strategy maps hover above
+    the table; the mood is dignified and quietly triumphant, cozy competence
+    rewarded, yet the vast dark chamber and the weight of the decision keep the
+    existential dread present at the edges; cinematic digital matte-painting,
+    desaturated teal and olive with warm amber ceremonial light; doubles as the
+    first event-fanfare art'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,11 @@ jsonschema>=4.0.0
 
 # YAML parsing (issue sync, metadata, config files)
 pyyaml>=6.0
+
+# Asset generation pipeline (tools/assets/generate_images.py).
+# openai is the default image backend; Pillow handles master/downscale saves.
+openai>=1.0
+Pillow>=10.0
+# Google Gemini "Nano Banana Pro" backend (gemini-3-pro-image) is DORMANT:
+# imported lazily and only used with --backend gemini, so it is optional.
+google-genai>=0.3

--- a/tools/assets/generate_images.py
+++ b/tools/assets/generate_images.py
@@ -2,8 +2,14 @@
 """
 Generalized batch image generator for pdoom1 art assets.
 
-Loads YAML prompt definitions and generates images using OpenAI's gpt-image-1 model.
+Loads YAML prompt definitions and generates images via a configurable backend.
 Supports filtering, dry-run mode, cost tracking, and version management.
+
+Backends:
+  - openai (default): OpenAI Images API, model gpt-image-1.5.
+  - gemini (dormant/opt-in): Google Gemini "Nano Banana Pro"
+    (gemini-3-pro-image), for reference-image-consistent generation.
+    google-genai is imported lazily, so the pipeline runs without it installed.
 """
 
 import argparse
@@ -13,11 +19,14 @@ import logging
 import sys
 from datetime import datetime, timezone
 from io import BytesIO
+from math import gcd
 from pathlib import Path
 
 import yaml
-from openai import OpenAI
 from PIL import Image
+
+# NOTE: openai/google-genai are imported lazily inside their backend helpers so
+# that --dry-run (and the non-active backend) work without those SDKs installed.
 
 # Fix Windows console encoding for emojis
 if sys.platform == "win32":
@@ -26,8 +35,32 @@ if sys.platform == "win32":
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Cost per image for gpt-image-1 at 1024x1024
-COST_PER_IMAGE_USD = 0.08
+# Default OpenAI model. gpt-image-1 retires 2026-10-23, so gpt-image-1.5 is the
+# active default. It keeps the same request shape (model/prompt/size, alpha via
+# background=transparent) and caps landscape at 1536x1024.
+# TODO: confirm exact id vs live docs (snapshot: gpt-image-1.5-2025-12-16).
+DEFAULT_OPENAI_MODEL = "gpt-image-1.5"
+
+# Google "Nano Banana Pro" (Gemini API). Dormant until --backend gemini.
+# TODO: confirm exact id vs live docs.
+DEFAULT_GEMINI_MODEL = "gemini-3-pro-image"
+
+DEFAULT_BACKEND = "openai"
+
+# Rough per-image cost (USD) for the dry-run/confirmation estimate only.
+# gpt-image-1 at 1024x1024 was $0.08; gpt-image-1.5 is ~20% cheaper and larger
+# canvases cost more. These are estimates -- confirm vs live pricing pages.
+COST_PER_IMAGE_USD = 0.08  # kept for backwards compat / default fallback
+
+
+def estimate_cost_per_image(size_str, backend=DEFAULT_BACKEND):
+    """Best-effort per-image cost estimate for dry-run reporting only."""
+    if backend == "gemini":
+        return 0.13  # Nano Banana Pro approx; confirm vs Gemini pricing
+    # OpenAI gpt-image-1.5 (medium quality), rough per-size estimates.
+    table = {"1024x1024": 0.06, "1536x1024": 0.09, "1024x1536": 0.09}
+    return table.get(str(size_str).lower(), COST_PER_IMAGE_USD)
+
 
 # Initialize client lazily to avoid errors in dry-run mode
 _client = None
@@ -87,11 +120,85 @@ def log(message, level="info"):
 
 
 def get_client():
-    """Lazy initialization of OpenAI client."""
+    """Lazy initialization of the OpenAI client (import kept local)."""
     global _client
     if _client is None:
+        from openai import OpenAI
+
         _client = OpenAI()
     return _client
+
+
+def _parse_size(size_str):
+    """Parse 'WxH' -> (width, height) ints, falling back to 1024x1024."""
+    try:
+        w, h = str(size_str).lower().split("x")
+        return int(w), int(h)
+    except (ValueError, AttributeError):
+        return 1024, 1024
+
+
+def _aspect_ratio(width, height):
+    """Reduce WxH to a 'W:H' aspect-ratio string (e.g. 1536x1024 -> '3:2')."""
+    g = gcd(width, height) or 1
+    return f"{width // g}:{height // g}"
+
+
+def _openai_generate_bytes(model, prompt, size_str):
+    """Call the OpenAI Images API and return raw image bytes.
+
+    gpt-image-1.5 keeps gpt-image-1's request shape (model/prompt/size, and
+    optional background='transparent' for alpha). Confirm the exact model id
+    and param surface vs live docs before a real run.
+    """
+    result = get_client().images.generate(model=model, prompt=prompt, size=size_str)
+    return base64.b64decode(result.data[0].b64_json)
+
+
+def _gemini_generate_bytes(model, prompt, size_str, reference_images=None):
+    """Call Google Gemini (Nano Banana Pro) and return raw image bytes.
+
+    DORMANT backend: only reached via --backend gemini. google-genai is imported
+    lazily here so the rest of the pipeline runs without it installed. Reads
+    GEMINI_API_KEY from the environment. Reference-image paths are passed as
+    extra content for style/subject consistency across a set.
+    """
+    import os
+
+    try:
+        from google import genai
+        from google.genai import types
+    except ImportError as exc:  # pragma: no cover - dormant backend
+        raise RuntimeError(
+            "google-genai is not installed. Run 'pip install google-genai' "
+            "to use --backend gemini."
+        ) from exc
+
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise RuntimeError("GEMINI_API_KEY is not set in the environment.")
+
+    client = genai.Client(api_key=api_key)
+
+    # Multimodal contents: prompt text followed by any reference images.
+    contents = [prompt]
+    for ref in reference_images or []:
+        contents.append(Image.open(ref))
+
+    width, height = _parse_size(size_str)
+
+    # TODO: confirm image_config / aspect_ratio surface vs live google-genai docs.
+    config = types.GenerateContentConfig(
+        response_modalities=["IMAGE"],
+        image_config=types.ImageConfig(aspect_ratio=_aspect_ratio(width, height)),
+    )
+    response = client.models.generate_content(model=model, contents=contents, config=config)
+
+    for part in response.candidates[0].content.parts:
+        inline = getattr(part, "inline_data", None)
+        if inline is not None and getattr(inline, "data", None):
+            return inline.data
+    raise RuntimeError("Gemini response contained no image data.")
 
 
 def load_prompts(yaml_path):
@@ -141,22 +248,42 @@ def compute_prompt_hash(prompt):
     return hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
 
 
-def generate_image(asset_id, full_prompt, output_dir, sizes, force=False, variant_num=None):
+def generate_image(
+    asset_id,
+    full_prompt,
+    output_dir,
+    sizes,
+    size_str="1024x1024",
+    unit_cost=COST_PER_IMAGE_USD,
+    model=DEFAULT_OPENAI_MODEL,
+    backend=DEFAULT_BACKEND,
+    force=False,
+    variant_num=None,
+    reference_images=None,
+):
     """
-    Generate image and downscaled versions.
+    Generate an image (via the chosen backend) and downscaled versions.
 
     Args:
-        variant_num: If provided, generates variant with suffix _vN (e.g., asset_v2_1024.png)
+        size_str: Master canvas size 'WxH' (e.g. '1536x1024'). Passed to the API
+            and used to name/scale the master.
+        sizes: List of target WIDTHS. Each downscale preserves the master aspect
+            ratio, so square masters behave exactly as before and landscape
+            banners downscale to landscape.
+        variant_num: If provided, generates variant with suffix _vN
+            (e.g., asset_v2_1536.png).
 
     Returns: (success: bool, cost: float, file_path: str)
     """
+    master_w, master_h = _parse_size(size_str)
+
     # Build filename with optional variant suffix
     if variant_num is not None:
         base_name = f"{asset_id}_v{variant_num}"
     else:
         base_name = asset_id
 
-    master_path = output_dir / f"{base_name}_1024.png"
+    master_path = output_dir / f"{base_name}_{master_w}.png"
 
     # Skip if exists unless force
     if master_path.exists() and not force:
@@ -164,37 +291,37 @@ def generate_image(asset_id, full_prompt, output_dir, sizes, force=False, varian
         log(f"SKIP: {base_name} - file exists", "debug")
         return False, 0.0, str(master_path)
 
-    log(f"  🎨 Generating {base_name}...")
+    log(f"  🎨 Generating {base_name} ({size_str}, {backend})...")
     log(f"GENERATE: {base_name}", "debug")
     log(f"PROMPT: {full_prompt}", "debug")
 
     try:
-        result = get_client().images.generate(
-            model="gpt-image-1", prompt=full_prompt, size="1024x1024"
-        )
+        if backend == "gemini":
+            img_bytes = _gemini_generate_bytes(model, full_prompt, size_str, reference_images)
+        else:
+            img_bytes = _openai_generate_bytes(model, full_prompt, size_str)
     except Exception as e:
         log(f"  ❌ ERROR generating {base_name}: {e}", "error")
         log(f"ERROR: {base_name} - {str(e)}", "error")
         return False, 0.0, None
 
     # Decode and save master
-    img_bytes = base64.b64decode(result.data[0].b64_json)
     img = Image.open(BytesIO(img_bytes)).convert("RGBA")
     img.save(master_path)
 
-    # Downscale to requested sizes
-    for size in sizes:
-        if size == 1024:
+    # Downscale to requested widths, preserving the master aspect ratio.
+    for width in sizes:
+        if width >= master_w:
             continue
-        resized = img.resize((size, size), Image.LANCZOS)
-        resized.save(output_dir / f"{base_name}_{size}.png")
+        height = max(1, round(master_h * width / master_w))
+        resized = img.resize((width, height), Image.LANCZOS)
+        resized.save(output_dir / f"{base_name}_{width}.png")
 
-    log(
-        f"  ✅ Saved: {master_path.name} (+ {len([s for s in sizes if s != 1024])} downscaled versions)"
-    )
+    downscaled = len([w for w in sizes if w < master_w])
+    log(f"  ✅ Saved: {master_path.name} (+ {downscaled} downscaled versions)")
     log(f"SUCCESS: {base_name} -> {master_path}", "debug")
 
-    return True, COST_PER_IMAGE_USD, str(master_path)
+    return True, unit_cost, str(master_path)
 
 
 def filter_assets(assets, category=None, status=None, ids=None):
@@ -240,6 +367,13 @@ Examples:
 
   # Add second variant to single-variant assets
   python tools/generate_images.py --file art_prompts/ui_icons.yaml --status generated --add-variant --yes
+
+  # Generate landscape hero banners (uses default_size from the YAML)
+  python tools/generate_images.py --file art_prompts/hero_banners.yaml --status pending --variants 3 --yes --update-yaml
+
+  # Opt into the Google Gemini "Nano Banana Pro" backend (needs GEMINI_API_KEY)
+  python tools/generate_images.py --file art_prompts/hero_banners.yaml --backend gemini \\
+      --reference-images ref_a.png ref_b.png --status pending --yes
         """,
     )
 
@@ -265,8 +399,35 @@ Examples:
         default=1,
         help="Number of variants to generate per asset (default: 1)",
     )
+    parser.add_argument(
+        "--backend",
+        choices=["openai", "gemini"],
+        default=DEFAULT_BACKEND,
+        help="Image backend: 'openai' (gpt-image-1.5, default) or 'gemini' "
+        "(Nano Banana Pro / gemini-3-pro-image, needs GEMINI_API_KEY).",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Override the model id. Defaults to gpt-image-1.5 (openai) or "
+        "gemini-3-pro-image (gemini).",
+    )
+    parser.add_argument(
+        "--reference-images",
+        nargs="+",
+        help="Reference image paths for style/subject consistency "
+        "(gemini backend). Applied to every asset in this run.",
+    )
 
     args = parser.parse_args()
+
+    # Resolve the active model from backend + optional override.
+    if args.model:
+        model = args.model
+    elif args.backend == "gemini":
+        model = DEFAULT_GEMINI_MODEL
+    else:
+        model = DEFAULT_OPENAI_MODEL
 
     # Load YAML
     yaml_path = Path(args.file)
@@ -279,7 +440,12 @@ Examples:
     # Extract config
     asset_type = data.get("asset_type", "unknown")
     output_sizes = data.get("output_sizes", [1024, 512, 256, 128, 64])
+    size_str = str(data.get("default_size", "1024x1024"))
+    unit_cost = estimate_cost_per_image(size_str, args.backend)
     assets = data.get("assets", [])
+
+    # Reference images: CLI applies to the whole run (gemini backend).
+    cli_reference_images = args.reference_images or []
 
     # Determine output directory
     output_dir = Path("art_generated") / asset_type / "v1"
@@ -306,6 +472,9 @@ Examples:
     print(f"\n{'='*60}")
     print(f"📋 Asset Type: {asset_type}")
     print(f"📁 Output Dir: {output_dir}")
+    print(f"🧩 Backend: {args.backend}")
+    print(f"🤖 Model: {model}")
+    print(f"📐 Size: {size_str}")
     print(f"🎯 Assets to generate: {len(filtered)}")
     if args.category:
         print(f"   Category filter: {args.category}")
@@ -329,34 +498,34 @@ Examples:
             print()
 
         if args.add_variant:
-            estimated_cost = len(filtered) * COST_PER_IMAGE_USD
+            estimated_cost = len(filtered) * unit_cost
             total_images = len(filtered)
             print(
-                f"\n💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: 1 new variant per asset @ ${COST_PER_IMAGE_USD} each)"
+                f"\n💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: 1 new variant per asset @ ~${unit_cost:.2f} each, est.)"
             )
         else:
-            estimated_cost = len(filtered) * args.variants * COST_PER_IMAGE_USD
+            estimated_cost = len(filtered) * args.variants * unit_cost
             total_images = len(filtered) * args.variants
             print(
-                f"\n💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: {len(filtered)} assets × {args.variants} variants @ ${COST_PER_IMAGE_USD} each)"
+                f"\n💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: {len(filtered)} assets × {args.variants} variants @ ~${unit_cost:.2f} each, est.)"
             )
         return 0
 
     # Confirm before generating
     if args.add_variant:
-        estimated_cost = len(filtered) * COST_PER_IMAGE_USD
+        estimated_cost = len(filtered) * unit_cost
         total_images = len(filtered)
         print(
             f"💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: 1 new variant per asset)\n"
         )
     elif args.variants > 1:
-        estimated_cost = len(filtered) * args.variants * COST_PER_IMAGE_USD
+        estimated_cost = len(filtered) * args.variants * unit_cost
         total_images = len(filtered) * args.variants
         print(
             f"💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: {len(filtered)} assets × {args.variants} variants)\n"
         )
     else:
-        estimated_cost = len(filtered) * COST_PER_IMAGE_USD
+        estimated_cost = len(filtered) * unit_cost
         total_images = len(filtered)
         print(f"💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images)\n")
 
@@ -397,6 +566,9 @@ Examples:
         full_prompt = build_full_prompt(data, asset)
         prompt_hash = compute_prompt_hash(full_prompt)
 
+        # Per-asset reference images (YAML) plus any CLI-wide ones (gemini).
+        reference_images = list(asset.get("reference_images", [])) + cli_reference_images
+
         variant_successes = 0
 
         for variant_num in range(start_variant, end_variant):
@@ -407,7 +579,17 @@ Examples:
                 v_num = None
 
             success, cost, file_path = generate_image(
-                asset_id, full_prompt, output_dir, output_sizes, args.force, variant_num=v_num
+                asset_id,
+                full_prompt,
+                output_dir,
+                output_sizes,
+                size_str=size_str,
+                unit_cost=unit_cost,
+                model=model,
+                backend=args.backend,
+                force=args.force,
+                variant_num=v_num,
+                reference_images=reference_images,
             )
 
             if success:
@@ -427,7 +609,7 @@ Examples:
                                 else "v1"
                             ),
                             "generated_at": datetime.now(timezone.utc).isoformat(),
-                            "model": "gpt-image-1",
+                            "model": model,
                             "full_prompt_hash": prompt_hash,
                             "file_path": file_path,
                             "cost_usd": cost,


### PR DESCRIPTION
## What & why

Modernizes the AI asset-generation pipeline and adds landscape hero-banner definitions.

**Migration (OpenAI `gpt-image-1` retires 2026-10-23).** The active model moves to `gpt-image-1.5` (keeps transparency/alpha, same request shape, caps landscape at 1536x1024). It's a single `DEFAULT_OPENAI_MODEL` constant plus a `--model` override, not hardcoded across the file. A code comment flags "confirm exact id vs live docs" (snapshot seen: `gpt-image-1.5-2025-12-16`).

## `generate_images.py`

- **Model migration**: `gpt-image-1` -> `gpt-image-1.5` (configurable via `--model`; metadata now records the actual model used).
- **New `--backend {openai,gemini}` (default `openai`)** — the default path is unchanged OpenAI. A **Google Gemini "Nano Banana Pro" (`gemini-3-pro-image`) backend is built but DORMANT**: reads `GEMINI_API_KEY`, supports reference images (`--reference-images` or per-asset `reference_images:`) for style-consistent sets, and saves into the same `art_generated/<type>/v1/` layout. `google-genai` is imported **lazily**, so the pipeline (and `--dry-run`) still runs with the SDK uninstalled.
- **YAML-driven sizing**: reads `default_size` so landscape 1536x1024 masters actually generate; downscales now preserve aspect ratio (square icons behave exactly as before). Cost estimate is size/backend-aware.

## `art_prompts/hero_banners.yaml` (new)

Same schema as `ui_icons.yaml` but landscape (`default_size: 1536x1024`, minimal `output_sizes`). Scene-based style base (SC2/XCOM digital matte-painting, Tarkov worn-metal, desaturated teal/olive, "cozy competence under existential dread"). **3 assets** (`status: pending`):

- `banner_title_hero` — dim near-future AI-lab/office at night, CRT-terminal glow, quietly ominous.
- `banner_doom_rising` — same world with dread escalating, for a doom-spike moment.
- `fanfare_strategic_moves` — a council/board granting new authority; doubles as the first event-fanfare art.

## `requirements.txt`

Pins `openai` + `Pillow` (were undeclared); adds optional `google-genai` (dormant/lazy).

## Verification (no image API called — costs money, no key)

- `--dry-run` on `hero_banners.yaml` runs clean, shows `Backend: openai`, `Model: gpt-image-1.5`, `Size: 1536x1024`, and a cost estimate.
- Imports don't break with `google-genai` uninstalled (confirmed locally).
- YAML parses; `--backend gemini` dry-run correctly resolves model to `gemini-3-pro-image`.
- pre-commit (black/isort/ruff + project standards) passes.

Not verified: exact live OpenAI/Gemini API model ids and Gemini `image_config`/`aspect_ratio` surface — flagged with TODO comments to confirm against live docs before a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)