### PR TITLE
fix(ui): feed shows in-game dates + right-align upgrade buttons

### DIFF
--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -886,9 +886,13 @@ func _on_error_occurred(error_msg: String):
 	log_message("[color=red]ERROR: " + error_msg + "[/color]")
 
 func log_message(text: String):
-	"""Add a message to the log with timestamp"""
-	var timestamp = Time.get_ticks_msec() / 1000.0
-	message_log.text += "\n[color=gray][%.1fs][/color] %s" % [timestamp, text]
+	"""Add a message to the log with an in-game date stamp (playtest: real-seconds
+	timestamps were meaningless to players — show the calendar date instead, reusing
+	GameState.get_formatted_date(), the same helper the HUD date badge uses)."""
+	var date_stamp := "?"
+	if game_manager != null and game_manager.state != null:
+		date_stamp = game_manager.state.get_formatted_date()
+	message_log.text += "\n[color=gray][%s][/color] %s" % [date_stamp, text]
 
 	# Auto-scroll to bottom
 	await get_tree().process_frame
@@ -1062,9 +1066,11 @@ func _populate_upgrades():
 
 		# Create button
 		var button = ThemeManager.create_button(upgrade_name)
-		# Blockier tiles (#594): hug content on the left instead of stretching across the
-		# wide right panel, and ~20% taller (32 -> 38) so they read as tighter, blockier tiles.
-		button.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+		# Blockier tiles (#594): hug content instead of stretching across the wide right
+		# panel, and ~20% taller (32 -> 38) so they read as tighter, blockier tiles.
+		# Playtest-3: right-align the column to free up central screen space (was
+		# SIZE_SHRINK_BEGIN, hugging the left edge instead).
+		button.size_flags_horizontal = Control.SIZE_SHRINK_END
 		button.custom_minimum_size = Vector2(200, 38)
 
 		# If purchased, show differently


### PR DESCRIPTION
## Summary
Two readability fixes from Pip's playtest-3 session:

- **Feed timestamps → in-game date**: the message feed printed real wall-clock seconds (`[722.7s] FEED · ...`), which is meaningless to players. `log_message()` in `godot/scripts/ui/main_ui.gd` now stamps entries with the in-game calendar date via `GameState.get_formatted_date()` — the same helper the top-left HUD date badge already uses (`game_manager.state.get_formatted_date()`, same pattern as an existing debug print at `game_manager.gd:843`). No new date-formatting logic invented, no intra-day sequencing added.
- **Upgrade buttons right-aligned**: per playtest feedback ("they look a lot better now they're smaller... I think they could all align right"), the upgrade button column (`UpgradesList` VBoxContainer, `godot/scenes/main.tscn`) now packs against the right edge. Changed `button.size_flags_horizontal` from `Control.SIZE_SHRINK_BEGIN` to `Control.SIZE_SHRINK_END` in `_populate_upgrades()`. Button sizes/contents untouched — only the column alignment changed.

## Test plan
- [x] Headless `--import` pass — clean, no errors
- [x] Fast unit gate: `python scripts/run_godot_tests.py --quick --ci-mode` → 356 tests, 0 failures, 38/38 files collected
- [x] Headless launch of `res://scenes/main.tscn` — loads cleanly, no parse/binding errors
- [ ] Slow simulation suite — intentionally not run (separate non-blocking CI tier; full gate runs on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)