### PR TITLE
Playtest flight recorder (F9) + burnout Push Through loyalty hit

### DIFF
--- a/godot/autoload/keybind_manager.gd
+++ b/godot/autoload/keybind_manager.gd
@@ -23,6 +23,10 @@ var keybinds: Dictionary = {
 	# Backslash toggles the full DEV MODE overlay (state readout + dev controls). Gated on
 	# BuildInfo.DEV_BUILD by the overlay itself. Reclaimed backslash from export_log/bug_reporter.
 	"dev_mode": {"key": KEY_BACKSLASH, "category": Category.DEBUG, "description": "Toggle Dev Mode Overlay"},
+	# Playtest flight recorder (WORKSHOP_2_BACKLOG "Playtest deep-dive protocol"): one press
+	# dumps a screenshot + state snapshot + marker note. Gated on BuildInfo.DEV_BUILD by
+	# FlightRecorder itself, same pattern as dev_mode. F9 is otherwise unused.
+	"flight_recorder": {"key": KEY_F9, "category": Category.DEBUG, "description": "Flight Recorder Capture (screenshot + state + note)"},
 	"admin_mode": {"key": KEY_BRACKETRIGHT, "category": Category.ADMIN, "description": "Toggle Admin Mode"},
 
 	# Gameplay
@@ -79,6 +83,7 @@ signal log_export_requested
 signal admin_mode_toggled
 signal debug_overlay_toggled
 signal dev_mode_toggled
+signal flight_recorder_requested
 
 func _ready():
 	load_keybinds()
@@ -293,6 +298,12 @@ func _input(event: InputEvent):
 	# Dev mode overlay (backslash) — full state readout + dev controls (dev builds only)
 	elif is_action_pressed(event, "dev_mode"):
 		dev_mode_toggled.emit()
+		get_viewport().set_input_as_handled()
+
+	# Flight recorder (F9) — screenshot + state snapshot + marker note in one press
+	# (dev builds only; FlightRecorder itself gates on BuildInfo.is_dev_build()).
+	elif is_action_pressed(event, "flight_recorder"):
+		flight_recorder_requested.emit()
 		get_viewport().set_input_as_handled()
 
 	# Admin mode

--- a/godot/data/events/core_events.json
+++ b/godot/data/events/core_events.json
@@ -252,12 +252,13 @@
 				},
 				{
 					"id": "ignore_burnout",
-					"text": "Push Through (no cost)",
+					"text": "Push Through (no cost, costs trust — affected researchers lose loyalty)",
 					"costs": {},
 					"effects": {
-						"doom": 3
+						"doom": 3,
+						"loyalty_hit": 15
 					},
-					"message": "Team morale suffered (+3 doom)"
+					"message": "Nobody quit, but pushing through cost trust — the most burned-out researchers lose loyalty. (+3 doom)"
 				}
 			]
 		},

