### PR TITLE
feat(ui): larger doom breakdown, blockier upgrade buttons, tighter action-icon spacing (#594)

### DIFF
--- a/godot/scripts/ui/doom_breakdown.gd
+++ b/godot/scripts/ui/doom_breakdown.gd
@@ -90,13 +90,13 @@ func set_sources(doom_sources) -> void:
 
 	var caption := Label.new()
 	caption.text = "Doom this turn:"
-	caption.add_theme_font_size_override("font_size", 10)
+	caption.add_theme_font_size_override("font_size", 20)
 	caption.add_theme_color_override("font_color", ThemeManager.get_color("text_dim"))
 	add_child(caption)
 
 	for entry in entries:
 		var line := Label.new()
 		line.text = entry["text"]
-		line.add_theme_font_size_override("font_size", 11)
+		line.add_theme_font_size_override("font_size", 22)
 		line.add_theme_color_override("font_color", color_for_sign(entry["sign"]))
 		add_child(line)

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -815,7 +815,7 @@ func _on_actions_available(actions: Array):
 
 	# Create a single-column vertical stack for icons on left edge
 	var icon_stack = VBoxContainer.new()
-	icon_stack.add_theme_constant_override("separation", 2)
+	icon_stack.add_theme_constant_override("separation", 1)  # #594: tighter vertical packing for 11+ icons
 	actions_list.add_child(icon_stack)
 
 	# Create icon buttons - single column layout
@@ -837,8 +837,10 @@ func _on_actions_available(actions: Array):
 
 			# Create icon-only button (square, fills width)
 			var icon_button = Button.new()
-			icon_button.custom_minimum_size = Vector2(70, 70)  # Larger square icon buttons
-			icon_button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+			icon_button.custom_minimum_size = Vector2(70, 70)  # square icon tiles
+			# #594: hug the 70px icon instead of ballooning across the wide left panel — this
+			# reclaims the empty padding around each icon (and stops expand_icon distorting them).
+			icon_button.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
 			icon_button.focus_mode = Control.FOCUS_NONE
 
 			# Get icon texture
@@ -918,9 +920,10 @@ func _populate_upgrades():
 
 		# Create button
 		var button = ThemeManager.create_button(upgrade_name)
-		# Constrain button width to prevent extending into middle
-		button.size_flags_horizontal = Control.SIZE_FILL
-		button.custom_minimum_size = Vector2(0, 32)
+		# Blockier tiles (#594): hug content on the left instead of stretching across the
+		# wide right panel, and ~20% taller (32 -> 38) so they read as tighter, blockier tiles.
+		button.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+		button.custom_minimum_size = Vector2(200, 38)
 
 		# If purchased, show differently
 		if is_purchased:


### PR DESCRIPTION
Playtest-driven UI **sizing/spacing pass** for #594. No layout redesign — just min-sizes, size-flags, separations, and font sizes.

## Changes
1. **Doom-this-turn text ~2x larger** (`godot/scripts/ui/doom_breakdown.gd`)
   - Per-source breakdown lines: font size 11 -> 22
   - "Doom this turn:" caption: font size 10 -> 20
   - Uses the spare vertical space below the trend graph.

2. **Blockier upgrade buttons** (`godot/scripts/ui/main_ui.gd`, `_populate_upgrades`)
   - Before: `size_flags_horizontal = SIZE_FILL`, `custom_minimum_size = (0, 32)` — stretched full-width across the wide right panel.
   - After: `size_flags_horizontal = SIZE_SHRINK_BEGIN`, `custom_minimum_size = (200, 38)` — narrower, left-hugging, ~20% taller (32 -> 38) tiles.

3. **Tighter action-icon spacing** (`godot/scripts/ui/main_ui.gd`, `_on_actions_available`)
   - Icon buttons: `size_flags_horizontal` `SIZE_EXPAND_FILL` -> `SIZE_SHRINK_CENTER` so each button hugs its 70px icon instead of ballooning across the wide left panel. This reclaims the empty padding around each icon and stops `expand_icon` from horizontally stretching/distorting the icons.
   - `icon_stack` separation 2 -> 1 for tighter vertical packing of the 11+ icons.

## Verification
- `--headless --import` pass clean.
- `python scripts/run_godot_tests.py --quick` — green (syntax + GUT unit tests).
- Headless boot of `res://scenes/main.tscn` — 0 script/parse errors; MainUI initializes and populates 10 unlocked action icons.
- **Human-eye caveat:** headless boot can't judge on-screen look/spacing. The actual visual balance — whether the 200px upgrade width truncates any long upgrade names, and how the shrink-centered icon column reads against the wide left panel — needs a human eye in an actual windowed run.

## Noted for the owner (not done here)
The left/right panels themselves are quite wide (`ContentArea` stretch ratios 0.3 / 0.3 / 1.0), so shrinking the buttons leaves the panels with surrounding empty space. Genuinely reclaiming that would mean re-tuning panel stretch ratios / structure — a layout design decision left to the owner per the task scope.

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)