### PR TITLE
feat(ui): reachable ledger + due reminder + travel menu + event-fanfare component (#578, #565)

### DIFF
--- a/godot/scenes/ui/fanfare_popup.tscn
+++ b/godot/scenes/ui/fanfare_popup.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3 uid="uid://cfanfarepopup01"]
+
+[ext_resource type="Script" path="res://scripts/ui/fanfare_popup.gd" id="1_fanfare"]
+
+[node name="FanfarePopup" type="CanvasLayer"]
+layer = 128
+script = ExtResource("1_fanfare")

--- a/godot/scripts/core/actions.gd
+++ b/godot/scripts/core/actions.gd
@@ -196,7 +196,9 @@ static func get_all_actions() -> Array[Dictionary]:
 			"costs": {},  # No cost to open menu
 			"category": "research",
 			"is_submenu": true,
-			"unlock_conditions": {"papers_min": 1}  # Need at least 1 paper to unlock
+			# #565: always visible in the action list so Travel/Conferences is discoverable,
+			# not hotkey-only. The T hotkey was already ungated, so the button matches it now.
+			"unlock_conditions": {}
 		},
 		# Financing submenu — the Liability Ledger (ADR-0003): every fix is a loan
 		{

--- a/godot/scripts/ui/fanfare_popup.gd
+++ b/godot/scripts/ui/fanfare_popup.gd
@@ -1,0 +1,160 @@
+extends CanvasLayer
+class_name FanfarePopup
+## Reusable Civ-style "fade-up reveal" popup for momentous events / unlocks (#578).
+##
+## Instead of a new action button silently appearing (and causing layout jank), call
+## FanfarePopup.show_fanfare(title, body, image_path) to fade a centred card up over the
+## screen: a title, flavour body text, an OPTIONAL image slot, and a Continue/dismiss.
+##
+## The image slot is optional and works text-only for now; hero banners from
+## art_prompts/hero_banners.yaml will drop into `image_path` later once generated.
+##
+## Example:
+##   FanfarePopup.show_fanfare(
+##       "STRATEGIC MOVES UNLOCKED",
+##       "Your reputation now opens doors to high-stakes plays...",
+##       "")  # or "res://assets/banners/strategic.png" later
+##
+## The whole tree is built in code so the .tscn stays a trivial one-node asset (no fragile
+## node-path wiring); dismiss is via the focused Continue button (Enter/Space) or a backdrop
+## click, so it never fights the main UI's global key handling.
+
+var _fade: Control          # everything under here is faded/tinted as one
+var _card: Panel            # the centred card that also slides up
+var _image: TextureRect
+var _title_label: Label
+var _body_label: Label
+var _continue_btn: Button
+var _dismissing: bool = false
+var _built: bool = false
+
+
+## Static entry point. `parent` defaults to the scene-tree root so callers can fire-and-forget.
+static func show_fanfare(title: String, body: String, image_path: String = "", parent: Node = null) -> FanfarePopup:
+	var popup: FanfarePopup = preload("res://scenes/ui/fanfare_popup.tscn").instantiate()
+	var host: Node = parent
+	if host == null:
+		var loop := Engine.get_main_loop()
+		if loop is SceneTree:
+			host = (loop as SceneTree).root
+	if host == null:
+		push_error("[FanfarePopup] no host node to attach to; aborting")
+		popup.free()
+		return null
+	host.add_child(popup)
+	popup.present(title, body, image_path)
+	return popup
+
+
+func _ready() -> void:
+	layer = 128  # above any in-scene CanvasLayers / the game UI
+	_build()
+
+
+func _build() -> void:
+	if _built:
+		return
+	_built = true
+
+	_fade = Control.new()
+	_fade.set_anchors_preset(Control.PRESET_FULL_RECT)
+	_fade.mouse_filter = Control.MOUSE_FILTER_STOP  # eat clicks so the game underneath doesn't react
+	add_child(_fade)
+
+	# Dimmed backdrop; clicking it dismisses.
+	var backdrop := ColorRect.new()
+	backdrop.color = Color(0.0, 0.0, 0.0, 0.55)
+	backdrop.set_anchors_preset(Control.PRESET_FULL_RECT)
+	backdrop.mouse_filter = Control.MOUSE_FILTER_STOP
+	backdrop.gui_input.connect(_on_backdrop_input)
+	_fade.add_child(backdrop)
+
+	# The card. Positioned/animated manually (not in a container) so it can slide up.
+	_card = Panel.new()
+	_card.custom_minimum_size = Vector2(460, 0)
+	var card_style := StyleBoxFlat.new()
+	card_style.bg_color = Color(0.10, 0.12, 0.16, 0.98)
+	card_style.set_border_width_all(2)
+	card_style.border_color = Color(0.55, 0.68, 0.60, 1.0)
+	card_style.set_corner_radius_all(10)
+	card_style.content_margin_left = 26
+	card_style.content_margin_right = 26
+	card_style.content_margin_top = 22
+	card_style.content_margin_bottom = 22
+	_card.add_theme_stylebox_override("panel", card_style)
+	_fade.add_child(_card)
+
+	var vbox := VBoxContainer.new()
+	vbox.set_anchors_preset(Control.PRESET_FULL_RECT)
+	vbox.add_theme_constant_override("separation", 14)
+	_card.add_child(vbox)
+
+	# Optional image slot (hero banner drops in here later).
+	_image = TextureRect.new()
+	_image.expand_mode = TextureRect.EXPAND_FIT_WIDTH_PROPORTIONAL
+	_image.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	_image.custom_minimum_size = Vector2(408, 0)
+	_image.visible = false
+	vbox.add_child(_image)
+
+	_title_label = Label.new()
+	_title_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_title_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_title_label.add_theme_font_size_override("font_size", 22)
+	_title_label.add_theme_color_override("font_color", Color(0.95, 0.88, 0.62))
+	vbox.add_child(_title_label)
+
+	_body_label = Label.new()
+	_body_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_body_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_body_label.custom_minimum_size = Vector2(408, 0)
+	_body_label.add_theme_font_size_override("font_size", 14)
+	_body_label.add_theme_color_override("font_color", Color(0.85, 0.87, 0.9))
+	vbox.add_child(_body_label)
+
+	_continue_btn = Button.new()
+	_continue_btn.text = "Continue"
+	_continue_btn.custom_minimum_size = Vector2(0, 34)
+	_continue_btn.pressed.connect(_dismiss)
+	vbox.add_child(_continue_btn)
+
+
+## Populate content and play the fade-up reveal. Safe to call once, right after instancing.
+func present(title: String, body: String, image_path: String = "") -> void:
+	_build()
+	_title_label.text = title
+	_body_label.text = body
+	if image_path != "" and ResourceLoader.exists(image_path):
+		_image.texture = load(image_path)
+		_image.visible = true
+	else:
+		_image.visible = false
+
+	# Wait for the card to lay out so we know its size, then centre + animate.
+	await get_tree().process_frame
+	var vp := get_viewport().get_visible_rect().size
+	var final_pos := (vp - _card.size) * 0.5
+	final_pos.y = maxf(final_pos.y, 20.0)
+	_card.position = final_pos + Vector2(0, 30)  # start a touch lower, then rise
+	_fade.modulate.a = 0.0
+
+	var tw := create_tween().set_parallel(true).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC)
+	tw.tween_property(_fade, "modulate:a", 1.0, 0.45)
+	tw.tween_property(_card, "position", final_pos, 0.45)
+
+	if is_instance_valid(_continue_btn):
+		_continue_btn.grab_focus()
+
+
+func _on_backdrop_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		_dismiss()
+
+
+func _dismiss() -> void:
+	if _dismissing:
+		return
+	_dismissing = true
+	var tw := create_tween()
+	tw.tween_property(_fade, "modulate:a", 0.0, 0.22)
+	tw.tween_callback(queue_free)

