### PR TITLE
fix: global keybinds yield to focused text fields + dialogs (#575, #567)

### DIFF
--- a/godot/autoload/keybind_manager.gd
+++ b/godot/autoload/keybind_manager.gd
@@ -246,9 +246,26 @@ func get_actions_by_category(category: Category) -> Array:
 			actions.append(action)
 	return actions
 
+## True if a text-entry widget (LineEdit/TextEdit) currently owns GUI focus.
+## Global keybinds must yield to text fields so typed characters reach the field
+## instead of firing shortcuts (issues #575, #567). Used as a gate by this
+## autoload's _input and by MainUI's shortcut handling.
+func is_text_input_focused() -> bool:
+	var vp := get_viewport()
+	if vp == null:
+		return false
+	var focus_owner := vp.gui_get_focus_owner()
+	return focus_owner is LineEdit or focus_owner is TextEdit
+
 ## Process input for global keybinds
 func _input(event: InputEvent):
 	if not event is InputEventKey:
+		return
+
+	# Yield to focused text fields — never steal characters being typed (#575).
+	# A bug-report form or any LineEdit/TextEdit must receive letters like 'n'/'t'
+	# rather than having them trigger global shortcuts.
+	if is_text_input_focused():
 		return
 
 	# Screenshot

--- a/godot/scripts/ui/bug_report_panel.gd
+++ b/godot/scripts/ui/bug_report_panel.gd
@@ -62,8 +62,10 @@ func _input(event):
 
 	# Handle keyboard shortcuts
 	if event is InputEventKey and event.pressed and not event.echo:
-		# Backslash (\), N key, or ESC to close bug reporter
-		if event.keycode == KEY_BACKSLASH or event.keycode == KEY_N or event.keycode == KEY_ESCAPE:
+		# Only ESC closes the panel. N and Backslash were previously close keys, but
+		# they are ordinary characters the user needs to type into the report fields —
+		# closing on them made filing a report nearly impossible (issue #575).
+		if event.keycode == KEY_ESCAPE:
 			hide_panel()
 			get_viewport().set_input_as_handled()
 

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -126,6 +126,12 @@ func _unhandled_key_input(event: InputEvent):
 func _input(event: InputEvent):
 	"""Handle keyboard shortcuts"""
 	if event is InputEventKey and event.pressed and not event.echo:
+		# Game/global shortcuts yield to focused text fields so typing works (#575).
+		# Bug-report form etc. own a LineEdit/TextEdit; let those keys reach the field.
+		# Dialog choice buttons use FOCUS_NONE, so this never blocks dialog keys.
+		if KeybindManager.is_text_input_focused():
+			return
+
 		# DEBUG: sweep doom for QA (PageUp/PageDown ±10). Debug builds only — auto-off in release.
 		# TODO: remove before any release/PR if undesired (currently gated, so release-safe).
 		if OS.is_debug_build() and (event.keycode == KEY_PAGEUP or event.keycode == KEY_PAGEDOWN):
@@ -153,14 +159,14 @@ func _input(event: InputEvent):
 		# This prevents ENTER/SPACE from triggering turn advancement while dialog is open
 		if active_dialog != null and is_instance_valid(active_dialog):
 			print("[MainUI] Dialog is active and valid!")
-			var dialog_keys = [KEY_Q, KEY_W, KEY_E, KEY_R, KEY_A, KEY_S, KEY_D, KEY_F, KEY_Z]
-			var key_index = dialog_keys.find(event.keycode)
-			print("[MainUI] Looking for keycode %d in dialog_keys, found at index: %d" % [event.keycode, key_index])
+			# Map the pressed key to a choice button. Dialogs label buttons with
+			# numbers ([1][2][3], e.g. hire pool) or letters ([Q][W][E], e.g. events);
+			# accept both so keys always match the shown buttons (#567, #575).
+			var key_index = _dialog_button_index_for_key(event.keycode)
+			print("[MainUI] Dialog key %d -> button index %d (buttons: %d)" % [event.keycode, key_index, active_dialog_buttons.size()])
 
 			if key_index >= 0 and key_index < active_dialog_buttons.size():
-				print("[MainUI] Key index %d is valid (buttons count: %d)" % [key_index, active_dialog_buttons.size()])
 				var btn = active_dialog_buttons[key_index]
-				print("[MainUI] Button at index: %s, valid: %s, disabled: %s" % [btn != null, is_instance_valid(btn) if btn != null else false, btn.disabled if btn != null else "N/A"])
 				if btn != null and is_instance_valid(btn) and not btn.disabled:
 					print("[MainUI] *** TRIGGERING DIALOG BUTTON: %s ***" % btn.text)
 					btn.pressed.emit()
@@ -168,8 +174,8 @@ func _input(event: InputEvent):
 					return
 				else:
 					print("[MainUI] Button not triggerable (null, invalid, or disabled)")
-			else:
-				print("[MainUI] Key index %d out of range or not found" % key_index)
+			# else: key isn't a choice for this dialog (e.g. R on a 3-option event).
+			# Fall through to ESC handling; other keys are blocked below. No scary log.
 
 			# ESC key: only close submenu dialogs (hiring, fundraising), NOT event dialogs
 			# Event dialogs must be completed to prevent soft-lock (issue #452)
@@ -267,18 +273,25 @@ func _unhandled_input(event: InputEvent):
 		print("[MainUI] _unhandled_input called, keycode: %d, active_dialog: %s" % [event.keycode, active_dialog != null])
 		# If dialog is active, handle dialog shortcuts with LETTERS (Q/W/E/R/A/S/D/F/Z)
 		if active_dialog != null and is_instance_valid(active_dialog):
-			# Letter keys for dialog options (Q/W/E/R/A/S/D/F/Z = 9 options)
-			var dialog_keys = [KEY_Q, KEY_W, KEY_E, KEY_R, KEY_A, KEY_S, KEY_D, KEY_F, KEY_Z]
-			var key_index = dialog_keys.find(event.keycode)
+			# Number or letter keys for dialog options; map to the shown buttons (#567, #575)
+			var key_index = _dialog_button_index_for_key(event.keycode)
 
-			if key_index >= 0:
-				print("[MainUI] Dialog letter key pressed, index: %d, buttons: %d" % [key_index, active_dialog_buttons.size()])
-				if key_index < active_dialog_buttons.size():
-					var btn = active_dialog_buttons[key_index]
-					if btn != null and is_instance_valid(btn) and not btn.disabled:
-						print("[MainUI] Triggering dialog button: %s" % btn.text)
-						btn.pressed.emit()
-						get_viewport().set_input_as_handled()
+			if key_index >= 0 and key_index < active_dialog_buttons.size():
+				var btn = active_dialog_buttons[key_index]
+				if btn != null and is_instance_valid(btn) and not btn.disabled:
+					print("[MainUI] Triggering dialog button: %s" % btn.text)
+					btn.pressed.emit()
+					get_viewport().set_input_as_handled()
+
+func _dialog_button_index_for_key(keycode: int) -> int:
+	"""Map a pressed key to a dialog choice-button index, or -1 if unmapped.
+	Dialogs label buttons either with numbers ([1][2][3], e.g. the hire candidate
+	pool) or letters ([Q][W][E], e.g. event choices). Accept both schemes so the
+	keys always match whatever buttons are displayed (issues #567, #575)."""
+	if keycode >= KEY_1 and keycode <= KEY_9:
+		return keycode - KEY_1
+	var letter_keys = [KEY_Q, KEY_W, KEY_E, KEY_R, KEY_A, KEY_S, KEY_D, KEY_F, KEY_Z]
+	return letter_keys.find(keycode)
 
 func _trigger_action_by_index(index: int):
 	"""Trigger action button by its index (for keyboard shortcuts)"""

--- a/godot/tests/unit/test_keybind_focus_gate.gd
+++ b/godot/tests/unit/test_keybind_focus_gate.gd
@@ -1,0 +1,72 @@
+extends GutTest
+## Regression tests: global keybinds must yield to focused text fields (#575, #567).
+##
+## KeybindManager.is_text_input_focused() is the shared gate used by the autoload's
+## own _input and by MainUI's shortcut handling. When a LineEdit/TextEdit owns focus
+## (e.g. the bug-report form), pressing a bound key must NOT fire the global shortcut,
+## so the character reaches the field instead.
+
+var line_edit: LineEdit
+
+func after_each():
+	# Release any focus we grabbed so tests don't leak state into each other.
+	var vp = KeybindManager.get_viewport()
+	if vp and vp.gui_get_focus_owner():
+		vp.gui_get_focus_owner().release_focus()
+	if is_instance_valid(line_edit):
+		line_edit.queue_free()
+	line_edit = null
+
+func _make_key_event(keycode: int) -> InputEventKey:
+	var ev = InputEventKey.new()
+	ev.keycode = keycode
+	ev.pressed = true
+	return ev
+
+func _clear_focus():
+	var vp = KeybindManager.get_viewport()
+	if vp and vp.gui_get_focus_owner():
+		vp.gui_get_focus_owner().release_focus()
+
+func test_gate_true_when_line_edit_focused():
+	line_edit = LineEdit.new()
+	add_child_autofree(line_edit)
+	line_edit.grab_focus()
+	await get_tree().process_frame
+	assert_true(KeybindManager.is_text_input_focused(),
+		"Gate should report text focus while a LineEdit owns focus")
+
+func test_gate_false_when_nothing_focused():
+	_clear_focus()
+	await get_tree().process_frame
+	assert_false(KeybindManager.is_text_input_focused(),
+		"Gate should be false when no text field is focused")
+
+# Use the admin_mode bind for behavioural checks: admin_mode_toggled has no autoload
+# listener, so emitting it in a headless test has no side effects (unlike
+# screenshot_requested, which drives a real save_png on a null headless viewport).
+func test_keybind_not_consumed_while_text_focused():
+	# With a text field focused, a bound global key must NOT fire — the gate yields
+	# the key to the field (#575).
+	line_edit = LineEdit.new()
+	add_child_autofree(line_edit)
+	line_edit.grab_focus()
+	await get_tree().process_frame
+
+	var admin_key = KeybindManager.keybinds["admin_mode"]["key"]
+	watch_signals(KeybindManager)
+	KeybindManager._input(_make_key_event(admin_key))
+	assert_signal_not_emitted(KeybindManager, "admin_mode_toggled",
+		"Global keybind must yield to a focused text field (#575)")
+
+func test_keybind_fires_when_no_text_focus():
+	# Sanity check the other direction: same key DOES fire when nothing is focused,
+	# so the gate isn't just disabling the shortcut outright.
+	_clear_focus()
+	await get_tree().process_frame
+
+	var admin_key = KeybindManager.keybinds["admin_mode"]["key"]
+	watch_signals(KeybindManager)
+	KeybindManager._input(_make_key_event(admin_key))
+	assert_signal_emitted(KeybindManager, "admin_mode_toggled",
+		"Global keybind should fire normally when no text field is focused")

--- a/godot/tests/unit/test_keybind_focus_gate.gd.uid
+++ b/godot/tests/unit/test_keybind_focus_gate.gd.uid
@@ -1,0 +1,1 @@
+uid://csoskk3txytn6


### PR DESCRIPTION
## Problem

Global keyboard shortcuts were stealing character keys that belonged to focused widgets — the same input-routing family across three symptoms:

- **#575 (bug report):** typing `n`/`t` in the F8 form fired global hotkeys instead of entering text; worse, `n`/`\` closed the panel outright.
- **#567 (event dialog):** pressing an unmapped choice key logged the confusing `Key index N out of range or not found`.
- **#575 (hire pool):** the candidate dialog labels buttons `[1][2][3]`, but the shared dialog handler only recognised letter keys, so number keys were dead.

## The gate

Added `KeybindManager.is_text_input_focused()` — returns true when a `LineEdit`/`TextEdit` owns GUI focus (`get_viewport().gui_get_focus_owner()`). Both `KeybindManager._input` and `MainUI._input` now bail early when it returns true, so typed characters reach the field rather than firing shortcuts. Dialog choice buttons use `FOCUS_NONE`, so the gate never blocks dialog keys.

## What was fixed

- **#575 bug-report text entry (fixed):** the focus gate stops global/game shortcuts from eating letters; `bug_report_panel` now closes only on ESC (N and `\` were ordinary characters the user needs to type).
- **#575 hire number keys (fixed):** new `MainUI._dialog_button_index_for_key()` maps both number (1-9) and letter (Q/W/E/R/A/S/D/F/Z) keys to the shown choice buttons, so keys always match the displayed labels. This wires the hire pool's `[1][2][3]`.
- **#567 event-dialog mapping (fixed):** same helper; unmapped keys are now silently ignored instead of logging the scary "out of range" message. The event dialog's letter mapping was already consistent, so the observed failure was pressing a key with no corresponding option on a shorter event — that now no-ops cleanly.

## Tests

- New `tests/unit/test_keybind_focus_gate.gd` (4 asserts): the gate reports focus correctly, a bound global key does **not** fire while a `LineEdit` is focused, and the same key **does** fire when nothing is focused.
- `python scripts/run_godot_tests.py --quick` — green.

## Human verification needed

The gate and dialog mapping are covered by unit tests, but the real keypress-in-UI behaviour (actually typing a bug report end-to-end, selecting hire candidates with 1/2/3, and choosing event options) needs a human eye in the running game — automated headless input focus is an imperfect proxy for live widget focus.

Refs #575, #567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)