### PR TITLE
chore: agent-efficiency — CLAUDE.md + commit-hook/import fixes + audit roadmap (Pip review)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,51 @@
+# Line-ending normalization for P(Doom)1
+#
+# Why this file exists:
+#   The repo has core.autocrlf=true. Without these rules, git rewrites LF->CRLF
+#   in the working tree on checkout, while Godot AND the pre-commit
+#   `mixed-line-ending --fix=lf` hook both want LF. The result was that every
+#   commit tripped the hook (CRLF->LF rewrite + abort + re-add). Forcing eol=lf
+#   keeps the working tree LF so the hook, Godot, and git all agree.
+#
+# The index is already stored as LF (autocrlf normalized on the way in), so
+# adding this file does NOT trigger a mass renormalization diff.
+
+# Default: treat as text, store LF in repo, check out LF in working tree.
+* text=auto eol=lf
+
+# --- Text formats that must stay LF (source + Godot resources) ---
+*.gd       text eol=lf
+*.py       text eol=lf
+*.md       text eol=lf
+*.txt      text eol=lf
+*.json     text eol=lf
+*.yaml     text eol=lf
+*.yml      text eol=lf
+*.cfg      text eol=lf
+*.toml     text eol=lf
+*.sh       text eol=lf
+*.tscn     text eol=lf
+*.tres     text eol=lf
+*.import   text eol=lf
+*.uid      text eol=lf
+*.gdshader text eol=lf
+*.svg      text eol=lf
+
+# --- Binary assets: never apply text/EOL conversion ---
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.webp  binary
+*.gif   binary
+*.ico   binary
+*.bmp   binary
+*.mp3   binary
+*.wav   binary
+*.ogg   binary
+*.ttf   binary
+*.otf   binary
+*.woff  binary
+*.woff2 binary
+*.zip   binary
+*.pdf   binary
+*.exe   binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md — P(Doom)1 agent cheat-sheet
+
+Operational notes for Claude/LLM agents. Keep it short; update in place when a
+convention changes. For the systems map read **`docs/ARCHITECTURE.md` FIRST**.
+
+## What this is
+Turn-based AI-safety strategy game. **Godot 4.5.1, pure GDScript** (no Python
+runtime — the old Python bridge is gone). Python exists only for CI/tooling in
+`scripts/` and `tools/`. Windows dev machine; CI is Ubuntu.
+
+## Run the game
+- `godot --path godot` (or `make run`). On Pip's machine Godot is
+  `C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe`.
+
+## Tests — two tiers, don't conflate them
+- **Fast gate (this is what you run for scoped changes):**
+  `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`
+  (`tests/unit`, non-recursive). The runner does the `--import` pass itself.
+- **Slow simulation tier:** `--simulation` (`tests/unit/simulation`, full-run /
+  replay / determinism, ~3 min). **Non-blocking** in CI — do NOT wait on it for a
+  scoped change. Run it only when you touched simulation/economy/replay code.
+- **Fresh worktree gotcha:** GUT quits(0) before running anything if the class
+  cache is cold. The runner's import pass fixes this; if you invoke Godot/GUT
+  directly, run `godot --headless --path godot --import` first. Running headless
+  Godot also floods stderr with SCRIPT ERROR class-cache lines on the first pass —
+  expected noise, not a real failure.
+- `make test` = fast gate; `make run` = game.
+
+## `.import` / `.uid` files — the staging trap
+- Both are **tracked on purpose** (Godot 4 convention: `.import` = import
+  metadata, `.uid` = stable resource IDs). `godot/.godot/` and `godot/.import/`
+  are correctly gitignored; the per-asset `*.import` / `*.uid` files are not.
+- Running `--import` **rewrites/touches ~1200 `.import` files** and may emit new
+  `.uid` files. **Do NOT stage that churn.** Never `git add -A` / `git add .`.
+  Stage only the files you changed (`git add <path>`), or discard the churn with
+  `git checkout -- godot/` before committing.
+
+## Commit hooks & line endings
+- Pre-commit runs `mixed-line-ending --fix=lf`, `enforce-standards` (ASCII-only,
+  scans the whole tree — slowish), black/isort/ruff (Python only).
+- **`.gitattributes` now forces `eol=lf`** repo-wide, so the old CRLF↔LF fight
+  (every doc commit failing once on the line-ending hook under
+  `core.autocrlf=true`) is fixed. If a NEW file was authored with CRLF the hook
+  still rewrites it once — re-`git add` and re-commit is normal for that one file.
+- **ASCII-only:** no non-ASCII chars in `.py/.md/.json/.yaml/.txt/.cfg/.sh`
+  (no smart quotes, em-dashes as `--`, no emoji in source/docs). `enforce-standards`
+  blocks the commit otherwise.
+
+## Git workflow
+- Branch from **freshly-fetched** `origin/main`, not a stale local ref:
+  `git fetch origin main && git checkout -b <branch> origin/main`.
+- **Never stage `.claude/settings.local.json`** (always shows modified; it's local).
+- Merge to main via admin-merge (Pip reviews first for agent PRs). PR body ends
+  with the Claude Code footer; commit trailer `Co-Authored-By: Claude ...`.
+
+## Where things live
+- `docs/ARCHITECTURE.md` — systems→code→ADR map. **READ FIRST.**
+- `docs/game-design/` — `DESIGN_PHILOSOPHY.md` (the "why"), `decisions/`
+  (ADR-0001…0016 — trust the files, the `decisions/README.md` index is stale),
+  `WORKSHOP_2_BACKLOG.md`, `BUILD_BRIEF_*` build briefs.
+- `godot/scripts/core/` — game logic (game_state, turn_manager, actions,
+  doom_system, finance_engine, events, …). Deterministic, testable.
+- `godot/scripts/ui/` — screens/panels (`main_ui.gd` is the 3k-line monolith).
+- `godot/autoload/` — singletons (event_service, game_config, theme_manager, …).
+- `godot/data/` — data-driven balance/events/actions/scenarios (JSON). Prefer
+  editing data over hardcoding.
+- `godot/tests/` — `unit/` (fast), `unit/simulation/` (slow), `integration/`.
+
+## CI is honest now (#640)
+Green CI means tests actually ran. Earlier the gate reported green while running
+ZERO tests (cold class cache → GUT quit(0)); `run_godot_tests.py` now parses the
+JUnit XML, enforces a min-test floor, and fails if any `test_*.gd` was silently
+dropped. Trust green.

--- a/docs/AGENT_EFFICIENCY_AUDIT.md
+++ b/docs/AGENT_EFFICIENCY_AUDIT.md
@@ -1,0 +1,170 @@
+# Agent-Efficiency Audit & Roadmap
+
+**Purpose:** make the repo cheaper and smoother for future Claude/LLM agents to
+load, navigate, and work in — fewer wasted tokens, fewer repeated mistakes.
+
+**Philosophy: SLOW, ITERATIVE, LOW-RISK.** This is not a big-bang refactor plan.
+Each item is scoped to be landed on its own, in its own PR, when convenient. Items
+are ranked by **leverage-per-risk**. Each is tagged **[SAFE QUICK WIN]** (an agent
+can just do it) or **[NEEDS PIP'S CALL]** (a judgement/architecture decision).
+
+The two highest-value fixes (root `CLAUDE.md`, and the `.gitattributes` +
+line-ending fix) are **already done** in the PR that introduced this file.
+
+---
+
+## Top findings, ranked by leverage-per-risk
+
+### 1. No root `CLAUDE.md` — every agent re-derived conventions [DONE]
+**Cost:** every fresh session re-discovered the import pass, the test tiers, the
+`.import`/`.uid` staging trap, ASCII-only, branch-from-origin — hundreds of wasted
+tokens and repeated mistakes per session. **Fix:** added root `CLAUDE.md` (a
+scannable cheat-sheet). **Risk:** none. **Maintenance:** update in place when a
+convention changes; keep it short (if it grows past ~2 screens it stops being read).
+
+### 2. CRLF↔LF commit-hook fight [DONE]
+**Root cause:** `core.autocrlf=true` (local + global) with **no `.gitattributes`**.
+Git wrote CRLF into the working tree on checkout; Godot and the pre-commit
+`mixed-line-ending --fix=lf` hook both want LF — so every doc commit tripped the
+hook once (CRLF→LF rewrite + abort + re-add). **Fix:** added `.gitattributes` with
+`* text=auto eol=lf` (+ explicit `binary` for assets). The index was already LF, so
+this produced **zero mass-renormalization diff** (verified: `git status` stays
+clean after adding it). **Risk:** minimal. **Not done (proposed for Pip):** a
+deliberate one-shot `git add --renormalize .` to flush the mixed CRLF/LF working
+trees across all worktrees — a large one-time diff. Only worth it if the churn
+keeps recurring; the `.gitattributes` fix should prevent recurrence on its own, so
+this is optional.
+
+### 3. `.import` / `.uid` churn after every import pass [DOCUMENTED — no code change needed]
+**Finding:** tracking is **correct** per Godot 4 convention — 1213 `.import` + 218
+`.uid` files tracked; `godot/.godot/` and `godot/.import/` correctly ignored. The
+churn (~1200 modified `.import`, stray `.uid`) is Godot **rewriting them during the
+required `--import` pass**, not a gitignore bug. **Fix:** the staging rule is now in
+`CLAUDE.md` — stage only changed files, never `git add -A`, discard churn with
+`git checkout -- godot/`. **Risk:** none. **[NEEDS PIP'S CALL]** if the rewrite is
+deterministic noise (same bytes re-touched), a local `git config` or a tiny
+pre-commit guard could auto-drop unstaged `.import` churn — but that risks hiding
+real import changes, so left as a documented discipline, not automation.
+
+### 4. Whole-tree ASCII rescan on every commit [SAFE QUICK WIN — small]
+**Cost:** `enforce-standards` runs with `pass_filenames: false` and `rglob`s the
+entire tree (`*.py *.md *.txt *.json *.yaml *.yml *.toml *.cfg *.sh`) on **every
+commit**, re-reading thousands of files even for a one-file doc change. Slow, and
+it's the second half of the "every commit is slow" complaint. **Fix options (low
+risk):** (a) let pre-commit pass the staged filenames (`pass_filenames: true`) and
+have `enforce_standards.py --pre-commit` check only those; (b) add `godot/`,
+`docs/archive/`, `web_export/`, `_website_export/` to its `exclude_dirs`. **Risk:**
+low — but changes commit-gate semantics, so verify the ASCII gate still catches a
+planted non-ASCII char before landing. **[NEEDS PIP'S CALL]** on whether the
+per-commit scan should stay whole-tree (belt-and-suspenders) vs staged-only (fast).
+
+### 5. `main_ui.gd` is a 3188-line monolith [NEEDS PIP'S CALL — already in flight]
+**Cost:** the single biggest read-cost hotspot; any UI task loads 3k lines. **Note:**
+a UI build lane (`feat/plan-watch-scaffold` / `feat/office-floor-sprites`) is
+actively working this file — **do not touch it from an efficiency PR** (merge
+conflict risk). **Recommendation:** once those lanes land, decompose by screen/panel
+into `godot/scripts/ui/panels/` (it already imports many panel scripts). Slow,
+deliberate, one panel at a time. Left entirely to Pip/UI-lane.
+
+---
+
+## Large-file inventory (read-cost hotspots)
+
+Biggest GDScript files (excluding `addons/`), by line count. Files >~600 lines are
+decomposition *candidates* — not mandates. Core-logic files are testable and mostly
+cohesive; UI files are the better split targets.
+
+| Lines | File | Note |
+|------:|------|------|
+| 3188 | `godot/scripts/ui/main_ui.gd` | monolith — **in flight, do not touch** |
+| 1134 | `godot/scripts/core/game_state.gd` | central state; cohesive, high-traffic |
+| 1024 | `godot/autoload/event_service.gd` | event dispatch singleton |
+|  892 | `godot/scripts/game_manager.gd` | top-level orchestrator |
+|  865 | `godot/scripts/core/actions.gd` | action catalog — data-extract candidate |
+|  822 | `godot/scripts/core/turn_manager.gd` | turn sequencing |
+|  698 | `godot/tests/unit/test_risk_system.gd` | large test file (fine) |
+|  533 | `godot/scripts/core/doom_system.gd` | |
+|  525 | `godot/scripts/core/events.gd` | |
+|  521 | `godot/scripts/core/risk_pool.gd` | |
+|  480 | `godot/scripts/ui/staff_perks_panel.gd` | UI split candidate |
+
+**Recommendation:** treat only `main_ui.gd` (post-lane) and possibly `actions.gd`
+(extract the action table into `godot/data/actions/`) as active candidates. The
+core files at 800–1100 lines are coherent single-responsibility units — splitting
+them would add cross-file navigation cost without clear benefit. **[NEEDS PIP'S CALL]**
+
+---
+
+## Module boundaries & navigability
+
+- **Good:** `core/` (logic) vs `ui/` (presentation) vs `autoload/` (singletons) vs
+  `data/` (JSON) is a clean, discoverable split. `data/`-driven balance/events means
+  agents edit JSON, not code — keep leaning into this.
+- **Minor friction:** two files live at `godot/scripts/` root (`game_manager.gd`,
+  `leaderboard.gd`) outside the `core/ui/` split. **[SAFE QUICK WIN]** low value —
+  could move under `core/`, but they're easy to find; skip unless touching them.
+- **Naming:** mostly consistent `snake_case.gd`. No systemic rename needed.
+
+## Class-cache SCRIPT-ERROR flood (#629 follow-on)
+
+**Finding:** the first headless Godot invocation on a cold cache prints a wall of
+`SCRIPT ERROR` / class-cache lines before the import completes — pure noise that
+looks like failure and costs agent tokens/attention. `run_godot_tests.py` already
+does the import pass first, so the fast gate is clean. **Recommendation [SAFE QUICK
+WIN, small]:** document the noise (done — in `CLAUDE.md`), and optionally have the
+runner suppress/summarize the first-pass stderr so logs an agent reads are shorter.
+Do NOT suppress in CI (you'd hide real parse errors). Low priority.
+
+## Test-tier clarity
+
+**Finding:** the fast vs slow split is real and well-built (`run_godot_tests.py`
+docstring + `godot-tests.yml` explain it), but a fresh agent doesn't read those
+first. **Fix:** `CLAUDE.md` now states the fast-gate command and "don't wait on
+`--simulation` for scoped changes." **Risk:** none. No further action needed.
+
+## Doc sprawl [NEEDS PIP'S CALL — the biggest slow-burn opportunity]
+
+**Cost:** **624 tracked `.md` files.** 57 loose `.md` at `docs/` root, 21 loose
+`.md` at `godot/` root (e.g. `CAT_EVENT_COMPLETE.md`, `OPTION_A_..._COMPLETE.md`,
+`PHASE_5_QUICK_REFERENCE.md` — status/handover notes that read like scratch).
+`WORKSHOP_2_BACKLOG.md` alone is 708 lines. An agent searching docs pays a big
+grep/scan tax and often hits stale or superseded files. **Recommendations (slow,
+iterative):**
+1. **[SAFE QUICK WIN]** move the 21 loose `godot/*.md` completion/handover notes
+   into `godot/docs/` or `docs/archive/` — they clutter the code root an agent lists
+   first. Verify nothing links them before moving.
+2. **[NEEDS PIP'S CALL]** add a `docs/README.md` index (one line per live doc,
+   grouped) so agents navigate by index instead of `ls`-ing 57 files. `ARCHITECTURE.md`
+   already flags that some indexes (e.g. `decisions/README.md`) are stale — an index
+   only helps if it's maintained.
+3. **[NEEDS PIP'S CALL]** split/retire: several `*_COMPLETE.md`, `ISSUE_###_FIX_*.md`
+   and duplicate ARCHITECTURE variants look like finished-work records — candidates
+   for `docs/archive/` (already excluded from the ASCII hook).
+
+## Dead / duplicate code spotted (read-only pass — verify before acting)
+
+- **Two `ARCHITECTURE.md` variants** (`docs/ARCHITECTURE.md` dev map vs
+  `docs/ARCHITECTURE_FUNDERS.md`) — intentional and cross-linked; not dead, but the
+  funders one is noted as pre-L1/stale. Leave; maybe add a stale banner.
+- **Two `TESTING_GUIDE.md`** (`docs/TESTING_GUIDE.md` and `godot/TESTING_GUIDE.md`) —
+  likely overlapping/divergent. **[SAFE QUICK WIN]** consolidate to one canonical,
+  link the other. Verify contents differ first.
+- **Root-level shell/py one-offs** (`generate_batch_option_c.sh`,
+  `test_output.png`/`test_openai_api.py`/`generate_icons.py` — the last three are
+  already gitignored) — candidates to move under `tools/`. **[NEEDS PIP'S CALL]**
+- No dead GDScript identified in this read-only pass; a proper unused-symbol sweep
+  needs Godot tooling and is out of scope for a low-risk audit.
+
+---
+
+## Suggested order of attack (all optional, all independent)
+
+1. Land this PR (CLAUDE.md + `.gitattributes` + this doc). **[DONE here]**
+2. Scope `enforce-standards` to staged files or exclude `godot/`/exports (#4).
+3. Move loose `godot/*.md` handover notes out of the code root (doc-sprawl #1).
+4. Add a maintained `docs/README.md` index (doc-sprawl #2).
+5. Consolidate the duplicate `TESTING_GUIDE.md`s.
+6. (After UI lanes land) decompose `main_ui.gd` panel-by-panel.
+
+Nothing here blocks anything else. Do them one at a time, verify the fast gate
+after each, and keep blast radius small.


### PR DESCRIPTION
## What

Slow-iterative, low-risk changes to make the repo cheaper for future Claude/LLM agents to load, navigate, and work in. **No product code touched** — docs / config / repo-tooling only. No conflict with the in-flight UI lanes (`main_ui.gd` / `main.tscn` / OfficeFloor untouched).

## Changes

1. **Root `CLAUDE.md`** — a scannable agent cheat-sheet capturing the conventions a fresh session currently re-discovers every time: fast-gate test command + the required `--import` pass, fast vs slow (`--simulation`, non-blocking) tiers, the `.import`/`.uid` staging trap (never `git add -A`), ASCII-only + commit-hook behavior, branch-from-freshly-fetched-`origin/main`, where systems live, and the honest-CI note (#640).

2. **`.gitattributes`** — fixes the CRLF↔LF commit-hook fight.
   - **Root cause:** `core.autocrlf=true` (local + global) with **no `.gitattributes`**. Git wrote CRLF into the working tree on checkout; Godot and the pre-commit `mixed-line-ending --fix=lf` hook both want LF, so every doc commit tripped the hook once (rewrite + abort + re-add).
   - **Fix:** `* text=auto eol=lf` (+ explicit `binary` for assets). The index was already LF, so this produces **zero mass-renormalization diff** (verified `git status` stays clean after adding it). Minimal blast radius; a deliberate one-shot `git add --renormalize .` is *proposed but NOT done* (documented in the audit for Pip to run if churn recurs).
   - **Verified:** the commit that introduced these files passed `mixed line ending....Passed` on the **first try** — no abort.

3. **`docs/AGENT_EFFICIENCY_AUDIT.md`** — prioritized, leverage-per-risk roadmap. Covers the largest-file/monolith inventory, module boundaries, the class-cache SCRIPT-ERROR flood, test-tier clarity, doc sprawl (624 tracked `.md`), and duplicate-doc findings. Each item tagged SAFE QUICK WIN vs NEEDS PIP'S CALL. Explicitly framed as slow-iterative, not a big-bang refactor.

## `.import` / `.uid` finding

Tracking is **correct** per Godot 4 convention (1213 `.import` + 218 `.uid` tracked; `godot/.godot/` + `godot/.import/` correctly ignored). The ~1200-file churn is Godot **rewriting them during the required `--import` pass** — a staging-discipline issue, not a gitignore bug. Documented the rule in `CLAUDE.md` rather than changing tracking (a mass untrack would be high blast-radius).

## Verification

- Fast unit gate (`run_godot_tests.py --quick --ci-mode --min-tests 300`) passes (exit 0) with these changes.
- Test commit confirmed the line-ending hook no longer aborts.

**Do not merge — for Pip's review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)