### PR TITLE
feat(ui): plan/watch two-screen scaffold + terminal styling (Phase A, Pip review)

### DIFF
--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -47,6 +47,7 @@ var doom_breakdown  # #578 colour-coded per-source doom "blow-by-blow" (script-i
 var event_dialog  # #622 L10: event dialog presenter (script-instantiated child)
 var ledger_screen  # #622 L10: Liability Ledger UI (leather palette + summary button + screen builder)
 var employee_panel  # #622 L10: employee roster + staff ID card (becomes L2's assignment surface)
+var screen_mode: ScreenModeController  # Lane 1 / Phase A: PLAN<->WATCH two-screen mode controller
 # EE-7 (ADR-0012 loss legibility): per-resource "last turn" delta chips beside the
 # money/compute/reputation/doom readouts. Snapshot at each turn boundary; a chip shows
 # the change over the last completed turn, green=helped red=hurt (doom inverted).
@@ -158,6 +159,10 @@ func _ready():
 	right_zones.add_child(employee_access_btn)
 	right_zones.move_child(employee_access_btn, ledger_summary_btn.get_index() + 1)
 
+	# Lane 1 / Phase A: PLAN<->WATCH two-screen scaffold + first terminal-styling pass.
+	# Built AFTER all panels exist so it can register them for per-mode visibility.
+	_setup_plan_watch_scaffold()
+
 	# Always-visible DEV BUILD corner badge so a playtester can confirm exactly which
 	# build he's running (version + git stamp). Draws on its own CanvasLayer over the UI.
 	add_child(DevBuildBadge.new())
@@ -189,6 +194,69 @@ func _ready():
 	# Call init on next frame to ensure everything is ready
 	await get_tree().process_frame
 	_on_init_button_pressed()
+
+func _setup_plan_watch_scaffold() -> void:
+	"""Lane 1 / Phase A (BUILD_BRIEF_PLAN_WATCH_UI): stand up the two-screen structure over
+	the existing single UI — a mode controller + banner + WATCH control strip, existing
+	panels sorted into PLAN vs WATCH, and a first terminal-styling pass. The game stays
+	fully playable: COMMIT THE MONTH (the End Turn button) drives PLAN->WATCH; the month
+	review returns to PLAN (see _on_turn_phase_changed / _on_end_turn_button_pressed)."""
+	# --- background: dark CRT phosphor field on its own layer (no layout disturbance) ---
+	var bg_layer := CanvasLayer.new()
+	bg_layer.layer = -10
+	var bg := ColorRect.new()
+	bg.color = TerminalTheme.BG_DARK
+	bg.set_anchors_preset(Control.PRESET_FULL_RECT)
+	bg.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	bg_layer.add_child(bg)
+	add_child(bg_layer)
+
+	# --- mode controller + its owned chrome ---
+	screen_mode = ScreenModeController.new()
+	add_child(screen_mode)
+
+	# Mode banner just under the TopBar.
+	var banner := screen_mode.build_banner()
+	add_child(banner)
+	move_child(banner, $TopBar.get_index() + 1)
+
+	# WATCH control strip (speed dial + day/reserve readout) just above the content area.
+	var watch_bar := screen_mode.build_watch_bar()
+	add_child(watch_bar)
+	move_child(watch_bar, banner.get_index() + 1)
+
+	# Speed dial -> real playback speed.
+	screen_mode.speed_changed.connect(func(secs: float): game_manager.day_tick_seconds = secs)
+
+	# --- sort existing panels into PLAN vs WATCH ---
+	# PLAN (strategy): the hand, upgrades to plan, the planning verbs. Hidden while watching.
+	screen_mode.register_plan_only($ContentArea/LeftPanel)                 # the action hand + research selector
+	screen_mode.register_plan_only($ContentArea/RightPanel/UpgradesLabel)
+	screen_mode.register_plan_only($ContentArea/RightPanel/UpgradesScroll)
+	screen_mode.register_plan_only($ContentArea/MiddlePanel/CommandZone)   # Do-Nothing / pass — a planning verb
+	screen_mode.register_plan_only(undo_last_button)
+	screen_mode.register_plan_only(clear_queue_button)
+	screen_mode.register_plan_only(reserve_ap_button)
+	screen_mode.register_plan_only(commit_plan_button)
+	screen_mode.register_plan_only(end_turn_button)                        # END TURN == COMMIT THE MONTH
+	# WATCH (tactics): the playback control strip. Doom/feed/queue stay visible in BOTH
+	# (context in PLAN, live instruments in WATCH); response windows overlay as dialogs.
+	screen_mode.register_watch_only(watch_bar)
+
+	# The End Turn button is the PLAN->WATCH commit — relabel it in the plan register.
+	end_turn_button.text = "COMMIT THE MONTH ▶"
+
+	# --- first terminal-styling pass over the default greys ---
+	TerminalTheme.style_panel($ContentArea/RightPanel/QueuePanel, TerminalTheme.RULE, TerminalTheme.PANEL_BG)
+	TerminalTheme.style_panel($InfoBar, TerminalTheme.RULE, TerminalTheme.PANEL_BG_DEEP)
+	TerminalTheme.style_feed(message_log)  # the feed: monospace, phosphor text
+	# Amber the two title labels into the terminal register.
+	$TopBar/TitleLabel.add_theme_color_override("font_color", TerminalTheme.AMBER)
+	$ContentArea/MiddlePanel/TitleZone/TitleLabel.add_theme_color_override("font_color", TerminalTheme.AMBER)
+
+	# Start in PLAN (the game opens at the month plan).
+	screen_mode.enter_plan()
+
 
 func _unhandled_key_input(event: InputEvent):
 	"""Handle keyboard shortcuts for dialogs (runs after focus but before _unhandled_input)"""
