### PR TITLE
feat(ui): DEV BUILD indicator + bigger leather ledger + open-ledger keybind

### DIFF
--- a/godot/autoload/keybind_manager.gd
+++ b/godot/autoload/keybind_manager.gd
@@ -33,6 +33,7 @@ var keybinds: Dictionary = {
 	"bug_reporter": {"key": KEY_BACKSLASH, "category": Category.UI, "description": "Open Bug Reporter"},
 	# "employee_tab": {"key": KEY_E, "category": Category.UI, "description": "Employee Screen"},  # DISABLED: moving to main UI
 	"settings": {"key": KEY_F10, "category": Category.UI, "description": "Settings Menu"},
+	"open_ledger": {"key": KEY_L, "category": Category.UI, "description": "Open Liability Ledger"},
 
 	# Quick Menu Access (configurable shortcuts for common menus)
 	"menu_hire": {"key": KEY_H, "category": Category.GAMEPLAY, "description": "Open Hiring Menu"},
@@ -62,7 +63,7 @@ var profiles: Dictionary = {}  # profile_name -> keybind dict
 
 # Config file
 const CONFIG_PATH = "user://keybinds.cfg"
-const KEYBINDS_CONFIG_VERSION = 2  # bump when default binds change; stale saved configs refresh to defaults
+const KEYBINDS_CONFIG_VERSION = 3  # bump when default binds change; stale saved configs refresh to defaults
 var config = ConfigFile.new()
 
 # Signals

--- a/godot/build_stamp.txt
+++ b/godot/build_stamp.txt
@@ -1,0 +1,3 @@
+commit=fd60eb6
+date=2026-07-11
+branch=feat/dev-build-overlay-ledger

--- a/godot/scripts/core/build_info.gd
+++ b/godot/scripts/core/build_info.gd
@@ -1,0 +1,70 @@
+extends RefCounted
+class_name BuildInfo
+## Dev-build identification: version + a per-commit build stamp so a playtester can
+## confirm *exactly* which build he is running (playtester couldn't tell builds apart).
+##
+## The stamp is produced out-of-band by tools/write_build_stamp.py, which writes
+## res://build_stamp.txt (key=value lines) from `git rev-parse --short HEAD` + the
+## build date. We read that file here at startup. Chosen for reliability over
+## cleverness: the date always resolves, the commit is best-effort, and if the file
+## is missing (fresh checkout, never stamped) we degrade to "unstamped" rather than
+## crash. Re-run the tool before packaging to refresh the commit.
+##
+## The pure readers here are unit-tested (test_dev_build_indicator.gd); the on-screen
+## badge (dev_build_badge.gd) still needs a human eye.
+
+## Master switch for the DEV BUILD indicators. On by default in dev; flip to false
+## for a clean release cut (or gate on OS.is_debug_build() via is_dev_build()).
+const DEV_BUILD := true
+
+## res:// text file written by tools/write_build_stamp.py. Not a Godot resource, so
+## it produces no .import churn; read via FileAccess.
+const STAMP_PATH := "res://build_stamp.txt"
+
+## Parse the stamp file into a Dictionary of {key: value}. Empty dict if absent.
+static func _read_stamp() -> Dictionary:
+	var out: Dictionary = {}
+	if not FileAccess.file_exists(STAMP_PATH):
+		return out
+	var f := FileAccess.open(STAMP_PATH, FileAccess.READ)
+	if f == null:
+		return out
+	while not f.eof_reached():
+		var line := f.get_line().strip_edges()
+		if line.is_empty() or not line.contains("="):
+			continue
+		var parts := line.split("=", false, 1)
+		if parts.size() == 2:
+			out[parts[0].strip_edges()] = parts[1].strip_edges()
+	f.close()
+	return out
+
+## Short git commit hash the build came from, or "" if not stamped.
+static func get_commit() -> String:
+	return String(_read_stamp().get("commit", ""))
+
+## Build date (ISO) recorded at stamp time, or "" if not stamped.
+static func get_build_date() -> String:
+	return String(_read_stamp().get("date", ""))
+
+## True while this build should show the DEV BUILD indicators.
+static func is_dev_build() -> bool:
+	return DEV_BUILD
+
+## Compact commit+date stamp, e.g. "fd60eb6 · 2026-07-11". Always non-empty:
+## falls back to the date, then to "unstamped", so the overlay never shows blank.
+static func get_stamp() -> String:
+	var commit := get_commit()
+	var date := get_build_date()
+	if not commit.is_empty() and not date.is_empty():
+		return "%s · %s" % [commit, date]
+	if not commit.is_empty():
+		return commit
+	if not date.is_empty():
+		return date
+	return "unstamped"
+
+## One-line badge text for the corner indicator, e.g.
+## "DEV BUILD  v0.11.0  ·  fd60eb6 · 2026-07-11". Always non-empty.
+static func get_badge_text() -> String:
+	return "DEV BUILD  v%s  ·  %s" % [GameConfig.CURRENT_VERSION, get_stamp()]

--- a/godot/scripts/core/build_info.gd.uid
+++ b/godot/scripts/core/build_info.gd.uid
@@ -1,0 +1,1 @@
+uid://dqlu136rh3tpu

--- a/godot/scripts/ui/dev_build_badge.gd
+++ b/godot/scripts/ui/dev_build_badge.gd
@@ -1,0 +1,70 @@
+extends CanvasLayer
+class_name DevBuildBadge
+## Always-visible "DEV BUILD" corner badge (playtester couldn't tell which build he ran).
+##
+## A high-contrast amber-on-dark badge pinned to the top-right corner, drawn on its own
+## CanvasLayer so it floats over everything on both the main game screen and the
+## welcome/loading screen. Shows GameConfig.CURRENT_VERSION plus the per-commit build
+## stamp from BuildInfo (git short hash + date) so a tester can confirm the exact build.
+##
+## Gated on BuildInfo.is_dev_build(): if that constant is flipped false for a release
+## cut, the badge instances but hides itself. On-screen look still needs a human eye.
+##
+## Usage: `add_child(DevBuildBadge.new())` from any screen's _ready().
+
+## High layer so the badge sits above normal UI and other CanvasLayers (e.g. overlays).
+const BADGE_LAYER := 200
+
+func _ready() -> void:
+	layer = BADGE_LAYER
+	if not BuildInfo.is_dev_build():
+		visible = false
+		return
+	_build_badge()
+
+func _build_badge() -> void:
+	# Anchor a container to the top-right corner of the viewport.
+	var anchor := Control.new()
+	anchor.name = "DevBadgeAnchor"
+	anchor.anchor_left = 1.0
+	anchor.anchor_right = 1.0
+	anchor.anchor_top = 0.0
+	anchor.anchor_bottom = 0.0
+	anchor.offset_left = -360.0
+	anchor.offset_top = 8.0
+	anchor.offset_right = -8.0
+	anchor.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(anchor)
+
+	# The badge panel — dark translucent base with a bright glowing amber border for
+	# an unmissable "not a real build" read.
+	var panel := PanelContainer.new()
+	panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	panel.size_flags_horizontal = Control.SIZE_SHRINK_END
+
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.12, 0.10, 0.02, 0.88)
+	style.border_color = Color(1.0, 0.72, 0.0, 1.0)  # bright amber "glow" edge
+	style.set_border_width_all(3)
+	style.set_corner_radius_all(6)
+	style.content_margin_left = 12
+	style.content_margin_right = 12
+	style.content_margin_top = 6
+	style.content_margin_bottom = 6
+	# Soft outer shadow to fake a glow around the badge.
+	style.shadow_color = Color(1.0, 0.72, 0.0, 0.35)
+	style.shadow_size = 6
+	panel.add_theme_stylebox_override("panel", style)
+	anchor.add_child(panel)
+
+	var label := Label.new()
+	label.name = "DevBadgeLabel"
+	label.text = BuildInfo.get_badge_text()
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	label.add_theme_font_size_override("font_size", 15)
+	label.add_theme_color_override("font_color", Color(1.0, 0.82, 0.25))
+	# Dark outline so the amber text stays legible over any background (menu art, etc.).
+	label.add_theme_color_override("font_outline_color", Color(0, 0, 0, 0.9))
+	label.add_theme_constant_override("outline_size", 4)
+	panel.add_child(label)

