### PR TITLE
fix: fanfare dimming backdrop + bug-report thanks disables Submit (#603)

### DIFF
--- a/godot/scripts/ui/bug_report_panel.gd
+++ b/godot/scripts/ui/bug_report_panel.gd
@@ -102,6 +102,8 @@ func reset_form():
 	name_input.editable = false
 	contact_input.editable = false
 	confirmation_label.visible = false
+	# Re-enable Submit when the panel is reused (it is disabled in the thanks state, #603).
+	submit_button.disabled = false
 
 ## Validate form input
 func validate_form() -> String:
@@ -174,6 +176,9 @@ func _on_attribution_toggled(toggled_on: bool):
 
 ## Handle successful report save
 func _on_report_saved(_filepath: String):
+	# Disable Submit in the thanks/submitted state so it can't be clicked again (#603).
+	# reset_form() (called on hide/reuse) re-enables it.
+	submit_button.disabled = true
 	show_confirmation("Thank you! Your report has been saved.\n\nWe'll create a GitHub issue soon. Check back for updates!")
 
 	# Reset form after short delay

--- a/godot/scripts/ui/fanfare_popup.gd
+++ b/godot/scripts/ui/fanfare_popup.gd
@@ -20,6 +20,7 @@ class_name FanfarePopup
 ## click, so it never fights the main UI's global key handling.
 
 var _fade: Control          # everything under here is faded/tinted as one
+var _backdrop: ColorRect    # full-viewport dimming behind the card (blocks the game visually)
 var _card: Panel            # the centred card that also slides up
 var _image: TextureRect
 var _title_label: Label
@@ -61,13 +62,17 @@ func _build() -> void:
 	_fade.mouse_filter = Control.MOUSE_FILTER_STOP  # eat clicks so the game underneath doesn't react
 	add_child(_fade)
 
-	# Dimmed backdrop; clicking it dismisses.
-	var backdrop := ColorRect.new()
-	backdrop.color = Color(0.0, 0.0, 0.0, 0.55)
-	backdrop.set_anchors_preset(Control.PRESET_FULL_RECT)
-	backdrop.mouse_filter = Control.MOUSE_FILTER_STOP
-	backdrop.gui_input.connect(_on_backdrop_input)
-	_fade.add_child(backdrop)
+	# Dimming backdrop: a near-opaque black overlay that covers the whole viewport and
+	# sits behind the card, so background event triggers can't animate through it (#603).
+	# Fades in/out with the card (via _fade.modulate) for the Civ-II "party arrives" reveal.
+	# Kept a touch below fully opaque so it darkens rather than fully hides the game.
+	_backdrop = ColorRect.new()
+	_backdrop.name = "Backdrop"
+	_backdrop.color = Color(0.0, 0.0, 0.0, 0.8)
+	_backdrop.set_anchors_preset(Control.PRESET_FULL_RECT)
+	_backdrop.mouse_filter = Control.MOUSE_FILTER_STOP
+	_backdrop.gui_input.connect(_on_backdrop_input)
+	_fade.add_child(_backdrop)
 
 	# The card. Positioned/animated manually (not in a container) so it can slide up.
 	_card = Panel.new()
@@ -139,8 +144,8 @@ func present(title: String, body: String, image_path: String = "") -> void:
 	_fade.modulate.a = 0.0
 
 	var tw := create_tween().set_parallel(true).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC)
-	tw.tween_property(_fade, "modulate:a", 1.0, 0.45)
-	tw.tween_property(_card, "position", final_pos, 0.45)
+	tw.tween_property(_fade, "modulate:a", 1.0, 0.5)  # backdrop + card fade in together (~0.5s)
+	tw.tween_property(_card, "position", final_pos, 0.5)
 
 	if is_instance_valid(_continue_btn):
 		_continue_btn.grab_focus()

