### PR TITLE
fix: event outcome correctness + legibility — poaching specimen + audit (#631)

### DIFF
--- a/godot/scripts/core/events.gd
+++ b/godot/scripts/core/events.gd
@@ -279,6 +279,11 @@ static func execute_event_choice(event: Dictionary, choice_id: String, state: Ga
 	# (L9 #621); non-scalar effects (researcher creation/removal, mascot) keep
 	# their special handling here.
 	var effects = chosen_option.get("effects", {})
+	# #631 loss legibility: staffing effects (hire / poach) are not scalar deltas,
+	# so they never showed up in the log — the player couldn't tell a poach even
+	# happened, let alone WHO left. Collect a human-readable note per staffing
+	# change and return them so the event log names the person + the team delta.
+	var staffing_notes: Array[String] = []
 	for key in effects.keys():
 		var value = effects[key]
 
@@ -287,30 +292,20 @@ static func execute_event_choice(event: Dictionary, choice_id: String, state: Ga
 
 		match key:
 			"safety_researchers":
-				# Create actual Researcher objects for the new system
-				for i in range(value):
-					var researcher = Researcher.new()
-					researcher.generate_random(state.rng)
-					researcher.specialization = "safety"
-					state.add_researcher(researcher)
+				_apply_staffing_effect(state, "safety", int(value), staffing_notes)
 			"capability_researchers":
-				for i in range(value):
-					var researcher = Researcher.new()
-					researcher.generate_random(state.rng)
-					researcher.specialization = "capabilities"
-					state.add_researcher(researcher)
+				_apply_staffing_effect(state, "capabilities", int(value), staffing_notes)
 			"has_cat":
 				state.has_cat = (value > 0)
 			"lose_researcher":
-				# Remove a random researcher (poaching)
-				if state.researchers.size() > 0:
-					var idx = state.rng.randi() % state.researchers.size()
-
-					# Record RNG outcome for verification
-					VerificationTracker.record_rng_outcome("poach_researcher_select", float(idx), state.turn)
-
-					var researcher = state.researchers[idx]
-					state.remove_researcher(researcher)
+				# Poaching: a rival recruits away up to `value` researchers of ANY
+				# specialization, targeting the LEAST loyal first (loyalty is
+				# poaching resistance — researcher.gd:18). Each departure is named.
+				for i in range(int(value)):
+					var poached := _poach_least_loyal(state, "")
+					if poached == null:
+						break
+					staffing_notes.append(_format_departure(state, poached))
 
 	# EE-7 (loss legibility): report the NET resource deltas this choice applied
 	# (effects minus costs) so the event log can state them explicitly. Staffing /
@@ -322,7 +317,77 @@ static func execute_event_choice(event: Dictionary, choice_id: String, state: Ga
 			deltas[k] = net
 
 	var message = chosen_option.get("message", "Event resolved")
-	return {"success": true, "message": message, "deltas": deltas}
+	var result := {"success": true, "message": message, "deltas": deltas}
+	# main_ui._on_action_executed renders result.messages as extra log lines, so
+	# the staffing change (who joined/left) is now visible to the player (#631).
+	if not staffing_notes.is_empty():
+		result["messages"] = staffing_notes
+	return result
+
+
+static func _apply_staffing_effect(state: GameState, spec: String, delta: int, notes: Array) -> void:
+	"""Apply a staffing effect and record a legible note per person (#631).
+	delta > 0 hires `delta` researchers of `spec` (real Researcher objects, named);
+	delta < 0 loses |delta| of `spec` to poaching, LEAST loyal first (loyalty is
+	poaching resistance, researcher.gd:18). Previously a negative value was a silent
+	no-op: Resources.add() rejects the name, and the old `for i in range(value)`
+	create-loop ran range(-1) == empty — so "Let Them Go" removed nobody."""
+	if delta > 0:
+		for i in range(delta):
+			var researcher := Researcher.new()
+			# Set spec before generate_random so salary_expectation uses the right
+			# base_cost; generate_random does not touch specialization.
+			researcher.specialization = spec
+			researcher.generate_random(state.rng)
+			state.add_researcher(researcher)
+			notes.append("Hired %s (%s) — %s team now %d" % [
+				researcher.researcher_name, spec, spec,
+				state.get_researcher_count_by_spec(spec)])
+	elif delta < 0:
+		for i in range(-delta):
+			var poached := _poach_least_loyal(state, spec)
+			if poached == null:
+				break
+			notes.append(_format_departure(state, poached))
+
+
+static func _poach_least_loyal(state: GameState, spec_filter: String) -> Researcher:
+	"""Remove and return the researcher most vulnerable to poaching — the LEAST
+	loyal (loyalty = poaching resistance, researcher.gd:18) — optionally restricted
+	to a specialization. Deterministic (stable min, first-index wins ties). Returns
+	null when no matching researcher exists. Consumes no RNG (replaces the old
+	random pick); the chosen index is still recorded so replay hashes stay sensitive
+	to the poach."""
+	var target: Researcher = null
+	var target_idx := -1
+	for i in range(state.researchers.size()):
+		var r: Researcher = state.researchers[i]
+		if spec_filter != "" and not _spec_matches(r.specialization, spec_filter):
+			continue
+		if target == null or r.loyalty < target.loyalty:
+			target = r
+			target_idx = i
+	if target == null:
+		return null
+	VerificationTracker.record_rng_outcome("poach_researcher_select", float(target_idx), state.turn)
+	state.remove_researcher(target)
+	return target
+
+
+static func _spec_matches(spec: String, spec_filter: String) -> bool:
+	"""Match a researcher's specialization to a staffing filter, folding
+	interpretability/alignment into "safety" — the same grouping GameState uses for
+	its legacy safety_researchers count (game_state.gd add/remove_researcher)."""
+	if spec_filter == "safety":
+		return spec in ["safety", "interpretability", "alignment"]
+	return spec == spec_filter
+
+
+static func _format_departure(state: GameState, r: Researcher) -> String:
+	"""Legible one-liner naming a poached researcher and the resulting team size."""
+	return "%s (%s, loyalty %d) poached by a rival lab — %s team now %d" % [
+		r.researcher_name, r.specialization, r.loyalty,
+		r.specialization, state.get_researcher_count_by_spec(r.specialization)]
 
 static func _mark_event_triggered(event: Dictionary, turn: int, state: GameState):
 	"""Mark an event as triggered, handling both one-time and cooldown tracking"""

--- a/godot/tests/unit/test_events.gd
+++ b/godot/tests/unit/test_events.gd
@@ -316,3 +316,85 @@ func test_multi_resource_effects():
 	assert_ne(state.doom, initial_doom, "Doom should change")
 	assert_ne(state.reputation, initial_reputation, "Reputation should change")
 	assert_ne(state.research, initial_research, "Research should change")
+
+# ---------------------------------------------------------------------------
+# #631: poaching outcome correctness + legibility
+# ---------------------------------------------------------------------------
+
+func _make_researcher(spec: String, name: String, loyalty: int) -> Researcher:
+	"""Deterministic researcher for poaching tests (no RNG, explicit loyalty)."""
+	var r := Researcher.new()
+	r.specialization = spec
+	r.researcher_name = name
+	r.loyalty = loyalty
+	return r
+
+func test_lose_researcher_removes_exactly_one_least_loyal_and_names_them():
+	# researcher_poached / let_them_go uses the `lose_researcher` effect.
+	# Loyalty is poaching resistance (researcher.gd:18) — the LEAST loyal leaves.
+	state.add_researcher(_make_researcher("safety", "Loyal Larry", 90))
+	state.add_researcher(_make_researcher("safety", "Fickle Fran", 20))
+	state.add_researcher(_make_researcher("capabilities", "Steady Sam", 70))
+	var before := state.researchers.size()
+
+	var events = GameEvents.get_all_events()
+	var poach = _find_event_by_id(events, "researcher_poached")
+	assert_false(poach.is_empty(), "researcher_poached event should exist")
+
+	var result = GameEvents.execute_event_choice(poach, "let_them_go", state)
+
+	assert_true(result["success"], "Letting them go should succeed")
+	assert_eq(state.researchers.size(), before - 1, "Exactly one researcher removed")
+	# The least loyal (Fickle Fran, loyalty 20) is the one poached.
+	var names := []
+	for r in state.researchers:
+		names.append(r.researcher_name)
+	assert_does_not_have(names, "Fickle Fran", "Least-loyal researcher was poached")
+	assert_has(names, "Loyal Larry", "Loyal researcher retained")
+	# Legibility: the log names WHO left.
+	assert_true(result.has("messages"), "Result carries staffing notes")
+	var joined: String = "\n".join(result["messages"])
+	assert_string_contains(joined, "Fickle Fran", "Departure note names the researcher")
+
+func test_let_them_go_decrements_legacy_safety_count():
+	# The legacy scalar count must track the removal too (game_state accounting).
+	state.add_researcher(_make_researcher("safety", "A", 10))
+	state.add_researcher(_make_researcher("safety", "B", 80))
+	state.add_researcher(_make_researcher("safety", "C", 80))
+	var before_count := state.safety_researchers
+	var events = GameEvents.get_all_events()
+	var poach = _find_event_by_id(events, "researcher_poached")
+	GameEvents.execute_event_choice(poach, "let_them_go", state)
+	assert_eq(state.safety_researchers, before_count - 1, "Legacy safety count drops by one")
+
+func test_rival_poaching_let_go_actually_removes_a_researcher():
+	# Regression for the #631 no-op: rival_poaching/let_go used safety_researchers:-1,
+	# which Resources.add rejects and the old create-loop ran range(-1) == empty,
+	# so NOBODY left even though flavor said "Lost researcher".
+	state.add_researcher(_make_researcher("safety", "Keeper", 95))
+	state.add_researcher(_make_researcher("safety", "Leaver", 15))
+	var before := state.researchers.size()
+	var before_money := state.money
+
+	var events = GameEvents.get_all_events()
+	var rival = _find_event_by_id(events, "rival_poaching")
+	assert_false(rival.is_empty(), "rival_poaching event should exist")
+
+	var result = GameEvents.execute_event_choice(rival, "let_go", state)
+
+	assert_true(result["success"], "let_go should succeed")
+	assert_eq(state.researchers.size(), before - 1, "One safety researcher actually leaves")
+	assert_eq(state.money, before_money + 20000.0, "Saved $20k as flavor states")
+	assert_true(result.has("messages"), "Departure is legible")
+	var joined: String = "\n".join(result["messages"])
+	assert_string_contains(joined, "Leaver", "Least-loyal safety researcher named")
+
+func test_poach_with_no_researchers_is_safe_noop():
+	# No researchers -> no crash, no phantom removal, no staffing note.
+	assert_eq(state.researchers.size(), 0, "Start empty")
+	var events = GameEvents.get_all_events()
+	var poach = _find_event_by_id(events, "researcher_poached")
+	var result = GameEvents.execute_event_choice(poach, "let_them_go", state)
+	assert_true(result["success"], "Still resolves")
+	assert_eq(state.researchers.size(), 0, "Nobody removed")
+	assert_false(result.has("messages"), "No staffing note when nobody leaves")


### PR DESCRIPTION
Fixes #631.

## Problem (playtest 2026-07-13, Pip)
> "I'm not sure we lose a researcher who is getting poached, and we don't know which one, and if we let them go, I don't think we lose a researcher."

Both diagnosed failure modes were real, in two different events.

## Fixes

### 1. Poaching specimen
- **`rival_poaching` / "Let Them Go"** — effect was `safety_researchers: -1`. This was a **silent no-op**: `ResourceAccessor.add()` rejects the `safety_researchers` name (not a scalar), so it fell to the `match` arm, whose old create-loop ran `for i in range(-1)` == empty. Nobody left, but the flavor said "Lost researcher". Negative staffing effects now actually remove a researcher.
- **`researcher_poached` / "Let Them Leave"** — effect `lose_researcher` removed a **random** researcher, never consulted loyalty, and never named who left.
- **Loyalty is now poaching resistance** (`researcher.gd:18`): the **least-loyal** researcher is the one poached — deterministic (stable min, first-index tie-break), consumes **no** RNG. The chosen index is still recorded via `VerificationTracker` so replay hashes stay sensitive to the poach.
- **Legibility**: hire and poach now append a named note to `result.messages` (e.g. `Fickle Fran (safety, loyalty 20) poached by a rival lab — safety team now 1`). `main_ui._on_action_executed` already renders `result.messages`, and scalar deltas (money +$20k, doom +3) already show via the EE-7 Δ line — so the loss is now fully visible.

Implementation is a small set of helpers in `events.gd`: `_apply_staffing_effect` (hire N / poach |N| of a spec), `_poach_least_loyal`, `_spec_matches` (folds interpretability/alignment into "safety", matching GameState's legacy count accounting), `_format_departure`.

## Audit coverage (bounded, per issue)

**Checked — all 26 core events (`data/events/core_events.json`) + all 36 risk events (`data/events/risk_events.json`).**

- **Scalar-effect events** (money/compute/research/papers/reputation/doom): effect matches flavor and is already legible via the EE-7 Δ line + the prose message. This covers the large majority — funding_crisis, talent_recruitment, ai_breakthrough, funding_windfall, compute_deal, media_scandal, government_regulation, technical_failure, workplace_conflict, harassment_complaint, salary_dispute, mental_health_crisis, office_theft, policy_violation, research_leak, competitor_intel, whistleblower_approach, employee_whistleblower, plant_source_opportunity, competitor_password_breach, your_security_audit, and all 36 risk events. No mismatches found.
- **Non-scalar staffing effects** (the actual bug surface): hires (`safety_researchers`/`capability_researchers` +N), poaches (`lose_researcher`, negative staffing) — **fixed + made legible** as above.
- **`has_cat`** (stray_cat): sets the flag correctly, message + doom delta legible. OK.
- **`rival_poaching` / "Counter-Offer"** ($80k, empty effects, "retained researchers"): correct — you pay to keep everyone; not a bug.

### Follow-up debt (report only — out of bounded scope)
- **Risk events with staffing flavor but scalar-only effect**: `insider_threat` "Key Resignation" / "Senior researcher quits" describe a departure but only dock `research`. Converting these to real researcher removal is a balance-sensitive design change (risk events apply via `turn_manager` `add_resources`, a different path from `execute_event_choice`), so left as-is and flagged here.
- **`employee_burnout` / "Push Through"**: flavor "researchers considering leaving" but no staffing loss (only +doom). Arguably intended (you retained under strain); noted, not changed.
- Hire notes are emitted for event-driven hires; non-event hire flows (candidate pool) were not touched.

## Test evidence
- New tests in `test_events.gd`: `test_lose_researcher_removes_exactly_one_least_loyal_and_names_them`, `test_let_them_go_decrements_legacy_safety_count`, `test_rival_poaching_let_go_actually_removes_a_researcher` (regression for the no-op), `test_poach_with_no_researchers_is_safe_noop`. They drive the poaching path directly through `execute_event_choice`.
- **Full unit suite green: 346/346** (direct GUT, `-gdir=res://tests/unit`), incl. determinism/replay and loss-legibility suites.

## Sibling coordination (#630)
Branched from `origin/main` @ 10913fc; this touches only `events.gd` `execute_event_choice` (staffing arms + new helpers) and `test_events.gd`. If #630 also edits `execute_event_choice`, resolve preserving both sides — my changes are localized to the staffing `match` arms and appended helper funcs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)