--- a/godot/scripts/ui/dev_build_badge.gd.uid
+++ b/godot/scripts/ui/dev_build_badge.gd.uid
@@ -1,0 +1,1 @@
+uid://b6rrqn2woq87r

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -45,6 +45,16 @@ var doom_trend_graph  # #512 doom trend sparkline (script-instantiated)
 var doom_breakdown  # #578 colour-coded per-source doom "blow-by-blow" (script-instantiated)
 var ledger_summary_label: Button  # BL-1 compact Liability Ledger summary; clickable -> ledger screen (#578)
 var _ledger_due_soon_logged: bool = false  # #578: only log the "payment due" reminder on entry, not every frame
+
+# Leather-ledger palette (playtester: "rich brown leathery colour"). Warm saddle base
+# with a darker border; ink colours are bright/warm so state stays legible on brown.
+const _LEDGER_LEATHER := Color(0.32, 0.20, 0.11)        # base saddle brown
+const _LEDGER_LEATHER_HOVER := Color(0.40, 0.26, 0.15)  # lighter on hover — inviting
+const _LEDGER_LEATHER_PRESSED := Color(0.24, 0.15, 0.08)
+const _LEDGER_LEATHER_BORDER := Color(0.14, 0.08, 0.03)  # dark stitched edge
+const _LEDGER_INK_CLEAN := Color(0.86, 0.80, 0.62)       # warm parchment cream
+const _LEDGER_INK_DUE := Color(1.0, 0.55, 0.42)          # warm red — payment due
+const _LEDGER_INK_SECRET := Color(1.0, 0.80, 0.45)       # warm amber — secrets/owed
 var _seen_unlocked_actions: Dictionary = {}  # #578: action ids seen unlocked, to detect NEW unlocks for fanfare
 var _actions_primed: bool = false  # skip fanfare on the very first action population (baseline)
 var current_turn_phase: String = "NOT_STARTED"
