### PR TITLE
docs(design): Fable workshop #2 — ADR-0009..0014 + build lanes L1-L8

### DIFF
--- a/docs/TECH_DEBT_REGISTER.md
+++ b/docs/TECH_DEBT_REGISTER.md
@@ -1,0 +1,140 @@
+# Tech Debt Register — pre-rewrite audit (2026-07-12)
+
+> **Provenance:** three parallel code audits (hardcoded-values census; duplication/dead-
+> code sweep; monolith seam analysis) run at the close of Fable workshop #2, funded as a
+> deliberate debt-reduction pass before the ADR-0009..0013 rewrite. Every item carries a
+> **build lane** (see `docs/game-design/WORKSHOP_2_BUILD_LANES.md`) and a **phase**:
+> BEFORE the rewrite (behavior-preserving), DURING (rewritten anyway), or **LET-DIE**
+> (do not touch — the rewrite deletes it). Implementation sessions: fix items in your
+> lane, log new debt here, never polish LET-DIE code.
+
+## Live bugs (fix in L0)
+
+1. **`log_exporter` is doubly dead.** It reads the never-initialized autoload
+   `GameManager` (`project.godot:32`) while the real instance is the scene child
+   (`main.tscn:35-36`, used by `main_ui.gd:77`, `employee_screen.gd:17`) — AND it
+   references fields that don't exist on GameState: `research_progress` (real:
+   `research`), `papers_published` (`papers`), `game_seed` (`game_seed_str`) at
+   `log_exporter.gd:54-58`. Consolidate GameManager (#608), fix the field names.
+2. **`take_loan` is defined twice** in `execute_action` (`actions.gd:636` and `:699`) —
+   the second match arm is unreachable dead code.
+3. **Replay schema gap:** producer never emits the `schedule` key
+   (`verification_tracker.gd:232-242`) that the verifier reads
+   (`replay_simulator.gd:28`). DQ-6 is a live code gap.
+4. **Doom thresholds are mutually inconsistent across four copies:**
+   `doom_system.gd:360-371` says 25/50/70/90; `doom_meter.gd:125-131` and
+   `game_over_screen.gd:203-212` say 30/60/80; `main_ui.gd:474-477` warns at 70/80.
+   Three different answers to "what counts as critical." Canonical:
+   `theme_manager.gd:365-389` (data-driven bands) — route everything through it (L6).
+5. **`pass` vs `pass_turn` twin ids** — two "do nothing" code paths that are NOT
+   interchangeable (`actions.gd:242/491-497/506`, `main_ui.gd:522-535/3755+`;
+   `get_action_by_id("pass_turn")` returns `{}`). Collapse to one id via a constant.
+
+## No balance-config surface exists (→ L9)
+
+Zero gameplay tunables are centralized. `game_config.gd` holds player settings only;
+every price, rate, probability, cooldown, and doom coefficient is an inline literal
+across `actions.gd` (~120+ literals), `events.gd` (~30 events × effect dicts +
+cooldowns 15–80 turns), `ledger.gd` (interest/fuses/magnitudes), `turn_manager.gd`
+(salary `/260`, productivity, AP grant), `game_state.gd` (starting resources, risk
+tables), `doom_system.gd`, `rivals.gd`, `risk_pool.gd`, `researcher.gd`,
+`conferences.gd`, `game_manager.gd` (difficulty AP). Three balancing JSONs
+(`data/events/balancing/*.json`) exist but are **loaded by nothing** — wire or delete.
+
+**Fix (L9): a `Balance` autoload** (Resource/JSON-backed, mirroring the proven
+`scenario_loader` pattern) so sweeps swap a file instead of editing code. Migration
+order (lowest-risk first):
+1. The seam: `get_months_per_turn()` (`game_state.gd:383` — hardcodes 1.0, already
+   consumed by risk pools) returns a Balance value; route salary `/260`
+   (`turn_manager.gd:145-149`), `TURNS_PER_WEEK` (`game_state.gd:77`), and the week→turn
+   `×5` conversions (`actions.gd:1063`, `paper_submissions.gd:190`) through the L0
+   Clock, which reads Balance. The whole day→month flip becomes one number + calendar.
+2. Time-coupled durations as calendar-time: ledger fuses, event
+   `cooldown_turns`/`min_turn`/`trigger_turn`, conference weeks — resolved to turns via
+   the Clock.
+3. Dedupe UI thresholds into Balance/ThemeManager (kills the desync class).
+4. Lift pure balance literals in batches by file, current values as defaults
+   (behavior-neutral until a sweep varies them).
+5. Wire `difficulty.json` as multipliers over Balance; activate or delete
+   `rarity_curves.json`/`variable_mapping.json`.
+
+Structural (fine to hardcode): win/loss comparisons (doom≥100, rep≤0), 0–100 clamps,
+enums/phases, save keys, calendar shape.
+
+## Data masquerading as code (→ L9)
+
+- **`events.gd`: ~1,100 of 1,483 lines are dict literals** (`get_all_events` ~830 +
+  `get_risk_events` ~275). Externalization is two-thirds done already — the scheduler
+  merges three sources uniformly (`events.gd:874-896`: built-ins, scenario events,
+  EventService JSON pipeline). Move built-ins to `data/events/core_events.json` +
+  `risk_events.json`; the remaining ~300-line engine splits cleanly into scheduler
+  (L1 rewrites it) vs condition-eval + effect-applier (stable).
+- **`actions.gd`: definitions (101–500) are already pure dictionaries** grouped by
+  domain → `data/actions/*.json` via a loader copied from `scenario_loader.gd`.
+  `_apply_risk_contributions` (846–969) is a pure `action_id → {pool: weight}` table →
+  `data/actions/risk_contributions.json`.
+- Blocker in both: inline `GameConfig.format_money()` in option text → template as
+  placeholders resolved at display time (historical events already do this).
+- Payoff: L1 operates on ~600 lines of engine instead of 2,665 of engine-plus-data.
+- Effect layer (DURING, with the cost-schema rewrite): replace the 340-line
+  `execute_action` match with a registry (`action_id → Callable`, per-domain handler
+  modules). The scattered refund-on-failure pattern
+  (`state.add_resources(action["costs"])`) is the most AP-coupled piece — new shape:
+  handlers signal success/failure, one caller owns spend/refund. All
+  `VerificationTracker.record_rng_outcome` calls must survive any split (determinism).
+
+## `main_ui.gd` decomposition (→ L10; 3,786 lines, all dialogs built imperatively)
+
+Extraction precedent exists (`research_quality_selector.gd` et al — child script
+mounted in `_ready`). Follow it; do not invent a new pattern.
+
+- **Extract BEFORE the rewrite** (turn-model-independent):
+  `event_dialog.gd` (:2975–3223 — **first**, L1's response windows reuse exactly this
+  presenter), `ledger_screen.gd` (:1857–1985), `employee_panel.gd` (:3304–3582 — grows
+  into the L2 assignment surface), `submenu_chrome.gd` (:1088–1195).
+- **Extract DURING** (content survives, AP triggers die): hiring / fundraising /
+  financing / publicity / strategic / travel / operations dialogs. Travel
+  (:2359–2865, paper submission + conference attendance) is the richest — real domain
+  UI, feeds L3.
+- **LET-DIE — do not extract or polish:** command/queue/reserve-AP/commit-plan zone
+  (:397–544 — this IS the AP plan model being replaced), queued-actions viz
+  (:2866–2974), `_calculate_queued_costs`, the AP-affordability half of the action-bar
+  builder (:909–928).
+- Layering leaks to sever during extraction: direct state writes at `main_ui.gd:535`
+  (`queued_actions.append`), `:1524-1526` (hire queue + candidate pool).
+
+## Duplication kill-list
+
+| What | Canonical | Divergent copies | Lane |
+|---|---|---|---|
+| Affordability | `GameState.can_afford` + `select_action` enforcement | 8× pre-checks in main_ui + a different inline loop at `:909-920` | L10 (mostly let-die) |
+| Doom bands | `theme_manager.gd:365-389` | doom_meter, game_over_screen, doom_system, main_ui (see bug #4) | L6 |
+| Money format | `GameConfig.format_money` | `game_over_screen._fmt_money`, 2 dead `format_number`, ad-hoc `"$%.0f"` | L0 |
+| Severance rule | engine should own | `employee_screen.gd:36-47` (game math in a screen) | L2 |
+| Resource-name match | new shared `ResourceAccessor` | `events.gd` `evaluate_condition` + `execute_event_choice` + `event_service._map_variable` | L9 |
+| Staff counts | `GameState.get_total_staff` | `game_over_screen.gd:169-172` inline | L0 |
+
+## Dead code (delete in L0)
+
+- `game_controller.gd` (244 lines, referenced by no scene; divergent win/lose + old
+  5-arg ScoreEntry) — **confirms backlog EE-1**.
+- `end_game_screen.gd` + `scenes/end_game_screen.tscn` (orphaned; live path is
+  `game_over_screen.gd` via `main.tscn:456`).
+- Dead stub `main_ui.gd:544-547`; commented block `doom_system.gd:382+`.
+
+## Conventions going forward (clean-as-you-go, all lanes)
+
+- **Ids:** constants registry for action/event ids — no new bare strings (the
+  pass/pass_turn split is this failure mode).
+- **Logging:** ErrorHandler or a debug-gated logger; no new raw `print()`. Burn-down:
+  `game_manager.gd` 44, `main_ui.gd` 108 (engine core is already clean: 0–2 each).
+- **Node access:** autoload identifier or `%UniqueName`; never `../../` relative paths
+  (three styles currently coexist for the same node).
+- **State writes:** UI never mutates `game_manager.state` directly.
+- **Typing:** typed signatures in core scripts (game_manager.gd is the laggard).
+
+## Change log
+
+- **2026-07-12** — Register opened from the workshop-#2 closing audit (3 parallel
+  auditors). Lanes L9/L10 created to hold the balance-surface and UI-decomposition
+  work; L0 scope expanded with the live bugs above.

--- a/docs/game-design/DESIGN_PHILOSOPHY.md
+++ b/docs/game-design/DESIGN_PHILOSOPHY.md
@@ -40,6 +40,13 @@ actually seems better?"*
 community's heartbeat** — patches don't need to be frequent, they need to be *legible
 events* people argue about.
 
+**(2026-07-12)** *"people voluntarily adopting good actions will generate the space for
+better actions to come about, and this is how small and middle power players can affect
+things - norm and market setting"*
+→ Pip's real-world theory of change, now load-bearing structure (ADR-0010): doom bends
+where work is **adopted**, not where it's written. This is the second structural claim
+(after "you can't win, only buy time") that is never patched for freshness.
+
 ### On losing (the core emotional design)
 
 **(2026-07-04)** *"the game's default value is that they'll lose, and lose repeatedly,
@@ -64,6 +71,14 @@ whereas other players will level multiples to 99 in one season."*
 community ("I got to turn 20"), requiring an exponentially hard ladder. Mechanism: the
 Liability Ledger — your own accumulated debts are the difficulty curve (ADR-0003).
 
+**(2026-07-12)** *"a well balanced ladder might have people overtaking each other by days
+in a period where their decisions are locked in in months or quarters, which leads to
+interesting paths on a ladder style race for increments."*
+→ **Coarse hands, fine scoreboard.** Decisions lock at month grain; the score resolves at
+day grain (the badge is the exact death date, ADR-0009). The gap between the two grains
+is where ladder drama lives — photo-finishes between players who never had day-level
+control.
+
 **(2026-07-04)** *"only the vastness of the design space will be what stops a determined
 player just brute-forcing their way to a high score… although I would laud the
 initiative!"*
@@ -80,6 +95,15 @@ Antagonist_Lab"*
 → **Every mitigation is a loan.** The game's tension generator: trades that pay now and
 bill later, sequenced (ADR-0003). Skill is debt-portfolio selection.
 
+**(2026-07-12)** *"I want to leave options for the player to contribute towards
+capabilities in a way that increases danger but allows them more resources, as well,
+that's a good and useful temptation and also correctly acknowledges the dual-use element
+of the technology we're exploring in the AI safety space."*
+→ **The dual-use temptation is priced, not forbidden.** Capabilities work is a legal lane
+that pays in money/compute/hype and bills in doom — the Situational-Awareness-essay arc
+(awareness → personal reputation → someone funds your capabilities-heavy play) is the
+canonical real-world generator. Deepest ledger entry in the game.
+
 **(2026-07-04)** *"Much like the founding location in civ matters, I feel like players
 will start to point themselves in strategic directions in their early decisions."*
 → **The opening is a commitment device** — early moves aim the run; balance work exists
@@ -91,6 +115,79 @@ come with their own problems, bother."*
 → **Staff are leverage, not simulation subjects.** Canon: AP are the founder's personal
 hours — the one resource that never scales. Every hire converts money into action
 bandwidth and arrives with a liability rider.
+
+### On the turn (the core loop)
+
+**(2026-07-12)** *"I suppose what I want is the feeling of making a little plan and then
+having to make trade-offs against the perfect execution of that plan. And the scale of
+those interventions and balancing it is what is going to drive the game's narrative
+tension."*
+→ **A turn is a plan you watch collide with reality.** Two decision speeds — plan-time
+(sorcery) and interrupt-time (instant) — over a resolution tick (the day) that owns no
+routine decisions. Guard rule: no mechanic may hang a decision on the day tick.
+
+**(2026-07-12)** *"I suppose I want to feel in control, comfortable when I delegate, and
+like the end results are a result of my selections as opposed to pure simulations
+running?"*
+→ Extends skill-legibility (ADR-0002) inward: **every period's outcome must trace to a
+selection the player made** — a plan, a response, or a deliberate inaction. The sim
+generates pressure, never authorship.
+
+**(2026-07-12)** *"if players reserve a healthy amount of slack in their systems, they
+will be able to weather unusual events, but maybe they will get away by being greedy and
+overcommitting themselves."* and *"I don't think we can let players bank time."*
+→ **Slack is insurance the player is allowed to gamble against.** Reserved capacity
+answers events painlessly; overcommitting is a legal bet that sometimes pays. Unspent
+time evaporates at reset — banking is dead; crisp commitment-loss over soft fallbacks.
+
+**(2026-07-12)** *"as a CEO, I care about managing the first half dozen people or so.
+Then I probably want team leaders to stop me making employee-level decisions. Then I
+probably want divisions to manage the teams... A game that forces me to manage every
+employee if we scale to 100 employees will become draining."*
+→ **The management grain coarsens as the org scales** (Factorio's complexity-progression
+*feeling*): people → team leads → divisions. Attention, switching costs, and the waste of
+abandoning work are the intended mid/late-game challenge material, not more knobs.
+
+**(2026-07-12)** *"the player's situational awareness (or they can opt to turn off e.g.
+medium news to reduce notification or decision spam) impact the number of tactical events
+they *get* to respond to, as opposed to simply finding out they've happened"*
+→ Cashes out ADR-0004's "SA buys lead time" mechanically: **situational awareness
+purchases response windows** — the difference between an event you could answer and one
+you merely read about afterward. Muting a channel is a legal, priced choice, not a
+settings toggle.
+
+### On work and delegation (the effort economy)
+
+**(2026-07-12)** *"I have never been around unassigned workers before, because there's
+always been a backlog."*
+→ **Idle staff don't exist; unmanaged staff do.** Work always happens — the question is
+*whose ordering of the backlog wins*. Unmanaged researchers drive at their own agendas
+(thematically honest: costly humans with their own problems). Management effort steers;
+it never creates.
+
+**(2026-07-12)** *"the main thing a team lead does is stop employees from annoying me
+with employee things"* and *"Each new employee is kinda cutting down the time I need to
+do other things, so I want someone to just take this routine stuff off my hands."*
+→ **Staff buy back founder time.** Hires don't add to an AP pool (the pool illusion is
+dead) — they reduce the founder-price of routine actions and *absorb interrupt classes*.
+A team lead is an interrupt shield with an agenda rider. Denominate manager value in the
+response-window economy (ADR-0009), not in output multipliers.
+
+**(2026-07-12)** *"something about how information flows up (Robert Anton Wilson /
+Celine's Law might play here in mechanically interesting ways)"*
+→ Delegation costs sight: a manager's report is an **inward SA channel with fidelity
+loss** (hierarchies produce rosy reports upward — Celine's law as mechanic, not mysticism:
+report accuracy degrades with punishment-culture and manager incentives). Skip-level
+audits are a founder-time spend to re-ground truth. Folds inward-SA (ADR-0008 deferral)
+into existing SA machinery.
+
+**(2026-07-12)** *"successes plus schmoozing in finance leads to better VC offers than
+successes plus time at AI safety conferences, which would have in turn led to better
+grant applications or higher quality safety applicants"*
+→ **Social capital is typed and compounding — the founder currency buys doors, and doors
+compound.** Extends "the opening is a commitment device": which rooms you spend founder
+hours in locks strategic paths (Hustler vs Operator divergence is literally this).
+Early hires are reputation seeds who attract their own juniors.
 
 ### On honesty and legibility
 