@@ -547,6 +615,9 @@ func _on_end_turn_button_pressed():
 	# playback (auto-pause on response windows, month review at the boundary). The old
 	# single day-step lives on ONLY behind the DEV MODE overlay ("Day step (dev)").
 	game_manager.end_month()
+	# Phase A: COMMIT THE MONTH is the PLAN->WATCH transition.
+	if screen_mode:
+		screen_mode.enter_watch()
 
 func _on_commit_plan_button_pressed():
 	"""Commit queued actions AND reserve remaining AP (no warnings)"""
@@ -582,6 +653,9 @@ func _on_commit_plan_button_pressed():
 
 	# Commit the plan — the L1 month path (see _on_end_turn_button_pressed).
 	game_manager.end_month()
+	# Phase A: committing the plan is the PLAN->WATCH transition.
+	if screen_mode:
+		screen_mode.enter_watch()
 
 func _on_employee_tab_button_pressed():
 	"""Switch to employee management screen - DISABLED: employee info moving to main UI"""
@@ -608,6 +682,10 @@ func _on_game_state_updated(state: Dictionary):
 
 	if research_quality_selector:
 		research_quality_selector.update_from_state(state)
+
+	# Phase A: keep the WATCH day/reserve readout live during month playback.
+	if screen_mode:
+		screen_mode.update_from_state(state)
 
 	# Update resource displays (Issue #472 - enhanced turn display with calendar)
 	var turn_display = state.get("turn_display", "")
@@ -848,6 +926,10 @@ func _on_turn_phase_changed(phase_name: String):
 		commit_plan_button.disabled = false
 		undo_last_button.disabled = (queued_actions.size() == 0)
 		clear_queue_button.disabled = (queued_actions.size() == 0)
+		# Phase A: reaching the plan phase (game start / after month review) returns to PLAN.
+		# Mid-month window pauses emit "turn_start", not "action_selection", so WATCH is kept.
+		if screen_mode:
+			screen_mode.enter_plan()
 	elif phase_name == "turn_end" or phase_name == "TURN_END":
 		phase_color = "yellow"
 		phase_display = "EXECUTING - Your actions are running..."

