### PR TITLE
fix: throttle paper-decision flood + wrap event dialog text (#630)

### DIFF
--- a/godot/data/balance/defaults.json
+++ b/godot/data/balance/defaults.json
@@ -5,6 +5,10 @@
 		"first_event_turn": 2,
 		"max_new_events_per_turn": 2
 	},
+	"papers": {
+		"_description": "Paper-decision pacing (#630 stopgap): at most max_decisions_per_turn paper accept/reject decisions surface per turn; clustered decision_turns otherwise flood a click-through wall. Surplus stays UNDER_REVIEW and resolves on later turns (never dropped). 0 = unlimited (pre-#630). Superseded by ADR-0009/0012/0014 response windows.",
+		"max_decisions_per_turn": 3
+	},
 	"ledger": {
 		"_description": "Liability Ledger (ADR-0003): factory magnitudes, fuses, interest; the doom/rep teeth for unpayable bills; secret-exposure chance (BL-2).",
 		"doom_per_unpaid_1000": 3.5,

--- a/godot/scripts/core/paper_submissions.gd
+++ b/godot/scripts/core/paper_submissions.gd
@@ -21,6 +21,16 @@ enum Topic {
 	GOVERNANCE        # AI governance/policy
 }
 
+# #630 stopgap: paper decisions resolve on a path NOT governed by
+# GameEvents.MAX_NEW_EVENTS_PER_TURN, so clustered decision_turns (several papers
+# submitted in the same window) all resolve on one turn → a click-through wall
+# (playtest saw 28+ at once). Cap how many decisions surface per turn; the surplus
+# stays UNDER_REVIEW and resolves on subsequent turns (spread out, never dropped).
+# Balance-tunable ("papers.max_decisions_per_turn", L9 #621); const is the fallback.
+# The real fix is ADR-0009 response windows + ADR-0012 taxonomy + ADR-0014 SA-gated
+# delivery (lands with L1/L4); this only makes present-build QA bearable.
+const MAX_PAPER_DECISIONS_PER_TURN := 3
+
 # Paper submission data structure
 class PaperSubmission:
 	var id: String
@@ -158,8 +168,19 @@ static func generate_paper_title(topic: int, rng: RandomNumberGenerator) -> Stri
 	return "%s %s%s" % [prefix, subject, suffix]
 
 static func process_paper_decisions(papers: Array, current_turn: int, player_reputation: float, rng: RandomNumberGenerator) -> Array[Dictionary]:
-	"""Process paper decisions for all papers at decision turn"""
+	"""Process paper decisions for all papers at decision turn.
+
+	#630 stopgap: throttle how many decisions surface per turn. Papers whose
+	decision_turn has arrived but exceed the per-turn cap stay UNDER_REVIEW and
+	re-qualify next turn (their decision_turn is already <= current_turn), so the
+	burst spreads across turns and NO outcome is dropped. Papers are scanned in
+	submission (array) order, so the oldest submissions resolve first and none
+	starve. rng is consumed only for papers actually decided this turn, keeping
+	resolution deterministic given game state (fewer randf() this turn, the
+	deferred ones consume theirs on a later turn)."""
 	var results: Array[Dictionary] = []
+	# max_decisions <= 0 disables the cap (unlimited), matching pre-#630 behavior.
+	var max_decisions := Balance.inum("papers.max_decisions_per_turn", MAX_PAPER_DECISIONS_PER_TURN)
 
 	for paper in papers:
 		if paper.status != Status.UNDER_REVIEW:
@@ -167,6 +188,12 @@ static func process_paper_decisions(papers: Array, current_turn: int, player_rep
 
 		if current_turn < paper.decision_turn:
 			continue
+
+		# Per-turn surfacing cap (#630): each processed paper appends exactly one
+		# result, so results.size() is the count decided this turn. Once the budget
+		# is spent, stop — the remaining eligible papers defer to a later turn.
+		if max_decisions > 0 and results.size() >= max_decisions:
+			break
 
 		# Time for decision!
 		var conf = Conferences.get_conference_by_id(paper.target_conference_id)

--- a/godot/scripts/ui/event_dialog.gd
+++ b/godot/scripts/ui/event_dialog.gd
@@ -111,8 +111,14 @@ func _show_next_event() -> void:
 
 	print("[EventDialog] Created Panel for event, size: %s, position: %s" % [dialog.size, dialog.position])
 
-	# Create main container
+	# Create main container. #630: anchor it to fill the fixed-size Panel (a Panel is
+	# NOT a container, so children default to their content-driven minimum size at
+	# (0,0)). Without this, a long title_label forces the VBox min-width past the
+	# 600px panel and the wrapped body text spills over the right border. Anchoring
+	# clamps the content width to the panel, giving the autowrap labels a real width
+	# to wrap within (inner area = 600 - 2*15 = 570px).
 	var margin = MarginContainer.new()
+	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	margin.add_theme_constant_override("margin_left", 15)
 	margin.add_theme_constant_override("margin_right", 15)
 	margin.add_theme_constant_override("margin_top", 15)
@@ -122,18 +128,22 @@ func _show_next_event() -> void:
 	var main_vbox = VBoxContainer.new()
 	margin.add_child(main_vbox)
 
-	# Add title
+	# Add title (#630: autowrap so a long event name wraps instead of forcing the
+	# content wider than the panel).
 	var title_label = Label.new()
 	title_label.text = event.get("name", "Event")
 	title_label.add_theme_font_size_override("font_size", 18)
 	title_label.add_theme_color_override("font_color", Color.GOLD)
+	title_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	title_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	main_vbox.add_child(title_label)
 
-	# Add description label
+	# Add description label. #630: smart word-wrap + fill the container width so long
+	# body text wraps to the panel's inner width instead of clipping past the margins.
 	var desc_label = Label.new()
 	desc_label.text = event.get("description", "An event has occurred!")
-	desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD
-	desc_label.custom_minimum_size = Vector2(560, 0)
+	desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	desc_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	main_vbox.add_child(desc_label)
 
 	# Add spacing

--- a/godot/tests/unit/test_paper_decision_cap.gd
+++ b/godot/tests/unit/test_paper_decision_cap.gd
@@ -1,0 +1,89 @@
+extends GutTest
+## #630 stopgap — paper-decision flood throttle.
+##
+## Papers whose decision_turn has arrived resolve on a path NOT governed by
+## GameEvents.MAX_NEW_EVENTS_PER_TURN, so clustered decision_turns otherwise dump a
+## click-through wall (playtest 2026-07-13 saw 28+ at once). process_paper_decisions
+## now caps how many decisions surface per turn (Balance "papers.max_decisions_per_turn");
+## the surplus stays UNDER_REVIEW and resolves on later turns — no outcome dropped.
+
+const CURRENT_TURN := 10
+const DECISION_TURN := 5  # already due: DECISION_TURN < CURRENT_TURN
+
+
+func _make_due_paper(idx: int) -> PaperSubmissions.PaperSubmission:
+	var paper := PaperSubmissions.PaperSubmission.new()
+	paper.id = "paper_test_%d" % idx
+	paper.title = "Test Paper %d" % idx
+	paper.status = PaperSubmissions.Status.UNDER_REVIEW
+	paper.decision_turn = DECISION_TURN
+	# Invalid conference id → deterministic auto-reject (no rng, no Conferences
+	# dependency). The per-turn cap/break happens BEFORE the decision branch, so an
+	# auto-reject paper exercises the throttle identically to a real accept/reject.
+	paper.target_conference_id = "no_such_conf_for_test"
+	return paper
+
+
+func _count_status(papers: Array, status: int) -> int:
+	var n := 0
+	for p in papers:
+		if p.status == status:
+			n += 1
+	return n
+
+
+func test_cap_throttles_decisions_per_turn():
+	var cap := Balance.inum("papers.max_decisions_per_turn", 3)
+	assert_true(cap > 0, "test assumes a positive per-turn cap in defaults.json")
+	var total := cap + 4
+	var papers := []
+	for i in range(total):
+		papers.append(_make_due_paper(i))
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 12345
+	var results := PaperSubmissions.process_paper_decisions(papers, CURRENT_TURN, 50.0, rng)
+	assert_eq(results.size(), cap, "only 'cap' decisions surface on a single turn")
+	assert_eq(
+		_count_status(papers, PaperSubmissions.Status.UNDER_REVIEW), total - cap,
+		"the surplus stays UNDER_REVIEW (deferred, not dropped)")
+
+
+func test_deferred_papers_resolve_on_later_turns_none_dropped():
+	var cap := Balance.inum("papers.max_decisions_per_turn", 3)
+	assert_true(cap > 0)
+	var total := cap * 2 + 1  # needs 3 passes to drain the backlog
+	var papers := []
+	for i in range(total):
+		papers.append(_make_due_paper(i))
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 999
+	var resolved := 0
+	var guard := 0
+	# Re-run the SAME turn's decision step; deferred papers re-qualify each pass
+	# (decision_turn already <= CURRENT_TURN), draining 'cap' at a time.
+	while _count_status(papers, PaperSubmissions.Status.UNDER_REVIEW) > 0 and guard < 20:
+		guard += 1
+		var results := PaperSubmissions.process_paper_decisions(papers, CURRENT_TURN, 50.0, rng)
+		assert_true(results.size() <= cap, "never exceeds the cap on any single pass")
+		resolved += results.size()
+	assert_eq(resolved, total, "every paper eventually resolves — no outcome dropped")
+	assert_eq(
+		_count_status(papers, PaperSubmissions.Status.UNDER_REVIEW), 0,
+		"backlog fully drained")
+
+
+func test_papers_not_yet_due_are_untouched():
+	# A paper whose decision_turn is in the future must not resolve, and must not
+	# consume the per-turn budget meant for due papers.
+	var papers := []
+	var due := _make_due_paper(0)
+	papers.append(due)
+	var future := _make_due_paper(1)
+	future.decision_turn = CURRENT_TURN + 3
+	papers.append(future)
+	var rng := RandomNumberGenerator.new()
+	var results := PaperSubmissions.process_paper_decisions(papers, CURRENT_TURN, 50.0, rng)
+	assert_eq(results.size(), 1, "only the due paper resolves")
+	assert_eq(
+		future.status, PaperSubmissions.Status.UNDER_REVIEW,
+		"the not-yet-due paper stays UNDER_REVIEW")


### PR DESCRIPTION
Fixes #630 — two present-build stopgaps found in playtest (2026-07-13, turn 33: 28+ click-through events queued at once, mostly paper decisions; several event dialogs overspilled their text margins).

## Fix 1 — Paper-decision flood (`paper_submissions.gd`, `data/balance/defaults.json`)
Papers set `decision_turn` when submitted; when several are submitted in a window their `decision_turn`s cluster and all resolve on one `execute_turn` via `PaperSubmissions.process_paper_decisions` — a path **not** governed by `GameEvents.MAX_NEW_EVENTS_PER_TURN`.

`process_paper_decisions` now caps how many decisions surface per turn (`Balance.inum("papers.max_decisions_per_turn", 3)`, following the L9 #621 Balance pattern; `0` = unlimited/pre-#630). Papers scanned in submission (array) order, so oldest resolve first and none starve. Surplus stays `UNDER_REVIEW` — its `decision_turn` is already `<= current_turn`, so it re-qualifies next turn and drains at the cap rate. **No outcome is dropped.** `rng` is consumed only for papers actually decided this turn, so resolution stays deterministic given game state (deferred papers consume their `randf()` on the later turn they resolve).

## Fix 2 — Dialog text overflow (`event_dialog.gd`)
A `Panel` is not a container, so the `MarginContainer` defaulted to its content-driven minimum size at `(0,0)`; a long event title forced the content min-width past the fixed 600px panel and the wrapped body text spilled over the right border. Now:
- `MarginContainer` anchored `PRESET_FULL_RECT` — clamps content to the panel (inner area 570px), giving the autowrap labels a real width to wrap within.
- `title_label` gets `AUTOWRAP_WORD_SMART` so a long name wraps instead of forcing width.
- `desc_label` switched to `AUTOWRAP_WORD_SMART` + horizontal fill.

## Structural context (not built here)
Real fix is ADR-0009 response windows + ADR-0012 taxonomy + ADR-0014 SA-gated delivery, landing with L1/L4. This is the stopgap so QA is bearable.

## Test evidence
- New `tests/unit/test_paper_decision_cap.gd` (3 tests, 11 asserts, all pass):
  - `test_cap_throttles_decisions_per_turn` — cap+4 due papers → exactly `cap` resolve, rest stay `UNDER_REVIEW`.
  - `test_deferred_papers_resolve_on_later_turns_none_dropped` — re-running the step drains `cap`/turn until zero; total resolved == total submitted (no drop).
  - `test_papers_not_yet_due_are_untouched` — future `decision_turn` doesn't resolve or consume budget.
- Full unit suite green: **349/349** (direct GUT invocation, after `--import`).
- Headless launch clean (no script/parse errors; Balance defaults.json parsed).

## Coordination note
This branch does **not** touch `events.gd`, so no conflict with the sibling #631 agent from my side.