### PR TITLE
feat: L7 save/load full-state round-trip (#618)

### DIFF
--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -32,6 +32,11 @@ var current_game_active: bool = false
 var games_played: int = 0
 var config_mode: String = "default"  # "default" = weekly seed (locked), "custom" = user configured
 
+# L7 (#618) save/load handoff (transient, not saved to config file): the welcome
+# screen sets this before switching to main.tscn; MainUI's autostart consumes it
+# and boots GameManager.load_saved_game() instead of start_new_game().
+var pending_load_path: String = ""
+
 # Version tracking for What's New feature
 var last_seen_version: String = ""  # Empty = never seen patch notes
 const CURRENT_VERSION: String = "0.11.0"

--- a/godot/scenes/pause_menu.tscn
+++ b/godot/scenes/pause_menu.tscn
@@ -160,6 +160,13 @@ size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 16
 text = "Resume Game (ESC)"
 
+[node name="SaveButton" type="Button" parent="Panel/VBox/ButtonContainer"]
+custom_minimum_size = Vector2(250, 40)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 16
+text = "Save Game"
+
 [node name="MainMenuButton" type="Button" parent="Panel/VBox/ButtonContainer"]
 custom_minimum_size = Vector2(250, 40)
 layout_mode = 2
@@ -178,5 +185,6 @@ text = "Quit to Desktop"
 [connection signal="value_changed" from="Panel/VBox/SettingsContainer/AudioSettings/SFXVolumeRow/Slider" to="." method="_on_sfx_volume_changed"]
 [connection signal="value_changed" from="Panel/VBox/SettingsContainer/AudioSettings/MusicVolumeRow/Slider" to="." method="_on_music_volume_changed"]
 [connection signal="pressed" from="Panel/VBox/ButtonContainer/ResumeButton" to="." method="_on_resume_pressed"]
+[connection signal="pressed" from="Panel/VBox/ButtonContainer/SaveButton" to="." method="_on_save_pressed"]
 [connection signal="pressed" from="Panel/VBox/ButtonContainer/MainMenuButton" to="." method="_on_main_menu_pressed"]
 [connection signal="pressed" from="Panel/VBox/ButtonContainer/QuitButton" to="." method="_on_quit_pressed"]

--- a/godot/scenes/welcome.tscn
+++ b/godot/scenes/welcome.tscn
@@ -130,6 +130,19 @@ theme_override_styles/pressed = SubResource("StyleBoxFlat_pressed")
 theme_override_styles/focus = SubResource("StyleBoxFlat_focus")
 text = "Launch Lab"
 
+[node name="LoadGameButton" type="Button" parent="VBox/MenuContainer"]
+custom_minimum_size = Vector2(400, 50)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/font_pressed_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 24
+theme_override_styles/normal = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover = SubResource("StyleBoxFlat_hover")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_pressed")
+theme_override_styles/focus = SubResource("StyleBoxFlat_focus")
+text = "Load Game"
+
 [node name="CustomSeedButton" type="Button" parent="VBox/MenuContainer"]
 custom_minimum_size = Vector2(400, 50)
 layout_mode = 2

--- a/godot/scripts/core/doom_system.gd
+++ b/godot/scripts/core/doom_system.gd
@@ -426,16 +426,18 @@ func to_dict() -> Dictionary:
 		"current_doom": current_doom,
 		"doom_velocity": doom_velocity,
 		"doom_momentum": doom_momentum,
+		"pending_rival_doom": _pending_rival_doom,  # L7 (#618): mid-turn buffer, 0 between turns
 		"doom_sources": doom_sources.duplicate(),
 		"doom_multipliers": doom_multipliers.duplicate(),
 		"doom_modifiers": doom_modifiers.duplicate()
 	}
 
 func from_dict(data: Dictionary):
-	"""Deserialize doom system state"""
-	current_doom = data.get("current_doom", 50.0)
-	doom_velocity = data.get("doom_velocity", 0.0)
-	doom_momentum = data.get("doom_momentum", 0.0)
+	"""Deserialize doom system state (explicit float casts: JSON numbers arrive as float)"""
+	current_doom = float(data.get("current_doom", 50.0))
+	doom_velocity = float(data.get("doom_velocity", 0.0))
+	doom_momentum = float(data.get("doom_momentum", 0.0))
+	_pending_rival_doom = float(data.get("pending_rival_doom", 0.0))
 	if data.has("doom_sources"):
 		doom_sources = data["doom_sources"].duplicate()
 	if data.has("doom_multipliers"):

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -738,28 +738,56 @@ static func format_score(turns: int, integral: int) -> String:
 	return "Turn %d · %d" % [turns, integral]
 
 
+# ============================================================================
+# SERIALIZATION — SAVE/LOAD CONVENTION (L7, #618)
+#
+# to_dict() is BOTH the UI payload and the save-file state body; from_dict()
+# must rebuild an equivalent GameState from it. The invariant the round-trip
+# test enforces: from_dict(to_dict()) — including a JSON stringify/parse hop —
+# yields a state whose to_dict() is deep-equal AND whose next turn is
+# turn-for-turn identical (rng stream included).
+#
+# Rules for registering new state (L2 workstreams and later systems):
+#   1. Every stateful subsystem owns its own to_dict()/from_dict() pair
+#      (see Ledger, DoomSystem, RiskPool, Researcher, RivalLab, PaperSubmission).
+#   2. GameState composes them under ONE stable top-level key per subsystem;
+#      from_dict() restores under the same key. Add both sides in the same PR.
+#   3. JSON-safe values only: String/float/int/bool/Array/Dictionary. No
+#      Callables or object refs. int64s that can exceed 2^53 (e.g. rng state)
+#      travel as Strings, because JSON parses every number back as float.
+#   4. from_dict() casts explicitly (int()/float()/String()) and loop-appends
+#      into typed arrays — JSON hands back untyped floats and untyped Arrays.
+#   5. Derived/display values (turn_display, tech_debt_color, rival summaries,
+#      available_ap, ...) are recomputed, never restored.
+#   6. Extend tests/unit/test_save_load_roundtrip.gd so the new state is
+#      exercised before the save point.
+#
+# Replay (ADR-0006) is unaffected: it rebuilds from turn 0. This is SNAPSHOT
+# fidelity for mid-game save/load (and later DQ-11 fork/divergence).
+# ============================================================================
+
 func to_dict() -> Dictionary:
-	"""Serialize state for UI"""
+	"""Serialize state for UI + save/load (see convention block above)"""
 	var rival_summaries = []
+	var rival_full_dicts = []
 	for rival in rival_labs:
 		rival_summaries.append(RivalLabs.get_rival_summary(rival))