--- a/godot/scripts/ui/screen_mode.gd
+++ b/godot/scripts/ui/screen_mode.gd
@@ -1,0 +1,176 @@
+class_name ScreenModeController
+extends Node
+## Plan/Watch two-screen mode controller (BUILD_BRIEF_PLAN_WATCH_UI Lane 1 / Phase A).
+##
+## The model (ruled): TWO screens with a mode switch between them.
+##   PLAN  = strategy — lay out the month before it plays (the hand / queue / team).
+##   WATCH = tactics  — the committed month plays out in day-ticks (feed / doom / windows).
+##   COMMIT THE MONTH transitions PLAN -> WATCH; month-end review returns to PLAN.
+##
+## Phase-A scaffold approach: this does NOT reparent the existing widget tree (main_ui.gd
+## is heavily coupled to absolute node paths — moving nodes would break it). Instead it
+## REGISTERS the existing panels as plan-only / watch-only and toggles their visibility,
+## plus owns two NEW pieces of chrome it builds itself: the mode BANNER and the WATCH
+## control strip (playback speed + day/reserve readout). Follow-up lanes promote this into
+## genuinely separate PlanScreen/WatchScreen scenes once the widget coupling is untangled.
+
+enum Mode { PLAN, WATCH }
+
+signal mode_changed(mode: int)
+signal speed_changed(seconds: float)   # WATCH speed dial -> game_manager.day_tick_seconds
+
+var current_mode: int = Mode.PLAN
+
+# NEW chrome this controller owns (built here, mounted by main_ui).
+var banner: PanelContainer
+var watch_bar: PanelContainer
+var _banner_label: RichTextLabel
+var _day_label: Label
+var _reserve_label: Label
+
+# Existing panels toggled per mode (registered by main_ui).
+var _plan_only: Array[Node] = []
+var _watch_only: Array[Node] = []
+
+# Speed presets for the WATCH playback dial (seconds per visible day-tick).
+const _SPEEDS := {"1x": 0.20, "2x": 0.10, "4x": 0.05}
+
+
+func register_plan_only(n: Node) -> void:
+	if n != null and not _plan_only.has(n):
+		_plan_only.append(n)
+
+func register_watch_only(n: Node) -> void:
+	if n != null and not _watch_only.has(n):
+		_watch_only.append(n)
+
+
+func build_banner() -> PanelContainer:
+	"""The mode banner — a boxed strip naming the current screen + its verb. Amber in PLAN,
+	green in WATCH (the two registers). main_ui inserts the returned node under the TopBar."""
+	banner = PanelContainer.new()
+	banner.name = "ModeBanner"
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 8)
+	margin.add_theme_constant_override("margin_right", 8)
+	margin.add_theme_constant_override("margin_top", 2)
+	margin.add_theme_constant_override("margin_bottom", 2)
+	banner.add_child(margin)
+	_banner_label = RichTextLabel.new()
+	_banner_label.bbcode_enabled = true
+	_banner_label.fit_content = true
+	_banner_label.scroll_active = false
+	_banner_label.add_theme_font_override("normal_font", TerminalTheme.mono_font())
+	margin.add_child(_banner_label)
+	return banner
+
+
+func build_watch_bar() -> PanelContainer:
+	"""The WATCH-only control strip: playback speed dial + live day / reserve readout
+	(brief WATCH header — playback controls + reserve remaining). Play/pause is a clean
+	STUB for a follow-up lane; the speed dial is REAL (drives day_tick_seconds)."""
+	watch_bar = PanelContainer.new()
+	watch_bar.name = "WatchControls"
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+	watch_bar.add_child(row)
+
+	var tag := Label.new()
+	tag.text = "▶ PLAYBACK"
+	tag.add_theme_color_override("font_color", TerminalTheme.GREEN)
+	tag.add_theme_font_override("font", TerminalTheme.mono_font())
+	row.add_child(tag)
+
+	# Play/pause — STUB (follow-up lane owns real pause; auto-pause on windows already works).
+	var pause_stub := Button.new()
+	pause_stub.text = "⏸"
+	pause_stub.disabled = true
+	pause_stub.tooltip_text = "Pause/resume — stub (follow-up lane). Windows already auto-pause playback."
+	pause_stub.focus_mode = Control.FOCUS_NONE
+	row.add_child(pause_stub)
+
+	# Speed dial — REAL: sets game_manager.day_tick_seconds via speed_changed.
+	for key in ["1x", "2x", "4x"]:
+		var b := Button.new()
+		b.text = key
+		b.focus_mode = Control.FOCUS_NONE
+		b.tooltip_text = "Playback speed"
+		b.pressed.connect(func(): speed_changed.emit(_SPEEDS[key]))
+		row.add_child(b)
+
+	var spacer := Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(spacer)
+
+	_day_label = Label.new()
+	_day_label.text = "day —"
+	_day_label.add_theme_color_override("font_color", TerminalTheme.TEXT)
+	_day_label.add_theme_font_override("font", TerminalTheme.mono_font())
+	row.add_child(_day_label)
+
+	var sep := Label.new()
+	sep.text = "·"
+	sep.add_theme_color_override("font_color", TerminalTheme.RULE_BRIGHT)
+	row.add_child(sep)
+
+	_reserve_label = Label.new()
+	_reserve_label.text = "reserve —"
+	_reserve_label.tooltip_text = "Held Attention — the slack available to spend on mid-month response windows."
+	_reserve_label.add_theme_color_override("font_color", TerminalTheme.AMBER)
+	_reserve_label.add_theme_font_override("font", TerminalTheme.mono_font())
+	row.add_child(_reserve_label)
+
+	return watch_bar
+
+
+func enter_plan() -> void:
+	set_mode(Mode.PLAN)
+
+func enter_watch() -> void:
+	set_mode(Mode.WATCH)
+
+
+func set_mode(m: int) -> void:
+	current_mode = m
+	var is_plan := m == Mode.PLAN
+	for n in _plan_only:
+		if is_instance_valid(n):
+			(n as CanvasItem).visible = is_plan
+	for n in _watch_only:
+		if is_instance_valid(n):
+			(n as CanvasItem).visible = not is_plan
+	_refresh_banner()
+	mode_changed.emit(m)
+
+
+func update_from_state(state: Dictionary) -> void:
+	"""Refresh WATCH readouts (day / reserve) from the live game state each tick."""
+	var cal: Dictionary = state.get("calendar", {})
+	if _day_label != null and not cal.is_empty():
+		var months := ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+		var mi: int = int(cal.get("month", 1)) - 1
+		var mname: String = months[mi] if mi >= 0 and mi < 12 else "?"
+		_day_label.text = "day %d — %s %d" % [int(cal.get("day", 0)), mname, int(cal.get("year", 0))]
+	if _reserve_label != null:
+		var mp: Dictionary = state.get("month_plan", {})
+		var total := int(mp.get("attention_total", 0))
+		var spent := int(mp.get("attention_spent", 0))
+		var reserved := int(mp.get("attention_reserved", 0))
+		# Remaining slack = whatever isn't committed to strategic work this month.
+		var remaining: int = max(0, total - spent)
+		if reserved > 0:
+			remaining = reserved
+		_reserve_label.text = "reserve %d" % remaining
+
+
+func _refresh_banner() -> void:
+	if _banner_label == null:
+		return
+	if current_mode == Mode.PLAN:
+		if banner != null:
+			TerminalTheme.style_panel(banner, TerminalTheme.AMBER_DIM, TerminalTheme.PANEL_BG_DEEP)
+		_banner_label.text = "[color=#ffb833]▓▓ PLAN[/color]  [color=#a87a28]· strategy · lay out the month, then[/color] [color=#ffb833]COMMIT THE MONTH ▶[/color]"
+	else:
+		if banner != null:
+			TerminalTheme.style_panel(banner, TerminalTheme.GREEN_DIM, TerminalTheme.PANEL_BG_DEEP)
+		_banner_label.text = "[color=#5cec78]▓▓ WATCH[/color]  [color=#369048]· tactics · the month plays out — respond to windows as they arrive[/color]"

