### PR TITLE
qa: shutdown resource hygiene + silent-error audit

### DIFF
--- a/godot/autoload/music_manager.gd
+++ b/godot/autoload/music_manager.gd
@@ -41,6 +41,10 @@ var current_track_index: int = 0
 var is_crossfading: bool = false
 var music_enabled: bool = true
 
+# The in-flight crossfade tween, tracked so it can be killed on stop/shutdown. Left
+# untracked, a tween still running at quit leaks (ObjectDB warning at exit).
+var _crossfade_tween: Tween = null
+
 func _ready():
 	print("[MusicManager] Initializing music system...")
 
@@ -152,11 +156,13 @@ func _crossfade_to_track(new_stream: AudioStream):
 
 	# Crossfade animation
 	var tween = create_tween()
+	_crossfade_tween = tween
 	tween.set_parallel(true)
 	tween.tween_property(active_player, "volume_db", -80, CROSSFADE_DURATION)
 	tween.tween_property(inactive_player, "volume_db", 0, CROSSFADE_DURATION)
 
 	await tween.finished
+	_crossfade_tween = null
 
 	# Stop old player and swap
 	active_player.stop()
@@ -186,7 +192,11 @@ func stop_music():
 	print("[MusicManager] Stopping music")
 
 	if is_crossfading:
-		get_tree().create_tween().kill()
+		# Kill the actual in-flight crossfade tween. The old code created a fresh tween and
+		# killed that instead — a no-op that left the real crossfade running.
+		if _crossfade_tween != null and _crossfade_tween.is_valid():
+			_crossfade_tween.kill()
+		_crossfade_tween = null
 		is_crossfading = false
 
 	var tween = create_tween()
@@ -225,6 +235,22 @@ func get_current_track_name() -> String:
 	if active_player.stream:
 		return active_player.stream.resource_path.get_file().get_basename()
 	return "None"
+
+## Shutdown cleanup. Autoloads are freed during SceneTree teardown at quit; without this
+## the running crossfade Tween plus the playing AudioStreamPlayback/AudioStream objects are
+## still live when the engine's leak check runs, producing the "ObjectDB instances leaked"
+## warning and "resources still in use at exit" error. Killing the tween and clearing both
+## players' streams releases those references before the check.
+func _exit_tree() -> void:
+	if _crossfade_tween != null and _crossfade_tween.is_valid():
+		_crossfade_tween.kill()
+	_crossfade_tween = null
+	if is_instance_valid(player_a):
+		player_a.stop()
+		player_a.stream = null
+	if is_instance_valid(player_b):
+		player_b.stop()
+		player_b.stream = null
 
 ## Debug: Print music library
 func print_library():