--- a/godot/tests/unit/test_bug_report_panel.gd
+++ b/godot/tests/unit/test_bug_report_panel.gd
@@ -1,0 +1,31 @@
+extends GutTest
+## Regression tests for the bug-report panel Submit button state (#603).
+##
+## After submitting, the panel flashes a "thanks" state; the Submit button must be
+## disabled there so it can't be clicked again, and re-enabled when the panel is reused.
+
+func _make_panel():
+	var scene = load("res://scenes/ui/bug_report_panel.tscn")
+	var panel = scene.instantiate()
+	add_child_autofree(panel)  # triggers _ready(), binding @onready node refs
+	return panel
+
+func test_submit_enabled_by_default():
+	var panel = _make_panel()
+	assert_false(panel.submit_button.disabled, "Submit should start enabled")
+
+func test_submit_disabled_in_thanks_state():
+	# _on_report_saved is a coroutine (it awaits a reset timer); the synchronous prefix
+	# disables the button, which is what we assert. The node is freed at teardown, so the
+	# pending timer resume is dropped rather than touching a freed instance.
+	var panel = _make_panel()
+	panel._on_report_saved("user://dummy_report.json")
+	assert_true(panel.submit_button.disabled,
+		"Submit should be disabled in the thanks/submitted state (#603)")
+
+func test_reset_form_reenables_submit():
+	var panel = _make_panel()
+	panel.submit_button.disabled = true  # simulate the post-submit state
+	panel.reset_form()
+	assert_false(panel.submit_button.disabled,
+		"reset_form should re-enable Submit so the panel is reusable (#603)")

--- a/godot/tests/unit/test_bug_report_panel.gd.uid
+++ b/godot/tests/unit/test_bug_report_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://jdysiloc1n8n

--- a/godot/tests/unit/test_fanfare_popup.gd
+++ b/godot/tests/unit/test_fanfare_popup.gd
@@ -18,6 +18,16 @@ func test_fanfare_present_text_only():
 	assert_eq(popup._body_label.text, "Test body text", "body should be set")
 	assert_false(popup._image.visible, "image slot hidden when no path is given")
 
+func test_fanfare_has_dimming_backdrop():
+	# #603: a near-opaque full-viewport backdrop must sit behind the card so background
+	# event triggers can't animate through the reveal.
+	var popup = FanfarePopup.new()
+	add_child_autofree(popup)
+	assert_not_null(popup._backdrop, "fanfare should build a dimming backdrop node")
+	assert_true(popup._backdrop is ColorRect, "backdrop should be a ColorRect overlay")
+	assert_gt(popup._backdrop.color.a, 0.5,
+		"backdrop should be substantially opaque to darken/block the game behind it (#603)")
+
 func test_fanfare_present_ignores_missing_image_path():
 	var popup = FanfarePopup.new()
 	add_child_autofree(popup)


### PR DESCRIPTION
Fixes two playtest popup bugs from #603.

## 1. Fanfare lets the background show through
When the fanfare reveal pops, background event triggers were animating underneath it (visually disturbing). The dimming `ColorRect` behind the card (`fanfare_popup.gd`) is now a proper backdrop:
- Near-opaque black (`alpha 0.8`) so it darkens/blocks the game behind it — tasteful, not fully immersion-breaking.
- Named `Backdrop`, covers the full viewport, sits behind the card but above the game (layer 128 CanvasLayer).
- Fades in with the card over ~0.5s and fades out with it on dismiss (Civ-II "a party arrives to negotiate" feel).

## 2. Bug-report "thanks" Submit still clickable
After a successful submit, the panel flashes a thanks state but Submit stayed clickable (`bug_report_panel.gd`). Submit is now `disabled` in `_on_report_saved` (the thanks state) and re-enabled in `reset_form()` so the panel is reusable.

## Tests
- `test_fanfare_popup.gd`: backdrop node exists, is a `ColorRect`, and is substantially opaque.
- `test_bug_report_panel.gd` (new): Submit starts enabled, disables in the thanks state, and re-enables on reset.
- `run_godot_tests.py --quick` green; `main.tscn` boots headless with no script errors.

## Human-eye caveat
The actual fade timing, opacity feel, and look need a human eye in-game — the automated tests only assert the backdrop exists and is opaque enough, not that it looks right.

Refs #603. Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)