--- a/godot/scripts/ui/screen_mode.gd.uid
+++ b/godot/scripts/ui/screen_mode.gd.uid
@@ -1,0 +1,1 @@
+uid://b5mepxoi8j7d5

--- a/godot/scripts/ui/terminal_theme.gd
+++ b/godot/scripts/ui/terminal_theme.gd
@@ -1,0 +1,62 @@
+class_name TerminalTheme
+extends RefCounted
+## First-pass terminal / mainframe styling register for the Plan/Watch scaffold
+## (BUILD_BRIEF_PLAN_WATCH_UI "Aesthetic": amber/green CRT, boxes + rules, lightly
+## modernized — NOT literal retro). This is a THIN static helper: a palette + a few
+## StyleBoxFlat/font builders that the Plan/Watch UI applies over the default greys.
+## Deliberately code-driven (no .tres churn) so Pip can react and a follow-up art lane
+## can promote it to a real Theme resource + scanline shader.
+
+# --- Palette ---------------------------------------------------------------
+# Near-black, faintly green-tinted phosphor background.
+const BG_DARK := Color(0.035, 0.05, 0.043)
+const PANEL_BG := Color(0.07, 0.093, 0.082)
+const PANEL_BG_DEEP := Color(0.05, 0.066, 0.058)
+
+# Amber = PLAN register (strategy, calm). Green = WATCH register (tactics, live).
+const AMBER := Color(1.0, 0.72, 0.20)
+const AMBER_DIM := Color(0.66, 0.48, 0.16)
+const GREEN := Color(0.36, 0.93, 0.47)
+const GREEN_DIM := Color(0.21, 0.56, 0.30)
+
+const TEXT := Color(0.82, 0.86, 0.78)
+const TEXT_DIM := Color(0.50, 0.58, 0.50)
+const RULE := Color(0.20, 0.36, 0.26)          # box borders / hairlines
+const RULE_BRIGHT := Color(0.30, 0.52, 0.36)
+
+
+static func box(border: Color, bg: Color = PANEL_BG, border_width: int = 1) -> StyleBoxFlat:
+	"""A boxed panel in the terminal register — flat fill + a single hairline rule."""
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = bg
+	sb.border_color = border
+	sb.set_border_width_all(border_width)
+	sb.set_corner_radius_all(0)  # terminals have square corners
+	sb.content_margin_left = 8
+	sb.content_margin_right = 8
+	sb.content_margin_top = 4
+	sb.content_margin_bottom = 4
+	return sb
+
+
+static func mono_font() -> SystemFont:
+	"""Best-available system monospace — the 'monospace-ish' the brief asks for, without
+	shipping a font asset. Degrades gracefully to the platform default if none match."""
+	var f := SystemFont.new()
+	f.font_names = PackedStringArray(["Consolas", "DejaVu Sans Mono", "Courier New", "monospace"])
+	return f
+
+
+static func style_panel(node: Control, border: Color = RULE, bg: Color = PANEL_BG) -> void:
+	"""Apply the boxed-panel look to any PanelContainer-like Control (adds a 'panel' stylebox)."""
+	if node == null:
+		return
+	node.add_theme_stylebox_override("panel", box(border, bg))
+
+
+static func style_feed(label: RichTextLabel) -> void:
+	"""The WATCH feed / message log: monospace, dim green-tinted text."""
+	if label == null:
+		return
+	label.add_theme_font_override("normal_font", mono_font())
+	label.add_theme_color_override("default_color", TEXT)

