### PR TITLE
fix: compute is actually consumed by research/actions (#576)

### DIFF
--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -169,6 +169,11 @@ func start_turn() -> Dictionary:
 	var doom_from_capabilities = 0.0
 	var doom_reduction_from_safety = 0.0
 	var productive_count = 0
+	# #576: compute is a consumable, not just a capacity gate. Each productive
+	# researcher burns compute this turn; we accumulate the total here and
+	# actually decrement state.compute after the loop (previously the `-= 1`
+	# below only touched the local `available_compute`, so compute never fell).
+	var compute_consumed = 0.0
 	var leak_occurred = false
 	var leak_doom = 0.0
 
@@ -186,7 +191,12 @@ func start_turn() -> Dictionary:
 		var has_compute = available_compute > 0
 
 		if is_managed and has_compute:
-			available_compute -= 1
+			# Flat 1 compute/researcher/turn for now. PARKED (#576 follow-up):
+			# "researchers request compute at different rates" — make this a
+			# per-researcher rate (by specialization / skill) instead of 1.
+			var compute_request = 1
+			available_compute -= compute_request
+			compute_consumed += compute_request
 			productive_count += 1
 
 			# Get effective productivity (accounts for burnout, traits)
@@ -249,6 +259,14 @@ func start_turn() -> Dictionary:
 
 	# Apply research gains
 	state.add_resources({"research": research_from_employees})
+
+	# #576: actually burn the compute the researchers consumed this turn.
+	# Matches the money-spend pattern above (add_resources with a negative).
+	# compute_consumed <= int(state.compute) by construction (the has_compute
+	# gate stops handing out compute at 0), so this stays non-negative.
+	if compute_consumed > 0:
+		state.add_resources({"compute": -compute_consumed})
+		state.compute = max(0.0, state.compute)
 
 	# Issue #500: research-quality risk contributions (feeds risk pools, not doom directly)
 	state.apply_research_quality_risk(state.turn)

--- a/godot/tests/unit/test_turn_manager.gd
+++ b/godot/tests/unit/test_turn_manager.gd
@@ -52,16 +52,18 @@ func test_start_turn_ap_scales_with_staff():
 	assert_eq(state.action_points, 6, "AP should scale: 3 + int(6 * 0.5) = 6")
 
 func test_start_turn_deducts_staff_salaries():
-	# Test that staff salaries are deducted ($5k per employee)
+	# #573: salaries are now per-workday (annual / 260), not a flat $5k/turn.
+	# With only legacy staff counts (no Researcher objects) the fallback bills
+	# total_staff * (60000/260) per turn.
 	state.safety_researchers = 3
 	state.capability_researchers = 2
-	# Total staff = 5, salaries = 5 * $5000 = $25,000
+	# Total staff = 5
 	var initial_money = state.money
 
 	turn_manager.start_turn()
 
-	var expected_money = initial_money - 25000
-	assert_eq(state.money, expected_money, "Should deduct $25k in salaries")
+	var expected_money = initial_money - 5 * (60000.0 / 260.0)
+	assert_almost_eq(state.money, expected_money, 0.01, "Should deduct per-workday salaries (#573)")
 
 func test_start_turn_no_research_without_individual_researchers():
 	# Research generation now comes from individual researcher system,
@@ -73,6 +75,48 @@ func test_start_turn_no_research_without_individual_researchers():
 	turn_manager.start_turn()
 
 	assert_eq(state.research, 0.0, "No research without individual researchers")
+
+func test_start_turn_burns_compute_for_productive_researchers():
+	# #576 REGRESSION: compute is a consumable, not just a capacity gate.
+	# Each productive (managed, has-compute) researcher must actually burn
+	# compute each turn. Previously the decrement only touched a local var,
+	# so state.compute never fell and playtesters saw it accumulate forever.
+	state.compute = 100.0
+	# 3 researchers, all within founder management capacity (9) -> all productive.
+	state.researchers = [
+		Researcher.new("safety"),
+		Researcher.new("safety"),
+		Researcher.new("capabilities"),
+	]
+
+	turn_manager.start_turn()
+
+	# Compute burn is deterministic (1 per productive researcher), independent of
+	# the RNG research roll: 3 productive researchers -> 3 compute consumed.
+	assert_eq(state.compute, 97.0, "3 productive researchers should burn 3 compute (100 -> 97)")
+
+func test_start_turn_compute_drops_over_multiple_turns():
+	# #576 REGRESSION: over several turns compute should trend DOWN when
+	# researchers are working and no compute is purchased.
+	state.compute = 100.0
+	state.researchers = [Researcher.new("safety"), Researcher.new("capabilities")]
+
+	var start_compute = state.compute
+	for _i in range(5):
+		turn_manager.start_turn()
+
+	# 2 productive researchers * 5 turns = 10 compute burned.
+	assert_lt(state.compute, start_compute, "Compute should decrease over turns when researchers work")
+	assert_eq(state.compute, 90.0, "2 researchers over 5 turns should burn 10 compute (100 -> 90)")
+
+func test_start_turn_compute_not_burned_without_researchers():
+	# Guard: with no researchers there is nothing to consume compute.
+	state.compute = 100.0
+	state.researchers = []
+
+	turn_manager.start_turn()
+
+	assert_eq(state.compute, 100.0, "Compute should be unchanged with no researchers")
 
 func test_execute_turn_processes_queued_actions():
 	# Test that execute_turn runs queued actions


### PR DESCRIPTION
Fixes #576 — playtester: "Compute doesn't seem to get burned."

## Root cause
Compute only ever accumulated; nothing decremented `state.compute`.

- In `turn_manager.gd`'s per-turn researcher productivity loop, `available_compute = int(state.compute)` is a **local** copy used as a capacity gate. Each productive (managed, has-compute) researcher did `available_compute -= 1` — but that burn was **never written back** to `state.compute`. So the decrement was a no-op on the real resource.
- No action or upgrade declares a `compute` cost, so `spend_resources()` (which *does* subtract compute) was never triggered for compute either.

Net: `buy_compute`, events, upgrades, and acquisitions add compute; nothing ever spends it.

## Fix
Scoped to the compute/research execution path (not the event-trigger code, per the parallel lane):
- Accumulate `compute_consumed` in the productivity loop (1 per productive researcher, made an explicit `compute_request` variable to make future per-rate tuning trivial).
- After applying research gains, `state.add_resources({"compute": -compute_consumed})` — matching the existing money-spend pattern (`add_resources` with a negative). `compute_consumed <= int(state.compute)` by construction (the has-compute gate stops at 0), so compute stays non-negative; clamped at 0 for safety.

Magnitude (1 compute/researcher/turn) is a sensible placeholder — **tuning parked** (workshop #2).

## Before/after (from new regression tests)
- 3 productive researchers, 1 turn: `compute 100 -> 97`
- 2 researchers, 5 turns: `compute 100 -> 90`
- 0 researchers: `compute` unchanged (100 -> 100)

## Parked design idea
"Researchers request compute at different rates" — left as a follow-up. The loop now has a `compute_request` variable that a future change can vary by specialization/skill instead of the flat 1.

## Test-harness fix (collateral, needed to run the regression)
`test_turn_manager.gd` (and `test_events.gd`, `test_game_manager.gd`) still called the **removed** static `GameEvents.reset_triggered_events()` (WS-0 moved the registry to per-`GameState` state). That is a genuine parse error, so GUT **silently skipped the whole file and still exited 0** — a false green. This PR removes the dead call in `test_turn_manager.gd` and corrects a stale `#573` per-workday salary assertion in the same file, so it now loads and runs (29/29 pass).

> Note for a separate lane: `test_events.gd` and `test_game_manager.gd` remain silently-skipped for the same obsolete-call reason (unblocking them surfaces further pre-existing stale assertions, e.g. difficulty starting-money). Left out of scope for #576.

## Verification
- `--headless --import` pass, then `python scripts/run_godot_tests.py --quick` — green.
- `test_turn_manager.gd`: 29/29 pass, including 3 new compute regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)