+		rival_full_dicts.append(rival.to_dict())
 
 	# Sync doom from doom system
 	if doom_system:
 		doom = doom_system.current_doom
 
-	# Get doom system data
+	# Doom system data: the persistent core comes from doom_system.to_dict() (so
+	# multipliers/modifiers round-trip — previously hand-rolled and lossy), plus
+	# derived display strings the UI reads.
 	var doom_data = {}
 	if doom_system:
-		doom_data = {
-			"doom": doom,
-			"doom_velocity": doom_system.doom_velocity,
-			"doom_momentum": doom_system.doom_momentum,
-			"doom_trend": doom_system._get_doom_trend(),
-			"doom_status": doom_system.get_doom_status(),
-			"momentum_description": doom_system.get_momentum_description(),
-			"doom_sources": doom_system.doom_sources.duplicate()
-		}
+		doom_data = doom_system.to_dict()
+		doom_data["doom"] = doom
+		doom_data["doom_trend"] = doom_system._get_doom_trend()
+		doom_data["doom_status"] = doom_system.get_doom_status()
+		doom_data["momentum_description"] = doom_system.get_momentum_description()
 	else:
 		doom_data = {"doom": doom}
 
@@ -777,6 +805,11 @@ func to_dict() -> Dictionary:
 	var candidate_dicts = []
 	for candidate in candidate_pool:
 		candidate_dicts.append(candidate.to_dict())
+
+	# Pending-hire queue (FIFO of selected candidates)
+	var pending_hire_dicts = []
+	for candidate in pending_hire_queue:
+		pending_hire_dicts.append(candidate.to_dict())
 
 	# Serialize paper submissions (Issue #468)
 	var paper_dicts = []
@@ -826,48 +859,129 @@ func to_dict() -> Dictionary:
 		"researchers": researcher_dicts,
 		"candidate_pool": candidate_dicts,
 		"paper_submissions": paper_dicts,
-		"attended_conferences": attended_conferences
+		"attended_conferences": attended_conferences,
+		# --- Full-fidelity save/load fields (L7, #618) ---
+		"game_seed": game_seed_str,
+		"rng_state": str(rng.state) if rng else "",  # int64 as String (JSON floats lose precision past 2^53)
+		"event_schedule": event_schedule.duplicate(true),  # WS-C: part of seed identity
+		"triggered_events": triggered_events.duplicate(),  # WS-0 registry (was forgotten by from_dict)
+		"event_cooldowns": event_cooldowns.duplicate(),    # WS-0 registry (was forgotten by from_dict)
+		"queued_actions": queued_actions.duplicate(),
+		"pending_events": pending_events.duplicate(true),  # event defs are pure-data dicts
+		"current_phase": current_phase,
+		"can_end_turn": can_end_turn,
+		"used_event_ap": used_event_ap,
+		"max_action_points": max_action_points,  # difficulty modifier — next-turn AP base
+		"conference_year": conference_year,
+		"start_year": start_year,
+		"start_month": start_month,
+		"start_day": start_day,
+		"pending_hire_queue": pending_hire_dicts,
+		"rival_labs_full": rival_full_dicts  # "rival_labs" stays display summaries for the UI
 	}
 
 
 func from_dict(data: Dictionary) -> void:
-	"""Restore game state from serialized data (for save/load)"""
+	"""Restore game state from serialized data (for save/load).
+	L7 (#618): full-fidelity — see SERIALIZATION CONVENTION block above to_dict().
+	Explicit int()/float()/String() casts throughout: JSON parses every number as float."""
 	# Core resources
-	money = data.get("money", 100000)
-	compute = data.get("compute", 0.0)
-	research = data.get("research", 0.0)
-	research_quality_mode = data.get("research_quality_mode", DEFAULT_RESEARCH_QUALITY)  # Issue #500
-	papers = data.get("papers", 0)
-	reputation = data.get("reputation", 10.0)
-	doom = data.get("doom", 50.0)
+	money = float(data.get("money", 100000.0))
+	compute = float(data.get("compute", 0.0))
+	research = float(data.get("research", 0.0))
+	research_quality_mode = String(data.get("research_quality_mode", DEFAULT_RESEARCH_QUALITY))  # Issue #500
+	papers = float(data.get("papers", 0.0))
+	reputation = float(data.get("reputation", 10.0))
+	governance = float(data.get("governance", 50.0))  # was forgotten pre-L7
+	doom = float(data.get("doom", 50.0))
 	doom_history.clear()
 	for d in data.get("doom_history", []):
 		doom_history.append(float(d))
-	action_points = data.get("action_points", 3)
-	committed_ap = data.get("committed_ap", 0)
-	reserved_ap = data.get("reserved_ap", 0)
-	stationery = data.get("stationery", 100.0)
-	technical_debt = data.get("technical_debt", 0.0)
+	action_points = int(data.get("action_points", 3))
+	max_action_points = int(data.get("max_action_points", 3))
+	committed_ap = int(data.get("committed_ap", 0))
+	reserved_ap = int(data.get("reserved_ap", 0))
+	used_event_ap = int(data.get("used_event_ap", 0))
+	stationery = float(data.get("stationery", 100.0))
+	technical_debt = float(data.get("technical_debt", 0.0))
 
 	# Staff counts (legacy)
-	safety_researchers = data.get("safety_researchers", 0)
-	capability_researchers = data.get("capability_researchers", 0)
-	compute_engineers = data.get("compute_engineers", 0)
-	managers = data.get("managers", 0)
+	safety_researchers = int(data.get("safety_researchers", 0))
+	capability_researchers = int(data.get("capability_researchers", 0))
+	compute_engineers = int(data.get("compute_engineers", 0))
+	managers = int(data.get("managers", 0))
 
 	# Game state
-	turn = data.get("turn", 0)
-	doom_integral = data.get("doom_integral", 0.0)
-	game_over = data.get("game_over", false)
-	victory = data.get("victory", false)
-	has_cat = data.get("has_cat", false)
+	turn = int(data.get("turn", 0))
+	doom_integral = float(data.get("doom_integral", 0.0))
+	game_over = bool(data.get("game_over", false))
+	victory = bool(data.get("victory", false))
+	has_cat = bool(data.get("has_cat", false))
 	# Handle typed arrays properly
 	purchased_upgrades.clear()
 	for upgrade in data.get("purchased_upgrades", []):
-		purchased_upgrades.append(upgrade)
+		purchased_upgrades.append(String(upgrade))
 	attended_conferences.clear()
 	for conf in data.get("attended_conferences", []):
