### PR TITLE
fix(hud): turn counter + F9→F6 rebind + remove stale win-condition string

### DIFF
--- a/godot/autoload/keybind_manager.gd
+++ b/godot/autoload/keybind_manager.gd
@@ -25,8 +25,9 @@ var keybinds: Dictionary = {
 	"dev_mode": {"key": KEY_BACKSLASH, "category": Category.DEBUG, "description": "Toggle Dev Mode Overlay"},
 	# Playtest flight recorder (WORKSHOP_2_BACKLOG "Playtest deep-dive protocol"): one press
 	# dumps a screenshot + state snapshot + marker note. Gated on BuildInfo.DEV_BUILD by
-	# FlightRecorder itself, same pattern as dev_mode. F9 is otherwise unused.
-	"flight_recorder": {"key": KEY_F9, "category": Category.DEBUG, "description": "Flight Recorder Capture (screenshot + state + note)"},
+	# FlightRecorder itself, same pattern as dev_mode. Rebound from F9 to F6 (Pip playtest:
+	# F9 collides with his Nvidia overlay hotkey). F6 is otherwise unused.
+	"flight_recorder": {"key": KEY_F6, "category": Category.DEBUG, "description": "Flight Recorder Capture (screenshot + state + note)"},
 	"admin_mode": {"key": KEY_BRACKETRIGHT, "category": Category.ADMIN, "description": "Toggle Admin Mode"},
 
 	# Gameplay
@@ -72,7 +73,7 @@ var profiles: Dictionary = {}  # profile_name -> keybind dict
 
 # Config file
 const CONFIG_PATH = "user://keybinds.cfg"
-const KEYBINDS_CONFIG_VERSION = 4  # bump when default binds change; stale saved configs refresh to defaults
+const KEYBINDS_CONFIG_VERSION = 5  # bump when default binds change; stale saved configs refresh to defaults
 var config = ConfigFile.new()
 
 # Signals
@@ -300,7 +301,7 @@ func _input(event: InputEvent):
 		dev_mode_toggled.emit()
 		get_viewport().set_input_as_handled()
 
-	# Flight recorder (F9) — screenshot + state snapshot + marker note in one press
+	# Flight recorder (F6) — screenshot + state snapshot + marker note in one press
 	# (dev builds only; FlightRecorder itself gates on BuildInfo.is_dev_build()).
 	elif is_action_pressed(event, "flight_recorder"):
 		flight_recorder_requested.emit()

--- a/godot/scenes/main.tscn
+++ b/godot/scenes/main.tscn
@@ -71,6 +71,13 @@ theme_override_font_sizes/font_size = 18
 theme_override_colors/font_color = Color(0.9, 0.9, 0.3, 1)
 theme_override_styles/normal = SubResource("StyleBoxFlat_TurnCounter")
 
+[node name="TurnCountLabel" type="Label" parent="TabManager/MainUI/TopBar"]
+layout_mode = 2
+text = "Turn 1"
+tooltip_text = "Turn counter — number of workdays elapsed this run."
+theme_override_font_sizes/font_size = 14
+mouse_filter = 0
+
 [node name="Sep2" type="Label" parent="TabManager/MainUI/TopBar"]
 layout_mode = 2
 text = "|"
@@ -246,7 +253,7 @@ layout_mode = 2
 
 [node name="ExplanationLabel" type="Label" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/RightZones/DoomExplanation"]
 layout_mode = 2
-text = "Win: P(Doom) = 0% or beat baseline | Lose: P(Doom) = 100%"
+text = "Buy time · survival is the score | Lose: P(Doom) = 100%"
 horizontal_alignment = 1
 theme_override_font_sizes/font_size = 10
 theme_override_colors/font_color = Color(0.6, 0.7, 0.6, 0.8)

--- a/godot/scripts/debug/flight_recorder.gd
+++ b/godot/scripts/debug/flight_recorder.gd
@@ -2,7 +2,7 @@ extends CanvasLayer
 class_name FlightRecorder
 ## Playtest "flight recorder" — WORKSHOP_2_BACKLOG "Playtest deep-dive protocol":
 ## a couple of comprehensively logged human run-throughs, reviewed as a unit. One
-## press of F9 (the `flight_recorder` keybind) dumps, into a timestamped session
+## press of F6 (the `flight_recorder` keybind) dumps, into a timestamped session
 ## directory under user://, everything needed to reconstruct "what did Pip see and
 ## think, right here": (a) a screenshot, (b) a JSON state snapshot — reusing
 ## GameState.to_dict(), the SAME serializer save/load uses, not a parallel one —

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -3,6 +3,7 @@ extends VBoxContainer
 
 # References to UI elements (TopBar now has all resources in one line)
 @onready var turn_label = $TopBar/TurnLabel
+@onready var turn_count_label = $TopBar/TurnCountLabel
 @onready var money_label = $TopBar/MoneyLabel
 @onready var compute_label = $TopBar/ComputeLabel
 @onready var research_label = $TopBar/ResearchLabel
@@ -168,7 +169,7 @@ func _ready():
 	dev_overlay.main_ui = self
 	add_child(dev_overlay)
 
-	# Playtest flight recorder (F9) — screenshot + state snapshot + marker note in
+	# Playtest flight recorder (F6) — screenshot + state snapshot + marker note in
 	# one press (WORKSHOP_2_BACKLOG "Playtest deep-dive protocol"). Same wiring
 	# pattern as the DEV MODE overlay: gated on BuildInfo.DEV_BUILD by the node
 	# itself, resolves the live GameManager via main_ui.
@@ -614,6 +615,9 @@ func _on_game_state_updated(state: Dictionary):
 		turn_label.text = turn_display
 	else:
 		turn_label.text = "Turn: %d" % state.get("turn", 0)
+	# Playtest (Pip): the month-year/date badge above has no single number to track
+	# state by. This is a plain "Turn N" counter next to it (#F6 HUD lane).
+	turn_count_label.text = "Turn %d" % state.get("turn", 0)
 	money_label.text = "💰 %s" % GameConfig.format_money(state.get("money", 0))
 	compute_label.text = "🖥️ %.1f" % state.get("compute", 0)
 	research_label.text = "🔬 %.1f" % state.get("research", 0)

--- a/godot/tests/unit/test_flight_recorder.gd
+++ b/godot/tests/unit/test_flight_recorder.gd
@@ -1,25 +1,25 @@
 extends GutTest
-## Tests for the playtest flight recorder (F9) — WORKSHOP_2_BACKLOG "Playtest
+## Tests for the playtest flight recorder (F6) — WORKSHOP_2_BACKLOG "Playtest
 ## deep-dive protocol". Covers the keybind registration and the pure snapshot/
 ## manifest helpers; the actual screenshot (get_viewport().get_texture()) needs a
 ## live rendered viewport and a human eye, per the task spec — not unit-tested here.
 
 
-func test_flight_recorder_keybind_registered_on_f9():
+func test_flight_recorder_keybind_registered_on_f6():
 	assert_true(KeybindManager.keybinds.has("flight_recorder"),
 		"flight_recorder action must be registered as a named keybind")
-	assert_eq(KeybindManager.keybinds["flight_recorder"]["key"], KEY_F9,
-		"flight_recorder should default to F9")
+	assert_eq(KeybindManager.keybinds["flight_recorder"]["key"], KEY_F6,
+		"flight_recorder should default to F6 (rebound off F9 — Nvidia overlay collision)")
 
 
-func test_f9_emits_flight_recorder_requested():
+func test_f6_emits_flight_recorder_requested():
 	var ev := InputEventKey.new()
-	ev.keycode = KEY_F9
+	ev.keycode = KEY_F6
 	ev.pressed = true
 	watch_signals(KeybindManager)
 	KeybindManager._input(ev)
 	assert_signal_emitted(KeybindManager, "flight_recorder_requested",
-		"Pressing F9 should fire flight_recorder_requested")
+		"Pressing F6 should fire flight_recorder_requested")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three small HUD fixes from Pip's playtest (F6 HUD lane). Strictly scoped — no button layout, doom meter, submenus, or action-economy changes.

## 1. Turn # indicator (top-left HUD)
Playtest note: *"I want a Turn # indicator also, I need 1 number going up to understand my state. Put it up the top left next to the mon-year and month-date indicators."*

Added a compact `TurnCountLabel` ("Turn N") in the TopBar cluster, right after the month-year/date badge (`TurnLabel`) and before the money readout. Reads `state.turn` each state update, matching existing TopBar label styling (font size 14).

## 2. Rebind flight recorder F9 → F6
Playtest note: F9 collides with Pip's Nvidia overlay hotkey.

- `keybind_manager.gd`: `flight_recorder` default rebound `KEY_F9` → `KEY_F6`.
- Bumped `KEYBINDS_CONFIG_VERSION` 4 → 5 so any stale saved `keybinds.cfg` refreshes to the new default (same self-heal the code comment already documents).
- Verified **no collision**: F6 was unused across the keybind table.
- Updated the on-screen/doc hint comments (main_ui.gd, flight_recorder.gd, keybind_manager.gd) and the unit test (`test_flight_recorder.gd`) to F6.
- Note: `settings_menu.tscn`'s `[F9]` label is a separate "Quick load" shortcut, left untouched (out of scope).

## 3. Remove stale win-condition string
The center doom-panel label promised a win the engine never grants — `game_state.gd check_win_lose()` never sets victory (the game is unwinnable by design; you can only buy time).

- Old: `Win: P(Doom) = 0% or beat baseline | Lose: P(Doom) = 100%`
- New: `Buy time · survival is the score | Lose: P(Doom) = 100%`

Grounded in ADR-0002 ("There is no victory condition… you cannot win, only buy time") and DESIGN_PHILOSOPHY "On losing". The only hard requirement met here is that **no false "Win" claim remains** — final voice/wording is Pip's to tweak.

## Verification
- Headless `--import` pass + game smoke-run: no parse/runtime errors from these changes.
- `test_flight_recorder.gd`: 9/9 pass (updated F6 assertions).
- Full local unit suite: 355/355 tests green across 37 scripts (3743 asserts, exit 0).

Playtest source: Pip's F6 HUD-fixes lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