--- a/godot/scripts/core/events.gd
+++ b/godot/scripts/core/events.gd
@@ -306,6 +306,15 @@ static func execute_event_choice(event: Dictionary, choice_id: String, state: Ga
 					if poached == null:
 						break
 					staffing_notes.append(_format_departure(state, poached))
+			"loyalty_hit":
+				# employee_burnout "Push Through" interim content (WORKSHOP_2_BACKLOG
+				# "Burnout outcome model — RULED", Pip 2026-07-13, resolves the #631/#635
+				# "flavor claims strain, only doom lands" AMBIGUOUS case). Nobody quits and
+				# no efficiency/leave debuff is applied (that's L2 #613's job) — the
+				# affected researchers stay but trust erodes: `value` loyalty points come
+				# off the LOYALTY_HIT_COUNT least-loyal researchers, named for legibility,
+				# same targeting convention as remove_researchers/_poach_least_loyal.
+				_apply_loyalty_hit(state, int(value), staffing_notes)
 
 	# EE-7 (loss legibility): report the NET resource deltas this choice applied
 	# (effects minus costs) so the event log can state them explicitly. Staffing /
@@ -349,6 +358,29 @@ static func _apply_staffing_effect(state: GameState, spec: String, delta: int, n
 			if poached == null:
 				break
 			notes.append(_format_departure(state, poached))
+
+
+## How many researchers a "loyalty_hit" effect dents — matches the burnout event's
+## "several researchers are considering leaving" flavor (plural, not everyone).
+const LOYALTY_HIT_COUNT := 2
+
+
+static func _apply_loyalty_hit(state: GameState, amount: int, notes: Array) -> void:
+	"""Dock `amount` loyalty points off the LOYALTY_HIT_COUNT least-loyal researchers
+	(no removal, no efficiency/leave debuff — interim content, see loyalty_hit match
+	arm above). Least-loyal-first mirrors _poach_least_loyal's targeting so the
+	people most likely to already be flight-risks (DQ-22: loyalty hits raise poach
+	vulnerability) are the ones who take the hit. Safe no-op with an empty roster."""
+	if amount <= 0 or state.researchers.is_empty():
+		return
+	var pool: Array = state.researchers.duplicate()
+	pool.sort_custom(func(a, b): return a.loyalty < b.loyalty)
+	for i in range(min(LOYALTY_HIT_COUNT, pool.size())):
+		var r: Researcher = pool[i]
+		var before := r.loyalty
+		r.loyalty = max(0, r.loyalty - amount)
+		notes.append("%s (%s) loyalty %d -> %d — pushed through burnout, trust eroding" % [
+			r.researcher_name, r.specialization, before, r.loyalty])
 
 
 static func _poach_least_loyal(state: GameState, spec_filter: String) -> Researcher:

--- a/godot/scripts/debug/flight_recorder.gd
+++ b/godot/scripts/debug/flight_recorder.gd
@@ -1,0 +1,249 @@
+extends CanvasLayer
+class_name FlightRecorder
+## Playtest "flight recorder" — WORKSHOP_2_BACKLOG "Playtest deep-dive protocol":
+## a couple of comprehensively logged human run-throughs, reviewed as a unit. One
+## press of F9 (the `flight_recorder` keybind) dumps, into a timestamped session
+## directory under user://, everything needed to reconstruct "what did Pip see and
+## think, right here": (a) a screenshot, (b) a JSON state snapshot — reusing
+## GameState.to_dict(), the SAME serializer save/load uses, not a parallel one —
+## and (c) an auto-incrementing marker id + an optional short note, also appended
+## to one session manifest.jsonl so the whole run can be replayed as a timeline.
+##
+## Dev-build only (BuildInfo.is_dev_build(), same gate as DevModeOverlay); zero
+## effect on normal play when gated off. Registered the same way as the DEV MODE
+## overlay: a signal on KeybindManager, connected here, built in code (no .tscn).
+##
+## Pause semantics: this engine has no continuous auto-advance — MonthController
+## only steps forward via an explicit advance_tick() call triggered by player input
+## (End Turn / End Month). So capturing state never races a turn resolving on its
+## own. The one place a press CAN'T be instantaneous is the note popup: while it
+## waits for Enter/Esc, the full-rect modal (MOUSE_FILTER_STOP) blocks the game's
+## own buttons the same way any other modal dialog in this codebase does — this is
+## normal input-blocking, not a second pause mechanism layered on top of
+## MonthController's. If MonthController is already mid a window pause
+## (`month_controller.is_paused()`), the capture simply operates on that
+## already-halted state; nothing extra is needed there either.
+
+const SESSION_ROOT := "user://flight_recorder"
+## Above the DEV MODE overlay (150) so the note popup is never hidden behind it,
+## below the DEV BUILD badge (200).
+const OVERLAY_LAYER := 180
+
+## Reference to the MainUI node so the live GameManager/state can be resolved
+## the same way DevModeOverlay does (main_ui.gd wires this at instantiation).
+var main_ui: Node = null
+
+var session_dir: String = ""
+var marker_count: int = 0
+var _built := false
+var _root: Control = null
+var _note_edit: LineEdit = null
+var _pending: Dictionary = {}
+
+
+# --- Live-manager resolution (mirrors dev_mode_overlay.gd's _live_gm) -------
+
+func _live_gm() -> Node:
+	if main_ui != null:
+		var gm = main_ui.get("game_manager")
+		if gm != null:
+			return gm
+	return GameManager
+
+
+func _ready() -> void:
+	layer = OVERLAY_LAYER
+	if not BuildInfo.is_dev_build():
+		visible = false
+		return
+	_build_note_popup()
+	_built = true
+	if is_instance_valid(KeybindManager):
+		KeybindManager.flight_recorder_requested.connect(_on_capture_requested)
+
+
+# --- Pure helpers (unit-tested without a live viewport/GameManager) --------
+
+## Reuse the save-serialization path — do NOT hand-roll a parallel serializer.
+static func build_state_snapshot(state) -> Dictionary:
+	if state == null:
+		return {}
+	return state.to_dict()
+
+
+## Zero-padded marker id + timestamp, chosen so a press's three files
+## (…_note.txt, …_screenshot.png, …_state.json) sort adjacently by filename.
+static func marker_prefix(marker_id: int, timestamp: Dictionary) -> String:
+	return "%04d_%04d%02d%02d_%02d%02d%02d" % [
+		marker_id,
+		int(timestamp.get("year", 0)), int(timestamp.get("month", 0)), int(timestamp.get("day", 0)),
+		int(timestamp.get("hour", 0)), int(timestamp.get("minute", 0)), int(timestamp.get("second", 0)),
+	]
+
+
+static func session_dir_name(timestamp: Dictionary) -> String:
+	return "session_%04d%02d%02d_%02d%02d%02d" % [
+		int(timestamp.get("year", 0)), int(timestamp.get("month", 0)), int(timestamp.get("day", 0)),
+		int(timestamp.get("hour", 0)), int(timestamp.get("minute", 0)), int(timestamp.get("second", 0)),
+	]
+
+
+static func build_manifest_entry(marker_id: int, note: String, state, prefix: String) -> Dictionary:
+	return {
+		"marker_id": marker_id,
+		"turn": (state.turn if state != null else -1),
+		"note": note,
+		"files": {
+			"note": prefix + "_note.txt",
+			"screenshot": prefix + "_screenshot.png",
+			"state": prefix + "_state.json",
+		},
+	}
+
+
+# --- Capture flow ------------------------------------------------------------
+
+func _on_capture_requested() -> void:
+	if not _built:
+		return
+	var gm := _live_gm()
+	if gm == null or gm.get("state") == null:
+		return
+	_capture(gm.state)
+
+
+func _capture(state) -> void:
+	_ensure_session_dir()
+	marker_count += 1
+	var timestamp := Time.get_datetime_dict_from_system()
+	var prefix := marker_prefix(marker_count, timestamp)
+
+	# (a) Screenshot
+	var image := get_viewport().get_texture().get_image()
+	var screenshot_path := session_dir.path_join(prefix + "_screenshot.png")
+	var shot_err := image.save_png(screenshot_path)
+	if shot_err != OK:
+		push_error("[FlightRecorder] Failed to save screenshot: %s" % shot_err)
+
+	# (b) JSON state snapshot — GameState.to_dict(), the save/load serializer.
+	var snapshot := build_state_snapshot(state)
+	var state_path := session_dir.path_join(prefix + "_state.json")
+	var sf := FileAccess.open(state_path, FileAccess.WRITE)
+	if sf != null:
+		sf.store_string(JSON.stringify(snapshot, "\t"))
+		sf.close()
+	else:
+		push_error("[FlightRecorder] Failed to open state snapshot for writing: %s" % state_path)
+
+	# (c) Marker id + optional note — collected via the popup, then appended
+	# to the manifest once the player presses Enter/Esc.
+	_pending = {"prefix": prefix, "marker_id": marker_count, "state": state}
+	_show_note_popup()
+
+
+func _ensure_session_dir() -> void:
+	if session_dir != "":
+		return
+	var timestamp := Time.get_datetime_dict_from_system()
+	var name := session_dir_name(timestamp)
+	session_dir = SESSION_ROOT.path_join(name)
+	DirAccess.make_dir_recursive_absolute(session_dir)
+	# Print the absolute path on first use so a playtester can find the session
+	# without hunting for Godot's user:// mapping.
+	var abs_path := OS.get_user_data_dir().path_join("flight_recorder").path_join(name)
+	print("[FlightRecorder] Session directory: %s" % abs_path)
+
+
+func _append_manifest(entry: Dictionary) -> void:
+	var path := session_dir.path_join("manifest.jsonl")
+	var existing := ""
+	if FileAccess.file_exists(path):
+		var rf := FileAccess.open(path, FileAccess.READ)
+		if rf != null:
+			existing = rf.get_as_text()
+			rf.close()
+	var wf := FileAccess.open(path, FileAccess.WRITE)
+	if wf != null:
+		wf.store_string(existing + JSON.stringify(entry) + "\n")
+		wf.close()
+
+
+# --- Note popup UI (tiny textbox, Enter to save, Esc to skip) --------------
+
+func _build_note_popup() -> void:
+	_root = Control.new()
+	_root.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	# Blocks clicks to the game behind it while the note prompt is up — the same
+	# ordinary input-blocking any modal dialog in this codebase already does, not
+	# an extra sim-pause mechanism (see class doc).
+	_root.mouse_filter = Control.MOUSE_FILTER_STOP
+	_root.visible = false
+	add_child(_root)
+
+	var dim := ColorRect.new()
+	dim.color = Color(0, 0, 0, 0.35)
+	dim.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	dim.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_root.add_child(dim)
+
+	var panel := PanelContainer.new()
+	panel.set_anchors_and_offsets_preset(Control.PRESET_CENTER)
+	panel.custom_minimum_size = Vector2(420, 0)
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.05, 0.05, 0.08, 0.96)
+	style.border_color = Color(0.9, 0.6, 0.1)
+	style.set_border_width_all(2)
+	style.set_content_margin_all(12)
+	panel.add_theme_stylebox_override("panel", style)
+	_root.add_child(panel)
+
+	var vb := VBoxContainer.new()
+	panel.add_child(vb)
+
+	var title := Label.new()
+	title.text = "🛩  Flight recorder marker"
+	title.add_theme_color_override("font_color", Color(1.0, 0.75, 0.2))
+	vb.add_child(title)
+
+	_note_edit = LineEdit.new()
+	_note_edit.placeholder_text = "Optional note — Enter to save, Esc to skip"
+	_note_edit.text_submitted.connect(_on_note_submitted)
+	vb.add_child(_note_edit)
+
+
+func _show_note_popup() -> void:
+	_root.visible = true
+	_note_edit.text = ""
+	_note_edit.grab_focus()
+
+
+func _on_note_submitted(text: String) -> void:
+	_finish_marker(text)
+
+
+func _on_note_skipped() -> void:
+	_finish_marker("")
+
+
+func _finish_marker(note: String) -> void:
+	var prefix: String = _pending.get("prefix", "")
+	if prefix != "":
+		var note_path := session_dir.path_join(prefix + "_note.txt")
+		var nf := FileAccess.open(note_path, FileAccess.WRITE)
+		if nf != null:
+			nf.store_string(note)
+			nf.close()
+		var entry := build_manifest_entry(_pending.get("marker_id", 0), note, _pending.get("state"), prefix)
+		_append_manifest(entry)
+		if is_instance_valid(NotificationManager) and NotificationManager.has_method("info"):
+			NotificationManager.info("Flight recorder: marker %d captured" % entry["marker_id"])
+	_root.visible = false
+	_pending = {}
+
+
+func _input(event: InputEvent) -> void:
+	if _root == null or not _root.visible:
+		return
+	if event is InputEventKey and event.pressed and not event.echo and event.keycode == KEY_ESCAPE:
+		_on_note_skipped()
+		get_viewport().set_input_as_handled()

--- a/godot/scripts/debug/flight_recorder.gd.uid
+++ b/godot/scripts/debug/flight_recorder.gd.uid
@@ -1,0 +1,1 @@
+uid://borwknio8fwqu

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -168,6 +168,14 @@ func _ready():
 	dev_overlay.main_ui = self
 	add_child(dev_overlay)
 
+	# Playtest flight recorder (F9) — screenshot + state snapshot + marker note in
+	# one press (WORKSHOP_2_BACKLOG "Playtest deep-dive protocol"). Same wiring
+	# pattern as the DEV MODE overlay: gated on BuildInfo.DEV_BUILD by the node
+	# itself, resolves the live GameManager via main_ui.
+	var flight_recorder := FlightRecorder.new()
+	flight_recorder.main_ui = self
+	add_child(flight_recorder)
+
 	# Enable input processing for keyboard shortcuts
 	set_process_input(true)
 	set_process_unhandled_input(true)

--- a/godot/tests/unit/test_events.gd
+++ b/godot/tests/unit/test_events.gd
@@ -455,6 +455,7 @@ const HANDLED_EFFECT_KEYS := [
 	"compute_engineers",  # scalar legacy count (ResourceAccessor.add)
 	"safety_researchers", "capability_researchers",  # staffing arms
 	"has_cat", "lose_researcher",
+	"loyalty_hit",  # employee_burnout "Push Through" interim content (WORKSHOP_2_BACKLOG ruling)
 ]
 
 # Every cost key can_afford/spend_resources actually checks and deducts.
@@ -477,3 +478,57 @@ func test_all_core_event_cost_keys_are_payable():
 				assert_true(key in PAYABLE_COST_KEYS,
 					"%s/%s cost key '%s' is not checked by can_afford/spend_resources — it would be silently free (#631)" % [
 						event.get("id", "?"), option.get("id", "?"), key])
+
+# ---------------------------------------------------------------------------
+# employee_burnout / "Push Through" — interim loyalty-hit content
+# (WORKSHOP_2_BACKLOG "Burnout outcome model — RULED", Pip 2026-07-13, resolves
+# the #631/#635 AMBIGUOUS case: flavor said "considering leaving", effect was
+# doom-only). Push Through must no longer be toothless-beyond-doom: it now also
+# dents loyalty on the least-loyal researchers, named, with NO removal and NO
+# efficiency/leave debuff (that's L2 #613's job per the ruling).
+# ---------------------------------------------------------------------------
+
+func test_push_through_burnout_docks_loyalty_least_loyal_first_no_removal():
+	state.add_researcher(_make_researcher("safety", "Frayed Fiona", 20))
+	state.add_researcher(_make_researcher("safety", "Steady Sam", 80))
+	state.add_researcher(_make_researcher("capabilities", "Weary Wade", 10))
+	var before_count := state.researchers.size()
+	var before_doom := state.doom
+
+	var events = GameEvents.get_all_events()
+	var burnout = _find_event_by_id(events, "employee_burnout")
+	assert_false(burnout.is_empty(), "employee_burnout event should exist")
+
+	var result = GameEvents.execute_event_choice(burnout, "ignore_burnout", state)
+
+	assert_true(result["success"], "Push Through should succeed")
+	assert_eq(state.researchers.size(), before_count, "Push Through removes nobody (interim: loyalty-hit only)")
+	assert_eq(state.doom, before_doom + 3.0, "Doom still applies as flavor states")
+
+	# The two least-loyal researchers (Weary Wade 10, Frayed Fiona 20) take the hit;
+	# the most-loyal (Steady Sam 80) is untouched.
+	var by_name := {}
+	for r in state.researchers:
+		by_name[r.researcher_name] = r
+	assert_eq(by_name["Weary Wade"].loyalty, 0, "Least-loyal researcher's loyalty drops (clamped at 0)")
+	assert_eq(by_name["Frayed Fiona"].loyalty, 5, "Second least-loyal researcher's loyalty drops by 15")
+	assert_eq(by_name["Steady Sam"].loyalty, 80, "Most-loyal, unaffected researcher keeps his loyalty")
+
+	# Legibility: the affected researchers are named in the log (#631 pattern).
+	assert_true(result.has("messages"), "Loyalty hit is legible, not a silent stat change")
+	var joined: String = "\n".join(result["messages"])
+	assert_string_contains(joined, "Weary Wade", "Log names an affected researcher")
+	assert_string_contains(joined, "Frayed Fiona", "Log names the other affected researcher")
+	assert_does_not_have_string(joined, "Steady Sam", "Unaffected researcher not named")
+
+func test_push_through_burnout_with_no_researchers_is_safe_noop():
+	assert_eq(state.researchers.size(), 0, "Start empty")
+	var events = GameEvents.get_all_events()
+	var burnout = _find_event_by_id(events, "employee_burnout")
+	var result = GameEvents.execute_event_choice(burnout, "ignore_burnout", state)
+	assert_true(result["success"], "Still resolves with nobody on staff")
+	assert_eq(state.researchers.size(), 0, "Nobody to remove or dock")
+	assert_false(result.has("messages"), "No loyalty-hit note when nobody was affected")
+
+func assert_does_not_have_string(haystack: String, needle: String, msg: String) -> void:
+	assert_false(haystack.contains(needle), msg)

--- a/godot/tests/unit/test_flight_recorder.gd
+++ b/godot/tests/unit/test_flight_recorder.gd
@@ -1,0 +1,100 @@
+extends GutTest
+## Tests for the playtest flight recorder (F9) — WORKSHOP_2_BACKLOG "Playtest
+## deep-dive protocol". Covers the keybind registration and the pure snapshot/
+## manifest helpers; the actual screenshot (get_viewport().get_texture()) needs a
+## live rendered viewport and a human eye, per the task spec — not unit-tested here.
+
+
+func test_flight_recorder_keybind_registered_on_f9():
+	assert_true(KeybindManager.keybinds.has("flight_recorder"),
+		"flight_recorder action must be registered as a named keybind")
+	assert_eq(KeybindManager.keybinds["flight_recorder"]["key"], KEY_F9,
+		"flight_recorder should default to F9")
+
+
+func test_f9_emits_flight_recorder_requested():
+	var ev := InputEventKey.new()
+	ev.keycode = KEY_F9
+	ev.pressed = true
+	watch_signals(KeybindManager)
+	KeybindManager._input(ev)
+	assert_signal_emitted(KeybindManager, "flight_recorder_requested",
+		"Pressing F9 should fire flight_recorder_requested")
+
+
+# ---------------------------------------------------------------------------
+# Snapshot serialization — reuses GameState.to_dict() (the save/load path),
+# NOT a parallel serializer. This is the piece the task asks to unit-test.
+# ---------------------------------------------------------------------------
+
+func test_build_state_snapshot_reuses_to_dict():
+	var state := GameState.new("flight_recorder_test_seed")
+	var snapshot := FlightRecorder.build_state_snapshot(state)
+	var direct := state.to_dict()
+	assert_eq(snapshot.hash(), direct.hash(),
+		"build_state_snapshot must be exactly state.to_dict() — no parallel serializer")
+	assert_true(snapshot.has("turn"), "Snapshot carries the turn field")
+	assert_true(snapshot.has("money"), "Snapshot carries scalar resources")
+	assert_true(snapshot.has("researchers"), "Snapshot carries the researcher roster")
+	state.free()
+
+
+func test_build_state_snapshot_handles_null_state():
+	var snapshot := FlightRecorder.build_state_snapshot(null)
+	assert_eq(snapshot, {}, "Null state degrades to an empty dict, not a crash")
+
+
+func test_build_state_snapshot_is_json_round_trippable():
+	# The snapshot must survive JSON.stringify/parse_string (what actually gets
+	# written to the *_state.json file) without losing its shape.
+	var state := GameState.new("flight_recorder_json_seed")
+	state.turn = 7
+	var snapshot := FlightRecorder.build_state_snapshot(state)
+	var text := JSON.stringify(snapshot, "\t")
+	var parsed = JSON.parse_string(text)
+	assert_true(parsed is Dictionary, "Snapshot round-trips through JSON as a Dictionary")
+	assert_eq(int(parsed.get("turn", -1)), 7, "Turn value survives the JSON round trip")
+	state.free()
+
+
+# ---------------------------------------------------------------------------
+# File naming — screenshot/state/note for one press must sort adjacently.
+# ---------------------------------------------------------------------------
+
+func test_marker_prefix_is_zero_padded_and_sortable():
+	var ts := {"year": 2026, "month": 7, "day": 14, "hour": 9, "minute": 5, "second": 3}
+	var prefix := FlightRecorder.marker_prefix(1, ts)
+	assert_eq(prefix, "0001_20260714_090503")
+
+	var prefix10 := FlightRecorder.marker_prefix(10, ts)
+	assert_true(prefix < prefix10, "Marker 0001 sorts before marker 0010 (zero-padded)")
+
+
+func test_session_dir_name_format():
+	var ts := {"year": 2026, "month": 7, "day": 14, "hour": 9, "minute": 5, "second": 3}
+	assert_eq(FlightRecorder.session_dir_name(ts), "session_20260714_090503")
+
+
+func test_manifest_entry_files_share_marker_prefix_and_sort_adjacently():
+	var state := GameState.new("flight_recorder_manifest_seed")
+	state.turn = 3
+	var entry := FlightRecorder.build_manifest_entry(2, "specimen note", state, "0002_20260714_090503")
+
+	assert_eq(entry["marker_id"], 2)
+	assert_eq(entry["turn"], 3)
+	assert_eq(entry["note"], "specimen note")
+
+	var files: Dictionary = entry["files"]
+	var names: Array = files.values()
+	names.sort()
+	# All three filenames share the "0002_20260714_090503" prefix, so sorting
+	# them alphabetically keeps them adjacent regardless of key order.
+	for n in names:
+		assert_string_starts_with(String(n), "0002_20260714_090503",
+			"Each captured file for one press shares the marker prefix")
+	state.free()
+
+
+func test_manifest_entry_handles_null_state():
+	var entry := FlightRecorder.build_manifest_entry(5, "", null, "0005_x")
+	assert_eq(entry["turn"], -1, "Null state degrades to turn -1, not a crash")

--- a/godot/tests/unit/test_flight_recorder.gd.uid
+++ b/godot/tests/unit/test_flight_recorder.gd.uid
@@ -1,0 +1,1 @@
+uid://c4rv0kqj6ffqi


### PR DESCRIPTION
## Summary

Two small independent dev-tooling/content items:

**Playtest flight recorder** (docs/game-design/WORKSHOP_2_BACKLOG.md "Playtest deep-dive protocol"): F9, registered alongside the existing DEV MODE overlay's backslash toggle, dumps a screenshot + a JSON state snapshot (reuses `GameState.to_dict()`, the save/load serializer — no parallel serializer) + an auto-incrementing marker id with an optional note (tiny popup, Enter to save / Esc to skip) into a timestamped session directory under `user://flight_recorder/` (absolute path printed to console on first use). Marker events also append to one `manifest.jsonl` per session. Files share a zero-padded marker prefix so one press's three files sort adjacently. Dev-build-only (`BuildInfo.is_dev_build()`); zero effect on normal play.

**Burnout interim content** (#631, ruled in WORKSHOP_2_BACKLOG "Burnout outcome model — RULED", resolves the #631/#635 AMBIGUOUS case): `employee_burnout`'s "Push Through" outcome claimed strain but only applied doom. It now also docks loyalty on the two least-loyal researchers (least-loyal-first, same targeting convention as `remove_researchers`/`_poach_least_loyal` from #635), named for legibility, with outcome text updated to say so honestly. No efficiency debuffs or extended-leave states — that's lane L2's (#613) job per the ruling. #635's flavor-vs-effect property tests (`test_all_core_event_effect_keys_are_handled`) still pass — the new `loyalty_hit` key is whitelisted.

## Test plan

- [x] Fresh worktree `--import` pass (headless) before GUT, per known environment quirk
- [x] `test_events.gd` in isolation: 33/33 passing, 730 asserts (includes the 2 new burnout outcome tests)
- [x] `test_flight_recorder.gd` in isolation: 9/9 passing, 20 asserts
- [x] Full local unit suite (`-gdir=res://tests/unit`, Godot 4.5.1 headless): **421/421 passing, 40 scripts, 4491 asserts** (up from 412/412 baseline before this branch — CI is hollow per #629, so this is the real signal)
- [x] No `.import` churn staged

## Local test evidence

```
Scripts              40
Tests               421
Passing Tests       421
Asserts            4491
---- All tests passed! ----
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)