--- a/godot/scripts/ui/terminal_theme.gd.uid
+++ b/godot/scripts/ui/terminal_theme.gd.uid
@@ -1,0 +1,1 @@
+uid://vhqxfetn6fff

--- a/godot/tests/unit/test_screen_mode.gd
+++ b/godot/tests/unit/test_screen_mode.gd
@@ -1,0 +1,86 @@
+extends GutTest
+## Lane 1 / Phase A: the PLAN<->WATCH mode controller (scripts/ui/screen_mode.gd).
+## The month LOOP itself is covered by test_month_button_path.gd; this guards the UI
+## SEAM — that committing flips plan-only panels off / watch-only panels on, and back.
+
+var ctrl: ScreenModeController
+var plan_panel: Control
+var watch_panel: Control
+
+
+func before_each():
+	ctrl = ScreenModeController.new()
+	add_child_autofree(ctrl)
+	plan_panel = Control.new()
+	watch_panel = Control.new()
+	add_child_autofree(plan_panel)
+	add_child_autofree(watch_panel)
+	ctrl.register_plan_only(plan_panel)
+	ctrl.register_watch_only(watch_panel)
+
+
+func test_starts_showing_plan_hiding_watch():
+	ctrl.enter_plan()
+	assert_eq(ctrl.current_mode, ScreenModeController.Mode.PLAN, "in PLAN mode")
+	assert_true(plan_panel.visible, "plan-only panel visible in PLAN")
+	assert_false(watch_panel.visible, "watch-only panel hidden in PLAN")
+
+
+func test_commit_transitions_to_watch():
+	"""COMMIT THE MONTH: PLAN -> WATCH hides the plan hand, reveals the watch strip."""
+	ctrl.enter_plan()
+	ctrl.enter_watch()
+	assert_eq(ctrl.current_mode, ScreenModeController.Mode.WATCH, "in WATCH mode")
+	assert_false(plan_panel.visible, "plan-only panel hidden in WATCH")
+	assert_true(watch_panel.visible, "watch-only panel visible in WATCH")
+
+
+func test_review_returns_to_plan():
+	"""Month review closes back into PLAN — the loop is closed."""
+	ctrl.enter_watch()
+	ctrl.enter_plan()
+	assert_true(plan_panel.visible, "plan panel back on return to PLAN")
+	assert_false(watch_panel.visible, "watch strip hidden back in PLAN")
+
+
+func test_mode_changed_signal_fires():
+	watch_signals(ctrl)
+	ctrl.enter_watch()
+	assert_signal_emitted(ctrl, "mode_changed")
+
+
+func test_speed_dial_emits_speed_changed():
+	"""The WATCH speed dial drives day_tick_seconds via speed_changed (a REAL control)."""
+	var bar := ctrl.build_watch_bar()
+	add_child_autofree(bar)
+	watch_signals(ctrl)
+	# Find a speed button ("2x") in the built strip and press it.
+	var pressed_any := false
+	for b in _all_buttons(bar):
+		if b.text == "2x":
+			b.emit_signal("pressed")
+			pressed_any = true
+			break
+	assert_true(pressed_any, "found the 2x speed button in the watch strip")
+	assert_signal_emitted(ctrl, "speed_changed")
+
+
+func test_watch_readout_updates_from_state():
+	ctrl.build_watch_bar()
+	var state := {
+		"calendar": {"year": 2034, "month": 3, "day": 12},
+		"month_plan": {"attention_total": 20, "attention_spent": 6, "attention_reserved": 0},
+	}
+	# Should not error and should reflect the day; assert via no crash + label text.
+	ctrl.update_from_state(state)
+	assert_string_contains(ctrl._day_label.text, "day 12", "day readout reflects the calendar")
+	assert_string_contains(ctrl._reserve_label.text, "reserve", "reserve readout present")
+
+
+func _all_buttons(n: Node) -> Array:
+	var out: Array = []
+	if n is Button:
+		out.append(n)
+	for c in n.get_children():
+		out.append_array(_all_buttons(c))
+	return out

