### PR TITLE
fix: dev/F3 overlays read live game state + kill runtime errors + backslash-close (#600)

### DIFF
--- a/godot/scripts/debug/debug_overlay.gd
+++ b/godot/scripts/debug/debug_overlay.gd
@@ -18,6 +18,22 @@ var refresh_rate: float = 1.0
 var frame_times: Array[float] = []
 var max_frame_samples: int = 60
 
+## Resolve the *live* GameManager MainUI drives (#600). main.tscn instances a scene-local
+## `GameManager` node (a sibling of this overlay) which MainUI holds as `game_manager`; that
+## instance owns the live `state`. The bareword `GameManager` autoload singleton is a DIFFERENT
+## instance whose `state` is never populated — reading it is why this overlay reported
+## "No game state available" mid-game. Prefer MainUI's manager, then the scene node, then autoload.
+func _live_gm() -> Node:
+	var mui := get_node_or_null("../TabManager/MainUI")
+	if mui != null:
+		var gm = mui.get("game_manager")
+		if gm != null:
+			return gm
+	var scene_gm := get_node_or_null("../GameManager")
+	if scene_gm != null:
+		return scene_gm
+	return GameManager
+
 func _ready():
 	panel.visible = false
 
@@ -61,11 +77,12 @@ func update_display():
 	update_performance()
 
 func update_game_state():
-	if not GameManager or not GameManager.state:
+	var gm = _live_gm()
+	if not gm or not gm.state:
 		state_label.text = "[No game state available]"
 		return
 
-	var state = GameManager.state
+	var state = gm.state
 	var lines: Array[String] = []
 
 	# Header
@@ -215,10 +232,10 @@ func update_errors():
 		errors_list.add_child(label)
 		return
 
-	# Show error stats
+	# Show error stats (plain text — these are Labels, which don't parse BBCode)
 	var stats = ErrorHandler.get_error_stats()
 	var stats_label = Label.new()
-	stats_label.text = "[b]Error Stats[/b]\nTotal: %d | Errors: %d | Warnings: %d" % [
+	stats_label.text = "Error Stats\nTotal: %d | Errors: %d | Warnings: %d" % [
 		stats["total"],
 		stats["by_severity"].get("ERROR", 0) + stats["by_severity"].get("FATAL", 0),
 		stats["by_severity"].get("WARNING", 0)
@@ -229,19 +246,25 @@ func update_errors():
 	var separator = HSeparator.new()
 	errors_list.add_child(separator)
 
-	# Show recent errors
+	# Show recent errors.
+	# #600: previously this rendered `error.to_string()` inside a `[color=…]` BBCode tag on a
+	# plain Label. GameError (an inner class extending RefCounted) has no `_to_string()`, so
+	# `to_string()` returned "<RefCounted#…>", and the Label showed the BBCode literally — every
+	# entry read like "color white refcounted …" (the ~29-error spam a playtester reported).
+	# Use the human-readable format_message() and set the font colour directly.
 	for error in recent_errors:
 		var error_label = Label.new()
-		var color = "white"
+		var col := Color(0.85, 0.85, 0.85)  # INFO / default
 		match error.severity:
 			ErrorHandler.Severity.WARNING:
-				color = "yellow"
+				col = Color(0.95, 0.85, 0.30)
 			ErrorHandler.Severity.ERROR:
-				color = "orange"
+				col = Color(0.95, 0.60, 0.25)
 			ErrorHandler.Severity.FATAL:
-				color = "red"
+				col = Color(0.95, 0.35, 0.30)
 
-		error_label.text = "[color=%s]%s[/color]" % [color, error.to_string()]
+		error_label.text = error.format_message()
+		error_label.add_theme_color_override("font_color", col)
 		error_label.add_theme_font_size_override("font_size", 10)
 		error_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 		errors_list.add_child(error_label)
@@ -308,17 +331,22 @@ func _on_rate_slider_value_changed(value):
 	rate_label.text = "%.1fs" % value
 
 func _on_add_money_button_pressed():
-	if GameManager and GameManager.state:
-		GameManager.state.money += 50000
+	var gm = _live_gm()
+	if gm and gm.state:
+		gm.state.money += 50000
+		gm.game_state_updated.emit(gm.state.to_dict())
 		ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Debug: Added $50k", {})
 
 func _on_add_ap_button_pressed():
-	if GameManager and GameManager.state:
-		GameManager.state.action_points += 5
+	var gm = _live_gm()
+	if gm and gm.state:
+		gm.state.action_points += 5
+		gm.game_state_updated.emit(gm.state.to_dict())
 		ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Debug: Added 5 AP", {})
 
 func _on_trigger_event_button_pressed():
-	if GameManager and GameManager.state:
+	var gm = _live_gm()
+	if gm and gm.state:
 		# Show event selection popup
 		_show_event_selection_popup()
 
@@ -368,7 +396,8 @@ func _show_event_selection_popup():
 
 func _trigger_specific_event(event: Dictionary, popup: AcceptDialog):
 	"""Trigger a specific event"""
-	if not GameManager or not GameManager.state:
+	var gm = _live_gm()
+	if not gm or not gm.state:
 		return
 
 	var event_name = event.get("name", "Unknown Event")
@@ -377,11 +406,11 @@ func _trigger_specific_event(event: Dictionary, popup: AcceptDialog):
 	ErrorHandler.info(ErrorHandler.Category.EVENTS, "Debug: Triggering event '%s'" % event_name, {"event_id": event_id})
 
 	# Add to pending events so it will be shown to player
-	GameManager.state.pending_events.append(event)
+	gm.state.pending_events.append(event)
 
 	# Emit signal if main UI is listening
-	if GameManager.has_signal("event_triggered"):
-		GameManager.emit_signal("event_triggered", event)
+	if gm.has_signal("event_triggered"):
+		gm.emit_signal("event_triggered", event)
 
 	# Close popup
 	popup.queue_free()
@@ -390,11 +419,13 @@ func _trigger_specific_event(event: Dictionary, popup: AcceptDialog):
 	ErrorHandler.info(ErrorHandler.Category.EVENTS, "Event '%s' added to pending events" % event_name, {})
 
 func _on_commit_plan_button_pressed():
-	if GameManager and GameManager.is_initialized:
+	var gm = _live_gm()
+	if gm and gm.is_initialized:
 		ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Debug: Commit plan requested", {})
 		# Would need to implement commit plan
 
 func _on_reset_game_button_pressed():
-	if GameManager:
+	var gm = _live_gm()
+	if gm:
 		ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Debug: Reset game requested", {})
-		GameManager.start_new_game()
+		gm.start_new_game()

--- a/godot/scripts/debug/dev_mode_overlay.gd
+++ b/godot/scripts/debug/dev_mode_overlay.gd
@@ -30,6 +30,19 @@ var _event_dropdown: OptionButton = null
 var _built := false
 
 
+## Resolve the *live* GameManager that MainUI actually drives (#600).
+## main.tscn instances a scene-local `GameManager` node that MainUI holds as `game_manager`;
+## that node — NOT the bareword `GameManager` autoload singleton — owns the live `state`.
+## The autoload's `state` is never populated, which is why every readout previously showed
+## "No active game". Prefer MainUI's instance; fall back to the autoload only when unwired.
+func _live_gm() -> Node:
+	if main_ui != null:
+		var gm = main_ui.get("game_manager")
+		if gm != null:
+			return gm
+	return GameManager
+
+
 func _ready() -> void:
 	layer = OVERLAY_LAYER
 	# Gate on dev build: in a release cut this overlay builds nothing and stays inert.
@@ -40,8 +53,11 @@ func _ready() -> void:
 	_built = true
 	if is_instance_valid(KeybindManager):
 		KeybindManager.dev_mode_toggled.connect(_on_toggle)
-	if is_instance_valid(GameManager):
-		GameManager.game_state_updated.connect(_on_state_updated)
+	# Track the live manager MainUI drives, so nudges / turns refresh the readout (#600).
+	var gm := _live_gm()
+	if gm != null and gm.has_signal("game_state_updated") \
+			and not gm.game_state_updated.is_connected(_on_state_updated):
+		gm.game_state_updated.connect(_on_state_updated)
 
 
 func _on_toggle() -> void:
@@ -229,7 +245,8 @@ func _render() -> void:
 	for c in _info_vbox.get_children():
 		_info_vbox.remove_child(c)
 		c.queue_free()
-	var state = GameManager.state if is_instance_valid(GameManager) else null
+	var gm := _live_gm()
+	var state = gm.state if gm != null else null
 	for section in DevModeReadout.build_sections(state):
 		var head := Label.new()
 		head.text = "▸ " + str(section["title"])
@@ -247,7 +264,8 @@ func _render() -> void:
 # --- Control handlers ------------------------------------------------------
 
 func _nudge(field: String, delta: float) -> void:
-	var s = GameManager.state if is_instance_valid(GameManager) else null
+	var gm := _live_gm()
+	var s = gm.state if gm != null else null
 	if s == null:
 		return
 	match field:
@@ -261,7 +279,9 @@ func _nudge(field: String, delta: float) -> void:
 			s.doom = clampf(s.doom + delta, 0.0, 100.0)
 			if s.doom_system != null:
 				s.doom_system.current_doom = s.doom
-	GameManager.game_state_updated.emit(s.to_dict())
+	# Emit on the LIVE manager so MainUI's readouts refresh (autoload signal has no listeners).
+	if gm.has_signal("game_state_updated"):
+		gm.game_state_updated.emit(s.to_dict())
 	_render()
 
 
@@ -299,7 +319,7 @@ func _jump_f3() -> void:
 func _advance_turn() -> void:
 	# Dev advance: mirror end_turn()'s AP conversion + turn execution, but bypass the
 	# "no actions queued" guard so a turn can be forced even with an empty queue.
-	var gm = GameManager
+	var gm := _live_gm()
 	if not is_instance_valid(gm) or gm.state == null or gm.turn_manager == null:
 		return
 	gm.state.action_points -= gm.state.committed_ap
@@ -312,7 +332,7 @@ func _advance_turn() -> void:
 
 
 func _queue_event(event_id: String) -> void:
-	var gm = GameManager
+	var gm := _live_gm()
 	if not is_instance_valid(gm) or gm.state == null or event_id == "":
 		return
 	# Inject into the pending queue exactly like SeedSchedule's inject_event cause does.
@@ -335,7 +355,7 @@ func _trigger_random_event() -> void:
 	var all := GameEvents.get_all_events()
 	if all.is_empty():
 		return
-	var gm = GameManager
+	var gm := _live_gm()
 	var idx := 0
 	if is_instance_valid(gm) and gm.state != null and gm.state.rng != null:
 		idx = gm.state.rng.randi() % all.size()

--- a/godot/tests/unit/test_debug_overlay.gd
+++ b/godot/tests/unit/test_debug_overlay.gd
@@ -1,0 +1,50 @@
+extends GutTest
+## Regression tests for the F3 debug overlay (#600).
+##
+## Bug: the Errors tab rendered `error.to_string()` inside a `[color=…]` BBCode tag on a plain
+## Label. ErrorHandler.GameError (an inner class extending RefCounted) has no `_to_string()`, so
+## `to_string()` returned "<RefCounted#…>" and the Label showed the BBCode literally — every
+## entry read like "color white refcounted …". The fix renders `format_message()` with a real
+## font-colour override. These tests lock that in.
+
+const DEBUG_OVERLAY := preload("res://scenes/debug_overlay.tscn")
+
+
+func _fresh_overlay():
+	var overlay = DEBUG_OVERLAY.instantiate()
+	add_child_autofree(overlay)
+	return overlay
+
+
+func test_error_list_shows_readable_messages_not_refcounted():
+	ErrorHandler.clear_history()
+	ErrorHandler.report_err(ErrorHandler.Category.TURN, "regression_probe_boom", {"n": 1})
+
+	var overlay = _fresh_overlay()
+	overlay.update_errors()
+
+	var errors_list = overlay.errors_list
+	var found := false
+	for child in errors_list.get_children():
+		if child is Label:
+			var t: String = child.text
+			assert_false(t.contains("RefCounted"),
+				"#600: error rows must not render as '<RefCounted#…>'")
+			assert_false(t.begins_with("[color="),
+				"#600: plain Labels must not carry literal BBCode color tags")
+			if t.contains("regression_probe_boom"):
+				found = true
+	assert_true(found, "the logged error's readable message must appear in the Errors tab")
+
+
+func test_error_stats_header_has_no_literal_bbcode():
+	ErrorHandler.clear_history()
+	ErrorHandler.report_err(ErrorHandler.Category.TURN, "probe", {})
+
+	var overlay = _fresh_overlay()
+	overlay.update_errors()
+
+	for child in overlay.errors_list.get_children():
+		if child is Label:
+			assert_false(child.text.contains("[b]"),
+				"stats header must not show literal [b] tags on a plain Label")

--- a/godot/tests/unit/test_debug_overlay.gd.uid
+++ b/godot/tests/unit/test_debug_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://ce5lwv2a5r8ef

--- a/godot/tests/unit/test_dev_mode_overlay.gd
+++ b/godot/tests/unit/test_dev_mode_overlay.gd
@@ -67,3 +67,74 @@ func test_readout_covers_key_domains():
 func test_readout_handles_null_state():
 	var sections := DevModeReadout.build_sections(null)
 	assert_gt(sections.size(), 0, "null state must degrade to a placeholder section, not crash")
+
+
+# --- #600: the overlay must read the LIVE GameState MainUI holds, not the dead autoload ------
+#
+# main.tscn instances a scene-local GameManager node that MainUI drives; the bareword
+# `GameManager` autoload is a different instance whose `state` stays null. These stubs stand in
+# for "MainUI holding the live manager" so we can assert the overlay resolves it.
+
+class _FakeGM extends Node:
+	signal game_state_updated(state)
+	var state
+	var turn_manager
+	var is_initialized := true
+
+class _FakeMainUI extends Node:
+	var game_manager
+
+
+func test_overlay_resolves_live_manager_from_main_ui():
+	var overlay = DevModeOverlay.new()
+	var gm = _FakeGM.new()
+	var mui = _FakeMainUI.new()
+	mui.game_manager = gm
+	overlay.main_ui = mui
+	assert_eq(overlay._live_gm(), gm,
+		"#600: overlay must resolve the live game_manager MainUI holds, not the autoload")
+	overlay.free()
+	gm.free()
+	mui.free()
+
+
+func test_render_populates_sections_from_live_state():
+	# Reproduces #600: with a live-shaped GameState reachable via main_ui.game_manager, the
+	# readout must build the full multi-section dump — not the single "No active game" placeholder.
+	var overlay = DevModeOverlay.new()
+	var gm = _FakeGM.new()
+	gm.state = GameState.new()  # _init + reset() give working doom/risk/rival subsystems
+	var mui = _FakeMainUI.new()
+	mui.game_manager = gm
+	overlay.main_ui = mui
+	overlay._info_vbox = VBoxContainer.new()
+
+	overlay._render()
+
+	# Null state → 1 section → 3 nodes (head + body + separator). A live state renders ~7
+	# sections. Anything well above 3 proves the live path populated, not the placeholder.
+	assert_gt(overlay._info_vbox.get_child_count(), 6,
+		"live state must render multiple populated sections, not the null placeholder")
+
+	overlay._info_vbox.free()
+	gm.state.free()
+	overlay.free()
+	gm.free()
+	mui.free()
+
+
+func test_backslash_toggle_opens_then_closes():
+	# #600: backslash must CLOSE the overlay, not only open it. _on_toggle flips _root.visible;
+	# this locks in that a second press hides it. (Live keypress routing still needs a human eye.)
+	var overlay = DevModeOverlay.new()
+	overlay._built = true
+	overlay._root = Control.new()
+	overlay._root.visible = false
+
+	overlay._on_toggle()
+	assert_true(overlay._root.visible, "first backslash opens dev mode")
+	overlay._on_toggle()
+	assert_false(overlay._root.visible, "second backslash closes dev mode")
+
+	overlay._root.free()
+	overlay.free()


### PR DESCRIPTION
Fixes the DEV MODE (backslash) and F3 debug overlays reported in #600.

## Root cause (bugs 1 & 4 — "No active game state" + dead nudges)
`main.tscn` instances a **scene-local** `GameManager` node, and `main_ui.gd` binds to it via `get_node("../../GameManager")` and calls `start_new_game()` on it. Both overlays instead read the bareword `GameManager` **autoload singleton** — a *different* instance whose `state` is never populated. So every readout (resources / doom / risk / rivals / ledger) showed "No active game", and the DEV MODE resource +/- and advance-turn pokes mutated the dead autoload's null state → silent no-ops.

**Fix:** both overlays gained a `_live_gm()` resolver. DEV MODE reads `main_ui.game_manager`; F3 (no main_ui ref) resolves `../TabManager/MainUI.game_manager`, then the `../GameManager` scene node, then the autoload as a last resort. All state reads, nudges, advance-turn, event-queue pokes and `game_state_updated` emits now route through it — so readouts populate, pokes mutate the live state, and MainUI refreshes. `main_ui.gd` was **not** touched.

## Root cause (bug 2 — ~29 "color white refcounted" errors)
F3's Errors tab rendered `error.to_string()` inside a `[color=…]` BBCode tag on a **plain `Label`**. `ErrorHandler.GameError` is a RefCounted inner class with no `_to_string()`, so `to_string()` returned `<RefCounted#…>`, and the Label showed the BBCode literally — every logged row (INFO included) read like "color white … RefCounted…". These were **not** 29 distinct engine errors; it was normal log spam rendered unreadably. Verified empirically (`to_string()` → `<RefCounted#…>`, `format_message()` → `[ERROR/TURN] boom …`).

**Fix:** render `format_message()` with an `add_theme_color_override("font_color", …)` per severity; dropped literal `[b]` from the stats row.

## Bug 3 — backslash should close
`_on_toggle()` already flips `_root.visible` (opens *and* closes). Locked in with a regression test (open → close on two presses). Live keypress routing still wants a human eye.

## Tests
`python scripts/run_godot_tests.py --quick` → green (11 tests / 45 asserts in the two overlay files). New: overlay resolves MainUI's live manager; live-shaped GameState renders full multi-section readout (not the null placeholder); Errors tab shows readable text and never "RefCounted"/literal BBCode; backslash toggle closes. `main.tscn` boots headless with no new script/parse errors.

## Parked (not built)
- F3 **Game State** / **Performance** tabs still feed BBCode to plain `Label`s (literal `[b]`/`[color=…]` tags show). Separate cosmetic pass — would mean converting those nodes to `RichTextLabel` in the `.tscn`.
- **Design note:** dev-mode pokes write straight to `GameState` and can desync the verification/event log. They should be logged or gated before real use — flagged per the task, not implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)