-		attended_conferences.append(conf)
+		attended_conferences.append(String(conf))
+
+	# Calendar / conference-year (scenario start dates travel with the save)
+	start_year = int(data.get("start_year", start_year))
+	start_month = int(data.get("start_month", start_month))
+	start_day = int(data.get("start_day", start_day))
+	conference_year = int(data.get("conference_year", start_year))
+
+	# Turn-phase / planning state (mid-turn snapshot fidelity)
+	current_phase = int(data.get("current_phase", TurnPhase.ACTION_SELECTION)) as TurnPhase
+	can_end_turn = bool(data.get("can_end_turn", false))
+	queued_actions.clear()
+	for a in data.get("queued_actions", []):
+		queued_actions.append(String(a))
+	pending_events.clear()
+	for ev in data.get("pending_events", []):
+		if ev is Dictionary:
+			pending_events.append(ev.duplicate(true))
+
+	# WS-0 event-firing registry (the known-forgotten pair this lane exists for)
+	triggered_events.clear()
+	for eid in data.get("triggered_events", []):
+		triggered_events.append(String(eid))
+	event_cooldowns.clear()
+	var cooldown_data = data.get("event_cooldowns", {})
+	if cooldown_data is Dictionary:
+		for eid in cooldown_data.keys():
+			event_cooldowns[String(eid)] = int(cooldown_data[eid])
+
+	# WS-C scheduled causes (seed identity — survives reset(), must survive load too)
+	var schedule_data = data.get("event_schedule", null)
+	if schedule_data is Array:
+		event_schedule = []
+		for cause in schedule_data:
+			if cause is Dictionary:
+				var c = cause.duplicate(true)
+				if c.has("turn"):
+					c["turn"] = int(c["turn"])
+				event_schedule.append(c)
+
+	# Deterministic RNG: reseed from the seed string, then restore the exact
+	# stream position. Without this, a loaded game diverges from an unsaved
+	# continuation on the very next randf().
+	var seed_str = String(data.get("game_seed", ""))
+	if seed_str != "":
+		game_seed_str = seed_str
+		if rng == null:
+			rng = RandomNumberGenerator.new()
+		rng.seed = hash(game_seed_str)
+	var rng_state_data = data.get("rng_state", "")
+	if rng and rng_state_data is String and rng_state_data != "":
+		rng.state = rng_state_data.to_int()
+	elif rng and (rng_state_data is int or rng_state_data is float):
+		rng.state = int(rng_state_data)
+
+	# Restore the Liability Ledger (WS-1 — entries were forgotten pre-L7)
+	if ledger == null:
+		ledger = Ledger.new()
+	ledger.from_dict(data.get("ledger", {}))
 
 	# Restore doom system
 	if doom_system and data.has("doom_system"):
@@ -892,6 +1006,21 @@ func from_dict(data: Dictionary) -> void:
 			var candidate = Researcher.new()
 			candidate.from_dict(candidate_data)
 			candidate_pool.append(candidate)
+
+	# Restore pending-hire queue (FIFO)
+	pending_hire_queue.clear()
+	if data.has("pending_hire_queue"):
+		for candidate_data in data["pending_hire_queue"]:
+			var pending = Researcher.new()
+			pending.from_dict(candidate_data)
+			pending_hire_queue.append(pending)
+
+	# Restore rival labs (full state; "rival_labs" key is display summaries only)
+	if data.has("rival_labs_full"):
+		rival_labs.clear()
+		for rival_data in data["rival_labs_full"]:
+			if rival_data is Dictionary:
+				rival_labs.append(RivalLabs.RivalLab.from_dict(rival_data))
 
 	# Restore paper submissions
 	paper_submissions.clear()

--- a/godot/scripts/core/ledger.gd
+++ b/godot/scripts/core/ledger.gd
@@ -42,10 +42,27 @@ class Entry:
 
 	func to_dict() -> Dictionary:
 		return {
+			"id": id,
 			"source": source, "currency": currency, "principal": principal,
 			"fuse": fuse, "interest": interest, "secret": secret,
 			"side": side, "counterparty": counterparty, "settled": settled,
 		}
+
+	## L7 (#618): rebuild an Entry from serialized data. Numeric casts are explicit
+	## because JSON round-trips every number as float.
+	static func from_dict(d: Dictionary) -> Entry:
+		var e := Entry.new(
+			String(d.get("source", "")),
+			String(d.get("currency", "money")),
+			float(d.get("principal", 0.0)),
+			int(d.get("fuse", 0)),
+			float(d.get("interest", 0.0)),
+			bool(d.get("secret", false)),
+			int(d.get("side", Side.PAYABLE)),
+			String(d.get("counterparty", "")))
+		e.id = String(d.get("id", ""))
+		e.settled = bool(d.get("settled", false))
+		return e
 
 # How hard an unpayable money bill converts to doom — the "teeth" that guarantee
 # mortality when a debtor cannot cover a balloon payment. Config, not scattered magic.
@@ -182,6 +199,11 @@ func check_exposures(state, chance: float) -> Array:
 	return exposed
 
 func to_dict() -> Dictionary:
+	# Summary keys (outstanding_*, entry_count, ...) are consumed by the UI; "entries"
+	# carries the full per-entry state so a mid-game save/load round-trips (L7, #618).
+	var entry_dicts := []
+	for e in entries:
+		entry_dicts.append(e.to_dict())
 	return {
 		"outstanding_payable": outstanding(Side.PAYABLE),
 		"outstanding_receivable": outstanding(Side.RECEIVABLE),
@@ -189,4 +211,18 @@ func to_dict() -> Dictionary:
 		"secret_count": secret_entries().size(),
 		"soonest_fuse": soonest_fuse(),
 		"death_attribution": death_attribution.duplicate(true),
+		"entries": entry_dicts,
 	}
+
+
+## L7 (#618): restore the full ledger — every entry (incl. settled post-mortem trail)
+## and the death-attribution list. Summary keys are derived on read, so ignored here.
+func from_dict(data: Dictionary) -> void:
+	entries.clear()
+	for ed in data.get("entries", []):
+		if ed is Dictionary:
+			entries.append(Entry.from_dict(ed))
+	death_attribution.clear()
+	for a in data.get("death_attribution", []):
+		if a is Dictionary:
+			death_attribution.append(a.duplicate(true))

--- a/godot/scripts/core/paper_submissions.gd
+++ b/godot/scripts/core/paper_submissions.gd
@@ -79,19 +79,23 @@ class PaperSubmission:
 		}
 
 	static func from_dict(data: Dictionary) -> PaperSubmission:
+		# L7 (#618): explicit casts — JSON round-trips ints as floats, and an untyped
+		# JSON array cannot be assigned to the typed Array[String] member directly.
 		var paper = PaperSubmission.new()