@@ -112,6 +209,31 @@ for free as they become lethal; SA purchases buy *lead time*, not exclusive trut
 the scale at certain points… rival_lab could get a wave of funding at point X."*
 → **Author causes, never outcomes.** The designer's thumb touches inputs to the sim,
 never the doom variable (ADR-0005).
+
+**(2026-07-12)** *"Doom Arrives With Your To-Do List Being Infinitely Long Still is a
+real possibility that I'm not shy of playing into."*
+→ **Attention is the resource the UI must be honest about.** Standing offers expire,
+deferred items fall out of visibility, the backlog outgrows the screen — modeled
+straight, not hidden (ADR-0012). Losing track is a legal way to lose; the game shows
+you an honest backlog, not a complete one.
+
+**(2026-07-12)** *"we should start fundraising and then have the money come in *later*,
+so if it goes badly, that means we then need even more emergency measures if the ledger
+is coming due soon…. emphasise the spiky-in and smooth-out cash flow management
+challenge element of the game."*
+→ **Cash is spiky-in, smooth-out — and the most fungible resource.** Debt death must be
+tragedy, and tragedy requires foreseeability, which requires lead time on money: the
+duration rule (ADR-0009) re-derived independently from the loss-feeling requirement.
+The ledger doesn't own a death screen; called-due defaults cascade legibly into the
+deaths that exist (ADR-0012).
+
+**(2026-07-12)** *"The simulation won't lie, but maybe our managers will give us rosy
+pictures of what's going on. Undiscovered or late discovered errors and doom are a real
+world problem because nobody wants to bring the boss bad news…"*
+→ Sharpens ADR-0004's honesty line: **the sim never lies; characters do.** Instruments
+can be fooled, managers can be scared — deception lives in provenance and personnel,
+never in the engine's account of itself. Late-discovered doom via rosy reporting is a
+real-world failure mode the game now mirrors (ADR-0011 Celine's-law channels).
 
 ### On restraint (as little design as possible)
 
@@ -151,6 +273,16 @@ flat CRT type, not casualty counters. Personnel problems read as "bother," not t
 
 ## Change log
 
+- **2026-07-12 (beat 3)** — Workshop #2, ledger bite: infinite-to-do-list honesty,
+  spiky-in/smooth-out cash + tragedy-requires-lead-time (under honesty/legibility);
+  norm-and-market-setting theory of change marked never-patch (under purpose).
+- **2026-07-12 (beat 2)** — Workshop #2, effort allocation: added "On work and
+  delegation" (backlog-never-empty, staff-buy-back-time, managers-as-interrupt-shields,
+  Celine's-law reports, typed compounding social capital) + dual-use-temptation-is-priced
+  under tension/tradeoffs; ladder "coarse hands, fine scoreboard" under losing.
+- **2026-07-12** — Workshop #2, beat 1 (turn cadence): added "On the turn (the core
+  loop)" — plan-vs-execution tension, selection-attribution, slack-as-gambleable
+  insurance, coarsening management grain, SA-buys-response-windows.
 - **2026-07-04** — First fill, from Fable workshop #1 (purpose, losing, ledger,
   legibility, restraint, flavor; four tensions logged). Session also produced
   ADR-0002–0008 and amendments to ADR-0001.

