### PR TITLE
feat: L8 achievements skeleton — observer-only (#619)

### DIFF
--- a/godot/autoload/achievements.gd
+++ b/godot/autoload/achievements.gd
@@ -1,0 +1,221 @@
+extends Node
+## Achievements — observer-only run recognition (build lane L8, issue #619).
+##
+## THE CONTRACT (ADR-0002 anti-sink rule; WORKSHOP_2_BUILD_LANES §L8):
+## achievements are RECOGNITION, never in-run reward. This node is a read-only
+## listener. It consumes the Dictionary snapshots GameManager already emits via
+## `game_state_updated` — GameState.to_dict() copies, never the live GameState
+## object — and writes NOTHING back into sim, score, or any gameplay system.
+## No achievement may ever gate, grant, or price anything inside a run; a
+## proposed achievement with an in-run effect is rejected on sight, exactly as
+## ADR-0002 rejects stock score terms. tests/unit/test_achievements.gd asserts
+## that evaluate() leaves the snapshot byte-identical (the observer-only proof).
+##
+## Persistence is per-PROFILE, not per-save: user://achievements.json survives
+## runs and records the first-unlock date. Unlocks are permanent.
+##
+## Year marks derive from the game calendar (state.calendar; ADR-0009 "the badge
+## is the date") — never from turn arithmetic — so they survive turn-cadence
+## changes (the L0 plan-month migration).
+##
+## New candidates accumulate in WORKSHOP_2_BACKLOG.md DQ-17 ([ACHIEVEMENT] tags).
+
+signal achievement_unlocked(achievement: Dictionary)
+
+const SAVE_PATH_DEFAULT := "user://achievements.json"
+var save_path: String = SAVE_PATH_DEFAULT  # var, so tests can redirect it
+
+## v1 definitions. Flavor register: bureaucratic deadpan around enormous stakes
+## (WORLD_AND_LORE.md tone section; Papers, Please is the north star).
+const DEFINITIONS: Array = [
+	{"id": "year_2022", "title": "Still Here: 2022",
+		"flavor": "Five years of payroll met on time. The world persists. So, against expectation, do you."},
+	{"id": "year_2027", "title": "Still Here: 2027",
+		"flavor": "Most labs with your opening decade are case studies by now. You are a footnote with staff."},
+	{"id": "year_2032", "title": "Still Here: 2032",
+		"flavor": "The interns have interns. Doom does not respect seniority."},
+	{"id": "year_2037", "title": "Still Here: 2037",
+		"flavor": "You have outlived three funding paradigms and at least one ideology."},
+	{"id": "first_hire", "title": "Personnel File Opened",
+		"flavor": "A costly human, complete with their own problems. Congratulations."},
+	{"id": "first_departure", "title": "Offboarding Complete",
+		"flavor": "The badge has been returned. The institutional knowledge has not."},
+	{"id": "first_paper", "title": "Peer Reviewed",
+		"flavor": "Reviewer 2 had concerns. Humanity gains a PDF."},
+	{"id": "first_liability", "title": "Signed in Ink",
+		"flavor": "Money now, consequences later. The ledger will remember this so you don't have to."},
+	{"id": "doom90_survived", "title": "White Knuckles",
+		"flavor": "Doom passed 90. You filed the paperwork anyway."},
+]
+
+# EE-4 seam (deferred to boards work — do not implement here): "fastest X this
+# season" records are LEADERBOARD-derived, not observer-derived. Anticipated
+# shape in this file, keyed (season_id, achievement_id):
+#   "season_records": {"<season_id>": {"<achievement_id>": {
+#       "turns": int, "game_date": String, "entry_uuid": String}}}
+# EE-4 populates season_records from Leaderboard entries at submission time;
+# achievements.gd only ever reads them for display. Recognition, never reward.
+
+var unlocked: Dictionary = {}       # id -> {first_unlocked_utc, run_turn, game_date}
+var unlocked_this_run: Array = []   # ids unlocked this run, for the game-over screen
+var _prev: Dictionary = {}          # previous snapshot's transition basis
+
+const _MONTH_NAMES := ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+
+func _ready() -> void:
+	load_profile()
+	# Watch the registered GameManager autoload. NOTE (known debt, #619 report):
+	# the live game actually runs a scene-local GameManager node in main.tscn;
+	# main_ui registers that one via watch(). Watching both covers either path.
+	var gm := get_node_or_null("/root/GameManager")
+	if gm:
+		watch(gm)
+
+
+func watch(game_manager: Node) -> void:
+	"""Subscribe to a GameManager instance (idempotent). Observer-only: the sole
+	signal consumed is game_state_updated, whose payload is already a to_dict()
+	snapshot — never the live GameState."""
+	if game_manager == null or not game_manager.has_signal("game_state_updated"):
+		return
+	if not game_manager.game_state_updated.is_connected(_on_game_state_updated):
+		game_manager.game_state_updated.connect(_on_game_state_updated)
+
+
+func _on_game_state_updated(state: Dictionary) -> void:
+	evaluate(state)
+
+
+func evaluate(state: Dictionary) -> Array:
+	"""Evaluate all still-locked achievements against a state snapshot.
+	Returns the ids newly unlocked (possibly empty). READ-ONLY on `state` by
+	contract — the GUT test asserts the snapshot is byte-identical afterwards."""
+	var newly: Array = []
+	var turn := int(state.get("turn", 0))
+	if not _prev.is_empty() and turn < int(_prev.get("turn", 0)):
+		_reset_run_tracking()  # turn went backwards: a new run started
+	for def in DEFINITIONS:
+		if unlocked.has(def["id"]):
+			continue
+		if _predicate_holds(def["id"], state):
+			_unlock(def, state)
+			newly.append(def["id"])
+	_prev = {
+		"turn": turn,
+		"doom": float(state.get("doom", 0.0)),
+		"total_staff": int(state.get("total_staff", 0)),
+		"papers": float(state.get("papers", 0.0)),
+		"ledger_entries": int(state.get("ledger", {}).get("entry_count", 0)),
+	}
+	return newly
+
+
+func _predicate_holds(id: String, state: Dictionary) -> bool:
+	# Year marks carry no game_over gate: ADR-0009 badge-is-the-date semantics —
+	# a run whose death date lands in 2027 "made it to 2027".
+	var year := int(state.get("calendar", {}).get("year", 0))
+	match id:
+		"year_2022":
+			return year >= 2022
+		"year_2027":
+			return year >= 2027
+		"year_2032":
+			return year >= 2032
+		"year_2037":
+			return year >= 2037
+		"first_hire":
+			return not _prev.is_empty() \
+				and int(state.get("total_staff", 0)) > int(_prev.get("total_staff", 0))
+		"first_departure":
+			return not _prev.is_empty() \
+				and int(state.get("total_staff", 0)) < int(_prev.get("total_staff", 0))
+		"first_paper":
+			return not _prev.is_empty() \
+				and float(state.get("papers", 0.0)) > float(_prev.get("papers", 0.0))
+		"first_liability":
+			# Snapshot only exposes ledger aggregates (entry_count), not entry
+			# sources, so this fires on the first liability of ANY kind (loan,
+			# funding-with-strings, desperation lever) — deliberately broader
+			# than "first loan" to keep the observer snapshot-pure.
+			return not _prev.is_empty() \
+				and int(state.get("ledger", {}).get("entry_count", 0)) > int(_prev.get("ledger_entries", 0))
+		"doom90_survived":
+			# Doom was past 90 at the previous snapshot, a turn has since
+			# resolved, and the run is still alive: that turn was survived
+			# at doom > 90.
+			return not _prev.is_empty() \
+				and float(_prev.get("doom", 0.0)) > 90.0 \
+				and int(state.get("turn", 0)) > int(_prev.get("turn", 0)) \
+				and not state.get("game_over", false)
+	return false
+
+
+func _unlock(def: Dictionary, state: Dictionary) -> void:
+	var record := {
+		"first_unlocked_utc": Time.get_datetime_string_from_system(true),
+		"run_turn": int(state.get("turn", 0)),
+		"game_date": _format_game_date(state.get("calendar", {})),
+	}
+	unlocked[def["id"]] = record
+	unlocked_this_run.append(def["id"])
+	_save()
+	achievement_unlocked.emit({
+		"id": def["id"], "title": def["title"], "flavor": def["flavor"], "record": record,
+	})
+	# Toast via the existing NotificationManager ACHIEVEMENT type — display only.
+	if is_inside_tree():
+		var nm := get_node_or_null("/root/NotificationManager")
+		if nm:
+			nm.achievement("Achievement — %s" % def["title"])
+
+
+func is_unlocked(id: String) -> bool:
+	return unlocked.has(id)
+
+
+func get_definition(id: String) -> Dictionary:
+	for def in DEFINITIONS:
+		if def["id"] == id:
+			return def
+	return {}
+
+
+func _reset_run_tracking() -> void:
+	unlocked_this_run.clear()
+	_prev.clear()
+
+
+func _format_game_date(calendar: Dictionary) -> String:
+	if calendar.is_empty():
+		return ""
+	var month := int(calendar.get("month", 1))
+	return "%s %d, %d" % [
+		_MONTH_NAMES[clampi(month - 1, 0, 11)],
+		int(calendar.get("day", 1)),
+		int(calendar.get("year", 0)),
+	]
+
+
+# --- Persistence (per-profile; mirrors leaderboard.gd's JSON convention) -----
+
+func _save() -> void:
+	var file := FileAccess.open(save_path, FileAccess.WRITE)
+	if file == null:
+		push_warning("[Achievements] Could not write %s" % save_path)
+		return
+	file.store_string(JSON.stringify({"version": 1, "unlocked": unlocked}, "\t"))
+	file.close()
+
+
+func load_profile() -> void:
+	if not FileAccess.file_exists(save_path):
+		return
+	var file := FileAccess.open(save_path, FileAccess.READ)
+	if file == null:
+		return
+	var parsed = JSON.parse_string(file.get_as_text())
+	file.close()
+	if parsed is Dictionary and parsed.get("unlocked") is Dictionary:
+		unlocked = parsed["unlocked"]

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -31,6 +31,7 @@ MusicManager="*res://autoload/music_manager.gd"
 VerificationTracker="*res://autoload/verification_tracker.gd"
 EventService="*res://autoload/event_service.gd"
 GameManager="*res://scripts/game_manager.gd"
+Achievements="*res://autoload/achievements.gd"
 
 [display]
 

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -185,6 +185,15 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 	if upgrades.size() > 0:
 		stats_text += "\n[color=cyan]◆ Upgrades:[/color] [b]%d purchased[/b]\n" % upgrades.size()
 
+	# L8 achievements (#619): recognition only, never score (ADR-0002 anti-sink).
+	var achievements_node = get_node_or_null("/root/Achievements")
+	if achievements_node and not achievements_node.unlocked_this_run.is_empty():
+		stats_text += "\n[color=cyan]◆ Achievements this run:[/color]\n"
+		for ach_id in achievements_node.unlocked_this_run:
+			var ach_def = achievements_node.get_definition(ach_id)
+			if not ach_def.is_empty():
+				stats_text += "  [color=gold]★ %s[/color] [color=gray]— %s[/color]\n" % [ach_def["title"], ach_def["flavor"]]
+
 	# Victory/defeat flavor text
 	stats_text += "\n[center][color=gray]───────────────────[/color][/center]\n"
 	if is_victory:

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -80,6 +80,13 @@ func _ready():
 	event_dialog.dialog_closed.connect(_on_event_dialog_closed)
 	event_dialog.message_logged.connect(log_message)
 
+	# L8 (#619): register the scene-local GameManager with the achievements
+	# observer (read-only listener; contract in autoload/achievements.gd).
+	var achievements = get_node_or_null("/root/Achievements")
+	if achievements:
+		achievements.watch(game_manager)
+		achievements.achievement_unlocked.connect(_on_achievement_unlocked)
+
 	# Issue #500: research quality selector (script-instantiated; reparent in editor if preferred)
 	research_quality_selector = preload("res://scripts/ui/research_quality_selector.gd").new()
 	research_quality_selector.quality_selected.connect(_on_research_quality_selected)
@@ -739,6 +746,11 @@ func _on_action_executed(result: Dictionary):
 			log_message("[color=white]  " + str(msg) + "[/color]")
 
 	# Note: GameManager now handles auto-starting next turn
+
+func _on_achievement_unlocked(achievement: Dictionary) -> void:
+	"""L8 (#619): surface unlocks in the message log. Recognition only (ADR-0002)."""
+	log_message("[color=gold]★ Achievement — %s:[/color] [color=gray]%s[/color]" % [
+		achievement.get("title", "?"), achievement.get("flavor", "")])
 
 func _on_error_occurred(error_msg: String):
 	print("[MainUI] Error: ", error_msg)

--- a/godot/tests/unit/test_achievements.gd
+++ b/godot/tests/unit/test_achievements.gd
@@ -1,0 +1,115 @@
+extends GutTest
+## L8 (#619): achievements observer — unlock predicates + the observer-only
+## proof: evaluate() must leave the state snapshot byte-identical (ADR-0002
+## anti-sink rule; achievements are recognition, never in-run reward).
+
+const TEST_SAVE := "user://test_achievements_l8.json"
+
+var ach
+
+
+func before_each():
+	var AchievementsScript = load("res://autoload/achievements.gd")
+	ach = AchievementsScript.new()
+	ach.save_path = TEST_SAVE
+	autofree(ach)
+
+
+func after_each():
+	var dir := DirAccess.open("user://")
+	if dir and dir.file_exists("test_achievements_l8.json"):
+		dir.remove("test_achievements_l8.json")
+
+
+func _snapshot(overrides: Dictionary = {}) -> Dictionary:
+	"""A minimal GameState.to_dict()-shaped snapshot (only the fields the
+	observer reads), 2017 start per ADR-0009 fiction anchors."""
+	var state := {
+		"turn": 10,
+		"doom": 50.0,
+		"game_over": false,
+		"papers": 0.0,
+		"total_staff": 0,
+		"ledger": {"entry_count": 0},
+		"calendar": {"year": 2017, "month": 7, "day": 14},
+	}
+	for key in overrides:
+		state[key] = overrides[key]
+	return state
+
+
+func test_year_mark_unlocks_from_calendar():
+	var newly = ach.evaluate(_snapshot({"calendar": {"year": 2022, "month": 1, "day": 5}}))
+	assert_has(newly, "year_2022")
+	assert_true(ach.is_unlocked("year_2022"))
+	assert_false(ach.is_unlocked("year_2027"), "later year marks must stay locked")
+
+
+func test_year_mark_locked_before_the_year():
+	ach.evaluate(_snapshot())  # 2017
+	assert_false(ach.is_unlocked("year_2022"))
+
+
+func test_evaluate_never_mutates_the_snapshot():
+	# The observer-only proof. This evaluate() call actually unlocks something
+	# (year_2022), i.e. the busiest code path runs — and the snapshot must come
+	# out byte-identical and hash-identical.
+	var state = _snapshot({"calendar": {"year": 2022, "month": 1, "day": 5}})
+	var json_before = JSON.stringify(state)
+	var hash_before = hash(state)
+	var newly = ach.evaluate(state)
+	assert_gt(newly.size(), 0, "precondition: an unlock must actually fire")
+	assert_eq(JSON.stringify(state), json_before,
+		"evaluate() wrote into the state snapshot - observer contract broken")
+	assert_eq(hash(state), hash_before,
+		"state hash changed across evaluate() - observer contract broken")
+
+
+func test_first_hire_and_departure_transitions():
+	ach.evaluate(_snapshot({"total_staff": 0}))
+	assert_false(ach.is_unlocked("first_hire"), "no hire happened yet")
+	ach.evaluate(_snapshot({"total_staff": 1}))
+	assert_true(ach.is_unlocked("first_hire"))
+	assert_false(ach.is_unlocked("first_departure"))
+	ach.evaluate(_snapshot({"total_staff": 0}))
+	assert_true(ach.is_unlocked("first_departure"))
+
+
+func test_first_liability_fires_on_ledger_entry():
+	ach.evaluate(_snapshot())
+	assert_false(ach.is_unlocked("first_liability"))
+	ach.evaluate(_snapshot({"ledger": {"entry_count": 1}}))
+	assert_true(ach.is_unlocked("first_liability"))
+
+
+func test_doom90_requires_surviving_the_turn():
+	ach.evaluate(_snapshot({"turn": 10, "doom": 95.0}))
+	assert_false(ach.is_unlocked("doom90_survived"), "turn not yet resolved")
+	ach.evaluate(_snapshot({"turn": 11, "doom": 95.0}))
+	assert_true(ach.is_unlocked("doom90_survived"))
+
+
+func test_doom90_not_awarded_when_the_turn_kills_you():
+	ach.evaluate(_snapshot({"turn": 10, "doom": 95.0}))
+	ach.evaluate(_snapshot({"turn": 11, "doom": 100.0, "game_over": true}))
+	assert_false(ach.is_unlocked("doom90_survived"))
+
+
+func test_unlocks_persist_across_instances():
+	ach.evaluate(_snapshot({"calendar": {"year": 2027, "month": 3, "day": 3}}))
+	assert_true(ach.is_unlocked("year_2027"))
+	var second = load("res://autoload/achievements.gd").new()
+	second.save_path = TEST_SAVE
+	second.load_profile()
+	autofree(second)
+	assert_true(second.is_unlocked("year_2027"), "unlock must survive a reload")
+	assert_false(second.is_unlocked("year_2032"))
+
+
+func test_new_run_resets_run_scoped_list_but_not_profile():
+	ach.evaluate(_snapshot({"turn": 50, "calendar": {"year": 2022, "month": 1, "day": 5}}))
+	assert_has(ach.unlocked_this_run, "year_2022")
+	# Turn goes backwards: a fresh run started.
+	ach.evaluate(_snapshot({"turn": 0}))
+	assert_eq(ach.unlocked_this_run.size(), 0, "run-scoped list must reset")
+	assert_true(ach.is_unlocked("year_2022"), "profile unlock is permanent")


### PR DESCRIPTION
## L8 — Observer-only achievements (#619)

Recognition-only achievement system per **ADR-0002 (anti-sink)** and **ADR-0009 ("the badge is the date")**. Achievement evaluation is a pure read-only observer over a `GameState.to_dict()` snapshot — it **never** mutates GameState or score.

### Architecture
- **`autoload/achievements.gd`** — autoload observer. Subscribes to `GameManager.game_state_updated` (payload is already a `to_dict()` snapshot, never the live GameState). `evaluate(state)` reads the snapshot and writes only to its own `unlocked` / `unlocked_this_run`.
- **Persistence** — per-PROFILE (`user://achievements.json`), not per-save. First-unlock date recorded; unlocks are permanent and survive reloads.
- **Year marks** derive from `state.calendar.year` (sourced via L0's `Clock.date_for_turn(...)`), never from turn arithmetic — survive turn-cadence changes.
- **Surfacing reuses existing message paths, no new UI panels**: message-log line on unlock (`_on_achievement_unlocked` → `log_message`) and a game-over-screen "Achievements this run" list. No score/reward hook.

### Achievements shipped (9, v1)
| id | title | trigger |
|----|-------|---------|
| `year_2022` | Still Here: 2022 | calendar year ≥ 2022 |
| `year_2027` | Still Here: 2027 | calendar year ≥ 2027 |
| `year_2032` | Still Here: 2032 | calendar year ≥ 2032 |
| `year_2037` | Still Here: 2037 | calendar year ≥ 2037 |
| `first_hire` | Personnel File Opened | first staff hired |
| `first_departure` | Offboarding Complete | first staff departure |
| `first_paper` | Peer Reviewed | first paper published |
| `first_liability` | Signed in Ink | first ledger liability entry |
| `doom90_survived` | White Knuckles | doom passed 90 and the turn was survived |

### Verification
- **`test_achievements.gd`: 9/9 pass** (22 asserts) — year-mark unlock/lock, first-hire/departure transitions, first-liability, doom90 survive-vs-death gating, cross-instance persistence, new-run reset of run-scoped list.
- **Observer-only proof** — `test_evaluate_never_mutates_the_snapshot` asserts the snapshot is byte-identical (`JSON.stringify`) AND hash-identical across `evaluate()`. ADR-0002 anti-sink upheld.
- **Full unit suite: 334/334 pass** (29 scripts, 2774 asserts) after rebase onto current main (L0/L7/L9/L10).

### Rebase notes
Rebased cleanly onto main after L0 (#624), L7 (#623), L9 (#627), L10 (#628, main_ui restructure). Surfacing edits to `main_ui.gd` / `game_over_screen.gd` merged into the L10-restructured layout without conflict; confirmed post-rebase that the calendar/year date source still resolves via L0's Clock authority (`get_current_date()` → `Clock.date_for_turn`).

### Known debt (report only)
- `achievements.gd` `_ready` watches `/root/GameManager`, but the live game runs a scene-local GameManager registered via `main_ui.watch()`; both paths are covered but the dual-watch is noted debt (#619).
- EE-4 "fastest X this season" records are leaderboard-derived, deferred to boards work (seam left, not implemented).