@@ -97,17 +107,26 @@ func _ready():
 	# the main view stays uncrowded; the full ledger is a switchable screen (Financing).
 	# #578: it's now a flat Button so the summary is directly clickable to open the full
 	# ledger screen (playtester: "no easy way of getting to the ledger from the main UI").
+	# Playtester: the ledger access was "kind of hidden" — make it ~5x bigger with a
+	# rich brown leather look so it reads as a distinct, inviting object, not a label.
 	ledger_summary_label = Button.new()
-	ledger_summary_label.flat = true
+	ledger_summary_label.flat = false
 	ledger_summary_label.focus_mode = Control.FOCUS_NONE
 	ledger_summary_label.alignment = HORIZONTAL_ALIGNMENT_LEFT
-	ledger_summary_label.add_theme_font_size_override("font_size", 11)
-	ledger_summary_label.add_theme_color_override("font_color", Color(0.6, 0.75, 0.6))
-	ledger_summary_label.text = "Ledger: clean"
-	ledger_summary_label.tooltip_text = "Open the Liability Ledger"
+	ledger_summary_label.custom_minimum_size = Vector2(0, 64)  # heft — was an 11px flat label
+	ledger_summary_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	ledger_summary_label.add_theme_font_size_override("font_size", 20)
+	ledger_summary_label.add_theme_color_override("font_color", _LEDGER_INK_CLEAN)
+	_apply_leather_style(ledger_summary_label)
+	ledger_summary_label.text = "📖  Liability Ledger — clean"
+	ledger_summary_label.tooltip_text = "Open the Liability Ledger  (press L)"
 	ledger_summary_label.pressed.connect(_show_ledger_screen)
 	right_zones.add_child(ledger_summary_label)
 	right_zones.move_child(ledger_summary_label, doom_trend_graph.get_index() + 1)
+
+	# Always-visible DEV BUILD corner badge so a playtester can confirm exactly which
+	# build he's running (version + git stamp). Draws on its own CanvasLayer over the UI.
+	add_child(DevBuildBadge.new())
 
 	# Enable input processing for keyboard shortcuts
 	set_process_input(true)
@@ -276,6 +295,13 @@ func _input(event: InputEvent):
 				_show_travel_submenu()
 				_decorate_active_submenu(_find_action_button("travel"))
 				get_viewport().set_input_as_handled()