--- a/docs/game-design/FABLE_SESSION_2_KICKOFF.md
+++ b/docs/game-design/FABLE_SESSION_2_KICKOFF.md
@@ -1,5 +1,15 @@
 # Fable Design-Workshop #2 Kickoff
 
+> **STATUS: EXECUTED 2026-07-12.** Session ran full agenda + closing beat. Outcomes:
+> **ADR-0009** (plan-months, two decision speeds, badge-is-the-date), **ADR-0010**
+> (adoption routing, soft-with-teeth), **ADR-0011** (effort economy: founder hours,
+> staff lanes, manager compression), **ADR-0012** (event taxonomy + called-due
+> cascade), **ADR-0013** (cost-of-debt engine + financing instruments), **ADR-0014**
+> (conferences, presence, minimal location). DESIGN_PHILOSOPHY +11 entries;
+> WORLD_AND_LORE: 2037 vignette, staff archetypes, event-horizon guardrail, presence
+> channel. Backlog: DQ-11..17, EE-7..8, reconciliation notes. Implementation work
+> order: **`WORKSHOP_2_BUILD_LANES.md`** (L1–L8 + sweep gates G1–G3).
+
 > **How to use:** switch this session's model to Fable (`/model` → Fable), then paste
 > everything below the line as the opening message. Self-contained — a fresh Fable session
 > needs no prior transcript. Delete this note before pasting.

--- a/docs/game-design/WORKSHOP_2_BACKLOG.md
+++ b/docs/game-design/WORKSHOP_2_BACKLOG.md
@@ -47,6 +47,42 @@
 - **DQ-10 · Inward-SA / ledger visibility** *(#555)* — how much of the player's *own* ledger
   is visible is undecided; overlaps WS-2 SA and the inward-SA deferral (ADR-0008).
 
+### Workshop #2 additions (2026-07-12, beat 1 / ADR-0009)
+
+- **DQ-11 · Save/fork/divergence mechanics** — Pip open to them; legal under ADR-0006's
+  verification law. Needs design: UX, ladder norms (not rules), interaction with
+  seed-as-timeline fiction (a fork is *literally* a timeline fork — free flavor).
+- **DQ-12 · Rival narrative presence** — playtest note: rival still "narratively
+  invisible" despite mechanical doom pressure. Candidate home: response windows + month
+  review screen (rival actions as events you *see*, not just doom drift).
+- **DQ-13 · Doom nudge strength** — playtest note: "doom nudges overall probably a
+  little strong." Folds into the DQ-8 balance pass, re-denominated at month grain.
+- **DQ-14 · World-state progression display** — playtest note: "sense of progression
+  over time doesn't feel very strong." Candidate home: month review screen (ADR-0009
+  consequence) + era-keyed visual/UI shifts.
+- **DQ-15 · Researcher archetype roster — SEEDED** *(ADR-0011)* — Pip authored three
+  (people-pleaser interp, authoritarian governance pessimist, moral-crusader agent
+  foundations), Fable drafted two for veto (capabilities-curious optimist, burned-out
+  ex-frontier senior). Roster lives in WORLD_AND_LORE. Remaining: Pip's edit pass +
+  appetite fills.
+- **Promoted: conference/travel design** *(ADR-0010)* — now the mandatory middle of the
+  research→adoption value chain, no longer flavor; design with DQ-9 receivables +
+  ADR-0007 counterparties.
+- **DQ-16 · Conference-attendance subgame** *(ADR-0014)* — Pip's flagged ambition
+  ("that's how critical I think these are"). v1 ships attendance + yields only; revisit
+  when playtests show conference turns feel thin.
+- **DQ-17 · Achievement candidates register** *(build lane L8)* — observer-only,
+  never writes back to sim/score. Seed set: year marks, first-time-X. Tag
+  `[ACHIEVEMENT]` in future sessions and append here.
+- **Navigation principle — PROVISIONAL, not ratified** — hub-and-spoke guidance in
+  WORKSHOP_2_BUILD_LANES; rule it at workshop #3 with real screens in hand.
+- *(Parked in ADR-0009 itself: variable/coarsening cadence; quarter grain — each with
+  explicit revisit triggers.)*
+
+> **2026-07-12 reconciliation:** BL-1..3 absorbed into build lane L4; BL-5 into L6;
+> EE-2 **promoted** to lane L7 (6–8 hr runs require save/load); DQ-6 batches into L1's
+> replay schema bump; DQ-8 gated behind EE-8. See `WORKSHOP_2_BUILD_LANES.md`.
+
 ## Deferred build lanes — follow-up implementation (no design blocker)
 
 > These are why WS-1's ledger is **engine + soak only** right now — it works and is
@@ -66,6 +102,14 @@
   policy only; greedy-safety / capability-rush action-taking bots are a seam.
 
 ## Engineering errands — batched cleanup pass