-		paper.id = data.get("id", paper.id)
-		paper.title = data.get("title", "")
-		paper.target_conference_id = data.get("target_conference_id", "")
-		paper.submit_turn = data.get("submit_turn", -1)
-		paper.decision_turn = data.get("decision_turn", -1)
-		paper.presentation_deadline_turn = data.get("presentation_deadline_turn", -1)
-		paper.status = data.get("status", Status.DRAFTING)
-		paper.quality = data.get("quality", 0.5)
-		paper.topic = data.get("topic", Topic.SAFETY)
-		paper.research_invested = data.get("research_invested", 0.0)
-		paper.lead_researcher_name = data.get("lead_researcher_name", "")
-		paper.co_author_names = data.get("co_author_names", [])
+		paper.id = String(data.get("id", paper.id))
+		paper.title = String(data.get("title", ""))
+		paper.target_conference_id = String(data.get("target_conference_id", ""))
+		paper.submit_turn = int(data.get("submit_turn", -1))
+		paper.decision_turn = int(data.get("decision_turn", -1))
+		paper.presentation_deadline_turn = int(data.get("presentation_deadline_turn", -1))
+		paper.status = int(data.get("status", Status.DRAFTING))
+		paper.quality = float(data.get("quality", 0.5))
+		paper.topic = int(data.get("topic", Topic.SAFETY))
+		paper.research_invested = float(data.get("research_invested", 0.0))
+		paper.lead_researcher_name = String(data.get("lead_researcher_name", ""))
+		paper.co_author_names.clear()
+		for n in data.get("co_author_names", []):
+			paper.co_author_names.append(String(n))
 		return paper
 
 # ============================================

--- a/godot/scripts/core/researcher.gd
+++ b/godot/scripts/core/researcher.gd
@@ -407,18 +407,18 @@ func to_dict() -> Dictionary:
 	}
 
 func from_dict(data: Dictionary):
-	"""Deserialize from dictionary"""
-	researcher_name = data.get("name", "")
-	specialization = data.get("specialization", "safety")
-	skill_level = data.get("skill_level", 5)
-	salary_expectation = data.get("salary_expectation", 60000.0)
-	current_salary = data.get("current_salary", 60000.0)
-	base_productivity = data.get("base_productivity", 1.0)
-	loyalty = data.get("loyalty", 50)
-	burnout = data.get("burnout", 0.0)
-	turns_employed = data.get("turns_employed", 0)
-	jet_lag_turns = data.get("jet_lag_turns", 0)
-	jet_lag_severity = data.get("jet_lag_severity", 0.0)
+	"""Deserialize from dictionary (L7 #618: explicit casts — JSON numbers arrive as float)"""
+	researcher_name = String(data.get("name", ""))
+	specialization = String(data.get("specialization", "safety"))
+	skill_level = int(data.get("skill_level", 5))
+	salary_expectation = float(data.get("salary_expectation", 60000.0))
+	current_salary = float(data.get("current_salary", 60000.0))
+	base_productivity = float(data.get("base_productivity", 1.0))
+	loyalty = int(data.get("loyalty", 50))
+	burnout = float(data.get("burnout", 0.0))
+	turns_employed = int(data.get("turns_employed", 0))
+	jet_lag_turns = int(data.get("jet_lag_turns", 0))
+	jet_lag_severity = float(data.get("jet_lag_severity", 0.0))
 
 	if data.has("traits"):
 		traits.clear()

--- a/godot/scripts/core/rivals.gd
+++ b/godot/scripts/core/rivals.gd
@@ -54,6 +54,45 @@ class RivalLab:
 			return name + " (rumored)"
 		return name
 
+	## L7 (#618): full-state serialization. Everything mutable during a run
+	## (progress, funding, reputation, discovery state) must round-trip; identity
+	## fields (name, aggression, description) travel too so a save is self-contained.
+	func to_dict() -> Dictionary:
+		return {
+			"id": id,
+			"name": name,
+			"safety_progress": safety_progress,
+			"capability_progress": capability_progress,
+			"funding": funding,
+			"reputation": reputation,
+			"aggression": aggression,
+			"visibility": visibility,
+			"discovery_turn": discovery_turn,
+			"discovery_threshold": discovery_threshold,
+			"is_starter": is_starter,
+			"description": description,
+			"focus": focus,
+			"estimated_funding": estimated_funding,
+			"estimated_reputation": estimated_reputation,
+		}
+
+	static func from_dict(d: Dictionary) -> RivalLab:
+		var lab := RivalLab.new(String(d.get("name", "")), float(d.get("aggression", 0.5)))
+		lab.id = String(d.get("id", lab.id))
+		lab.safety_progress = float(d.get("safety_progress", 0.0))
+		lab.capability_progress = float(d.get("capability_progress", 0.0))
+		lab.funding = float(d.get("funding", 200000.0))
+		lab.reputation = float(d.get("reputation", 50.0))
+		lab.visibility = int(d.get("visibility", VisibilityState.KNOWN))
+		lab.discovery_turn = int(d.get("discovery_turn", -1))
+		lab.discovery_threshold = float(d.get("discovery_threshold", 0.0))
+		lab.is_starter = bool(d.get("is_starter", true))
+		lab.description = String(d.get("description", ""))
+		lab.focus = String(d.get("focus", lab.focus))
+		lab.estimated_funding = float(d.get("estimated_funding", 0.0))
+		lab.estimated_reputation = float(d.get("estimated_reputation", 0.0))
+		return lab
+
 static func get_rival_labs() -> Array[RivalLab]:
 	var rivals: Array[RivalLab] = []
 

--- a/godot/scripts/core/save_load.gd
+++ b/godot/scripts/core/save_load.gd
@@ -36,7 +36,10 @@ static func save_game(state: GameState, path: String = QUICKSAVE_PATH) -> Error:
 	var f := FileAccess.open(path, FileAccess.WRITE)
 	if f == null:
 		return FileAccess.get_open_error()
-	f.store_string(JSON.stringify(build_envelope(state), "\t"))
+	# full_precision=true is LOAD-BEARING: the default truncates float decimals,
+	# which shifts every restored float by ulps — the drift then compounds turn
+	# over turn, so a loaded game would slowly diverge from an unsaved one.
+	f.store_string(JSON.stringify(build_envelope(state), "\t", true, true))
 	f.close()
 	print("[SaveLoad] Saved turn %d to %s" % [state.turn, path])
 	return OK