--- a/godot/scripts/ui/fanfare_popup.gd.uid
+++ b/godot/scripts/ui/fanfare_popup.gd.uid
@@ -1,0 +1,1 @@
+uid://kfnmrw31xpme

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -43,7 +43,10 @@ var queued_actions: Array = []
 var research_quality_selector  # Issue #500
 var doom_trend_graph  # #512 doom trend sparkline (script-instantiated)
 var doom_breakdown  # #578 colour-coded per-source doom "blow-by-blow" (script-instantiated)
-var ledger_summary_label: Label  # BL-1 compact Liability Ledger summary (script-instantiated)
+var ledger_summary_label: Button  # BL-1 compact Liability Ledger summary; clickable -> ledger screen (#578)
+var _ledger_due_soon_logged: bool = false  # #578: only log the "payment due" reminder on entry, not every frame
+var _seen_unlocked_actions: Dictionary = {}  # #578: action ids seen unlocked, to detect NEW unlocks for fanfare
+var _actions_primed: bool = false  # skip fanfare on the very first action population (baseline)
 var current_turn_phase: String = "NOT_STARTED"
 
 # Active dialog state for keyboard shortcuts
@@ -92,10 +95,17 @@ func _ready():
 
 	# BL-1: compact Liability Ledger summary just below the doom trend. Kept terse so
 	# the main view stays uncrowded; the full ledger is a switchable screen (Financing).