+
+		# Open the Liability Ledger (L by default, configurable via KeybindManager).
+		# Reachable any time no dialog is active; the text-focus gate above already
+		# yields the key to focused LineEdit/TextEdit fields.
+		elif KeybindManager.is_action_pressed(event, "open_ledger"):
+			_show_ledger_screen()
+			get_viewport().set_input_as_handled()
 
 		# Escape to init game (if not started)
 		elif event.keycode == KEY_ESCAPE:
@@ -615,6 +641,26 @@ func _on_game_state_updated(state: Dictionary):
 	# Update employee roster display
 	_update_employee_roster(state)
 
+func _make_leather_box(bg: Color) -> StyleBoxFlat:
+	"""A warm saddle-leather StyleBoxFlat: dark stitched border + subtle rounding."""
+	var box := StyleBoxFlat.new()
+	box.bg_color = bg
+	box.border_color = _LEDGER_LEATHER_BORDER
+	box.set_border_width_all(3)
+	box.set_corner_radius_all(8)
+	box.content_margin_left = 14
+	box.content_margin_right = 14
+	box.content_margin_top = 8
+	box.content_margin_bottom = 8
+	return box
+
+func _apply_leather_style(btn: Button) -> void:
+	"""Give the ledger access button its rich brown leather look across all states."""
+	btn.add_theme_stylebox_override("normal", _make_leather_box(_LEDGER_LEATHER))
+	btn.add_theme_stylebox_override("hover", _make_leather_box(_LEDGER_LEATHER_HOVER))
+	btn.add_theme_stylebox_override("pressed", _make_leather_box(_LEDGER_LEATHER_PRESSED))
+	btn.add_theme_stylebox_override("focus", _make_leather_box(_LEDGER_LEATHER_HOVER))
+
 func _update_ledger_summary(ledger_data: Dictionary) -> void:
 	"""BL-1 compact summary: outstanding owed, soonest due, secret count. Deliberately
 	terse so the main view stays uncrowded; the full ledger is a switchable screen."""
@@ -624,8 +670,8 @@ func _update_ledger_summary(ledger_data: Dictionary) -> void:
 	var soonest: int = int(ledger_data.get("soonest_fuse", -1))
 	var secrets: int = int(ledger_data.get("secret_count", 0))
 	if ledger_data.is_empty() or (owed <= 0.0 and secrets == 0):
-		ledger_summary_label.text = "Ledger: clean  (click to view)"
-		ledger_summary_label.add_theme_color_override("font_color", Color(0.6, 0.75, 0.6))
+		ledger_summary_label.text = "📖  Liability Ledger — clean  (click / L)"
+		ledger_summary_label.add_theme_color_override("font_color", _LEDGER_INK_CLEAN)
 		_ledger_due_soon_logged = false
 		return
 	var due_txt := ("due %dt" % soonest) if soonest >= 0 else "no due"
@@ -634,19 +680,19 @@ func _update_ledger_summary(ledger_data: Dictionary) -> void:
 	# visibly (⚠ prefix + strong red) and drop a one-shot message-log line so the player is
 	# warned things are coming due, not just left to notice on their own.
 	var due_soon := soonest >= 0 and soonest <= 2 and owed > 0.0
-	var prefix := "⚠ " if due_soon else ""
+	var prefix := "⚠ " if due_soon else "📖  "
 	ledger_summary_label.text = "%sLedger: %s owed  |  %s%s" % [prefix, GameConfig.format_money(owed), due_txt, secret_txt]
 	if due_soon:
-		# Urgent: bright red, and log once on entry into the due-soon window.
-		ledger_summary_label.add_theme_color_override("font_color", Color(0.95, 0.42, 0.36))
+		# Urgent: warm red (legible on brown leather), and log once on entry into the window.
+		ledger_summary_label.add_theme_color_override("font_color", _LEDGER_INK_DUE)
 		if not _ledger_due_soon_logged:
 			var when_txt := "this turn" if soonest <= 0 else ("in %d turn%s" % [soonest, "" if soonest == 1 else "s"])