--- a/godot/scripts/core/save_load.gd
+++ b/godot/scripts/core/save_load.gd
@@ -1,0 +1,77 @@
+extends RefCounted
+class_name SaveLoad
+## L7 (#618): mid-game save/load — snapshot fidelity for 6-8 hr runs (EE-2, promoted).
+##
+## A save file is a JSON envelope:
+##   { save_format, game_version, saved_at, scenario_id, state: GameState.to_dict() }
+## The state body follows the SERIALIZATION CONVENTION documented above
+## GameState.to_dict() (JSON-safe values, int64s as Strings, derived fields ignored).
+##
+## Replay (ADR-0006) rebuilds from turn 0 and is untouched by this; DQ-11
+## fork/divergence builds on this same envelope later.
+
+const SAVE_DIR := "user://saves"
+const QUICKSAVE_PATH := "user://saves/quicksave.json"
+const SAVE_FORMAT := 1
+
+
+static func build_envelope(state: GameState) -> Dictionary:
+	return {
+		"save_format": SAVE_FORMAT,
+		"game_version": GameConfig.CURRENT_VERSION,
+		"saved_at": Time.get_datetime_string_from_system(),
+		# Scenario custom events live as node meta (Issue #483), not in state
+		# serialization — record the pack id so load can re-attach them.
+		"scenario_id": GameConfig.scenario_id,
+		"state": state.to_dict(),
+	}
+
+
+static func save_game(state: GameState, path: String = QUICKSAVE_PATH) -> Error:
+	if state == null:
+		return ERR_INVALID_PARAMETER
+	var err := DirAccess.make_dir_recursive_absolute(SAVE_DIR)
+	if err != OK and err != ERR_ALREADY_EXISTS:
+		return err
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	if f == null:
+		return FileAccess.get_open_error()
+	f.store_string(JSON.stringify(build_envelope(state), "\t"))
+	f.close()
+	print("[SaveLoad] Saved turn %d to %s" % [state.turn, path])
+	return OK
+
+
+static func has_save(path: String = QUICKSAVE_PATH) -> bool:
+	return FileAccess.file_exists(path)
+
+
+static func load_envelope(path: String = QUICKSAVE_PATH) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {}
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return {}
+	var text := f.get_as_text()
+	f.close()
+	var parsed = JSON.parse_string(text)
+	if not (parsed is Dictionary):
+		print("[SaveLoad] Corrupt save (not a JSON object): %s" % path)
+		return {}
+	return parsed
+
+
+## Rebuild a GameState from an envelope. Returns null on failure.
+## The caller owns the returned Node (GameState extends Node).
+static func restore_state(envelope: Dictionary) -> GameState:
+	var sd = envelope.get("state", {})
+	if not (sd is Dictionary) or sd.is_empty():
+		return null
+	var schedule: Array = []
+	if sd.get("event_schedule", null) is Array:
+		schedule = sd["event_schedule"]
+	# Seed + schedule are constructor-time identity (WS-C); from_dict then
+	# overwrites every member — including the rng stream position.
+	var state := GameState.new(String(sd.get("game_seed", "")), schedule)
+	state.from_dict(sd)
+	return state

--- a/godot/scripts/core/save_load.gd.uid
+++ b/godot/scripts/core/save_load.gd.uid
@@ -1,0 +1,1 @@
+uid://di06d8gkggrvv

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -438,6 +438,65 @@ func get_game_state() -> Dictionary:
 		return state.to_dict()
 	return {}
 
+# ============================================================================
+# SAVE / LOAD (L7, #618) — mid-game snapshot, full-state fidelity
+# ============================================================================
+
+func save_game(path: String = SaveLoad.QUICKSAVE_PATH) -> bool:
+	"""Snapshot the current game to a save file. Safe to call from the pause menu."""
+	if not is_initialized or state == null:
+		error_occurred.emit("Cannot save: no game in progress")
+		return false
+	var err := SaveLoad.save_game(state, path)
+	if err != OK:
+		error_occurred.emit("Save failed (error %d)" % err)
+		return false
+	action_executed.emit({"success": true, "message": "Game saved (turn %d)" % state.turn})
+	return true
+
+func load_saved_game(path: String = SaveLoad.QUICKSAVE_PATH) -> bool:
+	"""Restore a saved game and resume exactly where it left off (phase, queued
+	actions, pending events, rng stream). Returns false if no/corrupt save."""
+	var envelope := SaveLoad.load_envelope(path)
+	if envelope.is_empty():
+		error_occurred.emit("No save found to load")
+		return false
+	var loaded := SaveLoad.restore_state(envelope)
+	if loaded == null:
+		error_occurred.emit("Save file is corrupt or incompatible")
+		return false
+	if state != null:
+		state.queue_free()  # GameState extends Node; drop the old instance
+	state = loaded
+	# Scenario custom events live as node meta (Issue #483), not in state
+	# serialization — re-attach them from the pack recorded in the envelope.
+	var save_scenario_id := String(envelope.get("scenario_id", ""))
+	if not save_scenario_id.is_empty():
+		var loader = ScenarioLoader.new()
+		var scenario = loader.load_scenario(save_scenario_id)
+		var custom_events = scenario.get("events", [])
+		if custom_events.size() > 0:
+			state.set_meta("scenario_events", custom_events)
+	turn_manager = TurnManager.new(state)
+	is_initialized = true
+	# NOTE: replay verification rebuilds from turn 0 (ADR-0006); a loaded session
+	# is a snapshot continuation, so tracking restarts here only to keep the
+	# in-turn recording calls alive — the artifact is not replay-verifiable.
+	VerificationTracker.start_tracking(state.game_seed_str, GameConfig.CURRENT_VERSION)
+	MusicManager.play_context(MusicManager.MusicContext.GAMEPLAY)
+	print("[GameManager] Loaded save %s — turn %d, phase %s" % [
+		path, state.turn, GameState.TurnPhase.keys()[state.current_phase]])
+	game_state_updated.emit(state.to_dict())
+	if state.pending_events.size() > 0:
+		# Saved mid-event-resolution: surface the pending events again.
+		turn_phase_changed.emit("turn_start")
+		for event in state.pending_events:
+			event_triggered.emit(event)
+	else:
+		turn_phase_changed.emit("action_selection")
+		actions_available.emit(turn_manager.get_available_actions())
+	return true
+
 func resolve_event(event: Dictionary, choice_id: String):
 	"""Handle player's event choice - FIX #418: Use TurnManager"""
 	if not is_initialized:

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -395,8 +395,17 @@ func _trigger_action_by_index(index: int):
 			log_message("[color=cyan]Keyboard shortcut: %d[/color]" % (index + 1))
 
 func _on_init_button_pressed():
-	log_message("[color=cyan]Initializing game...[/color]")
 	init_button.disabled = true
