### PR TITLE
feat(ui): OfficeFloor employee sprites — Tier 0/1 standalone (Pip review)

### DIFF
--- a/godot/scenes/ui/office_floor/office_floor.tscn
+++ b/godot/scenes/ui/office_floor/office_floor.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=2 format=3 uid="uid://coff1floor0001"]
+
+[ext_resource type="Script" path="res://scripts/ui/office_floor/office_floor.gd" id="1_officefloor"]
+
+[node name="OfficeFloor" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+custom_minimum_size = Vector2(360, 260)
+script = ExtResource("1_officefloor")

--- a/godot/scenes/ui/office_floor/office_floor_demo.tscn
+++ b/godot/scenes/ui/office_floor/office_floor_demo.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://coff1demo00001"]
+
+[ext_resource type="Script" path="res://scripts/ui/office_floor/office_floor_demo.gd" id="1_offdemo"]
+
+[node name="OfficeFloorDemo" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_offdemo")

--- a/godot/scripts/ui/office_floor/employee_fsm.gd
+++ b/godot/scripts/ui/office_floor/employee_fsm.gd
@@ -1,0 +1,57 @@
+extends RefCounted
+class_name EmployeeFSM
+## Pure state-mapping logic for the OfficeFloor view (Tier 1).
+##
+## READ-ONLY / determinism-safe (ADR-0006): maps an employee STATE SNAPSHOT
+## (a plain Dictionary of copied values) to a sprite animation state. No game
+## state is read live and none is ever written; fully deterministic and unit
+## testable with zero rendering.
+##
+## The returned strings double as AnimatedSprite2D animation names, so a real
+## pixellab.ai SpriteFrames only needs clips called idle/walking/working/stressed.
+
+# Sprite / animation states.
+const STATE_IDLE := "idle"          # present but not working (disengaged / no data)
+const STATE_WALKING := "walking"    # aimless wander — unmanaged / drifting
+const STATE_WORKING := "working"    # heads-down at a desk
+const STATE_STRESSED := "stressed"  # burnout — head-in-hands
+
+const ALL_STATES := [STATE_IDLE, STATE_WALKING, STATE_WORKING, STATE_STRESSED]
+
+# Thresholds (tunable). BURNOUT_STRESSED matches Researcher.is_burned_out() (>=80).
+const BURNOUT_STRESSED := 80.0
+const LOYALTY_DISENGAGED := 15   # checked-out: physically present, not working
+
+## Map ONE employee snapshot -> sprite state. Every field is optional; absent
+## fields degrade gracefully (default idle/wander, never a false "working").
+##
+## Precedence (most salient problem first):
+##   1. stressed  — burnout >= BURNOUT_STRESSED
+##   2. walking   — unmanaged == true (drifting, no manager to focus them)
+##   3. idle      — loyalty <= LOYALTY_DISENGAGED (checked out)
+##   4. working   — assigned == true
+##   5. idle      — default / no signal
+static func map_state(emp: Dictionary) -> String:
+	var burnout := float(emp.get("burnout", 0.0))
+	if burnout >= BURNOUT_STRESSED:
+		return STATE_STRESSED
+
+	if bool(emp.get("unmanaged", false)):
+		return STATE_WALKING
+
+	if emp.has("loyalty") and int(emp["loyalty"]) <= LOYALTY_DISENGAGED:
+		return STATE_IDLE
+
+	if bool(emp.get("assigned", false)):
+		return STATE_WORKING
+
+	return STATE_IDLE
+
+## Map a whole roster snapshot (Array of Dictionaries) -> Array of state strings,
+## index-aligned with the input. Non-dict entries are skipped.
+static func map_roster(roster: Array) -> Array:
+	var out: Array = []
+	for emp in roster:
+		if emp is Dictionary:
+			out.append(map_state(emp))
+	return out

--- a/godot/scripts/ui/office_floor/employee_fsm.gd.uid
+++ b/godot/scripts/ui/office_floor/employee_fsm.gd.uid
@@ -1,0 +1,1 @@
+uid://bg5xffuor04g5

--- a/godot/scripts/ui/office_floor/employee_sprite.gd
+++ b/godot/scripts/ui/office_floor/employee_sprite.gd
@@ -1,0 +1,184 @@
+extends Node2D
+class_name OfficeEmployeeSprite
+## One employee rendered on the OfficeFloor. PURE VIEW: it only draws and moves
+## cosmetically. It never touches game state; its wander RNG is a private,
+## cosmetic RNG (NOT the seeded game RNG — ADR-0006).
+##
+## Tier 0: a colored blob + a hat, drawn with _draw() (OG-pdoom1 parity).
+## Tier 1: an AnimatedSprite2D playing the FSM animation (idle/walking/working/
+##         stressed). Placeholder SpriteFrames are generated in code; assigning a
+##         real pixellab.ai SpriteFrames (with those 4 clip names) swaps the art
+##         with no code change.
+
+const BODY_RADIUS := 11.0
+const ARRIVE_EPS := 4.0
+
+var tier: int = 0
+var sprite_state: String = EmployeeFSM.STATE_IDLE
+var emp_name: String = ""
+var body_color: Color = Color(0.6, 0.6, 0.65)
+var hat_color: Color = Color(0.15, 0.15, 0.18)
+
+var bounds: Rect2 = Rect2(0, 0, 400, 300)
+var desk_pos: Vector2 = Vector2.ZERO      # workstation used by the "working" state
+var speed: float = 42.0
+
+var _target: Vector2 = Vector2.ZERO
+var _rng := RandomNumberGenerator.new()   # cosmetic-only; deliberately un-seeded from the game
+var _anim: AnimatedSprite2D
+var _label: Label
+
+func _ready() -> void:
+	_rng.randomize()
+	_target = position
+	_anim = AnimatedSprite2D.new()
+	_anim.visible = false
+	add_child(_anim)
+	_label = Label.new()
+	_label.add_theme_font_size_override("font_size", 10)
+	_label.position = Vector2(-BODY_RADIUS - 2.0, BODY_RADIUS + 2.0)
+	_label.text = emp_name
+	add_child(_label)
+	_apply_tier()
+
+func configure(data: Dictionary) -> void:
+	## data: {state, name, body_color, hat_color, desk_pos}
+	sprite_state = data.get("state", EmployeeFSM.STATE_IDLE)
+	emp_name = data.get("name", "")
+	body_color = data.get("body_color", body_color)
+	hat_color = data.get("hat_color", hat_color)
+	desk_pos = data.get("desk_pos", desk_pos)
+	if _label:
+		_label.text = emp_name
+	_refresh_visual()
+
+func set_state(new_state: String) -> void:
+	if new_state == sprite_state:
+		return
+	sprite_state = new_state
+	_refresh_visual()
+
+func set_tier(t: int) -> void:
+	if t == tier:
+		return
+	tier = t
+	_apply_tier()
+
+## Assign a real (or shared placeholder) SpriteFrames. Must contain animations
+## named idle / walking / working / stressed.
+func set_sprite_frames(frames: SpriteFrames) -> void:
+	if _anim:
+		_anim.sprite_frames = frames
+		_refresh_visual()
+
+func _apply_tier() -> void:
+	if _anim == null:
+		return
+	if tier == 1:
+		if _anim.sprite_frames == null:
+			_anim.sprite_frames = _build_placeholder_frames(body_color, hat_color)
+		_anim.visible = true
+	else:
+		_anim.visible = false
+	_refresh_visual()
+	queue_redraw()
+
+func _refresh_visual() -> void:
+	if tier == 1 and _anim and _anim.sprite_frames and _anim.sprite_frames.has_animation(sprite_state):
+		_anim.play(sprite_state)
+	queue_redraw()
+
+func _process(delta: float) -> void:
+	match sprite_state:
+		EmployeeFSM.STATE_WORKING:
+			_target = desk_pos
+			position = position.move_toward(_target, speed * delta)
+		EmployeeFSM.STATE_WALKING:
+			if position.distance_to(_target) <= ARRIVE_EPS:
+				_pick_wander_target()
+			position = position.move_toward(_target, speed * delta)
+		_:
+			# idle / stressed hold position (heads-down / head-in-hands)
+			pass
+	_clamp_to_bounds()
+	if tier == 0:
+		queue_redraw()
+
+func _pick_wander_target() -> void:
+	_target = Vector2(
+		_rng.randf_range(bounds.position.x + BODY_RADIUS, bounds.end.x - BODY_RADIUS),
+		_rng.randf_range(bounds.position.y + BODY_RADIUS, bounds.end.y - BODY_RADIUS)
+	)
+
+func _clamp_to_bounds() -> void:
+	position.x = clampf(position.x, bounds.position.x + BODY_RADIUS, bounds.end.x - BODY_RADIUS)
+	position.y = clampf(position.y, bounds.position.y + BODY_RADIUS, bounds.end.y - BODY_RADIUS)
+
+# --- Tier 0 rendering: blob + hat ------------------------------------------
+func _draw() -> void:
+	if tier != 0:
+		return
+	var draw_body := body_color
+	var draw_hat := hat_color
+	# The floor doubles as a dashboard: tint by state so a problem reads at a glance.
+	match sprite_state:
+		EmployeeFSM.STATE_STRESSED:
+			draw_body = body_color.lerp(Color(0.85, 0.2, 0.2), 0.55)  # reddening
+		EmployeeFSM.STATE_WALKING:
+			draw_body = body_color.lerp(Color(0.85, 0.7, 0.2), 0.35)  # aimless amber
+		_:
+			pass
+	# body
+	draw_circle(Vector2.ZERO, BODY_RADIUS, draw_body)
+	draw_arc(Vector2.ZERO, BODY_RADIUS, 0.0, TAU, 24, Color(0, 0, 0, 0.4), 1.5)
+	# hat: brim + crown sitting on top of the blob
+	var brim := Rect2(-BODY_RADIUS, -BODY_RADIUS - 2.0, BODY_RADIUS * 2.0, 3.0)
+	draw_rect(brim, draw_hat)
+	var crown := Rect2(-BODY_RADIUS * 0.55, -BODY_RADIUS - 8.0, BODY_RADIUS * 1.1, 6.0)
+	draw_rect(crown, draw_hat)
+	# stressed: little "!" hands-on-head cue
+	if sprite_state == EmployeeFSM.STATE_STRESSED:
+		draw_line(Vector2(0, -BODY_RADIUS - 12.0), Vector2(0, -BODY_RADIUS - 16.0), Color(0.9, 0.2, 0.2), 2.0)
+
+# --- Tier 1 placeholder frame generation -----------------------------------
+# Builds a tiny 4-animation SpriteFrames of solid-colour "characters" with a hat,
+# a 1px bob between the two frames of moving states so motion reads. Real art
+# drops in via set_sprite_frames(); nothing here is load-bearing for behavior.
+static func _build_placeholder_frames(body: Color, hat: Color) -> SpriteFrames:
+	var sf := SpriteFrames.new()
+	var specs := {
+		EmployeeFSM.STATE_IDLE:     {"tint": body, "bob": 0, "fps": 2.0},
+		EmployeeFSM.STATE_WALKING:  {"tint": body.lerp(Color(0.85, 0.7, 0.2), 0.35), "bob": 2, "fps": 6.0},
+		EmployeeFSM.STATE_WORKING:  {"tint": body, "bob": 1, "fps": 4.0},
+		EmployeeFSM.STATE_STRESSED: {"tint": body.lerp(Color(0.85, 0.2, 0.2), 0.55), "bob": 1, "fps": 5.0},
+	}
+	# SpriteFrames ships with a "default" animation; reuse it as idle to avoid a stray clip.
+	var first := true
+	for state in specs.keys():
+		var anim_name: String = state
+		if first:
+			sf.rename_animation("default", anim_name)
+			first = false
+		elif not sf.has_animation(anim_name):
+			sf.add_animation(anim_name)
+		sf.set_animation_loop(anim_name, true)
+		sf.set_animation_speed(anim_name, specs[state]["fps"])
+		var bob: int = specs[state]["bob"]
+		sf.add_frame(anim_name, _make_char_texture(specs[state]["tint"], hat, 0))
+		sf.add_frame(anim_name, _make_char_texture(specs[state]["tint"], hat, bob))
+	return sf
+
+static func _make_char_texture(body: Color, hat: Color, bob: int) -> ImageTexture:
+	var w := 24
+	var h := 32
+	var img := Image.create(w, h, false, Image.FORMAT_RGBA8)
+	img.fill(Color(0, 0, 0, 0))
+	var oy := clampi(bob, 0, 4)
+	# body block
+	img.fill_rect(Rect2i(6, 12 + oy, 12, 16), body)
+	# head
+	img.fill_rect(Rect2i(8, 6 + oy, 8, 7), body.lerp(Color(1, 1, 1), 0.15))
+	# hat
+	img.fill_rect(Rect2i(6, 3 + oy, 12, 3), hat)
+	img.fill_rect(Rect2i(9, 0 + oy, 6, 3), hat)
+	return ImageTexture.create_from_image(img)

--- a/godot/scripts/ui/office_floor/employee_sprite.gd
+++ b/godot/scripts/ui/office_floor/employee_sprite.gd
@@ -1,7 +1,7 @@
 extends Node2D
 class_name OfficeEmployeeSprite
 ## One employee rendered on the OfficeFloor. PURE VIEW: it only draws and moves
-## cosmetically. It never touches game state; its wander RNG is a private,
+## cosmetically. It never touches game state; its wander/behavior RNG is a private,
 ## cosmetic RNG (NOT the seeded game RNG — ADR-0006).
 ##
 ## Tier 0: a colored blob + a hat, drawn with _draw() (OG-pdoom1 parity).
@@ -9,9 +9,27 @@ class_name OfficeEmployeeSprite
 ##         stressed). Placeholder SpriteFrames are generated in code; assigning a
 ##         real pixellab.ai SpriteFrames (with those 4 clip names) swaps the art
 ##         with no code change.
+##
+## Within a state, sprites run cheap cosmetic MICRO-BEHAVIORS (all private-RNG):
+##   working  -> occasionally leaves the desk for a food run (fridge / water
+##               cooler) or to pat the cat, then returns; and occasionally walks
+##               to a peer's desk to collaborate (started by OfficeFloor, which
+##               knows who else is working) then returns. All still the "working"
+##               state — human flavor, never a state change and never a bonus.
+##   walking  -> "aimless" isn't just drift: picks drift / window-gaze (a long
+##               stare out the window) / spin-on-the-spot, so disengagement reads.
 
 const BODY_RADIUS := 11.0
 const ARRIVE_EPS := 4.0
+
+# Micro-behavior tuning (seconds / per-second chances; all cosmetic).
+const BREAK_CHANCE_PER_SEC := 0.14      # once off cooldown, chance/sec to start a break
+const BREAK_COOLDOWN_RANGE := Vector2(5.0, 12.0)
+const BREAK_DWELL_RANGE := Vector2(1.5, 3.5)
+const WINDOW_GAZE_RANGE := Vector2(4.0, 9.0)
+const SPIN_RANGE := Vector2(2.0, 4.5)
+const DRIFT_RANGE := Vector2(2.0, 5.0)
+const SPIN_SPEED := 3.2                  # rad/s
 
 var tier: int = 0
 var sprite_state: String = EmployeeFSM.STATE_IDLE
@@ -21,12 +39,28 @@ var hat_color: Color = Color(0.15, 0.15, 0.18)
 
 var bounds: Rect2 = Rect2(0, 0, 400, 300)
 var desk_pos: Vector2 = Vector2.ZERO      # workstation used by the "working" state
+# Cosmetic destination landmarks on the floor (set by OfficeFloor from its bounds).
+var fridge_pos: Vector2 = Vector2.ZERO    # food run
+var water_pos: Vector2 = Vector2.ZERO     # water cooler
+var cat_pos: Vector2 = Vector2.ZERO       # pat the cat
+var window_pos: Vector2 = Vector2.ZERO    # window-gaze
 var speed: float = 42.0
 
 var _target: Vector2 = Vector2.ZERO
 var _rng := RandomNumberGenerator.new()   # cosmetic-only; deliberately un-seeded from the game
 var _anim: AnimatedSprite2D
 var _label: Label
+
+# working micro-behavior
+var _work_sub := "desk"                   # desk | to_break | on_break | to_collab | collaborating | returning
+var _break_cooldown := 0.0
+var _break_target := Vector2.ZERO
+var _break_kind := ""                     # "fridge" | "water" | "cat" | "collab" (legibility cue only)
+var _collab_target := Vector2.ZERO        # peer desk, set by OfficeFloor.try_start_collaboration()
+# aimless micro-behavior
+var _aimless := "drift"                   # drift | window | spin
+var _aimless_timer := 0.0
+var _spin_dir := 1.0
 
 func _ready() -> void:
 	_rng.randomize()
@@ -42,20 +76,28 @@ func _ready() -> void:
 	_apply_tier()
 
 func configure(data: Dictionary) -> void:
-	## data: {state, name, body_color, hat_color, desk_pos}
+	## data: {state, name, body_color, hat_color, desk_pos, snack_pos, cat_pos, window_pos}
+	var prev_state := sprite_state
 	sprite_state = data.get("state", EmployeeFSM.STATE_IDLE)
 	emp_name = data.get("name", "")
 	body_color = data.get("body_color", body_color)
 	hat_color = data.get("hat_color", hat_color)
 	desk_pos = data.get("desk_pos", desk_pos)
+	fridge_pos = data.get("fridge_pos", fridge_pos)
+	water_pos = data.get("water_pos", water_pos)
+	cat_pos = data.get("cat_pos", cat_pos)
+	window_pos = data.get("window_pos", window_pos)
 	if _label:
 		_label.text = emp_name
+	if sprite_state != prev_state:
+		_enter_state_behavior()
 	_refresh_visual()
 
 func set_state(new_state: String) -> void:
 	if new_state == sprite_state:
 		return
 	sprite_state = new_state
+	_enter_state_behavior()
 	_refresh_visual()
 
 func set_tier(t: int) -> void:
@@ -88,21 +130,141 @@ func _refresh_visual() -> void:
 		_anim.play(sprite_state)
 	queue_redraw()
 
+# Initialise the micro-behavior when a state is (re)entered.
+func _enter_state_behavior() -> void:
+	rotation = 0.0
+	if _label:
+		_label.rotation = 0.0
+	match sprite_state:
+		EmployeeFSM.STATE_WORKING:
+			_work_sub = "desk"
+			_break_kind = ""
+			_break_cooldown = _rng.randf_range(BREAK_COOLDOWN_RANGE.x, BREAK_COOLDOWN_RANGE.y)
+		EmployeeFSM.STATE_WALKING:
+			_pick_aimless()
+		_:
+			pass
+
 func _process(delta: float) -> void:
 	match sprite_state:
 		EmployeeFSM.STATE_WORKING:
-			_target = desk_pos
-			position = position.move_toward(_target, speed * delta)
+			_process_working(delta)
 		EmployeeFSM.STATE_WALKING:
+			_process_aimless(delta)
+		_:
+			# idle / stressed hold position (heads-down / head-in-hands)
+			rotation = 0.0
+	_clamp_to_bounds()
+	# Keep the name upright even while the body spins.
+	if _label:
+		_label.rotation = -rotation
+	if tier == 0:
+		queue_redraw()
+
+# working: productive-normal at the desk, with occasional human breaks + collabs.
+func _process_working(delta: float) -> void:
+	rotation = 0.0
+	match _work_sub:
+		"desk":
+			position = position.move_toward(desk_pos, speed * delta)
+			if position.distance_to(desk_pos) <= ARRIVE_EPS:
+				_break_cooldown -= delta
+				if _break_cooldown <= 0.0 and _rng.randf() < BREAK_CHANCE_PER_SEC * delta:
+					_start_break()
+		"to_break":
+			position = position.move_toward(_break_target, speed * delta)
+			if position.distance_to(_break_target) <= ARRIVE_EPS:
+				_work_sub = "on_break"
+				_aimless_timer = _rng.randf_range(BREAK_DWELL_RANGE.x, BREAK_DWELL_RANGE.y)
+		"on_break":
+			_aimless_timer -= delta
+			if _aimless_timer <= 0.0:
+				_work_sub = "returning"
+		"to_collab":
+			# stand just beside the peer's desk, not on top of it
+			var beside := _collab_target + Vector2(BODY_RADIUS * 1.6, 0.0)
+			position = position.move_toward(beside, speed * delta)
+			if position.distance_to(beside) <= ARRIVE_EPS:
+				_work_sub = "collaborating"
+				_aimless_timer = _rng.randf_range(BREAK_DWELL_RANGE.x, BREAK_DWELL_RANGE.y)
+		"collaborating":
+			_aimless_timer -= delta
+			if _aimless_timer <= 0.0:
+				_work_sub = "returning"
+		"returning":
+			position = position.move_toward(desk_pos, speed * delta)
+			if position.distance_to(desk_pos) <= ARRIVE_EPS:
+				_work_sub = "desk"
+				_break_kind = ""
+				_break_cooldown = _rng.randf_range(BREAK_COOLDOWN_RANGE.x, BREAK_COOLDOWN_RANGE.y)
+
+func _start_break() -> void:
+	# get-food -> fridge or water cooler; or pat the cat.
+	match _rng.randi() % 3:
+		0:
+			_break_kind = "fridge"
+			_break_target = fridge_pos
+		1:
+			_break_kind = "water"
+			_break_target = water_pos
+		_:
+			_break_kind = "cat"
+			_break_target = cat_pos
+	_work_sub = "to_break"
+
+## True when this employee is working AND parked at its own desk (available to
+## be pulled into a collaboration). Read-only.
+func is_at_desk() -> bool:
+	return sprite_state == EmployeeFSM.STATE_WORKING and _work_sub == "desk"
+
+## OfficeFloor pulls this employee over to a peer's desk to collaborate. Only
+## accepted while parked at own desk. Purely cosmetic: returns false if busy.
+func try_start_collaboration(peer_desk: Vector2) -> bool:
+	if not is_at_desk():
+		return false
+	_collab_target = peer_desk
+	_break_kind = "collab"
+	_work_sub = "to_collab"
+	return true
+
+# aimless (unmanaged/drifting): visibly disengaged, not just moving.
+func _process_aimless(delta: float) -> void:
+	_aimless_timer -= delta
+	match _aimless:
+		"drift":
+			rotation = 0.0
 			if position.distance_to(_target) <= ARRIVE_EPS:
 				_pick_wander_target()
 			position = position.move_toward(_target, speed * delta)
+			if _aimless_timer <= 0.0:
+				_pick_aimless()
+		"window":
+			rotation = 0.0
+			if position.distance_to(window_pos) > ARRIVE_EPS:
+				position = position.move_toward(window_pos, speed * delta)
+				_aimless_timer += delta   # don't burn gaze time until we've arrived
+			elif _aimless_timer <= 0.0:
+				_pick_aimless()
+		"spin":
+			# stand and spin on the spot
+			rotation += _spin_dir * SPIN_SPEED * delta
+			if _aimless_timer <= 0.0:
+				rotation = 0.0
+				_pick_aimless()
+
+func _pick_aimless() -> void:
+	match _rng.randi() % 3:
+		0:
+			_aimless = "drift"
+			_pick_wander_target()
+			_aimless_timer = _rng.randf_range(DRIFT_RANGE.x, DRIFT_RANGE.y)
+		1:
+			_aimless = "window"
+			_aimless_timer = _rng.randf_range(WINDOW_GAZE_RANGE.x, WINDOW_GAZE_RANGE.y)
 		_:
-			# idle / stressed hold position (heads-down / head-in-hands)
-			pass
-	_clamp_to_bounds()
-	if tier == 0:
-		queue_redraw()
+			_aimless = "spin"
+			_aimless_timer = _rng.randf_range(SPIN_RANGE.x, SPIN_RANGE.y)
+			_spin_dir = 1.0 if _rng.randf() < 0.5 else -1.0
 
 func _pick_wander_target() -> void:
 	_target = Vector2(
@@ -139,6 +301,16 @@ func _draw() -> void:
 	# stressed: little "!" hands-on-head cue
 	if sprite_state == EmployeeFSM.STATE_STRESSED:
 		draw_line(Vector2(0, -BODY_RADIUS - 12.0), Vector2(0, -BODY_RADIUS - 16.0), Color(0.9, 0.2, 0.2), 2.0)
+	# off-desk cue: small dot coloured by errand so the flavor reads on the floor
+	# (fridge/water=cyan-blue, cat=pink, collaborate=green).
+	if sprite_state == EmployeeFSM.STATE_WORKING and _work_sub != "desk":
+		var cue := Color(0.5, 0.75, 0.9)  # food (fridge/water)
+		match _break_kind:
+			"cat":
+				cue = Color(0.9, 0.5, 0.7)
+			"collab":
+				cue = Color(0.4, 0.85, 0.5)
+		draw_circle(Vector2(BODY_RADIUS - 1.0, -BODY_RADIUS - 4.0), 2.5, cue)
 
 # --- Tier 1 placeholder frame generation -----------------------------------
 # Builds a tiny 4-animation SpriteFrames of solid-colour "characters" with a hat,

--- a/godot/scripts/ui/office_floor/employee_sprite.gd.uid
+++ b/godot/scripts/ui/office_floor/employee_sprite.gd.uid
@@ -1,0 +1,1 @@
+uid://b4uf3xfrbfeny

--- a/godot/scripts/ui/office_floor/office_floor.gd
+++ b/godot/scripts/ui/office_floor/office_floor.gd
@@ -45,13 +45,41 @@ const SPEC_COLORS := {
 const DEFAULT_BODY_COLOR := Color(0.6, 0.6, 0.65)
 const HAT_COLOR := Color(0.14, 0.14, 0.18)
 
+const COLLAB_CHECK_RANGE := Vector2(2.5, 5.0)   # seconds between collaboration attempts
+const COLLAB_START_CHANCE := 0.5                # chance to actually pair when eligible
+
 var _sprites: Dictionary = {}   # id -> OfficeEmployeeSprite
 var _shared_frames: SpriteFrames = null   # optional real art shared across sprites
+var _rng := RandomNumberGenerator.new()   # cosmetic-only (collaboration timing); NOT the game RNG
+var _collab_timer := 0.0
 
 func _ready() -> void:
 	custom_minimum_size = Vector2(360, 260)
+	_rng.randomize()
+	_collab_timer = _rng.randf_range(COLLAB_CHECK_RANGE.x, COLLAB_CHECK_RANGE.y)
 	resized.connect(_on_resized)
 	queue_redraw()
+
+# Collaboration is orchestrated HERE because the floor knows who else is working.
+# Pure view: it only sends a cosmetic pair-up target to a sprite; no game state.
+func _process(delta: float) -> void:
+	_collab_timer -= delta
+	if _collab_timer <= 0.0:
+		_collab_timer = _rng.randf_range(COLLAB_CHECK_RANGE.x, COLLAB_CHECK_RANGE.y)
+		_maybe_start_collaboration()
+
+func _maybe_start_collaboration() -> void:
+	var available: Array = []
+	for id in _sprites:
+		var s: OfficeEmployeeSprite = _sprites[id]
+		if s.is_at_desk():
+			available.append(s)
+	if available.size() < 2 or _rng.randf() >= COLLAB_START_CHANCE:
+		return
+	var a: OfficeEmployeeSprite = available[_rng.randi() % available.size()]
+	var b: OfficeEmployeeSprite = available[_rng.randi() % available.size()]
+	if a != b:
+		a.try_start_collaboration(b.desk_pos)
 
 func _on_resized() -> void:
 	# Keep everyone inside the new bounds.
@@ -71,6 +99,7 @@ func _bounds() -> Rect2:
 ## Replace/refresh the rendered roster from a snapshot (read-only; copies values).
 func set_roster(snapshot: Array) -> void:
 	var b := _bounds()
+	var z := _zones(b)
 	var seen: Dictionary = {}
 	var total := snapshot.size()
 	for i in range(total):
@@ -83,23 +112,23 @@ func set_roster(snapshot: Array) -> void:
 		var spec := String(emp.get("specialization", ""))
 		var body: Color = SPEC_COLORS.get(spec, DEFAULT_BODY_COLOR)
 		var desk := _desk_for_index(i, total, b)
+		var cfg := {
+			"state": state, "name": String(emp.get("name", str(id))),
+			"body_color": body, "hat_color": HAT_COLOR, "desk_pos": desk,
+			"fridge_pos": z["fridge_pos"], "water_pos": z["water_pos"],
+			"cat_pos": z["cat_pos"], "window_pos": z["window_pos"],
+		}
 		if _sprites.has(id):
 			var spr: OfficeEmployeeSprite = _sprites[id]
 			spr.bounds = b
-			spr.configure({
-				"state": state, "name": String(emp.get("name", str(id))),
-				"body_color": body, "hat_color": HAT_COLOR, "desk_pos": desk,
-			})
+			spr.configure(cfg)
 		else:
 			var spr2: OfficeEmployeeSprite = EmployeeSpriteScript.new()
 			spr2.tier = tier
 			spr2.bounds = b
 			spr2.position = desk
 			add_child(spr2)
-			spr2.configure({
-				"state": state, "name": String(emp.get("name", str(id))),
-				"body_color": body, "hat_color": HAT_COLOR, "desk_pos": desk,
-			})
+			spr2.configure(cfg)
 			if _shared_frames != null:
 				spr2.set_sprite_frames(_shared_frames)
 			_sprites[id] = spr2
@@ -124,20 +153,47 @@ func set_sprite_frames(frames: SpriteFrames) -> void:
 
 func _relayout_desks() -> void:
 	var b := _bounds()
+	var z := _zones(b)
 	var ids := _sprites.keys()
 	var total := ids.size()
 	for i in range(total):
-		_sprites[ids[i]].desk_pos = _desk_for_index(i, total, b)
+		var spr: OfficeEmployeeSprite = _sprites[ids[i]]
+		spr.desk_pos = _desk_for_index(i, total, b)
+		spr.fridge_pos = z["fridge_pos"]
+		spr.water_pos = z["water_pos"]
+		spr.cat_pos = z["cat_pos"]
+		spr.window_pos = z["window_pos"]
 
-# Simple stable grid of desks across the floor interior.
-func _desk_for_index(i: int, total: int, b: Rect2) -> Vector2:
-	var n := maxi(total, 1)
-	var cols := int(ceil(sqrt(float(n))))
-	var rows := int(ceil(float(n) / float(cols)))
-	var col := i % cols
-	var row := i / cols
-	var cell := Vector2(b.size.x / float(cols), b.size.y / float(rows))
-	return b.position + Vector2((col + 0.5) * cell.x, (row + 0.5) * cell.y)
+# Cosmetic destination LANDMARKS derived from the floor bounds — placed at distinct
+# spots so a walking employee's destination reads at a glance (Tier-1 named points,
+# not a navmesh). window along the top wall; three corners: cat / water cooler /
+# fridge. Desks cluster around tables in the central band (see _table_centers).
+func _zones(b: Rect2) -> Dictionary:
+	var inset := Vector2(b.size.x * 0.10, b.size.y * 0.12)
+	return {
+		"window_pos": b.position + Vector2(b.size.x * 0.5, b.size.y * 0.07),
+		"cat_pos":    b.position + Vector2(inset.x, b.size.y - inset.y),                 # bottom-left
+		"water_pos":  b.position + Vector2(b.size.x - inset.x, inset.y),                 # top-right
+		"fridge_pos": b.position + Vector2(b.size.x - inset.x, b.size.y - inset.y),      # bottom-right
+	}
+
+# A couple of table centres in the central band (kept clear of the corner landmarks).
+func _table_centers(b: Rect2) -> Array:
+	var cy := b.position.y + b.size.y * 0.48
+	return [
+		b.position + Vector2(b.size.x * 0.36, cy - b.position.y),
+		b.position + Vector2(b.size.x * 0.64, cy - b.position.y),
+	]
+
+# Desks semi-clustered around the tables (NOT a grid): employee i joins table
+# i % num_tables and sits at a ring slot around it. Stable per index.
+func _desk_for_index(i: int, _total: int, b: Rect2) -> Vector2:
+	var tables := _table_centers(b)
+	var t := i % tables.size()
+	var slot := i / tables.size()
+	var radius: float = min(b.size.x, b.size.y) * 0.16
+	var angle := float(slot) * (TAU / 3.0) + float(t) * 0.6   # offset the two rings so they don't mirror
+	return tables[t] + Vector2(cos(angle), sin(angle) * 0.7) * radius
 
 # --- Floor background (tier-agnostic; sprites draw on top) ------------------
 func _draw() -> void:
@@ -145,11 +201,22 @@ func _draw() -> void:
 	draw_rect(Rect2(Vector2.ZERO, size), Color(0.09, 0.10, 0.11))       # room
 	draw_rect(b, Color(0.13, 0.15, 0.16))                              # floor
 	draw_rect(b, Color(0.3, 0.5, 0.35, 0.5), false, 1.5)              # bounds outline
-	# faint desk markers
+	# tables (desks cluster around these)
+	for c in _table_centers(b):
+		var r: float = min(b.size.x, b.size.y) * 0.10
+		draw_circle(c, r, Color(0.2, 0.22, 0.24, 0.7))
+		draw_arc(c, r, 0.0, TAU, 20, Color(0.3, 0.33, 0.36, 0.8), 1.5)
+	# faint desk markers around the tables
 	var total := _sprites.size()
 	for i in range(total):
 		var d := _desk_for_index(i, total, b)
-		draw_rect(Rect2(d + Vector2(-14, 6), Vector2(28, 6)), Color(0.25, 0.27, 0.29, 0.6))
+		draw_rect(Rect2(d + Vector2(-13, 5), Vector2(26, 5)), Color(0.25, 0.27, 0.29, 0.6))
+	# cosmetic landmark markers (window / cat / water cooler / fridge)
+	var z := _zones(b)
+	draw_rect(Rect2(Vector2(b.position.x + 6, b.position.y + 2), Vector2(b.size.x - 12, 5)), Color(0.45, 0.6, 0.75, 0.45))  # window strip (top wall)
+	draw_circle(z["cat_pos"], 9.0, Color(0.9, 0.5, 0.7, 0.4))            # cat corner (pink)
+	draw_rect(Rect2(z["water_pos"] - Vector2(7, 10), Vector2(14, 20)), Color(0.5, 0.75, 0.9, 0.4))   # water cooler
+	draw_rect(Rect2(z["fridge_pos"] - Vector2(9, 11), Vector2(18, 22)), Color(0.7, 0.85, 0.95, 0.4)) # fridge
 
 # ---------------------------------------------------------------------------
 # READ-ONLY GameState adapter. Static so callers can build a snapshot without

--- a/godot/scripts/ui/office_floor/office_floor.gd
+++ b/godot/scripts/ui/office_floor/office_floor.gd
@@ -1,0 +1,181 @@
+extends Control
+class_name OfficeFloor
+## Standalone, reusable office-floor VIEW for the WATCH screen.
+##
+## PURE VIEW (ADR-0006, non-negotiable): it READS a roster SNAPSHOT (an Array of
+## plain Dictionaries — copied values, never a live GameState reference) and
+## renders milling employees. It NEVER writes game state and nothing it does
+## feeds back into the sim, so it is determinism-safe by construction: replay
+## replays inputs->state, and a cosmetic view cannot alter a verified run. Sprite
+## wander randomness is cosmetic and deliberately does NOT use the seeded game RNG.
+##
+## PUBLIC API
+##   set_roster(snapshot: Array)   # array of employee dicts; adds/updates/removes sprites
+##   set_tier(t: int)              # 0 = placeholder blobs+hats, 1 = AnimatedSprite2D FSM
+##   tier                          # property (get/set)
+##   set_sprite_frames(frames)     # optional: real pixellab.ai art for Tier 1
+##   OfficeFloor.snapshot_from_state(state) -> Array   # static, read-only GameState adapter
+##
+## Employee snapshot dict fields (ALL optional; unknown fields ignored; see
+## EmployeeFSM for the state mapping and graceful-degrade rules):
+##   id:String/int, name:String, specialization:String,
+##   burnout:float(0-100), loyalty:int(0-100), unmanaged:bool, assigned:bool
+##
+## Scaling note: designed for 1..~12 sprites (Startup/Entity phases). For the
+## Titan phase (hundreds of staff) the intended approach is NOT one sprite each —
+## aggregate into division "pods"/heatmap tiles fed the same snapshot. That
+## aggregation is deliberately NOT built here (see build brief Tier 2/phase-scaling).
+
+const EmployeeSpriteScript := preload("res://scripts/ui/office_floor/employee_sprite.gd")
+
+@export var tier: int = 0: set = set_tier
+# Deferred seams (build brief "Deferred to later waves"): office aesthetic tier and
+# moral skew. Declared cheaply now so later art/logic has an anchor; currently unused.
+@export var office_tier: int = 0
+@export var moral_skew: float = 0.0
+
+# Specialization -> body colour (readout of role on the floor).
+const SPEC_COLORS := {
+	"safety":           Color(0.35, 0.75, 0.45),
+	"capabilities":     Color(0.85, 0.45, 0.30),
+	"interpretability": Color(0.55, 0.55, 0.9),
+	"alignment":        Color(0.4, 0.75, 0.8),
+	"manager":          Color(0.8, 0.75, 0.4),
+}
+const DEFAULT_BODY_COLOR := Color(0.6, 0.6, 0.65)
+const HAT_COLOR := Color(0.14, 0.14, 0.18)
+
+var _sprites: Dictionary = {}   # id -> OfficeEmployeeSprite
+var _shared_frames: SpriteFrames = null   # optional real art shared across sprites
+
+func _ready() -> void:
+	custom_minimum_size = Vector2(360, 260)
+	resized.connect(_on_resized)
+	queue_redraw()
+
+func _on_resized() -> void:
+	# Keep everyone inside the new bounds.
+	var b := _bounds()
+	for id in _sprites:
+		var spr: OfficeEmployeeSprite = _sprites[id]
+		spr.bounds = b
+	_relayout_desks()
+	queue_redraw()
+
+func _bounds() -> Rect2:
+	var s := size
+	if s.x < 40.0 or s.y < 40.0:
+		s = custom_minimum_size
+	return Rect2(Vector2(8, 8), s - Vector2(16, 16))
+
+## Replace/refresh the rendered roster from a snapshot (read-only; copies values).
+func set_roster(snapshot: Array) -> void:
+	var b := _bounds()
+	var seen: Dictionary = {}
+	var total := snapshot.size()
+	for i in range(total):
+		var emp = snapshot[i]
+		if not (emp is Dictionary):
+			continue
+		var id = emp.get("id", emp.get("name", str(i)))
+		seen[id] = true
+		var state := EmployeeFSM.map_state(emp)
+		var spec := String(emp.get("specialization", ""))
+		var body: Color = SPEC_COLORS.get(spec, DEFAULT_BODY_COLOR)
+		var desk := _desk_for_index(i, total, b)
+		if _sprites.has(id):
+			var spr: OfficeEmployeeSprite = _sprites[id]
+			spr.bounds = b
+			spr.configure({
+				"state": state, "name": String(emp.get("name", str(id))),
+				"body_color": body, "hat_color": HAT_COLOR, "desk_pos": desk,
+			})
+		else:
+			var spr2: OfficeEmployeeSprite = EmployeeSpriteScript.new()
+			spr2.tier = tier
+			spr2.bounds = b
+			spr2.position = desk
+			add_child(spr2)
+			spr2.configure({
+				"state": state, "name": String(emp.get("name", str(id))),
+				"body_color": body, "hat_color": HAT_COLOR, "desk_pos": desk,
+			})
+			if _shared_frames != null:
+				spr2.set_sprite_frames(_shared_frames)
+			_sprites[id] = spr2
+	# Remove sprites for employees no longer present.
+	for id in _sprites.keys():
+		if not seen.has(id):
+			_sprites[id].queue_free()
+			_sprites.erase(id)
+	queue_redraw()
+
+func set_tier(t: int) -> void:
+	tier = t
+	for id in _sprites:
+		_sprites[id].set_tier(t)
+	queue_redraw()
+
+## Supply a real Tier-1 SpriteFrames (animations: idle/walking/working/stressed).
+func set_sprite_frames(frames: SpriteFrames) -> void:
+	_shared_frames = frames
+	for id in _sprites:
+		_sprites[id].set_sprite_frames(frames)
+
+func _relayout_desks() -> void:
+	var b := _bounds()
+	var ids := _sprites.keys()
+	var total := ids.size()
+	for i in range(total):
+		_sprites[ids[i]].desk_pos = _desk_for_index(i, total, b)
+
+# Simple stable grid of desks across the floor interior.
+func _desk_for_index(i: int, total: int, b: Rect2) -> Vector2:
+	var n := maxi(total, 1)
+	var cols := int(ceil(sqrt(float(n))))
+	var rows := int(ceil(float(n) / float(cols)))
+	var col := i % cols
+	var row := i / cols
+	var cell := Vector2(b.size.x / float(cols), b.size.y / float(rows))
+	return b.position + Vector2((col + 0.5) * cell.x, (row + 0.5) * cell.y)
+
+# --- Floor background (tier-agnostic; sprites draw on top) ------------------
+func _draw() -> void:
+	var b := _bounds()
+	draw_rect(Rect2(Vector2.ZERO, size), Color(0.09, 0.10, 0.11))       # room
+	draw_rect(b, Color(0.13, 0.15, 0.16))                              # floor
+	draw_rect(b, Color(0.3, 0.5, 0.35, 0.5), false, 1.5)              # bounds outline
+	# faint desk markers
+	var total := _sprites.size()
+	for i in range(total):
+		var d := _desk_for_index(i, total, b)
+		draw_rect(Rect2(d + Vector2(-14, 6), Vector2(28, 6)), Color(0.25, 0.27, 0.29, 0.6))
+
+# ---------------------------------------------------------------------------
+# READ-ONLY GameState adapter. Static so callers can build a snapshot without
+# an OfficeFloor instance. Reads only; writes nothing. The integration lane
+# calls this each day-tick and hands the result to set_roster().
+# ---------------------------------------------------------------------------
+static func snapshot_from_state(state) -> Array:
+	var out: Array = []
+	if state == null:
+		return out
+	var researchers: Array = state.researchers if "researchers" in state else []
+	var total := researchers.size()
+	# get_unmanaged_count() reports how many exceed management capacity; we mark
+	# the trailing N as the drifting/unmanaged ones (view heuristic — order-only).
+	var unmanaged_n := 0
+	if state.has_method("get_unmanaged_count"):
+		unmanaged_n = state.get_unmanaged_count()
+	for i in range(total):
+		var r = researchers[i]
+		out.append({
+			"id": i,
+			"name": r.researcher_name if "researcher_name" in r else str(i),
+			"specialization": r.specialization if "specialization" in r else "",
+			"burnout": float(r.burnout) if "burnout" in r else 0.0,
+			"loyalty": int(r.loyalty) if "loyalty" in r else 50,
+			"unmanaged": i >= (total - unmanaged_n),
+			"assigned": true,   # employed researchers are working their specialization
+		})
+	return out

--- a/godot/scripts/ui/office_floor/office_floor.gd.uid
+++ b/godot/scripts/ui/office_floor/office_floor.gd.uid
@@ -1,0 +1,1 @@
+uid://dhf06xbogr6ex

--- a/godot/scripts/ui/office_floor/office_floor_demo.gd
+++ b/godot/scripts/ui/office_floor/office_floor_demo.gd
@@ -33,6 +33,8 @@ func _ready() -> void:
 	tier_btn.pressed.connect(_on_toggle_tier)
 	bar.add_child(tier_btn)
 
+	# EASTER EGG (keep): Pip wants this hidden fun-interaction left in for now, and
+	# it may survive into the real game later (integration lane's call). Do not remove.
 	var stress_btn := Button.new()
 	stress_btn.text = "Stress a random hire"
 	stress_btn.pressed.connect(_on_stress_random)
@@ -45,6 +47,16 @@ func _ready() -> void:
 
 	_status = Label.new()
 	bar.add_child(_status)
+
+	var legend := Label.new()
+	legend.add_theme_font_size_override("font_size", 11)
+	legend.text = "Watch a while. Desks cluster around two tables; corners are landmarks — cat " \
+		+ "(bottom-left), water cooler (top-right), fridge (bottom-right), window (top wall). " \
+		+ "Working staff occasionally do a food run (fridge/water), pat the cat, or walk to a " \
+		+ "peer's desk to COLLABORATE, then return. Unmanaged staff (Riley, Lane) drift, spin, or " \
+		+ "gaze out the window. Burnt-out = red '!'. All cosmetic — pure view, private RNG, no bonuses."
+	legend.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	root.add_child(legend)
 
 	_floor = OfficeFloorScene.instantiate()
 	_floor.size_flags_vertical = Control.SIZE_EXPAND_FILL

--- a/godot/scripts/ui/office_floor/office_floor_demo.gd
+++ b/godot/scripts/ui/office_floor/office_floor_demo.gd
@@ -1,0 +1,79 @@
+extends Control
+## Standalone demo/harness for the OfficeFloor component (Pip: open this to SEE it).
+## Spawns a mock roster covering every FSM state and lets you toggle Tier 0/1 and
+## reshuffle. Uses ONLY mock plain-data dicts — no GameState, proving OfficeFloor
+## is a pure view that needs nothing but a snapshot.
+
+const OfficeFloorScene := preload("res://scenes/ui/office_floor/office_floor.tscn")
+
+var _floor: OfficeFloor
+var _status: Label
+
+# Mock roster: each entry exercises a different mechanical -> sprite state.
+var _roster: Array = [
+	{"id": 0, "name": "Sage",   "specialization": "safety",           "burnout": 10.0, "loyalty": 70, "assigned": true,  "unmanaged": false}, # working
+	{"id": 1, "name": "Riley",  "specialization": "capabilities",     "burnout": 20.0, "loyalty": 60, "assigned": true,  "unmanaged": true},  # walking/drift
+	{"id": 2, "name": "Quinn",  "specialization": "interpretability", "burnout": 92.0, "loyalty": 55, "assigned": true,  "unmanaged": false}, # stressed
+	{"id": 3, "name": "Morgan", "specialization": "alignment",        "burnout": 15.0, "loyalty": 8,  "assigned": true,  "unmanaged": false}, # idle (disengaged)
+	{"id": 4, "name": "Parker", "specialization": "safety",           "burnout": 5.0,  "loyalty": 80, "assigned": true,  "unmanaged": false}, # working
+	{"id": 5, "name": "Lane",   "specialization": "capabilities",     "burnout": 40.0, "loyalty": 45, "assigned": true,  "unmanaged": true},  # walking/drift
+]
+
+func _ready() -> void:
+	set_anchors_preset(Control.PRESET_FULL_RECT)
+	var root := VBoxContainer.new()
+	root.set_anchors_preset(Control.PRESET_FULL_RECT)
+	add_child(root)
+
+	var bar := HBoxContainer.new()
+	root.add_child(bar)
+
+	var tier_btn := Button.new()
+	tier_btn.text = "Toggle Tier (0/1)"
+	tier_btn.pressed.connect(_on_toggle_tier)
+	bar.add_child(tier_btn)
+
+	var stress_btn := Button.new()
+	stress_btn.text = "Stress a random hire"
+	stress_btn.pressed.connect(_on_stress_random)
+	bar.add_child(stress_btn)
+
+	var calm_btn := Button.new()
+	calm_btn.text = "Calm everyone"
+	calm_btn.pressed.connect(_on_calm_all)
+	bar.add_child(calm_btn)
+
+	_status = Label.new()
+	bar.add_child(_status)
+
+	_floor = OfficeFloorScene.instantiate()
+	_floor.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_floor.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	root.add_child(_floor)
+
+	_floor.set_tier(0)
+	_push_roster()
+
+func _push_roster() -> void:
+	_floor.set_roster(_roster)
+	_update_status()
+
+func _update_status() -> void:
+	var counts := {}
+	for st in EmployeeFSM.map_roster(_roster):
+		counts[st] = counts.get(st, 0) + 1
+	_status.text = "  Tier %d  |  %d staff  |  %s" % [_floor.tier, _roster.size(), str(counts)]
+
+func _on_toggle_tier() -> void:
+	_floor.set_tier(1 if _floor.tier == 0 else 0)
+	_update_status()
+
+func _on_stress_random() -> void:
+	var i := randi() % _roster.size()
+	_roster[i]["burnout"] = 95.0
+	_push_roster()
+
+func _on_calm_all() -> void:
+	for e in _roster:
+		e["burnout"] = 10.0
+	_push_roster()

--- a/godot/scripts/ui/office_floor/office_floor_demo.gd.uid
+++ b/godot/scripts/ui/office_floor/office_floor_demo.gd.uid
@@ -1,0 +1,1 @@
+uid://cy61rshgb5p8l

--- a/godot/tests/unit/test_employee_fsm.gd
+++ b/godot/tests/unit/test_employee_fsm.gd
@@ -1,0 +1,73 @@
+extends GutTest
+## Unit tests for EmployeeFSM — the pure state-mapping logic behind the OfficeFloor
+## Tier-1 sprites. Tests the mapping (mechanical state -> sprite state) ONLY, never
+## rendering. This is the readout contract: the floor is the dashboard.
+
+func test_working_when_assigned_and_healthy():
+	var emp := {"assigned": true, "burnout": 10.0, "loyalty": 70, "unmanaged": false}
+	assert_eq(EmployeeFSM.map_state(emp), EmployeeFSM.STATE_WORKING, "Assigned + healthy -> working")
+
+func test_stressed_when_burnt_out():
+	# >= 80 matches Researcher.is_burned_out()
+	var emp := {"assigned": true, "burnout": 80.0, "loyalty": 70, "unmanaged": false}
+	assert_eq(EmployeeFSM.map_state(emp), EmployeeFSM.STATE_STRESSED, "Burnout>=80 -> stressed")
+
+func test_stressed_dominates_unmanaged():
+	# Burnout is the most salient problem; wins over drift.
+	var emp := {"assigned": true, "burnout": 95.0, "unmanaged": true}
+	assert_eq(EmployeeFSM.map_state(emp), EmployeeFSM.STATE_STRESSED, "Stressed outranks drifting")
+
+func test_walking_when_unmanaged():
+	var emp := {"assigned": true, "burnout": 20.0, "loyalty": 60, "unmanaged": true}
+	assert_eq(EmployeeFSM.map_state(emp), EmployeeFSM.STATE_WALKING, "Unmanaged (not burnt) -> walking/drift")
+
+func test_idle_when_disengaged_low_loyalty():
+	var emp := {"assigned": true, "burnout": 10.0, "loyalty": 5, "unmanaged": false}
+	assert_eq(EmployeeFSM.map_state(emp), EmployeeFSM.STATE_IDLE, "Very low loyalty -> idle (checked out)")
+
+func test_just_below_burnout_threshold_not_stressed():
+	var emp := {"assigned": true, "burnout": 79.9, "loyalty": 60, "unmanaged": false}
+	assert_eq(EmployeeFSM.map_state(emp), EmployeeFSM.STATE_WORKING, "Below 80 burnout is not stressed")
+
+# --- graceful degradation: absent fields default to idle/wander, never a false working ---
+func test_empty_dict_degrades_to_idle():
+	assert_eq(EmployeeFSM.map_state({}), EmployeeFSM.STATE_IDLE, "No data -> idle (graceful)")
+
+func test_missing_assigned_is_idle_not_working():
+	var emp := {"burnout": 10.0, "loyalty": 70}  # no 'assigned', not unmanaged
+	assert_eq(EmployeeFSM.map_state(emp), EmployeeFSM.STATE_IDLE, "Absent 'assigned' must not fake working")
+
+func test_missing_loyalty_does_not_force_idle():
+	var emp := {"assigned": true, "burnout": 10.0}  # no loyalty field
+	assert_eq(EmployeeFSM.map_state(emp), EmployeeFSM.STATE_WORKING, "Absent loyalty -> not treated as disengaged")
+
+func test_unmanaged_without_assigned_still_walks():
+	var emp := {"unmanaged": true}  # minimal
+	assert_eq(EmployeeFSM.map_state(emp), EmployeeFSM.STATE_WALKING, "Unmanaged flag alone -> walking")
+
+# --- roster-level mapping ---
+func test_map_roster_index_aligned():
+	var roster := [
+		{"assigned": true, "burnout": 5.0},                 # working
+		{"assigned": true, "burnout": 90.0},                # stressed
+		{"assigned": true, "unmanaged": true},              # walking
+		{},                                                 # idle
+	]
+	var states := EmployeeFSM.map_roster(roster)
+	assert_eq(states.size(), 4, "One state per employee")
+	assert_eq(states[0], EmployeeFSM.STATE_WORKING)
+	assert_eq(states[1], EmployeeFSM.STATE_STRESSED)
+	assert_eq(states[2], EmployeeFSM.STATE_WALKING)
+	assert_eq(states[3], EmployeeFSM.STATE_IDLE)
+
+func test_map_roster_skips_non_dict_entries():
+	var roster := [{"assigned": true, "burnout": 5.0}, "garbage", 42]
+	var states := EmployeeFSM.map_roster(roster)
+	assert_eq(states.size(), 1, "Non-dict entries are skipped")
+
+func test_all_states_are_distinct_and_named():
+	assert_eq(EmployeeFSM.ALL_STATES.size(), 4, "Four sprite states")
+	var uniq := {}
+	for s in EmployeeFSM.ALL_STATES:
+		uniq[s] = true
+	assert_eq(uniq.size(), 4, "All state names distinct")

--- a/godot/tests/unit/test_employee_fsm.gd.uid
+++ b/godot/tests/unit/test_employee_fsm.gd.uid
@@ -1,0 +1,1 @@
+uid://dprx4sfnoy31i


### PR DESCRIPTION
## OfficeFloor — standalone employee-sprite component (Lane 2)

Implements **Tier 0 + Tier 1** of the WATCH-screen office floor from
`docs/game-design/BUILD_BRIEF_PLAN_WATCH_UI.md`. Standalone & reusable — NOT wired
into `main_ui` (a separate lane owns WATCH integration).

### Architectural rule honored: PURE VIEW (ADR-0006)
`OfficeFloor` takes a **roster snapshot** (an `Array` of plain-data `Dictionary`
values — never a live `GameState` ref) and renders it. It **never writes game
state**, and nothing it does feeds back into the sim, so it is determinism-safe by
construction. All sprite motion/behavior uses **private cosmetic RNGs**, deliberately
**not** the seeded game RNG. Collaboration is a cosmetic read only — collaborators get
**no bonus** (a bonus would break the pure-view rule).

### FSM state mapping (mechanical → sprite), precedence top-down
| Priority | Condition (real field) | Sprite state |
|---|---|---|
| 1 | `burnout >= 80` (= `Researcher.is_burned_out()`) | **stressed** (head-in-hands) |
| 2 | `unmanaged == true` (from `get_unmanaged_count()`) | **walking** (aimless drift) |
| 3 | `loyalty <= 15` (checked out) | **idle** |
| 4 | `assigned == true` | **working** (at desk) |
| 5 | default / no data | **idle** (graceful degrade) |

Real roster fields driving it: `burnout`, `loyalty`, `specialization` (→ body color),
and roster-level `get_unmanaged_count()`. No per-researcher "assignment" field exists,
so `assigned` is derived (employed researchers work their specialization) and the
trailing N over management capacity are flagged `unmanaged`.

### Cosmetic micro-behaviors (within a state — pure view, private RNG, no game effect)
**Working (productive-normal, human, not robotic):**
- Occasional **food run** → walks to the **fridge** or **water cooler**, pauses, returns.
- Occasional **pat-the-cat** → walks to the **cat corner**, pauses, returns.
- Occasional **collaboration** → walks to a **peer's desk** (only peers also in the
  working state, orchestrated by OfficeFloor which knows who's working), brief co-located
  pause, returns. No bonus.

**Aimless (unmanaged/drifting — visibly disengaged, not just moving):**
- **drift** (wander to random points), **window-gaze** (walk to the window wall and stare
  a long time), or **spin-on-the-spot**.

### Landmark layout (destination legibility; Tier-1 named points, NOT a navmesh)
- Desks **semi-clustered around two tables** (not a grid).
- Corner landmarks: **cat** (bottom-left), **water cooler** (top-right), **fridge**
  (bottom-right); **window** along the top wall.
- Off-desk errands show a small colored cue dot on Tier 0 (food = blue, cat = pink,
  collaborate = green); the floor doubles as a dashboard.

### API
- `set_roster(snapshot: Array)` — add/update/remove sprites (reconciled by id)
- `set_tier(t: int)` / `tier` property — 0 = blobs, 1 = AnimatedSprite2D
- `set_sprite_frames(frames)` — swap in real pixellab.ai Tier-1 art (clips: idle/walking/working/stressed)
- `OfficeFloor.snapshot_from_state(state) -> Array` — static, read-only GameState adapter for the integration lane

### How to SEE it
Open `godot/scenes/ui/office_floor/office_floor_demo.tscn` in Godot and press Play
(F6 / run current scene). Mock roster of 6 covers every state; an on-screen legend
explains what to watch for. Buttons: **Toggle Tier (0/1)**, **Stress a random hire**
(kept as an easter egg per Pip — may survive into the real game), **Calm everyone**.
Let it run a few seconds to see food runs, cat pats, collaborations, and window-gazes.

### Scope
Handles 1..~12 employees. Late-game aggregation (Titan-phase pods/heatmap) is noted
in code but deliberately not built. Tier 2 (navmesh office / contextual pairs / event
reactions) and Tier 3 (LLM agents — breaks determinism) are OUT per brief.

### Tests
`tests/unit/test_employee_fsm.gd` — 13 tests, all passing (mapping + graceful degrade +
roster-level). Headless import, demo-scene load, Tier-1 frame-gen, and a 20s
collaboration/behavior smoke all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)