-			log_message("[color=orange]⚠ Ledger: %s payment due %s — open the ledger (click summary) to review.[/color]" % [GameConfig.format_money(owed), when_txt])
+			log_message("[color=orange]⚠ Ledger: %s payment due %s — open the ledger (click summary or press L) to review.[/color]" % [GameConfig.format_money(owed), when_txt])
 			_ledger_due_soon_logged = true
 	else:
 		_ledger_due_soon_logged = false
-		# Redden as secret liabilities mount (the exposure pressure surface)
-		ledger_summary_label.add_theme_color_override("font_color", Color(0.85, 0.78, 0.55) if secrets == 0 else Color(0.9, 0.55, 0.45))
+		# Warm parchment when only owed; warm amber as secret liabilities mount (exposure pressure).
+		ledger_summary_label.add_theme_color_override("font_color", _LEDGER_INK_CLEAN if secrets == 0 else _LEDGER_INK_SECRET)
 
 func _on_turn_phase_changed(phase_name: String):
 	print("[MainUI] Phase changed: ", phase_name)

--- a/godot/scripts/ui/welcome_screen.gd
+++ b/godot/scripts/ui/welcome_screen.gd
@@ -52,6 +52,10 @@ func _ready():
 	ai_safety_button.pressed.connect(_on_ai_safety_pressed)
 	exit_button.pressed.connect(_on_exit_pressed)
 
+	# Always-visible DEV BUILD corner badge (version + git stamp) so a playtester can
+	# confirm which build he's on right from the welcome/loading screen.
+	add_child(DevBuildBadge.new())
+
 	# Initialize What's New modal
 	_setup_whats_new_modal()
 

--- a/godot/tests/unit/test_dev_build_indicator.gd
+++ b/godot/tests/unit/test_dev_build_indicator.gd
@@ -1,0 +1,30 @@
+extends GutTest
+## Tests for the DEV BUILD indicator + open-ledger keybind.
+##
+## Covers the pure readers: BuildInfo.get_stamp()/get_badge_text() must always return a
+## non-empty string (never a blank overlay), and the open_ledger keybind action must be
+## registered on L. The actual on-screen badge/leather look still needs a human eye.
+
+func test_build_stamp_reader_returns_non_empty():
+	# Even with no stamp file, the reader degrades to "unstamped" rather than blank.
+	assert_ne(BuildInfo.get_stamp(), "", "Build stamp must never be empty")
+
+func test_badge_text_includes_version_and_dev_marker():
+	var text := BuildInfo.get_badge_text()
+	assert_ne(text, "", "Badge text must never be empty")
+	assert_string_contains(text, "DEV BUILD", "Badge must read as a dev build")
+	assert_string_contains(text, GameConfig.CURRENT_VERSION,
+		"Badge must show the current version so the tester can confirm the build")
+
+func test_is_dev_build_returns_bool():
+	assert_typeof(BuildInfo.is_dev_build(), TYPE_BOOL, "is_dev_build() should return a bool")
+
+func test_open_ledger_keybind_registered_on_L():
+	assert_true(KeybindManager.keybinds.has("open_ledger"),
+		"open_ledger action must be registered as a named keybind")
+	assert_eq(KeybindManager.keybinds["open_ledger"]["key"], KEY_L,
+		"open_ledger should default to the L key")
+
+func test_open_ledger_keybind_has_readable_name():
+	assert_eq(KeybindManager.get_key_name("open_ledger"), "L",
+		"open_ledger should surface a human-readable key name")

--- a/godot/tests/unit/test_dev_build_indicator.gd.uid
+++ b/godot/tests/unit/test_dev_build_indicator.gd.uid
@@ -1,0 +1,1 @@
+uid://b1qv3umfj15qr