--- a/godot/tests/unit/test_screen_mode.gd.uid
+++ b/godot/tests/unit/test_screen_mode.gd.uid
@@ -1,0 +1,1 @@
+uid://djgh8h1cento7


### PR DESCRIPTION
## Lane 1 / Phase A — Plan/Watch two-screen scaffold

Reviewable **first cut** of the two-screen structure from `BUILD_BRIEF_PLAN_WATCH_UI.md`. Do **not** merge — for Pip to react to and playtest. Deliberately a scaffold, not full polish.

### What it does
Stands up **PLAN (strategy) / WATCH (tactics)** as a mode switch over the *existing* single `main_ui`, **without rewriting the widgets** (main_ui is heavily coupled to absolute node paths — moving nodes would break it). Existing panels are sorted per-mode and toggled by visibility. The game stays **fully playable**: a full month plays through (plan → commit → watch day-ticks → resolve window → month review → next plan).

### What moved where
- **PLAN-only** (hidden while watching): the action hand (`LeftPanel` + research selector), Upgrades, the Do-Nothing/pass command, and the plan verbs (undo / clear / reserve / commit / COMMIT THE MONTH).
- **WATCH-only**: the new playback control strip (speed dial + live day / reserve readout).
- **Both** (context in PLAN, live instruments in WATCH): resources top bar, doom meter + trend, the queue (committed → in-flight), the message log (planning log → feed), the roster. Response windows overlay as dialogs (existing `event_dialog` machinery, auto-pause intact).