+
+- **EE-7 · Loss-legibility UI pass** *(workshop #2 beat 3, ADR-0012)* — per-resource
+  per-turn delta indicators near resource symbols; event-log improvement. Motivation:
+  the one human ledger-death specimen was low-res ("I don't recall… the feeling that I
+  was losing things badly"); future specimens need to be readable.
+- **EE-8 · Sweep death attribution** *(ADR-0012)* — exploit-finder must attribute
+  deaths to root-cause chains (default→rep→funding→doom is a *ledger* death); current
+  "dies of doom" hides the cascade. Prerequisite to all ADR-0013 tuning.
 
 - **EE-1 · Legacy `game_controller`/`end_game_screen` path** *(#550)* — constructs
   `ScoreEntry` with `doom_integral`=0 + unversioned board; appears superseded. Remove or

--- a/docs/game-design/WORKSHOP_2_BUILD_LANES.md
+++ b/docs/game-design/WORKSHOP_2_BUILD_LANES.md
@@ -1,0 +1,153 @@
+# Workshop #2 → Build Lanes (implementation instructions)
+
+> **How to use:** each lane below is a self-contained brief for a non-Fable
+> implementation session (or a series of them). Lanes cite their ADRs — **the ADR is
+> the authority; this doc is the work order.** Run lanes in dependency order; L6/L7/L8
+> are parallel-safe from day one. Do not freelance design: anything not covered by a
+> cited ADR goes to `WORKSHOP_2_BACKLOG.md` as a DQ, not into code.
+>
+> Produced by Fable workshop #2 (2026-07-12). ADR-0009..0014, DESIGN_PHILOSOPHY,
+> WORLD_AND_LORE updated same session.
+
+## The falsifiable claim (sweep gates)
+
+The whole workshop asserts three measurable things. Bake them in as acceptance gates:
+
+- **G1 (after L1+L4):** in a 20-seed × N-policy sweep, **no constant policy dominates**
+  (safety-spam must not be the best line), and greedy policies produce **>0
+  ledger-attributed deaths** (root-cause attribution per EE-8, not surface cause).
+- **G2 (after L3):** publish-and-socialize policies **beat basement-spam** on median
+  survival.
+- **G3 (after L5):** a philanthropy-only opening is **viable but slow**; trade-heavy
+  openings (equity/agenda/capabilities) are faster and bill later — distinct viable
+  openings, none dominant.
+
+## Lane order
+
+```
+L6 instrumentation ──┐            (start now, parallel)
+L7 save/load ────────┤            (start now, parallel)
+L8 achievements ─────┤            (start now, parallel, observer-only)
+L1 turn engine ──────┼─► L2 effort economy ─► L3 adoption+conferences
+                     └─► L4 events+ledger ──► L5 pricing engine
+```
+
+## L1 · Turn engine (ADR-0009) — CRITICAL PATH
+
+- Month = the turn: plan phase (allocate staff/founder-hours, set reserve, queue
+  strategic actions) → day-by-day resolution (speed control + auto-pause-on-window) →
+  month review screen.
+- **Guard rule: no routine decision on the day tick.** Days are physics and comedy.
+- Response-window framework: event fires → window with costed menu
+  [HANDLE-reserve / HANDLE-cannibalize / DEFER / IGNORE]. Menu semantics per ADR-0012
+  (L4 wires the ledger side; L1 builds the window plumbing).
+- Reserve: explicit at plan time, evaporates crisply at month end. Banking: delete.
+- Strategic actions get durations (fundraising money lands later — ADR-0012).
+- Re-denominate: salaries monthly; loans %/month placeholder until L5; event pacing
+  per month.
+- Replay artifact: schema bump — record `(event_id, window, choice, payment_source)`;
+  batch the schedule-provenance fix (DQ-6) into the same version bump.
+- Score internals unchanged (lexicographic days-survived · doom-integral); **display
+  badge = exact death date** ("I made it to March 2034").
+- Acceptance: deterministic replay round-trip including responses; constant-policy bots
+  still run (re-baseline for G1).
+
+## L2 · Effort economy (ADR-0011) — after L1
+
+- Delete the global AP pool. Founder-hours menu: doors (stakeholder face-time),
+  approvals (hires = "approve this salary," not paperwork), audits (skip-level),
+  reserve.
+- Per-person staff assignment to workstreams from a backlog; unassigned staff
+  self-direct **within their lane** (cross-lane drift is rare + diagnostic).
+- Workstreams: multi-month, produce artifacts; **milestone ticks** within a workstream
+  (working papers, blog posts) yield partial rep/SA — spikes without added player
+  judgment.
+- Managers: absorb their team's interrupt classes; plan-screen compression (members
+  housed under manager, expand-on-click; team report replaces per-member detail);
+  Celine's-law report channel stub (fidelity < 1); agenda riders via existing ledger
+  staff-rider factory.
+- Ops/admin: reduce founder-price of routine actions; automate classes over time.
+- Researcher model: lane × appetite × optional quirk-rider — roster in WORLD_AND_LORE
+  (DQ-15); retention promises are ledger entries.
+
+## L3 · Adoption, papers, conferences (ADR-0010 + ADR-0014) — after L2
+
+- Safety research splits: internal hardening (own-lab doom, private) vs publishable
+  agendas (world/rival doom, adoption-routed). Rival/world doom share must dominate the
+  integral or teeth are cosmetic.
+- Pipeline: research → paper → socialization → adoption (labs/governments) → doom
+  bends. Unadopted world-facing research is a PDF.
+- Reputation: per-person + per-org, **typed** (safety-rep vs finance-rep); typed
+  attention events (safety success → grants/interviews; reckless success → accel VC).
+- Conferences: seed-schedule entries, annual majors announced ~9 months out; exclusive
+  gatherings gated by contacts/safety-rep. Founder attendance (founder-hours + travel
+  cash) ≫ delegate (staff-month + travel cash). Yields: adoption acceleration, faster
+  rep (esp. introductions), **contacts-as-receivables** (ledger receivables content —
+  DQ-9), SA presence boost.
+- Location minimal: `where` on events; HQ defaults American; overseas team basing =
+  cheaper hires + downstream influence hooks (stub the hooks).
+
+## L4 · Event taxonomy + ledger intake (ADR-0012) — after L1, parallel with L2
+
+- Absorbs BL-1..3 (the DEFER menu IS the ledger's player-facing UI wiring).
+- Event classes: **un-snoozable** (borders, emergencies, legal threats, story events —
+  no DEFER), **deferrable** (mints ledger entry, carrying cost via L5 engine —
+  placeholder rate until then), **standing offers** (open N turns → expire to
+  no-engage, optional rep loss, NO ledger entry), **no-action-correct**.
+- Called-due cascade: unpaid staff work damaged for a period → leave → work abandoned →
+  severe rep penalty → credit lockout → funding starvation → rival pulls ahead → doom
+  spike. The ledger never owns a death screen; the cascade must be legible (EE-7).
+- The infinite to-do list is diegetic: overflow falls out of the foreground honestly.
+- Event content schema: class, expiry N, response-expected flag, `where`, carrying-cost
+  hook.
+
+## L5 · Pricing engine (ADR-0013) — after L4; numbers gated on L6
+
+- One engine for loans, defers, funding-with-strings:
+  `cost = f(org_type [major], counterparty [major], typed_rep, purpose_hype,
+  ledger_load [minor])`.
+- Purpose-tagged fundraising (hype prices the purpose); **no internal earmarked
+  budgets**.
+- Instruments: equity (single dilution scalar v1), board seats (stub as
+  "options-curtailed" flag until DQ-7 designs voting), agenda narrowing (constrains
+  legal workstreams).
+- Tuning target: philanthropy-only is starved-but-viable (G3).
+
+## L6 · Instrumentation (EE-7, EE-8) — start immediately
+
+- **EE-8 first:** root-cause death attribution in the exploit-finder (a doom death
+  downstream of a default is a ledger death). Prerequisite to ALL tuning.
+- Exploit-finder policy space: plan policy × response policy × assignment policy ×
+  publish/socialize policy (absorbs BL-5).
+- EE-7: per-resource per-turn delta indicators; event-log improvement (loss legibility).
+
+## L7 · Save/load (EE-2, PROMOTED) — start immediately
+
+- Full state round-trip including ledger entries, triggered_events/cooldowns, and (once
+  L2 lands) workstreams. 6–8 hr runs are untestable without it; DQ-11 forking builds on
+  it.
+
+## L8 · Achievements skeleton — start anytime, small
+
+- **Observer-only contract:** achievements are read-only listeners on run events; they
+  never write back to sim or score (ADR-0002 anti-sink rule — pure recognition, no
+  in-run reward).
+- v1 set: year marks (survived 2022 / 2027 / 2032 / 2037), "first time X" local profile
+  flags. "Fastest X this season" deferred until boards (EE-4).
+- Capture convention: design sessions tag `[ACHIEVEMENT]` candidates as they come up;
+  park them in WORKSHOP_2_BACKLOG.
+
+## Provisional UI guidance (NOT an ADR — revisit at workshop #3 with real screens)
+
+Hub-and-spoke default for implementers, adopted to prevent five freelance navigation
+patterns during the rebuild: the plan screen is the hub; every screen reachable within
+~1 action of it; ESC always steps toward the hub; response windows are the only modal
+interrupts. Pip has not ratified this as doctrine — log friction against it rather than
+inventing alternatives, and it gets ruled with real screens in hand.
+
+## Old-backlog reconciliation
+
+- BL-1..3 → absorbed into L4. BL-5 → absorbed into L6. EE-2 → promoted to L7.
+- DQ-6 → batch into L1's schema bump. DQ-8 → gated behind L6 (EE-8), executed in L5+G1.
+- DQ-2 (baseline yardstick) → re-baseline as part of G1.
+- DQ-7 (governance) → still undesigned; L5 stubs board seats against it.

--- a/docs/game-design/WORKSHOP_2_BUILD_LANES.md
+++ b/docs/game-design/WORKSHOP_2_BUILD_LANES.md
@@ -25,12 +25,19 @@ The whole workshop asserts three measurable things. Bake them in as acceptance g
 ## Lane order
 
 ```
-L6 instrumentation ──┐            (start now, parallel)
-L7 save/load ────────┤            (start now, parallel)
-L8 achievements ─────┤            (start now, parallel, observer-only)
-L1 turn engine ──────┼─► L2 effort economy ─► L3 adoption+conferences
-                     └─► L4 events+ledger ──► L5 pricing engine
+L0 stabilization ────┐  (start now — behavior-preserving; replays must verify)
+L6 instrumentation ──┤  (start now, parallel)
+L7 save/load ────────┤  (start now, parallel)
+L8 achievements ─────┤  (start now, parallel, observer-only)
+L9 balance/data ─────┤  (with/after L0 — defs→JSON + Balance seam before L1)
+L10 ui extractions ──┘  (start now — event_dialog first; L1 reuses it)
+L1 turn engine (after L0+L9) ─┬─► L2 effort economy ─► L3 adoption+conferences
+                              └─► L4 events+ledger ──► L5 pricing engine
 ```
+
+Debt map for L0/L9/L10 and the clean-as-you-go conventions:
+**`docs/TECH_DEBT_REGISTER.md`** (2026-07-12 audit — live bugs, LET-DIE list,
+duplication kill-list). Never polish LET-DIE code.
 
 ## L1 · Turn engine (ADR-0009) — CRITICAL PATH
 
@@ -136,6 +143,31 @@ L1 turn engine ──────┼─► L2 effort economy ─► L3 adoption+
   flags. "Fastest X this season" deferred until boards (EE-4).
 - Capture convention: design sessions tag `[ACHIEVEMENT]` candidates as they come up;
   park them in WORKSHOP_2_BACKLOG.
+
+## L9 · Balance surface + data externalization — with/after L0, before L1
+
+- **`Balance` autoload** (Resource/JSON-backed, mirroring `scenario_loader`): the
+  tuning surface the sweep needs (DQ-8/ADR-0013 numbers become file-swaps). Migration
+  order in `TECH_DEBT_REGISTER.md` §L9 — seam first (`get_months_per_turn` +
+  time-coupled durations through the L0 Clock), then thresholds, then literals in
+  batches (current values as defaults — behavior-neutral).
+- **Definitions → data:** `events.gd` built-in + risk events →
+  `data/events/*.json` (the merge pipeline already supports it); `actions.gd`
+  definitions + risk-contribution table → `data/actions/*.json`. Engine files shrink
+  2,665 → ~600 lines before L1 touches them.
+- Wire `data/events/balancing/difficulty.json` as multipliers or delete the dormant
+  trio. Shared `ResourceAccessor` replaces the 3× resource-name match.
+
+## L10 · main_ui decomposition — start now; extract-before list only
+
+- Extract now (turn-model-independent): **`event_dialog.gd` first** (L1's response
+  windows reuse it), `ledger_screen.gd`, `employee_panel.gd` (becomes L2's assignment
+  surface), `submenu_chrome.gd`. Follow the existing child-widget mount pattern.
+- Domain dialogs (hiring/fundraising/financing/publicity/strategic/travel/operations)
+  extract DURING L2/L3 when their AP triggers die — don't polish before.
+- **LET-DIE (do not touch):** command/queue/reserve-AP/commit-plan zone, queued-actions
+  viz, AP-affordability half of the action bar. Full list + layering leaks to sever:
+  `TECH_DEBT_REGISTER.md` §L10.
 
 ## Provisional UI guidance (NOT an ADR — revisit at workshop #3 with real screens)
 

--- a/docs/game-design/WORLD_AND_LORE.md
+++ b/docs/game-design/WORLD_AND_LORE.md
@@ -26,6 +26,15 @@ despair. Papers, Please is the tonal north star: bureaucratic deadpan around eno
 stakes. Population figures, if shown, are *presentation* of the doom-integral
 ("doom-years averted"), never a separate mechanic (ADR-0002).
 
+**The event-horizon guardrail (2026-07-12).** Pip: *"we're not saying or implying labs
+*really* do any of the truly weird stuff that's going to take place later in the game."*
+The fiction's claims about recognizably-real actors stop at the run's crossing of the
+real-world event horizon; past it, the timeline is openly ours (seeds *are* timelines —
+divergence is the premise, not a disclaimer). Player influence over other labs scales up
+mostly post-horizon, so the norm-setting mechanic (ADR-0010) never reads as an
+accusation about present-day labs. Researcher archetypes are likewise flavors, never
+portraits of real people.
+
 ## The player's org / lab
 
 **Who you are.** A founder whose only unscalable resource is their own hours — action
@@ -41,6 +50,35 @@ them to test every major system (a system should be interesting to at least two)
   it; money as strategy.
 - **The Operator** — skips to networking and politicking straight into influence;
   favors as strategy.
+
+**Staff archetypes (design-test roster, 2026-07-12, DQ-15/ADR-0011).** Template: *lane /
+unmanaged drift / appetite / quirk-rider*. Drift rule (held loosely, per Pip): **default
+drift stays within-lane**; cross-lane or off-the-map drift is rare and *diagnostic* —
+bad employee, bad manager, or something seriously awry. Drift isn't laziness, it's their
+mission winning the backlog-ordering fight. Flavors, never portraits of real people
+(event-horizon guardrail).
+
+Pip's three (near-verbatim):
+1. **The people-pleaser** — interpretability / drifts to building evals / needs
+   financial stability for family / easily swayed. *Free mechanics:* rosiest
+   Celine's-law reports on the org chart (a doom-legibility hazard inside payroll);
+   cheap to retain with certainty; first to wobble in desperation payroll.
+2. **The authoritarian pessimist** — governance / drifts to identifying and combating
+   deepfakes / wants authoritarian policies, willing to trade off privacy / pessimistic.
+   *Free mechanics:* your best door to government adoption (ADR-0010), with a
+   letterhead-risk rider; typed attention splits (ministries vs civil society).
+3. **The moral crusader** — agent foundations / drifts to lobbying for software moral
+   rights / mission purity (the org must not do dual-use) / introverted coder. *Free
+   mechanics:* adoption routing makes their unsocialized work stay a PDF — needs a
+   champion; capabilities hires are a departure trigger.
+
+Fable's two, drafted for Pip's edit/veto:
+4. **The capabilities-curious optimist** — scaling-efficiency / drifts to capability
+   gains that "also help safety, really" / wants compute + a magazine cover / genuine
+   believer. The priced temptation (ADR-0010) with a face inside the org.
+5. **The burned-out ex-frontier senior** — evals / drifts to quietly writing the
+   tell-all memoir (a secret ledger entry with an exposure fuse, ADR-0003 reuse) /
+   wants absolution / cynical.
 
 ## Rival labs & organizations
 
@@ -58,16 +96,49 @@ The weirdness is honest — real AI-race epistemics look like this — and the s
 lies about itself; instruments can be fooled, but *how* they can be fooled is
 knowable, and counter-intelligence is a thing you buy (ADR-0004). Channel flavors:
 espionage (fast, dirty, corrodes your governance), alliance (slow, public, obligates
-you), media (cheap, noisy), research (deep, narrow).
+you), media (cheap, noisy), research (deep, narrow) — and **presence** (2026-07-12,
+ADR-0014): you discover actors, alliances, and intentions by *being where they are* —
+Pip: *"We discover other players in the game by encountering their units moving around
+in the playing space"* — while news/newsletters are the cheaper, lower-fidelity
+discovery. The hallway track is an intelligence channel.
 
 The political register is the whip's office: *"there are critical votes coming up, and
 people are wavering. have you got them?"* Pledges, favors, counterparty dread —
 House of Cards, not Model UN.
 
+## The endgame — 2037, a vignette (2026-07-12)
+
+Pip's answer, verbatim, to "describe one late turn" (flagged by him as pure guess; kept
+as the canonical *feel* target):
+
+> *"I am negotiating to buy rents of entire data centres. I am dealing with stakeholders
+> negotiating with global financial firms. I am being asked how people should cast votes
+> on AI treaties. I am paying rent on hiring defensive drone swarms, losing reputation
+> because my researchers are being mind-hacked by cultists, and the cat is permanently on
+> fire. A manager is asking me to approve costs to evacuate the Berlin office to a bunker
+> in Mongolia. Payroll is automated, I am notified when a currency collapses. I have 5
+> delegates to send to 10 meetings."*
+
+Design payload, unpacked:
+- **The endgame scarcity is attention and representation, not money** — "5 delegates to
+  10 meetings" is the late-game resource problem in one sentence.
+- **Delegation silences mechanics**: payroll is *automated*; a currency collapse arrives
+  as a *notification*, not a decision. What you've delegated stops asking.
+- **Managers surface approvals, not tasks** (Berlin → Mongolia bunker: you rule on the
+  cost, not the logistics).
+- Escalation of counterparties: employees → team leads → global financial firms, treaty
+  bodies, drone-swarm contractors.
+- **The cat is permanently on fire** — the domestic running gag survives to the end of
+  the world; tone anchor (the cats are already in `assets/cats/`).
+
 ## Naming & terminology
 
 - **Doom-years averted** — the score tiebreaker; area under the survival curve
-  ("the QALY of the apocalypse"). Display: **"Turn 14 · 862"**.
+  ("the QALY of the apocalypse").
+- **The badge is the date** (ADR-0009) — public score is the exact calendar day the run
+  died ("I made it to March 2034"), replacing turn-count display; internals stay
+  lexicographic days-survived · doom-integral. Years are the community's native
+  timeline vocabulary — "I survived past 2027" is a boast and a joke simultaneously.
 - **The Ledger** — payables and receivables; liabilities and favors (ADR-0003).
 - **Seeds are timelines**; a seed = RNG + event schedule (ADR-0005).
 - **Lead time** — what SA purchases actually buy (ADR-0004).
@@ -76,6 +147,8 @@ House of Cards, not Model UN.
 
 ## Change log
 
+- **2026-07-12** — Workshop #2, beat 1: endgame-2037 vignette (attention/representation
+  scarcity, delegation silences mechanics, burning cat); badge-is-the-date naming.
 - **2026-07-04** — First fill, from Fable workshop #1: time-loop framing, epitaphs and
   tone register, founder-hours AP canon, Mogul/Hustler/Operator personas, provenance
   fiction, whip register, core terminology.