--- a/tools/write_build_stamp.py
+++ b/tools/write_build_stamp.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Write a build stamp that identifies exactly which commit a build came from.
+
+Produces ``godot/build_stamp.txt`` (a plain res:// text file the in-game DEV BUILD
+overlay reads at startup — see ``godot/scripts/core/build_info.gd``). Format is a
+few ``key=value`` lines so it stays trivially parseable from GDScript::
+
+    commit=abc1234
+    date=2026-07-11
+    branch=feat/dev-build-overlay-ledger
+
+Reliability model (we chose reliability over cleverness):
+  * ``date`` is always written from the system clock, so the stamp is never empty
+    even in a checkout with no git available.
+  * ``commit`` is best-effort ``git rev-parse --short HEAD``; if git is missing or
+    this is not a repo, it falls back to ``unknown`` and the overlay still shows a
+    dated stamp.
+
+Run this before cutting a build / export so the tester can confirm the exact build:
+
+    python tools/write_build_stamp.py
+
+Note: the committed stamp necessarily records the *parent* commit (HEAD before this
+change is committed). That is fine for "which build am I on" — it pins the build to
+a known point in history. Re-run in CI/packaging to refresh right before export.
+"""
+from __future__ import annotations
+
+import datetime
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STAMP_PATH = REPO_ROOT / "godot" / "build_stamp.txt"
+
+
+def _git(*args: str) -> str:
+    try:
+        out = subprocess.run(
+            ["git", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
+def main() -> int:
+    commit = _git("rev-parse", "--short", "HEAD") or "unknown"
+    branch = _git("rev-parse", "--abbrev-ref", "HEAD") or "unknown"
+    date = datetime.date.today().isoformat()
+
+    STAMP_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STAMP_PATH.write_text(
+        f"commit={commit}\ndate={date}\nbranch={branch}\n",
+        encoding="ascii",
+    )
+    print(f"[write_build_stamp] wrote {STAMP_PATH}")
+    print(f"  commit={commit} date={date} branch={branch}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What & why
Playtester couldn't tell which build he was running, found the ledger "kind of hidden", and there was no keyboard way to open it. This adds a prominent DEV BUILD indicator, enlarges + restyles the ledger access widget, and adds a proper named keybind to open the ledger.

## Task 1 — DEV BUILD indicator
- New reusable `DevBuildBadge` (`godot/scripts/ui/dev_build_badge.gd`): a high-contrast amber-on-dark corner badge on its own `CanvasLayer` (layer 200) so it floats over everything. Added on both the **main game screen** (`main_ui.gd`) and the **welcome/loading screen** (`welcome_screen.gd`).
- Shows `GameConfig.CURRENT_VERSION` + a per-commit **build stamp**.
- **How the stamp is produced (reliability over cleverness):** `tools/write_build_stamp.py` runs `git rev-parse --short HEAD` + build date and writes `godot/build_stamp.txt` (simple `key=value` lines, not a Godot resource so no `.import` churn). `BuildInfo` (`godot/scripts/core/build_info.gd`) reads it at startup. If the file is missing (fresh checkout) it degrades to the date, then to `"unstamped"` — never blank. **Re-run the tool before packaging/export** to refresh; the committed stamp pins the parent commit.
- On by default via `BuildInfo.DEV_BUILD = true` (flip to false for a clean release cut).
- Export note: `build_stamp.txt` is a non-resource `.txt`; if a packaged export strips it, add it to the export's non-resource filter.

## Task 2 — Ledger visibility + styling
- The ledger access widget is now ~5x larger (font 11->20, min height 64, expand-fill) with a **rich brown leather** `StyleBoxFlat` (base `Color(0.32,0.20,0.11)`, dark stitched border, rounded corners, hover lightens). Ink colours switched to warm parchment/amber/red so state stays legible on brown. Reads as a distinct, inviting object.

## Task 3 — Open-ledger keybind
- New named action `open_ledger` -> `KEY_L` in `keybind_manager.gd`, defined exactly like `debug_overlay`/F3 (reconfigurable `KEY_*`, not a magic literal). Wired in `MainUI._input` to `_show_ledger_screen()`, respecting the existing text-focus gate. `KEYBINDS_CONFIG_VERSION` bumped 2->3 so the new default reaches existing saved configs.

## Verify
- `--headless --import` pass: clean.
- `python scripts/run_godot_tests.py --quick`: green (new `test_dev_build_indicator.gd` covers stamp-reader-non-empty, badge text has version + "DEV BUILD", `open_ledger` registered on L).
- Boot-checked `main.tscn` and `welcome.tscn` headless: no script/parse errors.

## Human-eye caveat
The actual on-screen look — badge glow/contrast over the menu art, and the leather colour/size read — needs a human eye; only the pure logic is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)