+	# L7 (#618): if the welcome screen queued a saved game, boot into it instead
+	# of starting a new run. The flag is one-shot.
+	if GameConfig.pending_load_path != "":
+		var load_path: String = GameConfig.pending_load_path
+		GameConfig.pending_load_path = ""
+		log_message("[color=cyan]Loading saved game...[/color]")
+		if game_manager.load_saved_game(load_path):
+			return
+		log_message("[color=red]Load failed — starting a new game instead.[/color]")
+	log_message("[color=cyan]Initializing game...[/color]")
 	game_manager.start_new_game("test-seed")
 
 func _on_test_action_button_pressed():

--- a/godot/scripts/ui/pause_menu.gd
+++ b/godot/scripts/ui/pause_menu.gd
@@ -47,6 +47,19 @@ func _on_resume_pressed():
 	hide()
 	get_tree().paused = false
 
+func _on_save_pressed():
+	"""L7 (#618): snapshot the current game to the quicksave slot."""
+	var save_button: Button = $Panel/VBox/ButtonContainer/SaveButton
+	var gm = get_node_or_null("../GameManager")  # sibling at main.tscn root
+	if gm == null or not gm.has_method("save_game"):
+		print("[PauseMenu] Save failed: GameManager not found")
+		save_button.text = "Save failed"
+		return
+	if gm.save_game():
+		save_button.text = "Saved!"
+	else:
+		save_button.text = "Save failed"
+
 func _on_main_menu_pressed():
 	"""Return to main menu"""
 	print("[PauseMenu] Returning to main menu...")
@@ -64,6 +77,7 @@ func show_pause_menu():
 	"""Show the pause menu and pause the game"""
 	print("[PauseMenu] Pausing game...")
 	update_ui_from_game_config()
+	$Panel/VBox/ButtonContainer/SaveButton.text = "Save Game"  # reset any "Saved!" feedback
 	show()
 	get_tree().paused = true
 

--- a/godot/scripts/ui/welcome_screen.gd
+++ b/godot/scripts/ui/welcome_screen.gd
@@ -5,6 +5,7 @@ extends Control
 @onready var subtitle_label = $VBox/Subtitle
 @onready var menu_container = $VBox/MenuContainer
 @onready var launch_lab_button = $VBox/MenuContainer/LaunchLabButton
+@onready var load_game_button = $VBox/MenuContainer/LoadGameButton
 @onready var custom_seed_button = $VBox/MenuContainer/CustomSeedButton
 @onready var settings_button = $VBox/MenuContainer/SettingsButton
 @onready var guide_button = $VBox/MenuContainer/GuideButton