### Mode switch + COMMIT transition (files)
- `scripts/ui/screen_mode.gd` — `ScreenModeController`: `enter_plan()` / `enter_watch()` toggle registered panels + swap the banner register; owns the mode banner + WATCH strip; `speed_changed` drives real playback speed; `mode_changed` for later listeners.
- `scripts/ui/main_ui.gd` — `_setup_plan_watch_scaffold()` mounts + registers everything. `_on_end_turn_button_pressed` / `_on_commit_plan_button_pressed` call `enter_watch()` right after `game_manager.end_month()`. `_on_turn_phase_changed` calls `enter_plan()` on `action_selection` (fires at game start and after the month review; mid-month window pauses emit `turn_start`, so WATCH is kept). Per-tick `update_from_state` feeds the WATCH day/reserve readout.

### Terminal styling (first pass)
`scripts/ui/terminal_theme.gd` — code-driven amber/green CRT register: dark phosphor background (own CanvasLayer, no layout disturbance), boxed panels + hairline rules, system-monospace feed, amber titles. Amber = PLAN, green = WATCH. No `.tres` / no `.import` churn — a follow-up art lane can promote it to a real Theme + scanline shader.

### Stubbed for follow-ups (clean seams)
- Play/pause button is a visual **stub** (windows already auto-pause; real pause is a follow-up). Speed dial (1x/2x/4x) is **real**.
- Out of scope per brief: card-hand art, gantt duration bars, reserve-gauge polish, reorderable queue-order mechanic, two-instrument doom rework, OfficeFloor/employee sprites (separate lane). Panels stay visible in both modes rather than being rebuilt.

### Verification
- Fast unit gate (`run_godot_tests.py --quick`, excludes `tests/unit/simulation`): **362 tests, 0 failures, 39/39 files** (+6 new `test_screen_mode.gd` guarding the toggle seam).
- Headless launch of `main.tscn` boots clean (no script/parse errors); opens in PLAN.
- Month loop intact: `test_month_button_path.gd` (in the fast gate) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)