-	ledger_summary_label = Label.new()
+	# #578: it's now a flat Button so the summary is directly clickable to open the full
+	# ledger screen (playtester: "no easy way of getting to the ledger from the main UI").
+	ledger_summary_label = Button.new()
+	ledger_summary_label.flat = true
+	ledger_summary_label.focus_mode = Control.FOCUS_NONE
+	ledger_summary_label.alignment = HORIZONTAL_ALIGNMENT_LEFT
 	ledger_summary_label.add_theme_font_size_override("font_size", 11)
 	ledger_summary_label.add_theme_color_override("font_color", Color(0.6, 0.75, 0.6))
 	ledger_summary_label.text = "Ledger: clean"
+	ledger_summary_label.tooltip_text = "Open the Liability Ledger"
+	ledger_summary_label.pressed.connect(_show_ledger_screen)
 	right_zones.add_child(ledger_summary_label)
 	right_zones.move_child(ledger_summary_label, doom_trend_graph.get_index() + 1)
 
@@ -614,14 +624,29 @@ func _update_ledger_summary(ledger_data: Dictionary) -> void:
 	var soonest: int = int(ledger_data.get("soonest_fuse", -1))
 	var secrets: int = int(ledger_data.get("secret_count", 0))
 	if ledger_data.is_empty() or (owed <= 0.0 and secrets == 0):
-		ledger_summary_label.text = "Ledger: clean"
+		ledger_summary_label.text = "Ledger: clean  (click to view)"
 		ledger_summary_label.add_theme_color_override("font_color", Color(0.6, 0.75, 0.6))
+		_ledger_due_soon_logged = false
 		return
 	var due_txt := ("due %dt" % soonest) if soonest >= 0 else "no due"
 	var secret_txt := ("  |  %d secret" % secrets) if secrets > 0 else ""
-	ledger_summary_label.text = "Ledger: %s owed  |  %s%s" % [GameConfig.format_money(owed), due_txt, secret_txt]
-	# Redden as secret liabilities mount (the exposure pressure surface)
-	ledger_summary_label.add_theme_color_override("font_color", Color(0.85, 0.78, 0.55) if secrets == 0 else Color(0.9, 0.55, 0.45))
+	# #578: due-soon reminder. When the soonest payable fuse is within ~1-2 turns, flag it
+	# visibly (⚠ prefix + strong red) and drop a one-shot message-log line so the player is
+	# warned things are coming due, not just left to notice on their own.
+	var due_soon := soonest >= 0 and soonest <= 2 and owed > 0.0
+	var prefix := "⚠ " if due_soon else ""
+	ledger_summary_label.text = "%sLedger: %s owed  |  %s%s" % [prefix, GameConfig.format_money(owed), due_txt, secret_txt]
+	if due_soon:
+		# Urgent: bright red, and log once on entry into the due-soon window.
+		ledger_summary_label.add_theme_color_override("font_color", Color(0.95, 0.42, 0.36))
+		if not _ledger_due_soon_logged:
+			var when_txt := "this turn" if soonest <= 0 else ("in %d turn%s" % [soonest, "" if soonest == 1 else "s"])
+			log_message("[color=orange]⚠ Ledger: %s payment due %s — open the ledger (click summary) to review.[/color]" % [GameConfig.format_money(owed), when_txt])
+			_ledger_due_soon_logged = true
+	else:
+		_ledger_due_soon_logged = false
+		# Redden as secret liabilities mount (the exposure pressure surface)
+		ledger_summary_label.add_theme_color_override("font_color", Color(0.85, 0.78, 0.55) if secrets == 0 else Color(0.9, 0.55, 0.45))
 
 func _on_turn_phase_changed(phase_name: String):
 	print("[MainUI] Phase changed: ", phase_name)
