### PR TITLE
chore(test): update stale reset_triggered_events refs to GameState instance (#582)

### DIFF
--- a/godot/tests/unit/test_events.gd
+++ b/godot/tests/unit/test_events.gd
@@ -4,8 +4,9 @@ extends GutTest
 var state: GameState
 
 func before_each():
+	# WS-0: the fired-event registry (triggered_events / event_cooldowns) is now
+	# per-GameState instance state, so a fresh GameState resets it automatically.
 	state = GameState.new("test_seed")
-	GameEvents.reset_triggered_events()
 
 func _find_event_by_id(events: Array, id: String) -> Dictionary:
 	"""Helper to find a specific event in an array by id"""
@@ -95,12 +96,15 @@ func test_non_repeatable_event_only_triggers_once():
 	assert_false(has_crisis_2, "Should not trigger funding crisis second time (non-repeatable)")
 
 func test_reset_triggered_events_clears_history():
-	# Test that reset clears triggered events history
+	# Test that clearing the per-GameState registry clears triggered events history.
+	# WS-0: the fired-event registry lives on the GameState instance, so the
+	# instance-level reset is clearing state.triggered_events / state.event_cooldowns.
 	state.turn = 10
 	state.money = 40000
 
 	GameEvents.check_triggered_events(state, state.rng)
-	GameEvents.reset_triggered_events()
+	state.triggered_events.clear()
+	state.event_cooldowns.clear()
 
 	# Should be able to trigger again after reset
 	var events = GameEvents.check_triggered_events(state, state.rng)

--- a/godot/tests/unit/test_game_manager.gd
+++ b/godot/tests/unit/test_game_manager.gd
@@ -17,7 +17,8 @@ func before_each():
 	if EventService:
 		_saved_historical_events = EventService.transformed_events.duplicate()
 		EventService.transformed_events.clear()
-	GameEvents.reset_triggered_events()
+	# WS-0: the fired-event registry is per-GameState instance state; GameManager
+	# creates its own fresh GameState, so no global event-registry reset is needed.
 
 	# Preserve difficulty (autoload singleton) so difficulty tests don't leak
 	_saved_difficulty = GameConfig.difficulty

--- a/godot/tests/unit/test_turn_manager.gd
+++ b/godot/tests/unit/test_turn_manager.gd
@@ -6,8 +6,9 @@ var turn_manager: TurnManager
 var _saved_historical_events := []
 
 func before_each():
-	# Create fresh state and turn manager for each test
-	GameEvents.reset_triggered_events()
+	# Create fresh state and turn manager for each test.
+	# WS-0: the fired-event registry is per-GameState instance state; the fresh
+	# GameState.new() below resets it, so no global reset call is needed.
 	# Test isolation (#534): unit tests must NOT load the live ~1194-event historical
 	# timeline into pending_events. Resolve-all loops over it floods hist_arxiv_* output
 	# and hangs the headless suite. Built-in events (e.g. funding_crisis) still trigger.


### PR DESCRIPTION
Fixes #582.

## What
WS-0 moved the fired-event registry (`triggered_events` / `event_cooldowns`) from static class state on `GameEvents` to per-game **instance** state on `GameState`, and removed `GameEvents.reset_triggered_events()`. Three unit tests still called the removed function, producing a script load error that failed the whole file under the **full** GUT run (the `--quick` unit gate is where these live, so they were red once the function was gone).

## Fix (4 call sites across 3 files)
- `test_events.gd`, `test_turn_manager.gd`, `test_game_manager.gd` `before_each()`: dropped the redundant global reset — a fresh `GameState.new()` already starts with an empty registry (the members are declared `[]` / `{}`).
- `test_events.gd::test_reset_triggered_events_clears_history`: reset via the current **instance** mechanism — `state.triggered_events.clear()` / `state.event_cooldowns.clear()` — so the assertion still exercises the real API (re-triggering after clear) rather than being deleted.

## Verification
- `--headless --import` pass, then full GUT suite (`python scripts/run_godot_tests.py`).
- `test_events.gd`: **18/18 pass** (including `test_reset_triggered_events_clears_history`).
- No more missing-function / load errors in any of the three files.

### Pre-existing failures (out of scope)
The full run still shows 14 failures — 13 in `test_game_manager.gd`, 1 in `test_turn_manager.gd` — covering difficulty starting-money modifiers (e.g. Easy expects `367500`, gets `225000`), salary deductions, and signal/turn-flow timing. These were **masked** by the load error before this PR. Verified independent of this change by a controlled experiment: restoring the original tests plus a no-op `reset_triggered_events()` stub reproduces the exact same 14 failures. They relate to the recent difficulty-modifier work (#563), not the event registry, and are left for separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)