--- a/docs/game-design/decisions/ADR-0009-plan-months-two-speeds.md
+++ b/docs/game-design/decisions/ADR-0009-plan-months-two-speeds.md
@@ -1,0 +1,102 @@
+# ADR-0009 — Turn structure: plan-months, two decision speeds, day as resolution tick
+
+- **Status:** ACCEPTED
+- **Date:** 2026-07-12
+- **Session:** Fable workshop #2, beat 1 (issue #604)
+
+## Context
+
+Workshop #1's intent was a week-based planning loop; the build drifted to day-turns with
+the week surviving only as display (`game_state.gd` `TURNS_PER_WEEK`, "Day 3/5" HUD).
+The drift's real shape: **decisions attached to the resolution tick.** Evidence forcing
+the ruling: exploit-finder sweep (loan terms absurd at day cadence; only safety-spam
+beats passive), and Pip's playtest notes (repetitive event loop, weirdly slow pacing,
+*instantaneous* rewards from fundraising breaking time-feel, salary cadence off).
+
+Pip fixed the fiction anchors this session: **2017 start; ~2027 early-competent loss,
+2033 decent, 2037 hard, 2040 ≈ the 1% run.** Wall-clock ruling: a decent run is a
+Civ/X-com-campaign 6–8 hours (Pip: "60% 6–8 hours, 30% evening, 10% other").
+Grain arithmetic against those anchors: week ≈ 500+ turns to an early loss (dead);
+month ≈ 114 / 186 / 234 / 270 turns; quarter ≈ 38 / 62 / 78 / 90.
+
+## Decision
+
+1. **The turn is a month.** Fixed grain, v1. Plan phase: allocate staff and founder
+   hours, queue strategic actions, explicitly set reserve (slack).
+2. **The day is demoted to resolution tick** — sim substrate, calendar, animation,
+   score resolution. **Guard rule: no mechanic may hang a routine decision on the day
+   tick.** Days are for physics and comedy.
+3. **Two decision speeds** (MtG taxonomy, none of its machinery):
+   - *Plan speed* ("sorcery") — only castable at the month boundary.
+   - *Response windows* ("instant") — an event fires mid-month and, if a window opens,
+     offers a costed menu: **HANDLE from reserve** (painless — what insurance was for) ·
+     **HANDLE by cannibalizing** (delay/kill planned WIP) · **DEFER** (mints a Liability
+     Ledger entry with named terms) · **IGNORE** (stated immediate consequence at list
+     price). Defer/ignore pricing is the ledger beat's to detail (ADR-0010, this
+     workshop).
+4. **Reserve is crisp.** Unspent slack evaporates at month end. No banking ever (Pip:
+   *"I don't think we can let players bank time"*). Overcommitting is a legal gamble.
+5. **Strategic actions have durations.** Nothing strategic resolves instantaneously;
+   effects land mid-period or at the month review (fundraising is a campaign, hiring is
+   a search → offer-interrupt → onboarding drag).
+6. **The badge is the date.** Public score = the exact calendar day the run died
+   ("I made it to March 2034"); internals unchanged — lexicographic (days survived,
+   doom-integral) per ADR-0002. Ladder texture Pip named: players overtake each other
+   *by days* while decisions lock in *months* — coarse hands, fine scoreboard.
+
+## Beacons served / violated
+
+- **Rams #10 (as little design as possible):** one cadence ruling folds the loan-term
+  absurdity, salary cadence, event pacing, and banking (deleted) — and the response menu
+  reuses the ledger as its payment rail instead of adding a system.
+- **Rams #6 (honest):** durations match fiction; a muted channel's events resolve
+  honestly at list price; the insane 25%/turn loan becomes a *nameable* desperation tier
+  at month denomination instead of a bug.
+- **MaRo Interaction:** the reserve gamble makes the plan and the event stream interlock.
+  (Does *not* by itself fix the dominant-line finding — that's payoffs, beat 2.)
+
+## Interaction contract
+
+Reads/writes ≥2 existing systems: **calendar/game_state** (month boundary, day tick),
+**Liability Ledger** (DEFER intake — the flagship gains an intake valve every run hits),
+**SA channels** (window gating: SA buys response windows, ADR-0004 cashed out; muting a
+channel = auto-resolve without a window, priced), **replay artifact** (response records),
+**exploit-finder** (policies become plan-policy × response-policy), **payroll/loans**
+(re-denominated monthly).
+
+## Rejected alternatives
+
+- **Week (the original intent):** dead against the fiction window — ~500 turns to an
+  early loss can't carry fast replays or badge legibility.
+- **Quarter:** strong candidate (evening-length runs; native quarterly-report/runway
+  fiction; turn numbers matching the old badge intuitions). Lost to Pip's wall-clock
+  preference (6–8 hr campaigns) and early-game texture. **Revisit trigger:** month-grain
+  playtests showing decent runs well over ~8 hr, or empty/repetitive mid-run months.
+- **Variable/coarsening cadence** (month → quarter as the org scales): honest fit to the
+  delegation fantasy (*"They can't go to all these weekly stand-ups, after all!"*) —
+  parked until fixed grain demonstrably fails in playtest (Rams #10 discipline).
+- **Soft reserve fallback** (idle time does low-efficiency generic work): rejected v1 —
+  crisp evaporation keeps the commitment-loss legible.
+
+## Consequences / open questions
+
+- **Re-denomination pass:** salaries → monthly payroll; loans → %/month with cost-of-debt
+  as a function (org type / hype / reputation — merges with the DEFER pricing engine,
+  agenda 3+4); event density per month; `review_period_weeks` conversion.
+- **Replay schema bump:** record `(event_id, window, choice, payment_source)` per
+  response (ADR-0001/ADR-0006 artifact versioning; adjacent to DQ-6).
+- **Exploit-finder rework:** bots need plan-level and response-level policies — real
+  work, and it upgrades the instrument (next sweep question: which *response* policy
+  dominates?).
+- **UI:** day-tick playback needs speed control + auto-pause-on-window; the month review
+  screen is the natural home for world-state progression display (Pip's playtest note:
+  progression feel is weak).
+- **Risk (~40%):** late-game dead air if interrupt density doesn't scale with era —
+  expect a per-era density tuning pass.
+- **Partially closes ADR-0008's deliberately-open wall-clock item:** decent run 6–8 hr;
+  consistent with its fixed constraints (deep-run tail "several hundred turns" ≈ 270
+  months to 2040; a noob death ~2 fiction-years ≈ 24 turns still costs well under an
+  hour).
+- **Save/fork/divergence:** Pip is open ("I don't see strong reasons why we shouldn't");
+  legal under ADR-0006's verification law (a legal replay is a legal run however
+  produced). Parked to backlog — it's ladder *norms*, not rules.

--- a/docs/game-design/decisions/ADR-0010-adoption-routing.md
+++ b/docs/game-design/decisions/ADR-0010-adoption-routing.md
@@ -1,0 +1,74 @@
+# ADR-0010 — Adoption routing (soft-with-teeth): doom bends where work is adopted
+
+- **Status:** ACCEPTED
+- **Date:** 2026-07-12
+- **Session:** Fable workshop #2, beat 2 (issue #596 root cause)
+
+## Context
+
+The exploit sweep's dominant line (`safety_lean`, basement safety-spam, median 37 turns
+vs 7 for passive) exists because safety research bends doom **directly, privately, and
+state-independently** — papers are decorative, conferences float disconnected. Pip's
+paper taxonomy (this session): papers raise awareness, build the *writer's* reputation,
+speed follow-on work, and get **adopted** — into government policy or frontier-lab
+practice, including rivals'. Pip's normative ground, verbatim:
+
+> *"people voluntarily adopting good actions will generate the space for better actions
+> to come about, and this is how small and middle power players can affect things —
+> norm and market setting"*
+
+## Decision
+
+**Soft-with-teeth routing:**
+
+1. **Your own lab's doom contribution is basement-fixable.** Private safety work makes
+   *your* lab safer, no adoption required. (Honest: you really can secure your own shop
+   in private.)
+2. **World/rival doom — the majority share (#562 rival scaling) — bends only through
+   adoption:** research → paper → socialization (conferences, summits, direct
+   stakeholder work) → adoption by labs and/or governments → doom bends. Unadopted
+   world-facing research is a PDF.
+3. **Reputation is per-person and per-org**, and attention is *typed*: safety successes
+   attract interviews/grants/safety applicants; reckless capability moves attract accel
+   VC money. Both directions are priced, neither is forbidden (the dual-use temptation
+   is a design feature — see DESIGN_PHILOSOPHY, tension/tradeoffs).
+4. Papers additionally speed follow-on work (tech-tree effect) and unlock mitigations.
+5. **Event-horizon guardrail (lore):** the player's influence over other labs becomes
+   substantial mostly *after* the run crosses the real-world event horizon — the game
+   never implies real labs do the truly weird late-game stuff. (WORLD_AND_LORE.)
+
+## Beacons served / violated
+
+- **Rams #6 (honest):** the mechanic *is* Pip's real-world theory of change — norm and
+  market setting by small/middle powers. Structure, not numbers; don't patch it for
+  freshness (per the philosophy doc's load-bearing-structure rule).
+- **MaRo Interaction:** research, reputation, conferences, and rivals now interlock;
+  the social layer stops being decoration.
+- Kills the dominant line **by construction**: basement-spam can't reach the dominant
+  doom mass, so no payoff buff to safety-spam can restore it.
+
+## Interaction contract
+
+Reads/writes: **rival-doom pipeline** (#562 — rival share must dominate the integral
+for teeth), **reputation** (per-person + per-org, new read/write), **conference/travel**
+(promoted from flavor to load-bearing — the socialization step), **Liability Ledger**
+(funding-with-strings, promises), **SA** (awareness essays raise it), **exploit-finder**
+(new sweep target: publish-and-socialize must beat basement-spam).
+
+## Rejected alternatives
+
+- **Strong routing** (ALL safety value requires adoption): less honest — you can
+  privately secure your own lab — and it needlessly breaks the existing own-lab safety
+  architecture.
+- **Status quo** (direct doom reduction): sweep-proven degenerate.
+
+## Consequences / open questions
+
+- Safety research splits: **internal hardening** (own-lab, private) vs **publishable
+  agendas** (world-facing, adoption-routed).
+- Conference/travel design (agenda item 4) is promoted: it's now the mandatory middle of
+  the value chain, not garnish.
+- Balance verification target for the next sweep: rival/world doom share must dominate
+  the integral, or the teeth are cosmetic.
+- Adoption *by whom* needs a counterparty model — overlaps ADR-0007 alliances and DQ-9
+  receivables; design together.

--- a/docs/game-design/decisions/ADR-0011-effort-economy.md
+++ b/docs/game-design/decisions/ADR-0011-effort-economy.md
@@ -1,0 +1,84 @@
+# ADR-0011 — The effort economy: founder hours, staff lanes, manager compression
+
+- **Status:** ACCEPTED (shape); researcher archetype roster content owed (DQ-15)
+- **Date:** 2026-07-12
+- **Session:** Fable workshop #2, beat 2 (issue #596)
+
+## Context
+
+Current build: one global AP pool, spent instantly; staff add to the pool; researchers
+are single-function; banking exists but does nothing. The sweep's diagnosis in mechanism
+terms: one fungible currency + state-independent payoffs ⇒ constant-policy argmax
+(`safety_lean`) dominates. Pip's rulings across beats 1–2: banking is dead (ADR-0009);
+*"I have never been around unassigned workers before, because there's always been a
+backlog"*; *"each new employee is kinda cutting down the time I need to do other
+things"*; managers *"stop employees from annoying me with employee things."*
+
+## Decision
+
+1. **No global AP pool.** The pool illusion dies; staff never add founder AP.
+2. **Founder hours** (sacred, roughly fixed per month — canon since ADR-0008): spent on
+   **doors** (stakeholder face-time; which rooms you're in locks strategic paths),
+   **approvals** (hires, direction rulings — "approve this salary," not paperwork
+   clicks), **audits** (skip-level ground-truthing), and **reserve** (instant-speed
+   firefighting, ADR-0009).
+3. **Staff effort is per-person**, assigned at plan speed to workstreams from a backlog.
+   **Idle staff don't exist; unmanaged staff do** — unassigned researchers self-direct
+   per their agenda (whose ordering of the backlog wins?).
+4. **Workstreams** run multi-month and produce artifacts (papers, systems, campaigns) —
+   ADR-0009's no-instant-strategy rule, cashed out.
+5. **Managers are interrupt shields with agenda riders:** they absorb their team's class
+   of response windows (ADR-0009 economy), compress the plan screen (team → allocation
+   + standing policy; members visually housed under the manager), and report upward via
+   a **Celine's-law channel** — an inward SA channel with fidelity loss. The sim never
+   lies; *characters do*. Skip-level audits (founder hours) re-ground truth. Folds
+   ADR-0008's deferred inward-SA into existing SA machinery.
+6. **Ops/admin staff reduce the founder-price of routine actions** and automate whole
+   classes over time (endpoint: 2037 vignette's "payroll is automated").
+7. **The dual-use lane is priced:** capabilities work pays money/compute/hype and bills
+   doom (with ADR-0010's typed attention: accel VCs fund reckless success).
+8. **Researcher model (shape):** *lane preference* (fictionalized real agendas — e.g.
+   interpretability, evals, theory/agent-foundations, governance) × *appetites* (compute,
+   prestige/first-author, mentees, money, mission purity — **promises made to retain
+   staff are ledger entries**) × rare *quirk riders* (philosophical stances, secret
+   successionist — an exposure-event genre reusing ADR-0003 machinery, not a lane).
+
+## Beacons served / violated
+
+- **Rams #10:** managers reuse the window economy + SA channels; quirks reuse exposure
+  events; banking deleted; no new player-facing currency — typed effort is a *split* of
+  an existing one.
+- **MaRo Interaction:** typed lanes force a portfolio; with ADR-0010, the constant
+  policy is structurally unavailable, not merely under-rewarded.
+- **Honest:** "nobody wants to bring the boss bad news" — late-discovered doom via rosy
+  reporting mirrors the real failure mode.
+
+## Interaction contract
+
+Reads/writes: **response windows** (ADR-0009 — manager value denominated there),
+**SA** (inward channel, fidelity, audits), **Liability Ledger** (agenda riders, retention
+promises, dual-use bills), **reputation** (per-person, ADR-0010 — hires are reputation
+seeds who recruit juniors), **replay/exploit-finder** (assignment policies join the
+policy space).
+
+## Rejected alternatives
+
+- **Global pool with staff as AP-adders:** sweep-proven degenerate; also violates
+  founder-hours canon.
+- **Idle unassigned staff:** no such thing ("there's always a backlog").
+- **Managers as output multipliers:** rejected — their value is founder-attention
+  arbitrage, not throughput.
+- **Soft reserve fallback:** already rejected in ADR-0009.
+
+## Consequences / open questions
+
+- **DQ-15:** researcher archetype roster — Pip to author 3–5 vignette-style archetypes
+  (lane / unmanaged drift / appetite / optional quirk).
+- Plan-screen redesign: assignment UI, manager housing, team-satisfaction report
+  replacing per-member detail under management.
+- Retention/morale stays minimal v1: appetites bite through promises (ledger) and
+  departure riders, not a mood sim (ADR-0008 register: "bother," not HR gravity).
+- Sweep target: a managed portfolio must beat every constant line; new bot policy axes
+  (assignment + response + publish/socialize).
+- Balance seam: founder-hour prices for doors/audits/approvals are the new tuning
+  surface — they set the whole game's attention economy.

--- a/docs/game-design/decisions/ADR-0012-event-response-taxonomy.md
+++ b/docs/game-design/decisions/ADR-0012-event-response-taxonomy.md
@@ -1,0 +1,83 @@
+# ADR-0012 — Event response taxonomy: un-snoozable, deferrable, expiring
+
+- **Status:** ACCEPTED
+- **Date:** 2026-07-12
+- **Session:** Fable workshop #2, beat 3 (ledger bite)
+
+## Context
+
+ADR-0009 gave every response window a DEFER option routing through the Ledger. Left
+uniform, DEFER becomes a universal snooze button and the reserve-vs-greed gamble loses
+its sting (why hold reserve when everything waits?). Pip's ruling drew the taxonomy from
+real-world texture: some things wait expensively, some don't wait at all, and some
+correctly get no response.
+
+## Decision
+
+Four event classes:
+
+1. **Un-snoozable** — the window closes this turn: HANDLE (reserve or cannibalize) or
+   IGNORE at list price; DEFER is not for sale. Pip's classes: **movement of people
+   across state borders; emergency services; threat of legal action; scenario/story
+   events.** This class is what keeps reserve worth holding.
+2. **Deferrable** — DEFER mints a Ledger entry with a carrying cost priced per-event by
+   the ADR-0013 engine.
+3. **Standing offers** — open for N turns, then expire to a natural no-engage (possible
+   reputation loss where a response was expected). Expiry mints **no** ledger entry —
+   the offer simply evaporates.
+4. **No-action-correct** — some events legitimately deserve nothing. Taking no action
+   is not always a mistake, and the game must not punish it uniformly.
+
+**The infinite to-do list is diegetic.** Standing offers and deferrals may accumulate
+past what the UI foregrounds; items falling out of visibility is a *real phenomenon
+being modeled*, not a UI bug. Pip, verbatim: *"Doom Arrives With Your To-Do List Being
+Infinitely Long Still is a real possibility that I'm not shy of playing into."*
+
+**The ledger's kill path is a cascade, not a death screen.** Entries are called due;
+if you can't pay, consequences execute: unpaid staff work on for a period suffering
+damage → leave → work lost/abandoned → severe reputation penalties → credit lockout →
+funding starvation → rival pulls ahead → doom spikes. The ledger doesn't kill you — it
+feeds you to the thing that does, legibly. Register: **tragedy** ("I saw it coming"),
+which requires the player to have had a *real chance* to raise money in the interim —
+hence:
+
+**Fundraising has lead time.** Money lands turns after the raise begins (ADR-0009's
+duration rule applied to cash). Core tension named: **spiky-in, smooth-out** cash flow,
+with cash as the game's most fungible resource.
+
+## Beacons served / violated
+
+- **Rams #6 (honest):** the taxonomy mirrors real deferability; the infinite backlog is
+  played straight instead of hidden.
+- **Rams #10:** standing offers and no-action events need no ledger machinery at all;
+  only true deferrals touch the flagship.
+- **MaRo Interaction:** un-snoozables make reserve (ADR-0009) and event content
+  interlock; the cascade chains ledger → staff → reputation → funding → rival → doom.
+
+## Interaction contract
+
+Reads/writes: **response windows** (ADR-0009), **Ledger** (defer intake + called-due
+cascade), **reputation** (expiry losses, default penalties), **staff** (unpaid-work
+damage, departures, abandoned work), **rival pipeline** (funding starvation → rival
+lead), **ADR-0013 pricing engine** (carrying costs).
+
+## Rejected alternatives
+
+- **Universal DEFER** (everything snoozable): kills the reserve gamble.
+- **Ledger death as its own game-over type:** rejected — defaults cascade into the
+  existing doom/cash deaths through legible intermediate wreckage.
+- **Expiry-as-liability** (expired offers mint entries): rejected — evaporation is the
+  honest model for most offers, and the ledger should carry *chosen* debts.
+
+## Consequences / open questions
+
+- **Event content schema:** class field, expiry N, response-expected flag, carrying-cost
+  hook.
+- **Exploit-finder must attribute deaths to root-cause chains** — a doom death
+  downstream of a default is a *ledger* death for balance accounting; "dies of doom"
+  currently hides the cascade. Instrument before tuning.
+- **UI (backlog'd):** per-resource per-turn delta indicators; event-log improvement —
+  the one human ledger-death specimen (turn 23) was low-resolution because the player
+  couldn't see the spiral; legibility work is what makes future specimens usable.
+- Class shares per era (how much of the event stream is un-snoozable) — a tuning
+  surface, sweep-driven.

--- a/docs/game-design/decisions/ADR-0013-cost-of-debt-engine.md
+++ b/docs/game-design/decisions/ADR-0013-cost-of-debt-engine.md
@@ -1,0 +1,82 @@
+# ADR-0013 — Financing instruments & the cost-of-debt engine
+
+- **Status:** ACCEPTED (shape; numbers owed to the sweep)
+- **Date:** 2026-07-12
+- **Session:** Fable workshop #2, beat 3 (agenda items 3+4 merged)
+
+## Context
+
+Flat 25%/turn loans were a day-cadence artifact (ADR-0009) and a placeholder (DQ-8).
+With DEFER routing through the Ledger (ADR-0009/0012), loan terms and defer
+carrying-costs need one pricing engine, or the two halves of the flagship drift apart.
+
+## Decision
+
+**One pricing engine for all liabilities** (loans, defers, funding-with-strings),
+taking these arguments at Pip's weights:
+
+- **Org type — major.** Set at character/org creation; ties directly to building
+  early-game agency into setup (DQ-4 adjacent; "the opening is a commitment device").
+- **Counterparty / stakeholder risk & interest — major.** Who you owe changes what it
+  costs (VC, government, philanthropist, rival's proxy — counterparty dread lives here,
+  ADR-0007 register).
+- **Reputation — typed.** Safety-rep and finance-rep price debt *differently*, and
+  reputation affects grants, equity raises, and loans through different channels
+  (ADR-0010 typed attention, applied to capital).
+- **Hype — scoped to the raise's purpose.** Fundraising is purpose-tagged and the hype
+  cycle prices the purpose; **no internal earmarked budgets** (rejected as fiddly —
+  granularity lives in the raise, not the spend).
+- **Existing ledger load — minor direct**, mostly indirect through reputation and
+  counterparty appetite.
+
+**Instruments beyond debt** (all Ledger objects):
+
+- **Equity** (for-profits): early capital comes on good terms but eats equity — and
+  equity is a more valuable bargaining chip mid/late game. Selling cheap early is a
+  priced regret.
+- **Board seats** (nonprofits' equity-approximate): cash for seats that *curtail the
+  player's options in voting mechanisms* (hard dependency on DQ-7 governance design).
+- **Research-agenda narrowing**: cash for scope — the funder's strings constrain which
+  workstreams are legal.
+
+**The early-game curve, stated as design intent:** pure philanthropy is starved — the
+first thing players feel is the difficulty of getting enough cash in the door from any
+purely philanthropic approach. Trading (equity, agenda, capabilities work) buys speed —
+reputation and publication pipelines spike faster — and bills against **late-game
+optionality** (the capabilities route compromises later government/political
+influence). Financing is "every mitigation is a loan" applied to itself.
+
+## Beacons served / violated
+
+- **Rams #6:** an honest cost-of-capital function — org type, counterparty, reputation,
+  purpose — instead of a flat magic number.
+- **MaRo Interaction:** capital now interlocks with reputation (typed), hype, governance
+  (board seats), and the rival race.
+- The PoE exponential-difficulty ladder gets its mechanism: compounding early trades
+  *are* the difficulty curve (ADR-0003 thesis, now with a pricing engine).
+
+## Interaction contract
+
+Reads/writes: **Ledger** (all instruments are entries), **reputation** (typed, both
+directions), **hype cycle** (purpose pricing), **char/org creation** (org type; DQ-4),
+**governance/voting** (board seats curtail votes — DQ-7 now has a customer),
+**rival pipeline** (funding starvation cascade, ADR-0012).
+
+## Rejected alternatives
+
+- **Flat rates:** day-cadence placeholder, dies with ADR-0009.
+- **Internal earmarked budgets** (money "for" things): fiddly; purpose granularity
+  lives in the raise.
+- **Separate pricing for loans vs defers:** one engine or the flagship forks.
+
+## Consequences / open questions
+
+- **Numbers owed to the sweep** (DQ-8): rate curves per org type/counterparty, equity
+  dilution schedule, board-seat prices. Instrument root-cause death attribution first
+  (ADR-0012) or tuning is blind.
+- **DQ-7 (governance)** is now load-bearing twice over: the board-seat instrument needs
+  the voting mechanics it curtails.
+- Equity model granularity (cap table vs a single dilution scalar) — start scalar
+  (Rams #10), upgrade only if bargaining-chip play demands it.
+- Character/org setup design (org type as the pricing engine's biggest input) — feeds
+  the early-game agency thread.

--- a/docs/game-design/decisions/ADR-0014-conferences-presence-location.md
+++ b/docs/game-design/decisions/ADR-0014-conferences-presence-location.md
@@ -1,0 +1,74 @@
+# ADR-0014 — Conferences, presence, and minimal location
+
+- **Status:** ACCEPTED (v1 shape; yields/numbers owed to the sweep)
+- **Date:** 2026-07-12
+- **Session:** Fable workshop #2, closing beat
+
+## Context
+
+ADR-0010 made socialization the mandatory middle of the research→adoption value chain
+with no ruling on what attending *is*. Pip's rulings, this beat, with one ambition
+flagged: *"Part of me wants to make a conference attendance subgame, that's how critical
+I think these kinds of things are going to be for the game."* (Subgame parked; v1 is
+attendance + yields.)
+
+## Decision
+
+1. **Conferences are scheduled world events on the seed timeline** (ADR-0005 schedule
+   entries — the geopolitics-as-content pattern, reused). Annual majors announce ~9
+   months ahead: plannable at plan speed, and opening theory can grow around known
+   calendars. **Smaller/exclusive gatherings unlock behind contacts or safety
+   reputation** — invitation-gated event stream.
+2. **Founder attendance ≫ delegate attendance.** Founder pays founder-hours + travel
+   cash and gets the full yield: meaningful options opened, first-degree connections,
+   SA boosts. Delegates (a staff-month + travel cash) yield less but give coverage —
+   the 2037 "5 delegates to 10 meetings" scarcity, seeded from turn one. Travel cash
+   deliberately bites early (spiky cash flow, ADR-0012).
+3. **Conferences are accelerants and discovery venues, not the adoption roll itself.**
+   Adoption happens out in the world (ADR-0010); attendance *speeds* adoption of your
+   published work, builds reputation mechanically faster (especially introductions),
+   and **mints contacts-as-receivables** — the Ledger's friendly column gets its content
+   source (DQ-9's customer).
+4. **Discovery-by-presence.** You discover actors, alliances, and intentions by being
+   where they are (the units-moving-on-the-map analog); news/newsletters are the
+   cheaper, lower-fidelity discovery channel. Presence is effectively an SA channel
+   flavor alongside espionage/alliance/media/research.
+5. **Location exists minimally in v1:** HQ defaults American (park foreign legal-regime
+   modeling); the player can substantially base teams overseas — cheaper hires, with
+   different downstream influence/politics effects (mid/late-game payoff). Event schema
+   carries `where` from day one.
+6. **Ad-hoc meetings/opportunities stay instant-speed windows** (ADR-0009/0012), some
+   gated by contacts/rep. (Pip's "book a longer trip for planned meetings" instinct is
+   week-grain thinking — at month grain the trip is a plan allocation.)
+
+## Beacons served / violated
+
+- **MaRo Interaction:** conferences interlock papers (ADR-0010), reputation, SA,
+  receivables, travel cash, and founder-hours — six systems, zero new currencies.
+- **Rams #10:** accelerant not a new mechanic; schedule entries not a system; subgame
+  parked; foreign law parked.
+- **Rams #6:** this is how the field actually works — the hallway track is where
+  adoption starts.
+
+## Interaction contract
+
+Reads/writes: **seed schedule** (ADR-0005 entries + 9-month announcements), **founder
+hours** (ADR-0011), **cash** (travel), **reputation** (typed, per-person — delegate
+yield should scale with the delegate's own reputation), **SA** (presence channel),
+**Ledger receivables** (contacts; DQ-9), **adoption pipeline** (ADR-0010 accelerant).
+
+## Rejected alternatives
+
+- **Adoption rolls at the conference itself:** adoption lives in the world; conferences
+  only accelerate it.
+- **Full geo/legal modeling in v1:** parked; `where` field + overseas basing only.
+- **Conference subgame in v1:** parked to backlog as a flagged ambition.
+
+## Consequences / open questions
+
+- Yield numbers, invitation thresholds, travel prices — sweep-tuned (after EE-8).
+- Receivable/contact object format — design with DQ-9 + ADR-0007 counterparties.
+- Delegate yield scaling with per-person reputation (hires as reputation seeds,
+  ADR-0011) — natural, verify it doesn't make star-delegate spam dominant.
+- Overseas-basing downstream effects (influence/politics) — mid/late-game content,
+  design at workshop #3.


### PR DESCRIPTION
## Fable design workshop #2 — full session bundle

Workshop #2 reacted to the exploit-finder sweep (only safety-spam beats passive; 0 ledger deaths) and human playtest evidence. Six ADRs, an implementation work order, and philosophy/lore/backlog growth.

### Decisions
- **ADR-0009** — turn = 1 month (plan phase), day demoted to resolution tick, two decision speeds (plan / response windows), crisp reserve, action durations, **badge is the death date**. Closes #604.
- **ADR-0010** — adoption routing (soft-with-teeth): own-lab doom basement-fixable; world/rival doom bends only via publish→socialize→adoption. Kills the dominant line by construction.
- **ADR-0011** — effort economy: global AP pool deleted; founder hours (doors/approvals/audits/reserve); per-person staff lanes; managers as interrupt shields with Celine's-law reports. With ADR-0010, closes #596.
- **ADR-0012** — event taxonomy (un-snoozable / deferrable / standing-offer / no-action); DEFER mints ledger entries; called-due cascade; fundraising lead time.
- **ADR-0013** — one cost-of-debt engine for all liabilities: f(org type, counterparty, typed rep, purpose-hype); equity/board-seat/agenda-narrowing instruments; philanthropy starved by design.
- **ADR-0014** — conferences as scheduled accelerants + discovery-by-presence; minimal location (`where` field, overseas basing).

### Work order
`WORKSHOP_2_BUILD_LANES.md` — lanes L1–L8 with dependencies and **sweep gates G1–G3** as acceptance criteria (no constant policy dominates; publish-and-socialize beats basement-spam; distinct viable openings).

### Also
- DESIGN_PHILOSOPHY: +11 entries (Pip's words, capture protocol)
- WORLD_AND_LORE: 2037 endgame vignette, staff archetype roster, event-horizon guardrail, presence SA channel, date-badge naming
- WORKSHOP_2_BACKLOG: DQ-11..17, EE-7..8, old-item reconciliation (BL-1..3→L4, BL-5→L6, EE-2 promoted to L7)
- Kickoff doc stamped EXECUTED

🤖 Generated with [Claude Code](https://claude.com/claude-code)