@@ -701,6 +726,7 @@ func _on_actions_available(actions: Array):
 
 	# Group actions by category, filtering out locked actions
 	var categories = {}
+	var unlocked_ids := {}  # #578: track which ids are unlocked this pass (for new-unlock fanfares)
 	for action in actions:
 		# Check if action is unlocked based on game state
 		if not GameActions.is_action_unlocked(action, current_state):
@@ -708,6 +734,7 @@ func _on_actions_available(actions: Array):
 			continue  # Skip locked actions - they won't be shown
 
 		unlocked_count += 1
+		unlocked_ids[action.get("id", "")] = true
 		var category = action.get("category", "other")
 		if not categories.has(category):
 			categories[category] = []
@@ -715,6 +742,15 @@ func _on_actions_available(actions: Array):
 
 	if locked_count > 0:
 		print("[MainUI] Action Discovery: %d unlocked, %d locked (hidden)" % [unlocked_count, locked_count])
+
+	# #578: momentous-unlock fanfare. When Strategic Moves first becomes available, fade a
+	# Civ-style reveal up over the screen instead of the button just silently appearing.
+	# This is the ONE wired proof trigger; the same FanfarePopup API can front other unlocks.
+	if _actions_primed and unlocked_ids.has("strategic") and not _seen_unlocked_actions.has("strategic"):
+		_show_strategic_unlock_fanfare()
+	for id in unlocked_ids:
+		_seen_unlocked_actions[id] = true
+	_actions_primed = true
 
 	# Define category order
 	var category_order = ["hiring", "resources", "research", "funding", "management", "influence", "strategic", "other"]