@@ -31,6 +32,7 @@ func _ready():
 	# Collect all menu buttons in order
 	menu_buttons = [
 		launch_lab_button,
+		load_game_button,
 		custom_seed_button,
 		settings_button,
 		guide_button,
@@ -43,6 +45,7 @@ func _ready():
 
 	# Connect button signals
 	launch_lab_button.pressed.connect(_on_launch_lab_pressed)
+	load_game_button.pressed.connect(_on_load_game_pressed)
 	custom_seed_button.pressed.connect(_on_custom_seed_pressed)
 	settings_button.pressed.connect(_on_settings_pressed)
 	guide_button.pressed.connect(_on_guide_pressed)
@@ -51,6 +54,11 @@ func _ready():
 	whats_new_button.pressed.connect(_on_whats_new_pressed)
 	ai_safety_button.pressed.connect(_on_ai_safety_pressed)
 	exit_button.pressed.connect(_on_exit_pressed)
+
+	# L7 (#618): Load Game only makes sense when a quicksave exists.
+	load_game_button.disabled = not SaveLoad.has_save()
+	if load_game_button.disabled:
+		load_game_button.text = "Load Game (no save)"
 
 	# Always-visible DEV BUILD corner badge (version + git stamp) so a playtester can
 	# confirm which build he's on right from the welcome/loading screen.
@@ -124,6 +132,17 @@ func _on_launch_lab_pressed():
 	if err != OK:
 		print("[WelcomeScreen] ERROR: Failed to load config confirmation scene, error code: ", err)
 		push_error("Failed to load config_confirmation.tscn")
+
+func _on_load_game_pressed():
+	"""L7 (#618): resume the quicksave. MainUI's autostart consumes the flag."""
+	if not SaveLoad.has_save():
+		return
+	print("[WelcomeScreen] Loading saved game...")
+	GameConfig.pending_load_path = SaveLoad.QUICKSAVE_PATH
+	var err = get_tree().change_scene_to_file("res://scenes/main.tscn")
+	if err != OK:
+		GameConfig.pending_load_path = ""
+		print("[WelcomeScreen] ERROR: Failed to load main scene, error code: ", err)
 
 func _on_custom_seed_pressed():
 	print("[WelcomeScreen] Opening pre-game setup...")

--- a/godot/tests/unit/test_save_load_roundtrip.gd
+++ b/godot/tests/unit/test_save_load_roundtrip.gd
@@ -1,0 +1,202 @@
+extends GutTest
+## L7 (#618) — mid-game save/load round-trip. THE lane acceptance criterion.
+##
+## Plays N turns with a fixed seed (events resolved deterministically, ledger
+## entries injected, a researcher hired, a paper in flight, an action queued
+## mid-planning), saves through the REAL JSON file path, restores into a fresh
+## GameState, then asserts:
+##   1. to_dict() deep-equality (JSON-normalized both sides),
+##   2. the previously-forgotten fields (EE-2) explicitly,
+##   3. the next turn produces byte-identical state in both continuations
+##      (rng stream position included).
+##
+## Replay (ADR-0006) rebuilds from turn 0 and is untouched; this is snapshot
+## fidelity. See the SERIALIZATION CONVENTION block above GameState.to_dict().
+
+const SEED := "l7-roundtrip-seed"
+const TURNS_BEFORE_SAVE := 8
+const TEST_SAVE_NAME := "test_l7_roundtrip.json"
+const TEST_SAVE_PATH := "user://saves/" + TEST_SAVE_NAME
+
+
+func after_each():
+	var dir := DirAccess.open("user://saves")
+	if dir and dir.file_exists(TEST_SAVE_NAME):
+		dir.remove(TEST_SAVE_NAME)
+
+
+# --- deterministic turn driving -------------------------------------------------
+
+func _resolve_pending_events(tm: TurnManager, state: GameState) -> void:
+	# First affordable option wins — a pure function of state, so the pre-save run
+	# and the post-load continuation make identical choices.
+	var guard := 0
+	while state.pending_events.size() > 0 and guard < 50:
+		guard += 1
+		var event: Dictionary = state.pending_events[0]
+		var resolved := false
+		for opt in event.get("options", []):
+			if state.can_afford(opt.get("costs", {})):
+				var res = tm.resolve_event(event, opt.get("id", ""))
+				if res.get("success", false):
+					resolved = true
+					break
+		if not resolved:
+			# No affordable option: drop the event (mirrors BaselineSimulator) and
+			# keep the phase machine consistent.
+			state.pending_events.remove_at(0)
+			if state.pending_events.size() == 0:
+				state.current_phase = GameState.TurnPhase.ACTION_SELECTION
+				state.can_end_turn = true
+
+
+func _play_full_turn(tm: TurnManager, state: GameState) -> void:
+	tm.start_turn()
+	_resolve_pending_events(tm, state)
+	tm.execute_turn()
+
+
+func _end_turn(tm: TurnManager, state: GameState) -> void:
+	# Mirrors GameManager.end_turn(): committed AP converts to spent AP.
+	state.action_points -= state.committed_ap
+	state.committed_ap = 0
+	tm.execute_turn()
+
+
+# --- comparison helpers ----------------------------------------------------------
+
+func _norm(d: Dictionary) -> String:
+	# JSON round-trip both sides so int-vs-float and typed-vs-untyped array
+	# representation differences cannot mask (or fake) a divergence.
+	# full_precision=true so a single-ulp float drift is a FAILURE, not noise.
+	return JSON.stringify(JSON.parse_string(JSON.stringify(d, "", true, true)), "", true, true)
+
+
+func _report_divergence(a_json: String, b_json: String) -> void:
+	var a: Dictionary = JSON.parse_string(a_json)
+	var b: Dictionary = JSON.parse_string(b_json)
+	for k in a.keys():
+		var va := JSON.stringify(a[k])
+		var vb := JSON.stringify(b.get(k))
+		if va != vb:
+			gut.p("  DIVERGES [%s]\n    saved =%s\n    loaded=%s" % [k, va, vb])
+	for k in b.keys():
+		if not a.has(k):
+			gut.p("  EXTRA KEY in loaded [%s]" % k)
+
+
+func _assert_states_equal(state1: GameState, state2: GameState, context: String) -> void:
+	var d1 := _norm(state1.to_dict())
+	var d2 := _norm(state2.to_dict())
+	if d1 != d2:
+		gut.p("Round-trip divergence (%s):" % context)
+		_report_divergence(d1, d2)
+	assert_eq(d1, d2, "to_dict must be deep-equal: %s" % context)
+
+
+# --- a mid-game state worth saving ----------------------------------------------
+
+func _build_midgame(state: GameState, tm: TurnManager) -> void:
+	# Cash buffer so the injected loan bills without bankrupting the run inside
+	# the test horizon (deterministic either way, but alive is a stronger test).
+	state.add_resources({"money": 500000.0})
+	# Start low: the early doom ramp (rival momentum) reaches 100 by ~turn 5 from
+	# the default 50, and this test wants a run that is still ALIVE at the save.
+	state.doom = 5.0
+	state.doom_system.current_doom = 5.0
+
+	for i in range(3):
+		_play_full_turn(tm, state)
+
+	# WS-1 ledger content (BL-1: no clickable ledger actions yet, so inject):
+	# a compounding loan that will bill before the save point, and a small
+	# SECRET governance entry that stays live across it.
+	state.ledger.add(Ledger.loan(50000.0))
+	state.ledger.add(Ledger.Entry.new("test_secret", "governance", 500.0, 6, 0.1, true))
+
+	# A hired researcher (traits/skill round-trip) and a rushed research stance.
+	if state.candidate_pool.size() > 0:
+		state.hire_candidate(state.candidate_pool[0])
+	state.set_research_quality("rushed")
+	state.add_technical_debt(12.0, "roundtrip test")
+
+	# A paper in flight (Issue #468 structures).
+	var paper := PaperSubmissions.PaperSubmission.new()
+	paper.title = "Round-trip fidelity of latent snapshots"
+	paper.target_conference_id = "neurips_2017"
+	paper.status = PaperSubmissions.Status.UNDER_REVIEW
+	paper.submit_turn = state.turn
+	paper.quality = 0.7
+	paper.topic = PaperSubmissions.Topic.INTERPRETABILITY
+	paper.lead_researcher_name = "R. Oundtrip"
+	paper.co_author_names.append("A. Turing")
+	state.add_paper_submission(paper)
+
+	for i in range(TURNS_BEFORE_SAVE - 3):
+		_play_full_turn(tm, state)
+
+
+# --- the acceptance test ----------------------------------------------------------
+
+func test_save_load_roundtrip_deep_equality_and_next_turn_identical():
+	var state1: GameState = autofree(GameState.new(SEED))
+	var tm1: TurnManager = autofree(TurnManager.new(state1))
+	_build_midgame(state1, tm1)
+	assert_false(state1.game_over, "run must still be alive at the save point")
+	assert_gt(state1.triggered_events.size() + state1.event_cooldowns.size(), 0,
+		"test horizon should have fired at least one event (else the WS-0 registry check is vacuous)")
+	assert_gt(state1.ledger.entries.size(), 0, "ledger must have entries at the save point")
+
+	# Mid-planning snapshot: an action queued but not yet executed
+	# (mirrors GameManager.select_action's bookkeeping).
+	state1.queued_actions.append("fundraise")
+	state1.committed_ap += 1
+
+	# SAVE -> LOAD through the real file path (JSON coercions included).
+	assert_eq(SaveLoad.save_game(state1, TEST_SAVE_PATH), OK, "save must write")
+	assert_true(SaveLoad.has_save(TEST_SAVE_PATH), "save file must exist")
+	var envelope := SaveLoad.load_envelope(TEST_SAVE_PATH)
+	assert_false(envelope.is_empty(), "envelope must parse")
+	var state2: GameState = autofree(SaveLoad.restore_state(envelope))
+	assert_not_null(state2, "state must restore")
+
+	# 1) Deep equality of the full serialized state.
+	_assert_states_equal(state1, state2, "immediately after load")
+
+	# 2) The previously-forgotten fields (EE-2 + audit), explicitly.
+	assert_eq(state2.triggered_events, state1.triggered_events, "WS-0 triggered_events")
+	assert_eq(JSON.stringify(state2.event_cooldowns), JSON.stringify(state1.event_cooldowns), "WS-0 event_cooldowns")
+	assert_eq(state2.ledger.entries.size(), state1.ledger.entries.size(), "WS-1 ledger entries")
+	for i in range(state1.ledger.entries.size()):
+		assert_eq(state2.ledger.entries[i].to_dict(), state1.ledger.entries[i].to_dict(),
+			"ledger entry %d" % i)
+	assert_eq(state2.governance, state1.governance, "governance")
+	assert_eq(state2.queued_actions, state1.queued_actions, "queued_actions")
+	assert_eq(state2.committed_ap, state1.committed_ap, "committed_ap")
+	assert_eq(state2.max_action_points, state1.max_action_points, "max_action_points (difficulty)")
+	assert_eq(state2.rng.state, state1.rng.state, "rng stream position")
+	assert_eq(state2.rival_labs.size(), state1.rival_labs.size(), "rival count")
+	for i in range(state1.rival_labs.size()):
+		assert_eq(state2.rival_labs[i].to_dict(), state1.rival_labs[i].to_dict(), "rival %d" % i)
+
+	# 3) The next turn must be identical in both continuations: execute the
+	# queued action, then run a full further turn including event resolution.
+	var tm2: TurnManager = autofree(TurnManager.new(state2))
+	_end_turn(tm1, state1)
+	_end_turn(tm2, state2)
+	_assert_states_equal(state1, state2, "after executing the queued turn")
+
+	tm1.start_turn()
+	tm2.start_turn()
+	_resolve_pending_events(tm1, state1)
+	_resolve_pending_events(tm2, state2)
+	tm1.execute_turn()
+	tm2.execute_turn()
+	_assert_states_equal(state1, state2, "after one further full turn (rng stream continuity)")
+
+
+func test_restore_state_returns_null_for_garbage():
+	assert_null(SaveLoad.restore_state({}), "empty envelope -> null")
+	assert_null(SaveLoad.restore_state({"state": "not a dict"}), "non-dict state -> null")
+	assert_true(SaveLoad.load_envelope("user://saves/does_not_exist.json").is_empty(),
+		"missing file -> empty envelope")

--- a/godot/tests/unit/test_save_load_roundtrip.gd.uid
+++ b/godot/tests/unit/test_save_load_roundtrip.gd.uid
@@ -1,0 +1,1 @@
+uid://d2fycqp6shttq


### PR DESCRIPTION
Closes #618 (EE-2, promoted by ADR-0009). Work order: WORKSHOP_2_BUILD_LANES.md §L7.

Mid-game save/load with full snapshot fidelity: save from the pause menu, load from the welcome screen, and the loaded game continues **byte-identical** to the unsaved one — rng stream included. Replay (ADR-0006) rebuilds from turn 0 and is untouched.

## Gap audit — to_dict/from_dict vs GameState's actual members

**Missing from BOTH to_dict and from_dict:**
1. **RNG stream** (`game_seed_str` + `RandomNumberGenerator.state`) — a loaded game diverged from an unsaved continuation on the very first `randf()`; state travels as a String (int64 exceeds JSON float precision)
2. `triggered_events` (WS-0 registry) — the known EE-2 gap
3. `event_cooldowns` (WS-0 registry) — the known EE-2 gap
4. `event_schedule` (WS-C scheduled causes — part of seed identity)
5. `queued_actions` (mid-planning snapshot)
6. `pending_events` (mid-event-resolution snapshot; event defs are pure-data dicts)
7. `current_phase` + `can_end_turn` (turn phase machine)
8. `used_event_ap` (AP reserve system; only the derived `event_ap` was serialized)
9. `max_action_points` — difficulty modifier (Easy=4/Hard=2) silently reverted to 3 on load; next start_turn recomputed AP from the wrong base
10. **Rival labs full state** — only display summary strings were saved; funding/progress/visibility/discovery reset to `_init` defaults on load (rival doom pressure reset). `RivalLab.to_dict/from_dict` added; full state under new `rival_labs_full` key (`rival_labs` stays UI summaries)
11. `conference_year` — annual attended-conference reset would misfire
12. `start_year/month/day` — scenario start dates lost (calendar + historical-event gating)
13. `pending_hire_queue`

**In to_dict but NOT restored by from_dict:**
14. `governance` (ADR-0003 resource) — reset to default 50 on load
15. **Ledger (WS-1)** — `Ledger.to_dict` was summary-only (no entries), no `Ledger.from_dict`, `Entry` had no `from_dict` and omitted `id`. Entries incl. settled post-mortem trail + `death_attribution` now round-trip

**Lossy nested serialization:**
16. GameState's doom_system block was hand-rolled — omitted `doom_multipliers`/`doom_modifiers` (which `DoomSystem.from_dict` already supported) and `_pending_rival_doom`; now composes `doom_system.to_dict()` + display extras

**Hardening found en route:**
- JSON coercion: every number parses back as float — explicit `int()/float()/String()` casts across all `from_dict` paths (GameState, Researcher, PaperSubmission, DoomSystem, Entry, RivalLab)
- `PaperSubmission.co_author_names`: untyped JSON array assigned to a typed `Array[String]` member → runtime type error on any load with co-authors; now loop-appended
- **Save files must be written with `JSON.stringify(..., full_precision=true)`** — the default truncates float decimals, shifting every restored float by ulps that compound into visible divergence within one turn (caught by the round-trip test's next-turn assertion)

## L2 registration convention
Documented in a comment block above `GameState.to_dict()`: each subsystem owns a JSON-safe `to_dict/from_dict` pair; GameState composes under one stable key per subsystem; int64s as Strings; derived fields recomputed never restored; extend the round-trip test in the same PR.

## UX (kept minimal per lane brief)
- Pause menu: **Save Game** button → `user://saves/quicksave.json` (feedback via button text)
- Welcome screen: **Load Game** button (disabled when no save); handoff via `GameConfig.pending_load_path`, consumed by MainUI's autostart
- `GameManager.save_game()/load_saved_game()`: rebuilds GameState + TurnManager, re-attaches scenario event meta (#483), re-emits state/phase/pending-event signals so the UI resumes in place

## Test evidence (lane acceptance)
`tests/unit/test_save_load_roundtrip.gd`: plays 8 turns on a fixed seed (events resolved deterministically, ledger loan + secret entry injected — incl. an exposure→blackmail chain, researcher hired, paper in flight, action queued mid-planning), saves through the real JSON file path, restores fresh, asserts:
1. JSON-normalized `to_dict` deep-equality at full float precision,
2. every previously-forgotten field explicitly,
3. the queued end-turn AND one further full turn produce **byte-identical** state in both continuations.

Suite: **324/324 unit, 14/14 integration passing** locally (Godot 4.5.1 headless).

## Debt discovered (report only, not touched)
- `BaselineSimulator` reads `event.get("choices")` but events define `"options"` — its `choice_policy` branch never fires for built-in events (policy bracketing is partially vacuous)
- `main_ui.gd` autostarts every game with hard-coded seed `"test-seed"`; `GameConfig.game_seed` is not consulted at boot
- MediaSystem/PublicOpinion are never instantiated anywhere (dormant code, no live state — excluded from serialization scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)