### PR TITLE
fix: no pre-first-turn event + cap events triggered per turn (#568)

### DIFF
--- a/godot/scripts/core/events.gd
+++ b/godot/scripts/core/events.gd
@@ -7,6 +7,19 @@ class_name GameEvents
 # persisted across in-process games and replays, desyncing state.rng consumption between
 # otherwise-identical runs (candidate/rival divergence with matching score).
 
+# #568 event pacing:
+#   FIRST_EVENT_TURN — start_turn() increments state.turn BEFORE checking events, so turn 1 is
+#     the player's very first (as-yet-unacted) turn. Suppress all event firing until this turn,
+#     so the game doesn't open with a popup before the player has taken a single action.
+#   MAX_NEW_EVENTS_PER_TURN — cap on how many *new* events fire in a single turn. Without it, a
+#     turn where several probabilistic/threshold events happen to qualify dumps a "flood" of 6+
+#     popups at once. Excess qualifying events are simply not marked this turn, so random ones
+#     re-roll and turn/threshold beats re-evaluate on a later turn — the burst is spread out.
+#   NOTE (design, parked): this does NOT change the event *pool size / density* (how often events
+#     qualify in the first place) — that is a deliberate design call tracked in #578/#579.
+const FIRST_EVENT_TURN := 2
+const MAX_NEW_EVENTS_PER_TURN := 2
+
 static func get_all_events() -> Array[Dictionary]:
 	"""Return all event definitions"""
 	return [
@@ -840,22 +853,34 @@ static func get_all_events() -> Array[Dictionary]:
 	]
 
 static func check_triggered_events(state: GameState, rng: RandomNumberGenerator) -> Array[Dictionary]:
-	"""Check all events and return those that should trigger this turn"""
-	var to_trigger: Array[Dictionary] = []
+	"""Check all events and return those that should trigger this turn.
+
+	#568: no events fire before the player's first turn (FIRST_EVENT_TURN), and at most
+	MAX_NEW_EVENTS_PER_TURN new events fire on any single turn. Qualifying events are
+	collected WITHOUT being marked, then only the ones we actually fire get marked — so
+	events squeezed out by the cap simply defer to a later turn instead of being lost.
+	should_trigger() is still called for every candidate, so rng consumption (and thus
+	determinism / replay) is unchanged relative to the pre-cap behaviour."""
+	# Suppress event firing entirely until the player's first turn has begun.
+	if state.turn < FIRST_EVENT_TURN:
+		return []
+
+	# Two buckets so scripted beats (turn_exact / turn_and_resource / threshold) are never
+	# crowded out of the cap by a swarm of "random" events — scripted fire first.
+	var scripted: Array[Dictionary] = []
+	var random_pool: Array[Dictionary] = []
 
 	# Check built-in events
 	for event in get_all_events():
 		if should_trigger(event, state, rng):
-			to_trigger.append(event)
-			_mark_event_triggered(event, state.turn, state)
+			_bucket_candidate(event, scripted, random_pool)
 
 	# Check scenario-specific events (Issue #483: Mod/Scenario hook)
 	if state.has_meta("scenario_events"):
 		var scenario_events = state.get_meta("scenario_events")
 		for event in scenario_events:
 			if should_trigger(event, state, rng):
-				to_trigger.append(event)
-				_mark_event_triggered(event, state.turn, state)
+				_bucket_candidate(event, scripted, random_pool)
 
 	# Check historical events from EventService (Issue #442: API Event Fetching)
 	# Historical events are real AI safety timeline events transformed into game events
@@ -868,10 +893,30 @@ static func check_triggered_events(state: GameState, rng: RandomNumberGenerator)
 			if event_year < state.start_year:
 				continue
 			if should_trigger(event, state, rng):
-				to_trigger.append(event)
-				_mark_event_triggered(event, state.turn, state)
+				_bucket_candidate(event, scripted, random_pool)
+
+	# Fire scripted beats first, then random ones, up to the per-turn cap. Only fired
+	# events are marked; the rest defer (random → re-roll, threshold/turn → re-evaluate).
+	var to_trigger: Array[Dictionary] = []
+	for event in scripted:
+		if to_trigger.size() >= MAX_NEW_EVENTS_PER_TURN:
+			break
+		to_trigger.append(event)
+		_mark_event_triggered(event, state.turn, state)
+	for event in random_pool:
+		if to_trigger.size() >= MAX_NEW_EVENTS_PER_TURN:
+			break
+		to_trigger.append(event)
+		_mark_event_triggered(event, state.turn, state)
 
 	return to_trigger
+
+static func _bucket_candidate(event: Dictionary, scripted: Array[Dictionary], random_pool: Array[Dictionary]) -> void:
+	"""Route a qualifying event into the scripted or random bucket for cap prioritisation (#568)."""
+	if event.get("trigger_type", "") == "random":
+		random_pool.append(event)
+	else:
+		scripted.append(event)
 
 static func should_trigger(event: Dictionary, state: GameState, rng: RandomNumberGenerator) -> bool:
 	"""Check if event should trigger"""

--- a/godot/tests/unit/test_events.gd
+++ b/godot/tests/unit/test_events.gd
@@ -72,6 +72,7 @@ func test_funding_crisis_no_trigger_sufficient_money():
 
 func test_funding_windfall_triggers_on_threshold():
 	# Test funding windfall triggers with papers + reputation
+	state.turn = 5  # #568: events are suppressed before FIRST_EVENT_TURN
 	state.papers = 3.0
 	state.reputation = 40.0
 
@@ -101,6 +102,7 @@ func test_reset_triggered_events_clears_history():
 	# instance-level reset is clearing state.triggered_events / state.event_cooldowns.
 	state.turn = 10
 	state.money = 40000
+	GameEvents.check_triggered_events(state, state.rng)  # consumes funding_crisis on `state`
 
 	GameEvents.check_triggered_events(state, state.rng)
 	state.triggered_events.clear()
@@ -109,7 +111,91 @@ func test_reset_triggered_events_clears_history():
 	# Should be able to trigger again after reset
 	var events = GameEvents.check_triggered_events(state, state.rng)
 	var has_crisis = not _find_event_by_id(events, "funding_crisis").is_empty()
-	assert_true(has_crisis, "Should trigger funding crisis again after reset")
+	assert_true(has_crisis, "A fresh GameState should have clean event history")
+
+# --- #568 regression: event pacing (no pre-first-turn spawn + per-turn cap) ---
+
+func test_no_events_before_first_turn():
+	# #568(a): the player's very first turn (turn 1) must not open with an event,
+	# even when a threshold event's condition is already satisfied.
+	state.turn = 1
+	state.papers = 3.0
+	state.reputation = 40.0  # would otherwise satisfy funding_windfall
+	var events = GameEvents.check_triggered_events(state, state.rng)
+	assert_eq(events.size(), 0, "No event should fire before the first turn is played (#568)")
+
+func test_events_resume_from_first_event_turn():
+	# #568(a): once FIRST_EVENT_TURN is reached, qualifying events fire as normal.
+	state.turn = GameEvents.FIRST_EVENT_TURN
+	state.papers = 3.0
+	state.reputation = 40.0
+	var events = GameEvents.check_triggered_events(state, state.rng)
+	assert_false(_find_event_by_id(events, "funding_windfall").is_empty(),
+		"Threshold events should fire from FIRST_EVENT_TURN onward (#568)")
+
+func test_new_events_capped_per_turn():
+	# #568(b): a burst of simultaneously-qualifying events must not all fire at once.
+	# Inject a flood of always-true scenario events and assert the cap holds.
+	state.turn = 5
+	var flood: Array[Dictionary] = []
+	for i in range(6):
+		flood.append({
+			"id": "flood_%d" % i,
+			"name": "Flood %d" % i,
+			"description": "test flood event",
+			"type": "popup",
+			"trigger_type": "threshold",
+			"trigger_condition": "true",
+			"repeatable": false,
+			"options": [{"id": "ok", "text": "OK", "effects": {}, "message": "ok"}],
+		})
+	state.set_meta("scenario_events", flood)
+
+	var events = GameEvents.check_triggered_events(state, state.rng)
+	assert_eq(events.size(), GameEvents.MAX_NEW_EVENTS_PER_TURN,
+		"At most MAX_NEW_EVENTS_PER_TURN events should fire in one turn (#568)")
+	assert_true(events.size() <= 2, "Cap should keep the per-turn burst small (#568)")
+
+func test_capped_events_defer_not_lost():
+	# #568(b): events squeezed out by the cap are NOT marked, so they can still fire
+	# on a later turn (deferred, not dropped).
+	# Isolate from the live historical deck (#534) so only our flood competes for slots.
+	var saved_events := []
+	if EventService:
+		saved_events = EventService.transformed_events.duplicate()
+		EventService.transformed_events.clear()
+
+	state.turn = 5
+	var flood: Array[Dictionary] = []
+	for i in range(6):
+		flood.append({
+			"id": "flood_%d" % i,
+			"name": "Flood %d" % i,
+			"description": "test flood event",
+			"type": "popup",
+			"trigger_type": "threshold",
+			"trigger_condition": "true",
+			"repeatable": false,
+			"options": [{"id": "ok", "text": "OK", "effects": {}, "message": "ok"}],
+		})
+	state.set_meta("scenario_events", flood)
+
+	var fired_flood := {}
+	# Drain over several turns; every flood event should eventually fire exactly once.
+	for _t in range(10):
+		var events = GameEvents.check_triggered_events(state, state.rng)
+		assert_true(events.size() <= GameEvents.MAX_NEW_EVENTS_PER_TURN,
+			"Cap must hold on every turn (#568)")
+		for e in events:
+			var eid: String = e.get("id", "")
+			if eid.begins_with("flood_"):
+				fired_flood[eid] = true
+		state.turn += 1
+
+	if EventService:
+		EventService.transformed_events = saved_events
+
+	assert_eq(fired_flood.size(), 6, "All deferred events should eventually fire, none lost (#568)")
 
 func test_execute_event_choice_applies_effects():
 	# Test that event choices apply their effects


### PR DESCRIPTION
Fixes #568.

## Problem (playtester report)
- (a) The game **spawned with an event immediately, before the first turn cycle** — a popup appeared before the player had taken a single action.
- (b) On some turns **6+ events triggered at once** (an event "flood").

## Root cause
Both live in `GameEvents.check_triggered_events()` (called from `TurnManager.start_turn()`):
- **Pre-first-turn spawn:** `start_turn()` increments `state.turn` (0 -> 1) and *then* checks events (FIX #418 moved events before action selection). So the very first turn ran the event check before the player acted. Any turn-agnostic event (threshold events, historical/scenario events with no `min_turn`) could fire on turn 1.
- **Flood:** the function fired **every** event whose `should_trigger()` returned true on a given turn. When several probabilistic (`random`) and/or `threshold` events happened to qualify simultaneously, they were all queued into `pending_events` at once.

## Fix (scoped to `events.gd`)
- `FIRST_EVENT_TURN = 2`: suppress all event firing until the player's first turn has been played. No popup on game open.
- `MAX_NEW_EVENTS_PER_TURN = 2`: collect qualifying events **without marking them**, then fire at most 2 — scripted beats (`turn_exact` / `turn_and_resource` / `threshold`) prioritised over `random` ones so story beats aren't crowded out. Events squeezed out by the cap are **not marked**, so they defer to a later turn (random re-rolls; threshold/turn re-evaluate) rather than being dropped.

**Determinism preserved:** `should_trigger()` is still called for every candidate every turn (marking is the only thing deferred), so `state.rng` consumption is unchanged vs. the pre-cap behaviour. No change to `turn_manager.gd` (the event-triggering call site was already correct); the action/compute-execution path was not touched.

## Parked (design, not tuned here)
The deeper **event pool size / density** question (how often events qualify in the first place) is a deliberate design call — left to #578 / #579. This PR only removes the burst and the pre-first-turn spawn; the per-turn cap and `FIRST_EVENT_TURN` are named constants so they're trivial to tune once that design lands.

## Tests
- Un-breaks `test_events.gd`, which referenced the WS-0-removed `GameEvents.reset_triggered_events()` — a parse error that caused GUT to **silently skip the whole file** while still reporting green. (Note: `test_turn_manager.gd` / `test_game_manager.gd` reference the same removed function and remain skipped; un-skipping them surfaces *pre-existing, unrelated* failing assertions from the `/260` salary change (#573) and difficulty starting-money formulas — out of scope here, flagged for a separate cleanup.)
- New regression tests: no event before the first turn; events resume from `FIRST_EVENT_TURN`; per-turn cap holds under a 6-event flood; capped events defer (all eventually fire, none lost).
- `python scripts/run_godot_tests.py --quick` — green (22/22 in `test_events.gd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)