@@ -1994,6 +2030,18 @@ func _on_publicity_option_selected(action_id: String, action_name: String, dialo
 
 	print("[MainUI] Calling game_manager.select_action(%s)" % action_id)
 	game_manager.select_action(action_id)
+
+func _show_strategic_unlock_fanfare() -> void:
+	"""#578: Civ-style fade-up reveal when Strategic Moves first unlocks, instead of a button
+	silently appearing. Text-only for now; the image slot (arg 3) takes a hero banner from
+	art_prompts/hero_banners.yaml once those are generated."""
+	log_message("[color=gold]The board convenes: Strategic Moves are now available.[/color]")
+	FanfarePopup.show_fanfare(
+		"STRATEGIC MOVES UNLOCKED",
+		"The council of elders has deemed your standing sufficient. High-stakes plays now open to you — bold gambits that can bend the odds, each leaving its mark on the ledger of history. Wield them wisely.",
+		"",  # hero banner image slot — art_prompts/hero_banners.yaml drops in here later
+		get_tree().root)
+
 
 func _show_strategic_submenu():
 	"""Show popup dialog with strategic/high-stakes options with keyboard support - icon grid layout"""

--- a/godot/tests/unit/test_fanfare_popup.gd
+++ b/godot/tests/unit/test_fanfare_popup.gd
@@ -1,0 +1,34 @@
+extends GutTest
+## Tests for the FanfarePopup reveal component (#578) and Travel discoverability (#565).
+
+func test_fanfare_scene_loads_and_instantiates():
+	var scene = load("res://scenes/ui/fanfare_popup.tscn")
+	assert_not_null(scene, "fanfare_popup.tscn should load as a PackedScene")
+	var popup = scene.instantiate()
+	assert_not_null(popup, "fanfare_popup.tscn should instantiate")
+	assert_true(popup is FanfarePopup, "scene root should carry the FanfarePopup script")
+	popup.free()
+
+func test_fanfare_present_text_only():
+	# The image slot is optional; text-only must work (hero banners land later).
+	var popup = FanfarePopup.new()
+	add_child_autofree(popup)
+	await popup.present("Test Title", "Test body text", "")
+	assert_eq(popup._title_label.text, "Test Title", "title should be set")
+	assert_eq(popup._body_label.text, "Test body text", "body should be set")
+	assert_false(popup._image.visible, "image slot hidden when no path is given")
+
+func test_fanfare_present_ignores_missing_image_path():
+	var popup = FanfarePopup.new()
+	add_child_autofree(popup)
+	await popup.present("T", "B", "res://does/not/exist.png")
+	assert_false(popup._image.visible, "non-existent image path should leave the slot hidden")
+
+func test_travel_action_visible_without_papers():
+	# #565: Travel must be discoverable in the action list from turn 1, not hotkey-only.
+	var state = autofree(GameState.new("test_seed"))
+	var travel = GameActions.get_action_by_id("travel")
+	assert_eq(travel.get("id", ""), "travel", "travel action should exist")
+	assert_true(
+		GameActions.is_action_unlocked(travel, state.to_dict()),
+		"travel should be unlocked with 0 papers so its action-list button is visible")

--- a/godot/tests/unit/test_fanfare_popup.gd.uid
+++ b/godot/tests/unit/test_fanfare_popup.gd.uid
@@ -1,0 +1,1 @@
+uid://dgordd3dpog0h


### PR DESCRIPTION
Batched UI lane (all three touch `main_ui.gd`), from playtest feedback.

## Task 1 — Ledger reachability + due reminder (#578)
- The compact ledger summary widget under the doom trend is now a **flat clickable button** that opens the full Liability Ledger screen directly (reuses existing `_show_ledger_screen()`). Tooltip: "Open the Liability Ledger". Previously the ledger was only reachable via `Financing → View Ledger`.
- **Due-soon reminder**: when `state.ledger.soonest_fuse` is within ~2 turns and there's an outstanding payable, the summary reddens with a `⚠` prefix and a one-shot message-log line fires on entry into the due-soon window (`_ledger_due_soon_logged` guards against per-frame spam).

## Task 2 — Travel/Conferences discoverable (#565)
- Removed the `papers_min: 1` unlock gate on the `travel` action so its **action-list icon button is always visible**, matching the already-ungated `T` hotkey. Playtester couldn't find travel because the button was hidden until they had a paper. Wired to the existing `_show_travel_submenu()` handler — travel system unchanged.

## Task 3 — Event-fanfare popup component (#578)
- New reusable **`FanfarePopup`** (`scenes/ui/fanfare_popup.tscn` + `scripts/ui/fanfare_popup.gd`): a Civ-style **fade-up reveal** (CanvasLayer over the screen) with a **title**, **flavor text**, an **optional image slot**, and dismiss (focused Continue button / backdrop click — never fights global key handling). Self-contained; builds its tree in code.
- API: `FanfarePopup.show_fanfare(title, body, image_path := "", parent := <scene root>)`.
- **Proof trigger wired**: when **Strategic Moves** first unlocks (detected in `_on_actions_available` via a seen-unlocked set), the fanfare fades up instead of the button silently appearing. Works **text-only**; the image slot is left empty for now — hero banners from `art_prompts/hero_banners.yaml` drop in later.

## Verification
- `--headless --import` clean; `python scripts/run_godot_tests.py --quick` **green**; `main.tscn` boots with no script/parse errors.
- New `test_fanfare_popup.gd` (4 tests, all passing): runtime loads+instantiates the scene, text-only `present()`, missing-image-path handling, and travel-unlocked-without-papers.
- **Human-eye caveat**: the on-screen look/feel — fanfare fade/slide timing, card sizing, ledger-widget button styling, and the due-soon red — needs a human to eyeball in-game; automated checks only confirm it loads and behaves, not that it looks right.

References #578 and #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)