--- a/godot/docs/qa/SHUTDOWN_HYGIENE_2026-07-16.md
+++ b/godot/docs/qa/SHUTDOWN_HYGIENE_2026-07-16.md
@@ -1,0 +1,97 @@
+# Shutdown-Hygiene & Silent-Error Audit — 2026-07-16
+
+Lane: shutdown-hygiene & silent internal Godot errors. Godot 4.5.1 stable, headless.
+Branch `qa/shutdown-hygiene`. Investigate-and-report: unambiguous low-risk issues fixed with
+proof; everything needing judgment documented, not guessed.
+
+## How this was reproduced
+
+- **Clean shutdown leak dump:** `godot --headless --verbose --quit-after N` boots the real main
+  scene (`welcome.tscn` + all autoloads) and quits cleanly after N frames, so Godot's end-of-run
+  `ObjectDB` / `RID` / resource leak checks actually fire (a killed/timed-out process does NOT
+  run them). `N=120` (~2 s) lands mid-boot-crossfade; `N=400` lands after it settles.
+- **Gameplay-path silent errors:** the L1 month sweep (`tests/manual/test_l1_month_sweep.gd`,
+  72 runs driving plan→commit→day-tick playback→windows→boundary→death) plus the full
+  `tests/unit` GUT suite, both with stderr captured and grepped for
+  `push_error`/`SCRIPT ERROR`/`Nonexistent`/`Invalid`/`leaked`/`Orphan`.
+
+## Findings (ordered by severity)
+
+| # | Symptom | Owning file:line | Root cause | Severity | Status |
+|---|---------|------------------|------------|----------|--------|
+| 1 | 4 orphan Nodes leak per game instance (`game_state.gd`, `doom_system.gd`, `risk_pool.gd`, `turn_manager.gd`) — GUT orphan monitor prints "8 Orphans" after two games | `scripts/game_manager.gd:43` (`start_new_game`) and `:630` (`load_saved_game`) | `GameState`/`DoomSystem`/`RiskPool`/`TurnManager` all `extends Node` but are **never added to the scene tree**, so reassigning `state`/`turn_manager` orphans them. `start_new_game` freed nothing; `load_saved_game` freed only `state`, leaving its `doom_system`/`risk_system` and the old `turn_manager`. GameManager is an autoload persisting the whole process, so every restart / "play again" / load accumulates 4 leaked Nodes for the rest of the session. | **real-bug** (mid-session, accumulating) | **FIXED** + regression test |
+| 2 | `ObjectDB instances leaked at exit` + `2 resources still in use at exit`: a running `Tween`, `AudioStreamPlaybackMP3`, and the two MENU `AudioStream`s | `autoload/music_manager.gd` `_crossfade_to_track` (`await tween.finished`) | Autoload had no shutdown cleanup. If quit lands during the ~2 s boot crossfade, the coroutine suspended at `await tween.finished` keeps the `Tween` + the `new_stream` local alive; the players still hold their playbacks. | **cosmetic** (at-exit only; OS reclaims; does NOT accumulate mid-run — each crossfade completes and releases normally) | **PARTIALLY FIXED** — see note |
+| 3 | `stop_music()` fails to stop an in-flight crossfade | `autoload/music_manager.gd` `stop_music()` (was `get_tree().create_tween().kill()`) | Created a *fresh* tween and killed that instead of the real crossfade tween (which wasn't stored) — a no-op. Disabling music mid-crossfade left the crossfade running. | hygiene (minor, mid-run) | **FIXED** |
+| 4 | Headless GUT floods stderr with `SCRIPT ERROR: Parse Error: Identifier "FinanceEngine" not declared` (86×), `"FlightRecorder" not declared`, and `Nonexistent function 'get_all_actions'/'get_action_by_id'/'execute_action' in base 'GDScript'` — including a real backtrace at `turn_manager.gd:534` | environmental (Godot global class cache), not a code defect | Every one of those identifiers **is** declared (`finance_engine.gd:1`, `flight_recorder.gd:2`, `actions.gd:142/146/212`). The running game boots clean (only Finding #2 appears) and the sweep produces coherent evolving state, i.e. the statics resolve fine at runtime. This is the known "fresh-worktree headless GUT class-cache" gotcha: `--import` does not warm `global_script_class_cache.cfg` the way opening the editor once does, so GUT's dynamic per-script loads intermittently fail to resolve `class_name` references. | environmental / needs-verification | **Documented** (see recommendation) |
+| 5 | GUT reports "3 / 4 / 8 Orphans" on various tests | test scripts (e.g. `test_replay_verification.gd`) | Tests instantiate `GameState`+subsystems and don't free them (the same 4-Node shape as Finding #1 — the manual sweep already works around it by calling `.free()` explicitly). Test-code hygiene, not shipped code. | test hygiene | Documented |
+
+## Fixes applied
+
+### Finding #1 — GameManager leaks the previous game's Node subsystems (REAL, the headline)
+
+`scripts/game_manager.gd`: added `_release_game_objects()` which `queue_free()`s the old
+`state`, its orphaned `doom_system` + `risk_system`, and the old `turn_manager`, each guarded by
+`is_instance_valid`. Called at the top of `start_new_game` (after stopping month playback) and in
+`load_saved_game` in place of the old partial `state.queue_free()`.
+
+Safety verified before writing: every external reader reaches these subsystems through
+`state.doom_system` / `st.doom_system` (re-fetched from the current state, never cached across a
+reset — confirmed by grepping `ui/`, `debug/`, `core/`), so no live reference survives the swap.
+`Ledger` and `MonthController` are `RefCounted` and free themselves. `queue_free()` (deferred) is
+safe on these off-tree nodes and avoids invalidating an in-flight month-playback tick mid-frame.
+
+**Proof** (`tests/unit/test_game_lifecycle_hygiene.gd`): two consecutive `start_new_game` calls,
+asserting the global orphan-node count does not grow across the second call.
+- Fix disabled: `orphan delta=4` → **FAIL** (exactly state+doom+risk+turn_manager).
+- Fix enabled: `delta <= 0` → **PASS** (`1/1 passed`).
+
+### Finding #3 — stop_music no-op (FIXED)
+
+Now stores the crossfade tween in `_crossfade_tween` and `stop_music()` kills the real one.
+
+### Finding #2 — MusicManager shutdown leak (PARTIALLY FIXED)
+
+Added `_exit_tree()` that kills `_crossfade_tween` and clears both players' streams, and tracks
+the crossfade tween. **Verified:** quitting while music is settled (`--quit-after 400`, after the
+boot crossfade completes) now produces **zero** leaked instances / resources — previously it
+leaked regardless of timing.
+
+**Residual (left for Pip — judgment call):** if quit lands *inside* the ~2 s boot crossfade
+(`--quit-after 120`), the leak persists. Root cause is structural: `_crossfade_to_track` suspends
+on `await tween.finished`; a killed tween never emits `finished`, so the coroutine stays suspended
+holding the `Tween` and `new_stream`. `_exit_tree` cannot resume a coroutine. Fully closing it
+means restructuring the crossfade to a one-shot `tween.finished.connect(...)` callback (no
+suspended coroutine) — a refactor of audio behaviour I did not ship unreviewed under a hygiene PR,
+since it is cosmetic (at-exit, OS-reclaimed, non-accumulating) and headless can't verify the audio
+still sounds right. **Recommendation:** de-coroutine the crossfade, or add an explicit
+"is this crossfade still valid" guard after the await.
+
+Secondary observation feeding #2: `welcome_screen.gd` calls `MusicManager.play_context(MENU)`
+**twice** (lines 29 and 77), which forces an unnecessary crossfade at boot — the exact window that
+produces the reported "mid-crossfade teardown" leak. Collapsing that to one call would also shrink
+the leak window. Left for Pip (UI-flow judgment).
+
+## Recommendations (not fixed — need judgment / are environmental)
+
+- **Finding #4 / issue #629 (hollow CI):** the headless GUT run emits ~150 `SCRIPT ERROR` lines
+  from class-cache resolution that are *not* real defects but *do* bury any genuine error and make
+  a green/red read unreliable. Recommend: warm `global_script_class_cache.cfg` (open the project in
+  the editor once, or add a cache-priming step) before the headless GUT run in CI, then treat
+  residual `SCRIPT ERROR`/`push_error` as failures. This is a prerequisite for trusting the suite.
+- **Finding #5:** give the sim tests a teardown that frees `GameState` + `doom_system` +
+  `risk_system` + `turn_manager` (mirror the manual sweep's explicit `.free()`), removing the
+  orphan noise.
+
+## The single most important finding
+
+**Finding #1.** It is the only *accumulating mid-run/mid-session* leak: 4 Nodes per game, unbounded
+across a session of restarts/loads (a real bite for the now-many-minute calibrated sessions and
+"play again" loops), and it explains the "resources left running at the end" impression far better
+than the music leak. The MusicManager leak (Finding #2), by contrast, is a single at-exit snapshot
+that the OS reclaims and never accumulates during play.
+
+## Verification status
+
+- `test_game_lifecycle_hygiene.gd`: 1/1 pass (and demonstrably fails without the fix).
+- `--quit-after 400` after fix: zero leaks/resources-in-use.
+- No `.import` files are included in this change (worktree import churn excluded from the commit).

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -40,6 +40,13 @@ func start_new_game(game_seed: String = ""):
 	print("  Difficulty: %s" % GameConfig.get_difficulty_string())
 	print("  Scenario: %s" % (GameConfig.scenario_id if not GameConfig.scenario_id.is_empty() else "Standard"))
 
+	# Release the previous game's orphaned Node subsystems before replacing them. Without
+	# this, restarting / "play again" inside a session leaks 4 Nodes per game (see
+	# _release_game_objects). Stop any in-flight month playback first so no tick touches the
+	# state we are about to drop.
+	month_playback_active = false
+	_release_game_objects()
+
 	state = GameState.new(game_seed)
 
 	# Apply scenario overrides (before difficulty, so difficulty can further modify)
@@ -597,6 +604,24 @@ func get_game_state() -> Dictionary:
 # SAVE / LOAD (L7, #618) — mid-game snapshot, full-state fidelity
 # ============================================================================
 
+func _release_game_objects() -> void:
+	"""Free the previous game's Node-derived objects before a new game / load replaces them.
+
+	GameState, DoomSystem, RiskPool and TurnManager all extend Node but are NEVER added to
+	the scene tree, so simply reassigning `state`/`turn_manager` orphans them — 4 leaked
+	Nodes per game (confirmed by GUT's orphan monitor). Ledger and MonthController are
+	RefCounted and free themselves. Every external reader reaches these via `state.doom_system`
+	etc. (re-fetched from the current state), so no live reference survives a reset.
+	queue_free() is deferred and safe to call on an off-tree node."""
+	if state != null and is_instance_valid(state):
+		if state.doom_system != null and is_instance_valid(state.doom_system):
+			state.doom_system.queue_free()
+		if state.risk_system != null and is_instance_valid(state.risk_system):
+			state.risk_system.queue_free()
+		state.queue_free()
+	if turn_manager != null and is_instance_valid(turn_manager):
+		turn_manager.queue_free()
+
 func save_game(path: String = SaveLoad.QUICKSAVE_PATH) -> bool:
 	"""Snapshot the current game to a save file. Safe to call from the pause menu."""
 	if not is_initialized or state == null:
@@ -620,8 +645,10 @@ func load_saved_game(path: String = SaveLoad.QUICKSAVE_PATH) -> bool:
 	if loaded == null:
 		error_occurred.emit("Save file is corrupt or incompatible")
 		return false
-	if state != null:
-		state.queue_free()  # GameState extends Node; drop the old instance
+	# Drop the old game's Node subsystems (state + doom/risk + turn_manager). The previous
+	# code freed only `state`, leaking its orphaned doom_system/risk_system and the old
+	# turn_manager on every load.
+	_release_game_objects()
 	state = loaded
 	# Scenario custom events live as node meta (Issue #483), not in state
 	# serialization — re-attach them from the pack recorded in the envelope.

--- a/godot/tests/unit/test_game_lifecycle_hygiene.gd
+++ b/godot/tests/unit/test_game_lifecycle_hygiene.gd
@@ -1,0 +1,42 @@
+extends GutTest
+## Regression guard for the game-object lifecycle leak (docs/qa/SHUTDOWN_HYGIENE_2026-07-16.md,
+## Finding #1). GameState, DoomSystem, RiskPool and TurnManager all extend Node but are never
+## added to the scene tree, so before the fix every start_new_game / load_saved_game orphaned
+## the previous game's 4 Nodes (GUT's orphan monitor reported "8 Orphans" for two games in a
+## session). GameManager._release_game_objects() now frees them symmetrically on both paths.
+##
+## The test drives two consecutive start_new_game calls on a fresh GameManager and asserts the
+## global orphan-node count does not grow across the second call (the second start must free the
+## first game's subsystems before allocating its own).
+
+func test_start_new_game_frees_prior_game_node_subsystems() -> void:
+	var GM = load("res://scripts/game_manager.gd")
+	var gm = GM.new()
+	add_child_autofree(gm)
+
+	# Neutralise the background baseline simulator so it can't add per-call orphan noise.
+	var prev_mode = GameConfig.baseline_mode
+	var prev_seed = GameConfig.game_seed
+	GameConfig.baseline_mode = 0
+	GameConfig.game_seed = ""
+
+	gm.start_new_game("hygiene-seed-1")
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var orphans_after_first: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
+
+	gm.start_new_game("hygiene-seed-2")
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var orphans_after_second: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
+
+	# Clean up the trailing game's orphaned subsystems so this test does not pollute others.
+	gm._release_game_objects()
+	await get_tree().process_frame
+
+	GameConfig.baseline_mode = prev_mode
+	GameConfig.game_seed = prev_seed
+
+	var delta: int = orphans_after_second - orphans_after_first
+	# Before the fix delta was +4 (state + doom_system + risk_system + turn_manager).
+	assert_true(delta <= 0, "second start_new_game must not leak the prior game's Node subsystems (orphan delta=%d, expected <= 0)" % delta)


### PR DESCRIPTION
Investigate-and-report lane: quit-time resource leaks + silent internal Godot errors. Full findings: `godot/docs/qa/SHUTDOWN_HYGIENE_2026-07-16.md`. **Do not merge — for Pip review.**

## Headline finding (the real bug)
`GameManager` leaked **4 orphan Nodes per game** (`GameState` + `DoomSystem` + `RiskPool` + `TurnManager` — all `extends Node`, never added to the tree). `start_new_game` freed nothing; `load_saved_game` freed only `state`. Since GameManager is an autoload persisting the whole process, every restart / "play again" / load accumulated 4 leaked Nodes — an **accumulating mid-session leak**, not just an at-quit blip. GUT's orphan monitor independently showed "8 Orphans" for two games.

**Fix:** `_release_game_objects()` frees the old state + its orphaned subsystems + old turn_manager, called symmetrically on both paths. Verified safe: all external readers reach the subsystems via `state.doom_system` (re-fetched, never cached across a reset).

## Fixes in this PR (unambiguous, low-risk)
- **game_manager.gd** — the leak above. Regression test `test_game_lifecycle_hygiene.gd` proves it: orphan delta **4 → ≤0** (fails without the fix, passes with).
- **music_manager.gd** — added `_exit_tree` cleanup + tween tracking; verified **zero** leaks at `--quit-after 400` (settled music). Also fixed `stop_music()` killing a throwaway tween instead of the real crossfade.

## Left for Pip (documented, not guessed)
- Residual MusicManager leak **only** if quit lands inside the ~2 s boot crossfade (suspended `await tween.finished`) — cosmetic, at-exit, OS-reclaimed. Needs a callback-based crossfade refactor (audio-behaviour judgment).
- ~150 headless-GUT `class_name`-resolution `SCRIPT ERROR`s (`FinanceEngine`/`FlightRecorder`/`GameActions.*`) — environmental (cold class cache), not code defects; but they bury real errors → relevant to the hollow-CI issue #629.

## Verification
- `test_game_lifecycle_hygiene.gd`: 1/1 (and demonstrably fails without the fix).
- `test_game_manager.gd`: 35/35 (hammers start_new_game 40×).
- `--quit-after 400`: zero leaks / resources-in-use.
- No `.import` churn included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)