### PR TITLE
feat(ui): doom blow-by-blow — colour-coded per-source breakdown (#578)

### DIFF
--- a/godot/scripts/ui/doom_breakdown.gd
+++ b/godot/scripts/ui/doom_breakdown.gd
@@ -1,0 +1,102 @@
+extends VBoxContainer
+class_name DoomBreakdown
+## Doom "blow-by-blow" — colour-coded per-source breakdown of why doom moved this turn (#578).
+##
+## Surfaces state["doom_system"]["doom_sources"] (already computed by DoomSystem) as compact,
+## coloured lines near the doom meter / trend graph, like old turn-based combat logs
+## ("Rivals +12.3", "Safety -14.4"). Red = source pushing doom UP, green = source pulling it DOWN.
+## Only non-zero sources are shown, biggest movers first.
+##
+## The pure builder build_entries() and the classify()/label_for() helpers are unit-tested
+## (test_doom_breakdown.gd); the actual on-screen layout/legibility still needs a human eye.
+
+## Values whose magnitude is below this round to 0.0 at one decimal place — treat as "no move".
+const EPSILON := 0.05
+
+## Human-readable labels for known source keys. Unknown keys fall back to Capitalized words,
+## so a new DoomSystem source still renders sanely without touching this map.
+const SOURCE_LABELS := {
+	"base": "Base",
+	"rivals": "Rivals",
+	"safety": "Safety",
+	"momentum": "Momentum",
+	"specializations": "Specializations",
+	"capabilities": "Capabilities",
+	"events": "Events",
+	"technical_debt": "Technical Debt",
+	"cascades": "Cascades",
+	"market_pressure": "Market Pressure",
+	"unproductive": "Unproductive Staff",
+}
+
+static func label_for(source_key: String) -> String:
+	if SOURCE_LABELS.has(source_key):
+		return SOURCE_LABELS[source_key]
+	return source_key.capitalize()
+
+## +1 = increases doom (red), -1 = decreases doom (green), 0 = negligible (omit from display).
+static func classify(value: float) -> int:
+	if value > EPSILON:
+		return 1
+	if value < -EPSILON:
+		return -1
+	return 0
+
+## Colour for a classified sign, reusing the shared theme semantic colours.
+static func color_for_sign(sign_value: int) -> Color:
+	if sign_value > 0:
+		return ThemeManager.get_color("error")     # red — pushing doom up
+	if sign_value < 0:
+		return ThemeManager.get_color("success")   # green — pulling doom down
+	return ThemeManager.get_color("text_dim")
+
+## Pure builder: given a doom_sources dict, return the ordered per-source display entries.
+## Skips zero / negligible sources. Each entry is a Dictionary:
+##   {key, label, value, sign, text}   (text e.g. "Rivals +12.3" / "Safety -14.4")
+## Ordered by descending absolute magnitude so the biggest movers read first.
+static func build_entries(doom_sources: Dictionary) -> Array:
+	var entries: Array = []
+	for key in doom_sources.keys():
+		var value: float = float(doom_sources[key])
+		var sign_value: int = classify(value)
+		if sign_value == 0:
+			continue
+		entries.append({
+			"key": key,
+			"label": label_for(key),
+			"value": value,
+			"sign": sign_value,
+			"text": "%s %+.1f" % [label_for(key), value],
+		})
+	entries.sort_custom(func(a, b): return abs(a["value"]) > abs(b["value"]))
+	return entries
+
+func _ready() -> void:
+	add_theme_constant_override("separation", 1)
+	visible = false  # nothing to show until the first doom_sources arrives
+
+## Rebuild the breakdown from a doom_sources dict (state["doom_system"]["doom_sources"]).
+func set_sources(doom_sources) -> void:
+	# Clear previous lines immediately (avoid a one-frame duplicate that queue_free would leave).
+	while get_child_count() > 0:
+		var old := get_child(0)
+		remove_child(old)
+		old.free()
+
+	var entries := build_entries(doom_sources if doom_sources is Dictionary else {})
+	visible = not entries.is_empty()
+	if entries.is_empty():
+		return
+
+	var caption := Label.new()
+	caption.text = "Doom this turn:"
+	caption.add_theme_font_size_override("font_size", 10)
+	caption.add_theme_color_override("font_color", ThemeManager.get_color("text_dim"))
+	add_child(caption)
+
+	for entry in entries:
+		var line := Label.new()
+		line.text = entry["text"]
+		line.add_theme_font_size_override("font_size", 11)
+		line.add_theme_color_override("font_color", color_for_sign(entry["sign"]))
+		add_child(line)

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -42,6 +42,7 @@ var game_manager: Node
 var queued_actions: Array = []
 var research_quality_selector  # Issue #500
 var doom_trend_graph  # #512 doom trend sparkline (script-instantiated)
+var doom_breakdown  # #578 colour-coded per-source doom "blow-by-blow" (script-instantiated)
 var ledger_summary_label: Label  # BL-1 compact Liability Ledger summary (script-instantiated)
 var current_turn_phase: String = "NOT_STARTED"
 
@@ -83,6 +84,11 @@ func _ready():
 	doom_trend_graph.expand_requested.connect(_show_doom_trend_expanded)
 	right_zones.add_child(doom_trend_graph)
 	right_zones.move_child(doom_trend_graph, doom_meter_zone.get_index() + 1)
+
+	# #578: doom "blow-by-blow" — colour-coded per-source breakdown, just below the trend graph.
+	doom_breakdown = preload("res://scripts/ui/doom_breakdown.gd").new()
+	right_zones.add_child(doom_breakdown)
+	right_zones.move_child(doom_breakdown, doom_trend_graph.get_index() + 1)
 
 	# BL-1: compact Liability Ledger summary just below the doom trend. Kept terse so
 	# the main view stays uncrowded; the full ledger is a switchable screen (Financing).
@@ -532,6 +538,10 @@ func _on_game_state_updated(state: Dictionary):
 	# Feed the trend sparkline (#512)
 	if doom_trend_graph:
 		doom_trend_graph.set_history(state.get("doom_history", []))
+
+	# Feed the per-source doom breakdown (#578)
+	if doom_breakdown:
+		doom_breakdown.set_sources(state.get("doom_system", {}).get("doom_sources", {}))
 
 	# BL-1: refresh the compact Liability Ledger summary
 	_update_ledger_summary(state.get("ledger", {}))

--- a/godot/tests/unit/test_doom_breakdown.gd
+++ b/godot/tests/unit/test_doom_breakdown.gd
@@ -1,0 +1,71 @@
+extends GutTest
+## Unit tests for DoomBreakdown — the #578 colour-coded per-source doom "blow-by-blow".
+## Covers the pure builder: per-source signed text, red/green classification, and
+## omission of zero / negligible sources. On-screen layout still needs a human eye.
+
+func test_positive_source_classified_as_increase_red():
+	# A source pushing doom UP classifies as +1 and resolves to the theme "error" (red) colour.
+	assert_eq(DoomBreakdown.classify(12.3), 1, "Positive value should increase doom")
+	assert_eq(
+		DoomBreakdown.color_for_sign(1),
+		ThemeManager.get_color("error"),
+		"Doom-increasing source should be red (theme 'error')"
+	)
+
+func test_negative_source_classified_as_decrease_green():
+	# A source pulling doom DOWN classifies as -1 and resolves to the theme "success" (green).
+	assert_eq(DoomBreakdown.classify(-14.4), -1, "Negative value should decrease doom")
+	assert_eq(
+		DoomBreakdown.color_for_sign(-1),
+		ThemeManager.get_color("success"),
+		"Doom-decreasing source should be green (theme 'success')"
+	)
+
+func test_zero_and_negligible_classified_as_omit():
+	assert_eq(DoomBreakdown.classify(0.0), 0, "Exact zero should be omitted")
+	assert_eq(DoomBreakdown.classify(0.02), 0, "Below-epsilon positive should be omitted")
+	assert_eq(DoomBreakdown.classify(-0.03), 0, "Below-epsilon negative should be omitted")
+
+func test_build_entries_omits_zero_sources():
+	var sources := {
+		"base": 1.0,
+		"rivals": 12.3,
+		"safety": -14.4,
+		"momentum": 0.0,       # exactly zero — omitted
+		"specializations": 0.01,  # negligible — omitted
+	}
+	var entries := DoomBreakdown.build_entries(sources)
+	assert_eq(entries.size(), 3, "Only non-zero sources should be shown")
+	var keys: Array = []
+	for e in entries:
+		keys.append(e["key"])
+	assert_does_not_have(keys, "momentum", "Zero source omitted")
+	assert_does_not_have(keys, "specializations", "Negligible source omitted")
+
+func test_build_entries_signed_text_and_labels():
+	var entries := DoomBreakdown.build_entries({"rivals": 12.3, "safety": -14.4})
+	# Sorted by descending magnitude: safety (14.4) before rivals (12.3).
+	assert_eq(entries[0]["text"], "Safety -14.4", "Negative source shows human label + signed value")
+	assert_eq(entries[0]["sign"], -1, "Safety pulls doom down")
+	assert_eq(entries[1]["text"], "Rivals +12.3", "Positive source shows explicit + sign")
+	assert_eq(entries[1]["sign"], 1, "Rivals push doom up")
+
+func test_build_entries_sorted_by_magnitude():
+	var entries := DoomBreakdown.build_entries({
+		"base": 1.0,
+		"rivals": 12.3,
+		"safety": -14.4,
+	})
+	assert_eq(entries[0]["key"], "safety", "Biggest mover (|14.4|) first")
+	assert_eq(entries[1]["key"], "rivals", "Then |12.3|")
+	assert_eq(entries[2]["key"], "base", "Then |1.0|")
+
+func test_label_for_known_and_unknown_keys():
+	assert_eq(DoomBreakdown.label_for("technical_debt"), "Technical Debt", "Known key uses friendly label")
+	assert_eq(DoomBreakdown.label_for("market_pressure"), "Market Pressure", "Known key uses friendly label")
+	# Unknown key falls back to a capitalized rendering rather than crashing.
+	assert_eq(DoomBreakdown.label_for("some_new_source"), "Some New Source", "Unknown key capitalizes")
+
+func test_build_entries_empty_when_all_zero():
+	var entries := DoomBreakdown.build_entries({"base": 0.0, "rivals": 0.0})
+	assert_eq(entries.size(), 0, "All-zero sources produce an empty (hidden) breakdown")


### PR DESCRIPTION
## What

Surfaces the per-turn **doom breakdown** in the UI so the playtester can *see why doom moved each turn* — like an old turn-based combat log ("the orc hits you for 4"), colour-coded by source. Part of #578.

The data already existed (`state.doom_system.doom_sources`, computed each turn by `DoomSystem`); this PR only surfaces it — it does not recompute anything.

## Where it appears

A compact `DoomBreakdown` component sits in `RightZones`, **directly below the #512 doom trend graph** (which is below the doom meter). Each turn it renders a small caption ("Doom this turn:") followed by one coloured line per non-zero source, biggest movers first:

```
Doom this turn:
Safety -14.4      (green)
Rivals +12.3      (red)
Base  +1.0        (red)
```

## Colour logic

- Source **increasing** doom (value > +epsilon) → red, reusing theme `error`.
- Source **decreasing** doom (value < -epsilon) → green, reusing theme `success`.
- Zero / negligible (|value| ≤ 0.05, i.e. rounds to 0.0 at one decimal) → **omitted**.

Sources shown (any non-zero key from `doom_sources`): `base`, `rivals`, `safety`, `momentum`, `specializations`, `capabilities`, `events`, `technical_debt`, `cascades`, `market_pressure`, `unproductive`. Unknown keys fall back to a capitalized label, so a new `DoomSystem` source renders sanely without a code change here.

## Files

- `godot/scripts/ui/doom_breakdown.gd` — new component. Pure `build_entries()` builder + `classify()` / `label_for()` / `color_for_sign()` helpers, plus `set_sources()` which rebuilds the coloured labels.
- `godot/scripts/ui/main_ui.gd` — **minimal** hook only (another lane is editing input handling here): one var, instantiate below the trend graph, feed `set_sources()` from state each UI update.
- `godot/tests/unit/test_doom_breakdown.gd` — 8 tests / 21 asserts.

## Test result

`python scripts/run_godot_tests.py --quick` → **green**. New suite in isolation: **8/8 passed, 21 asserts**. Covers signed text ("Rivals +12.3" / "Safety -14.4"), red/green/omit classification, zero + negligible omission, magnitude ordering, and label fallback.

## Human-verification caveat

The unit tests cover the builder logic and colour classification, but the **actual on-screen rendering / legibility needs a human eye** — placement below the trend graph, font sizes, colour contrast against the dark panel, and that it stays compact (not a wall of text) across a real playthrough.

Refs #578. Do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)