### PR TITLE
feat(ui): extract PlanScreen/WatchScreen from main_ui monolith (supersedes #658)

### DIFF
--- a/godot/scenes/main.tscn
+++ b/godot/scenes/main.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=12 format=3 uid="uid://bvqxj8x5p6h8c"]
 
 [ext_resource type="Script" path="res://scripts/ui/main_ui.gd" id="2_main_ui"]
-[ext_resource type="Script" path="res://scripts/ui/plan_screen.gd" id="12_plan_screen"]
+[ext_resource type="PackedScene" uid="uid://plan_screen_pw01" path="res://scenes/ui/plan_screen.tscn" id="12_plan_screen"]
 [ext_resource type="Script" path="res://scripts/ui/instrument_panel.gd" id="13_instrument"]
-[ext_resource type="Script" path="res://scripts/ui/watch_screen.gd" id="14_watch_screen"]
+[ext_resource type="PackedScene" uid="uid://watch_screen_pw01" path="res://scenes/ui/watch_screen.tscn" id="14_watch_screen"]
 [ext_resource type="Texture2D" path="res://assets/images/office_cat.png" id="3_cat_texture"]
 [ext_resource type="PackedScene" uid="uid://cw3j8x5p6doom" path="res://scenes/ui/doom_meter.tscn" id="4_doom_meter"]
 [ext_resource type="PackedScene" uid="uid://gameover123456" path="res://scenes/ui/game_over_screen.tscn" id="5_gameover"]
@@ -169,60 +169,10 @@ layout_mode = 2
 size_flags_vertical = 3
 theme_override_constants/separation = 5
 
-[node name="PlanScreen" type="VBoxContainer" parent="TabManager/MainUI/ContentArea"]
+[node name="PlanScreen" parent="TabManager/MainUI/ContentArea" instance=ExtResource("12_plan_screen")]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.3
-script = ExtResource("12_plan_screen")
-
-[node name="GettingStartedHint" type="Label" parent="TabManager/MainUI/ContentArea/PlanScreen"]
-layout_mode = 2
-text = "TIP: Hire safety researchers to reduce P(Doom)"
-horizontal_alignment = 1
-theme_override_font_sizes/font_size = 10
-theme_override_colors/font_color = Color(0.5, 0.8, 0.5, 0.9)
-
-[node name="ActionsScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/PlanScreen"]
-layout_mode = 2
-size_flags_vertical = 3
-
-[node name="ActionsList" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/PlanScreen/ActionsScroll"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="UpgradesLabel" type="Label" parent="TabManager/MainUI/ContentArea/PlanScreen"]
-layout_mode = 2
-text = "Upgrades:"
-theme_override_font_sizes/font_size = 16
-theme_override_colors/font_color = Color(0.8, 0.9, 1.0, 1)
-
-[node name="UpgradesScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/PlanScreen"]
-layout_mode = 2
-size_flags_vertical = 3
-size_flags_stretch_ratio = 0.45
-
-[node name="UpgradesList" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/PlanScreen/UpgradesScroll"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="CommandZone" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/PlanScreen"]
-layout_mode = 2
-size_flags_vertical = 8
-alignment = 2
-
-[node name="CommandLabel" type="Label" parent="TabManager/MainUI/ContentArea/PlanScreen/CommandZone"]
-layout_mode = 2
-text = "Command"
-horizontal_alignment = 1
-theme_override_font_sizes/font_size = 11
-theme_override_colors/font_color = Color(0.6, 0.5, 0.8, 1)
-
-[node name="PassButton" type="Button" parent="TabManager/MainUI/ContentArea/PlanScreen/CommandZone"]
-layout_mode = 2
-custom_minimum_size = Vector2(120, 36)
-text = "Do Nothing"
-theme_override_font_sizes/font_size = 12
-theme_override_colors/font_color = Color(0.8, 0.7, 1.0, 1)
 
 [node name="InstrumentColumn" type="VBoxContainer" parent="TabManager/MainUI/ContentArea"]
 layout_mode = 2
@@ -339,29 +289,10 @@ layout_mode = 2
 text = "No actions queued..."
 modulate = Color(0.5, 0.5, 0.5, 1)
 
-[node name="WatchScreen" type="VBoxContainer" parent="TabManager/MainUI/ContentArea"]
+[node name="WatchScreen" parent="TabManager/MainUI/ContentArea" instance=ExtResource("14_watch_screen")]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.4
-script = ExtResource("14_watch_screen")
-
-[node name="MessageLogLabel" type="Label" parent="TabManager/MainUI/ContentArea/WatchScreen"]
-layout_mode = 2
-text = "Message Log:"
-
-[node name="MessageScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/WatchScreen"]
-layout_mode = 2
-size_flags_vertical = 3
-size_flags_stretch_ratio = 0.35
-
-[node name="MessageLog" type="RichTextLabel" parent="TabManager/MainUI/ContentArea/WatchScreen/MessageScroll"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-bbcode_enabled = true
-text = "[color=gray]Game not started...[/color]"
-fit_content = true
-scroll_following = true
 
 [node name="HSeparator2" type="HSeparator" parent="TabManager/MainUI"]
 layout_mode = 2

--- a/godot/scenes/main.tscn
+++ b/godot/scenes/main.tscn
@@ -1,6 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://bvqxj8x5p6h8c"]
+[gd_scene load_steps=12 format=3 uid="uid://bvqxj8x5p6h8c"]
 
 [ext_resource type="Script" path="res://scripts/ui/main_ui.gd" id="2_main_ui"]
+[ext_resource type="Script" path="res://scripts/ui/plan_screen.gd" id="12_plan_screen"]
+[ext_resource type="Script" path="res://scripts/ui/instrument_panel.gd" id="13_instrument"]
+[ext_resource type="Script" path="res://scripts/ui/watch_screen.gd" id="14_watch_screen"]
 [ext_resource type="Texture2D" path="res://assets/images/office_cat.png" id="3_cat_texture"]
 [ext_resource type="PackedScene" uid="uid://cw3j8x5p6doom" path="res://scenes/ui/doom_meter.tscn" id="4_doom_meter"]
 [ext_resource type="PackedScene" uid="uid://gameover123456" path="res://scenes/ui/game_over_screen.tscn" id="5_gameover"]
@@ -166,92 +169,128 @@ layout_mode = 2
 size_flags_vertical = 3
 theme_override_constants/separation = 5
 
-[node name="LeftPanel" type="VBoxContainer" parent="TabManager/MainUI/ContentArea"]
+[node name="PlanScreen" type="VBoxContainer" parent="TabManager/MainUI/ContentArea"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.3
+script = ExtResource("12_plan_screen")
 
-[node name="GettingStartedHint" type="Label" parent="TabManager/MainUI/ContentArea/LeftPanel"]
+[node name="GettingStartedHint" type="Label" parent="TabManager/MainUI/ContentArea/PlanScreen"]
 layout_mode = 2
 text = "TIP: Hire safety researchers to reduce P(Doom)"
 horizontal_alignment = 1
 theme_override_font_sizes/font_size = 10
 theme_override_colors/font_color = Color(0.5, 0.8, 0.5, 0.9)
 
-[node name="ActionsScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/LeftPanel"]
+[node name="ActionsScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/PlanScreen"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="ActionsList" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/LeftPanel/ActionsScroll"]
+[node name="ActionsList" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/PlanScreen/ActionsScroll"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="MiddlePanel" type="VBoxContainer" parent="TabManager/MainUI/ContentArea"]
+[node name="UpgradesLabel" type="Label" parent="TabManager/MainUI/ContentArea/PlanScreen"]
+layout_mode = 2
+text = "Upgrades:"
+theme_override_font_sizes/font_size = 16
+theme_override_colors/font_color = Color(0.8, 0.9, 1.0, 1)
+
+[node name="UpgradesScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/PlanScreen"]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.45
+
+[node name="UpgradesList" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/PlanScreen/UpgradesScroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="CommandZone" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/PlanScreen"]
+layout_mode = 2
+size_flags_vertical = 8
+alignment = 2
+
+[node name="CommandLabel" type="Label" parent="TabManager/MainUI/ContentArea/PlanScreen/CommandZone"]
+layout_mode = 2
+text = "Command"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 11
+theme_override_colors/font_color = Color(0.6, 0.5, 0.8, 1)
+
+[node name="PassButton" type="Button" parent="TabManager/MainUI/ContentArea/PlanScreen/CommandZone"]
+layout_mode = 2
+custom_minimum_size = Vector2(120, 36)
+text = "Do Nothing"
+theme_override_font_sizes/font_size = 12
+theme_override_colors/font_color = Color(0.8, 0.7, 1.0, 1)
+
+[node name="InstrumentColumn" type="VBoxContainer" parent="TabManager/MainUI/ContentArea"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.3
 alignment = 2
+script = ExtResource("13_instrument")
 
-[node name="TitleZone" type="CenterContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel"]
+[node name="TitleZone" type="CenterContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn"]
 layout_mode = 2
 
-[node name="TitleLabel" type="Label" parent="TabManager/MainUI/ContentArea/MiddlePanel/TitleZone"]
+[node name="TitleLabel" type="Label" parent="TabManager/MainUI/ContentArea/InstrumentColumn/TitleZone"]
 layout_mode = 2
 text = "P(DOOM)"
 horizontal_alignment = 1
 theme_override_font_sizes/font_size = 24
 theme_override_colors/font_color = Color(1.0, 0.6, 0.0, 1)
 
-[node name="CoreZone" type="HBoxContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel"]
+[node name="CoreZone" type="HBoxContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn"]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="CatZone" type="CenterContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone"]
+[node name="CatZone" type="CenterContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="OfficeCat" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/CatZone" instance=ExtResource("9_officecat")]
+[node name="OfficeCat" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/CatZone" instance=ExtResource("9_officecat")]
 layout_mode = 2
 visible = false
 
-[node name="RightZones" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone"]
+[node name="RightZones" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 0
 
-[node name="NumericDoomZone" type="CenterContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/RightZones"]
+[node name="NumericDoomZone" type="CenterContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones"]
 layout_mode = 2
 
-[node name="NumericDoomLabel" type="Label" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/RightZones/NumericDoomZone"]
+[node name="NumericDoomLabel" type="Label" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones/NumericDoomZone"]
 layout_mode = 2
 text = "58.5%"
 horizontal_alignment = 1
 theme_override_font_sizes/font_size = 18
 theme_override_colors/font_color = Color(1.0, 0.3, 0.3, 1)
 
-[node name="DoomMeterZone" type="CenterContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/RightZones"]
+[node name="DoomMeterZone" type="CenterContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="DoomMeterPanel" type="PanelContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/RightZones/DoomMeterZone"]
+[node name="DoomMeterPanel" type="PanelContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones/DoomMeterZone"]
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
 
-[node name="MarginContainer" type="MarginContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/RightZones/DoomMeterZone/DoomMeterPanel"]
+[node name="MarginContainer" type="MarginContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones/DoomMeterZone/DoomMeterPanel"]
 layout_mode = 2
 theme_override_constants/margin_left = 2
 theme_override_constants/margin_top = 2
 theme_override_constants/margin_right = 2
 theme_override_constants/margin_bottom = 2
 
-[node name="DoomMeter" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/RightZones/DoomMeterZone/DoomMeterPanel/MarginContainer" instance=ExtResource("4_doom_meter")]
+[node name="DoomMeter" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones/DoomMeterZone/DoomMeterPanel/MarginContainer" instance=ExtResource("4_doom_meter")]
 layout_mode = 2
 
-[node name="DoomExplanation" type="CenterContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/RightZones"]
+[node name="DoomExplanation" type="CenterContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones"]
 layout_mode = 2
 
-[node name="ExplanationLabel" type="Label" parent="TabManager/MainUI/ContentArea/MiddlePanel/CoreZone/RightZones/DoomExplanation"]
+[node name="ExplanationLabel" type="Label" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones/DoomExplanation"]
 layout_mode = 2
 text = "Buy time · survival is the score | Lose: P(Doom) = 100%"
 horizontal_alignment = 1
@@ -261,97 +300,61 @@ tooltip_text = "P(Doom) = Probability of catastrophic AI outcome.
 Win by solving alignment (0%) or finishing below the league baseline.
 Lose if doom reaches 100% or you finish above baseline."
 
-[node name="EmployeeRosterZone" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel"]
+[node name="EmployeeRosterZone" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn"]
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_constants/separation = 4
 
-[node name="RosterLabel" type="Label" parent="TabManager/MainUI/ContentArea/MiddlePanel/EmployeeRosterZone"]
+[node name="RosterLabel" type="Label" parent="TabManager/MainUI/ContentArea/InstrumentColumn/EmployeeRosterZone"]
 layout_mode = 2
 text = "Staff Roster"
 horizontal_alignment = 1
 theme_override_font_sizes/font_size = 12
 theme_override_colors/font_color = Color(0.7, 0.8, 0.9, 1)
 
-[node name="RosterScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel/EmployeeRosterZone"]
+[node name="RosterScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/EmployeeRosterZone"]
 layout_mode = 2
 size_flags_vertical = 3
 horizontal_scroll_mode = 0
 
-[node name="RosterContainer" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel/EmployeeRosterZone/RosterScroll"]
+[node name="RosterContainer" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/EmployeeRosterZone/RosterScroll"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 2
 
-[node name="CommandZone" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/MiddlePanel"]
-layout_mode = 2
-size_flags_vertical = 8
-alignment = 2
-
-[node name="CommandLabel" type="Label" parent="TabManager/MainUI/ContentArea/MiddlePanel/CommandZone"]
-layout_mode = 2
-text = "Command"
-horizontal_alignment = 1
-theme_override_font_sizes/font_size = 11
-theme_override_colors/font_color = Color(0.6, 0.5, 0.8, 1)
-
-[node name="PassButton" type="Button" parent="TabManager/MainUI/ContentArea/MiddlePanel/CommandZone"]
-layout_mode = 2
-custom_minimum_size = Vector2(120, 36)
-text = "Do Nothing"
-theme_override_font_sizes/font_size = 12
-theme_override_colors/font_color = Color(0.8, 0.7, 1.0, 1)
-
-[node name="RightPanel" type="VBoxContainer" parent="TabManager/MainUI/ContentArea"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.4
-
-[node name="UpgradesLabel" type="Label" parent="TabManager/MainUI/ContentArea/RightPanel"]
-layout_mode = 2
-text = "Upgrades:"
-theme_override_font_sizes/font_size = 16
-theme_override_colors/font_color = Color(0.8, 0.9, 1.0, 1)
-
-[node name="UpgradesScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/RightPanel"]
-layout_mode = 2
-size_flags_vertical = 3
-size_flags_stretch_ratio = 0.45
-
-[node name="UpgradesList" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/RightPanel/UpgradesScroll"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="QueueLabel" type="Label" parent="TabManager/MainUI/ContentArea/RightPanel"]
+[node name="QueueLabel" type="Label" parent="TabManager/MainUI/ContentArea/InstrumentColumn"]
 layout_mode = 2
 text = "Action Queue:"
 
-[node name="QueuePanel" type="PanelContainer" parent="TabManager/MainUI/ContentArea/RightPanel"]
+[node name="QueuePanel" type="PanelContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn"]
 layout_mode = 2
 size_flags_vertical = 0
 
-[node name="QueueContainer" type="HBoxContainer" parent="TabManager/MainUI/ContentArea/RightPanel/QueuePanel"]
+[node name="QueueContainer" type="HBoxContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/QueuePanel"]
 layout_mode = 2
 theme_override_constants/separation = 8
 
-[node name="QueueHint" type="Label" parent="TabManager/MainUI/ContentArea/RightPanel/QueuePanel/QueueContainer"]
+[node name="QueueHint" type="Label" parent="TabManager/MainUI/ContentArea/InstrumentColumn/QueuePanel/QueueContainer"]
 layout_mode = 2
 text = "No actions queued..."
 modulate = Color(0.5, 0.5, 0.5, 1)
 
-[node name="HSeparator" type="HSeparator" parent="TabManager/MainUI/ContentArea/RightPanel"]
+[node name="WatchScreen" type="VBoxContainer" parent="TabManager/MainUI/ContentArea"]
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.4
+script = ExtResource("14_watch_screen")
 
-[node name="MessageLogLabel" type="Label" parent="TabManager/MainUI/ContentArea/RightPanel"]
+[node name="MessageLogLabel" type="Label" parent="TabManager/MainUI/ContentArea/WatchScreen"]
 layout_mode = 2
 text = "Message Log:"
 
-[node name="MessageScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/RightPanel"]
+[node name="MessageScroll" type="ScrollContainer" parent="TabManager/MainUI/ContentArea/WatchScreen"]
 layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 0.35
 
-[node name="MessageLog" type="RichTextLabel" parent="TabManager/MainUI/ContentArea/RightPanel/MessageScroll"]
+[node name="MessageLog" type="RichTextLabel" parent="TabManager/MainUI/ContentArea/WatchScreen/MessageScroll"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -475,4 +478,4 @@ layout_mode = 1
 [connection signal="pressed" from="TabManager/MainUI/BottomBar/ControlButtons/EndTurnButton" to="TabManager/MainUI" method="_on_end_turn_button_pressed"]
 [connection signal="pressed" from="TabManager/MainUI/BottomBar/ControlButtons/CommitPlanButton" to="TabManager/MainUI" method="_on_commit_plan_button_pressed"]
 [connection signal="pressed" from="TabManager/MainUI/BottomBar/BugReportButton" to="TabManager/MainUI" method="_on_bug_report_button_pressed"]
-[connection signal="pressed" from="TabManager/MainUI/ContentArea/MiddlePanel/CommandZone/PassButton" to="TabManager/MainUI" method="_on_pass_button_pressed"]
+[connection signal="pressed" from="TabManager/MainUI/ContentArea/PlanScreen/CommandZone/PassButton" to="TabManager/MainUI" method="_on_pass_button_pressed"]

--- a/godot/scenes/ui/plan_screen.tscn
+++ b/godot/scenes/ui/plan_screen.tscn
@@ -1,0 +1,58 @@
+[gd_scene load_steps=2 format=3 uid="uid://plan_screen_pw01"]
+
+[ext_resource type="Script" path="res://scripts/ui/plan_screen.gd" id="1_plan"]
+
+[node name="PlanScreen" type="VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.3
+script = ExtResource("1_plan")
+
+[node name="GettingStartedHint" type="Label" parent="."]
+layout_mode = 2
+text = "TIP: Hire safety researchers to reduce P(Doom)"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 10
+theme_override_colors/font_color = Color(0.5, 0.8, 0.5, 0.9)
+
+[node name="ActionsScroll" type="ScrollContainer" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ActionsList" type="VBoxContainer" parent="ActionsScroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="UpgradesLabel" type="Label" parent="."]
+layout_mode = 2
+text = "Upgrades:"
+theme_override_font_sizes/font_size = 16
+theme_override_colors/font_color = Color(0.8, 0.9, 1.0, 1)
+
+[node name="UpgradesScroll" type="ScrollContainer" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.45
+
+[node name="UpgradesList" type="VBoxContainer" parent="UpgradesScroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="CommandZone" type="VBoxContainer" parent="."]
+layout_mode = 2
+size_flags_vertical = 8
+alignment = 2
+
+[node name="CommandLabel" type="Label" parent="CommandZone"]
+layout_mode = 2
+text = "Command"
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 11
+theme_override_colors/font_color = Color(0.6, 0.5, 0.8, 1)
+
+[node name="PassButton" type="Button" parent="CommandZone"]
+layout_mode = 2
+custom_minimum_size = Vector2(120, 36)
+text = "Do Nothing"
+theme_override_font_sizes/font_size = 12
+theme_override_colors/font_color = Color(0.8, 0.7, 1.0, 1)

--- a/godot/scenes/ui/watch_screen.tscn
+++ b/godot/scenes/ui/watch_screen.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=2 format=3 uid="uid://watch_screen_pw01"]
+
+[ext_resource type="Script" path="res://scripts/ui/watch_screen.gd" id="1_watch"]
+
+[node name="WatchScreen" type="VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.4
+script = ExtResource("1_watch")
+
+[node name="MessageLogLabel" type="Label" parent="."]
+layout_mode = 2
+text = "Message Log:"
+
+[node name="MessageScroll" type="ScrollContainer" parent="."]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 0.35
+
+[node name="MessageLog" type="RichTextLabel" parent="MessageScroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+bbcode_enabled = true
+text = "[color=gray]Game not started...[/color]"
+fit_content = true
+scroll_following = true

--- a/godot/scripts/ui/instrument_panel.gd
+++ b/godot/scripts/ui/instrument_panel.gd
@@ -1,0 +1,26 @@
+class_name InstrumentPanel
+extends VBoxContainer
+## Shared instrument column (BUILD_BRIEF_PLAN_WATCH_UI Lane 1) — the always-on readouts
+## that stay visible in BOTH PLAN and WATCH: the P(DOOM) gauge (with the doom trend /
+## breakdown / ledger + employee affordances mounted into RightZones at runtime by main_ui),
+## the staff roster, and the committed-month queue. The queue is the throughline between the
+## two screens: the plan you commit in PLAN is the queue you watch execute in WATCH.
+## Extracted from the main_ui monolith so the two screens embed one shared instrument set
+## rather than duplicating it.
+
+@onready var title_label: Label = $TitleZone/TitleLabel
+@onready var office_cat = $CoreZone/CatZone/OfficeCat
+@onready var right_zones: VBoxContainer = $CoreZone/RightZones
+@onready var numeric_doom_label: Label = $CoreZone/RightZones/NumericDoomZone/NumericDoomLabel
+@onready var doom_meter = $CoreZone/RightZones/DoomMeterZone/DoomMeterPanel/MarginContainer/DoomMeter
+@onready var doom_meter_zone: CenterContainer = $CoreZone/RightZones/DoomMeterZone
+@onready var roster_container: VBoxContainer = $EmployeeRosterZone/RosterScroll/RosterContainer
+@onready var queue_panel: PanelContainer = $QueuePanel
+@onready var queue_container: HBoxContainer = $QueuePanel/QueueContainer
+@onready var queue_hint: Label = $QueuePanel/QueueContainer/QueueHint
+
+
+func _ready() -> void:
+	# Terminal-styling pass for the shared instruments (was in main_ui._setup).
+	title_label.add_theme_color_override("font_color", TerminalTheme.AMBER)
+	TerminalTheme.style_panel(queue_panel, TerminalTheme.RULE, TerminalTheme.PANEL_BG)

--- a/godot/scripts/ui/instrument_panel.gd.uid
+++ b/godot/scripts/ui/instrument_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://bjsl807dlrq3v

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -272,9 +272,6 @@ func _unhandled_key_input(event: InputEvent):
 				accept_event()
 				return
 
-	# Populate upgrades list
-	_populate_upgrades()
-
 func _input(event: InputEvent):
 	"""Handle keyboard shortcuts"""
 	if event is InputEventKey and event.pressed and not event.echo:

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -2,6 +2,7 @@ extends VBoxContainer
 ## Main UI controller - connects UI elements to GameManager
 
 # References to UI elements (TopBar now has all resources in one line)
+# --- Shared top/bottom chrome (resource readouts + control bar; not screen-specific) ---
 @onready var turn_label = $TopBar/TurnLabel
 @onready var turn_count_label = $TopBar/TurnCountLabel
 @onready var money_label = $TopBar/MoneyLabel
@@ -11,12 +12,29 @@ extends VBoxContainer
 @onready var reputation_label = $TopBar/ReputationLabel
 @onready var ap_label = $TopBar/APLabel
 @onready var phase_label = $BottomBar/PhaseLabel
-@onready var message_log = $ContentArea/RightPanel/MessageScroll/MessageLog
-@onready var actions_list = $ContentArea/LeftPanel/ActionsScroll/ActionsList
-@onready var upgrades_list = $ContentArea/RightPanel/UpgradesScroll/UpgradesList
 @onready var info_label = $InfoBar/MarginContainer/InfoLabel
-@onready var queue_container = $ContentArea/RightPanel/QueuePanel/QueueContainer
-@onready var queue_hint = $ContentArea/RightPanel/QueuePanel/QueueContainer/QueueHint
+
+# --- The three extracted screens (BUILD_BRIEF_PLAN_WATCH_UI Lane 1) ---
+# PLAN (strategy) and WATCH (tactics) are real, script-backed screen subtrees; the shared
+# InstrumentPanel (doom / roster / committed-month queue) stays visible in both modes.
+# main_ui drives game logic against the screens' PUBLIC members rather than reaching through
+# absolute $ContentArea/<column>/... node paths — that coupling is what the split untangles.
+@onready var plan_screen: PlanScreen = $ContentArea/PlanScreen
+@onready var instruments: InstrumentPanel = $ContentArea/InstrumentColumn
+@onready var watch_screen: WatchScreen = $ContentArea/WatchScreen
+
+# Leaf widgets, resolved THROUGH the owning screen. Child _ready runs before the parent's,
+# so each screen's own @onready refs are already populated when these evaluate.
+@onready var message_log = watch_screen.message_log
+@onready var actions_list = plan_screen.actions_list
+@onready var upgrades_list = plan_screen.upgrades_list
+@onready var getting_started_hint = plan_screen.getting_started_hint
+@onready var queue_container = instruments.queue_container
+@onready var queue_hint = instruments.queue_hint
+@onready var doom_meter = instruments.doom_meter
+@onready var numeric_doom_label = instruments.numeric_doom_label
+@onready var office_cat = instruments.office_cat
+@onready var roster_container = instruments.roster_container
 
 @onready var init_button = $BottomBar/ControlButtons/InitButton
 @onready var test_action_button = $BottomBar/ControlButtons/TestActionButton
@@ -25,16 +43,11 @@ extends VBoxContainer
 @onready var clear_queue_button = $BottomBar/ControlButtons/ClearQueueButton
 @onready var end_turn_button = $BottomBar/ControlButtons/EndTurnButton
 @onready var commit_plan_button = $BottomBar/ControlButtons/CommitPlanButton
-@onready var doom_meter = $ContentArea/MiddlePanel/CoreZone/RightZones/DoomMeterZone/DoomMeterPanel/MarginContainer/DoomMeter
-@onready var numeric_doom_label = $ContentArea/MiddlePanel/CoreZone/RightZones/NumericDoomZone/NumericDoomLabel
 @onready var game_over_screen = $"../GameOverScreen"
 @onready var bug_report_panel = $"../BugReportPanel"
 @onready var bug_report_button = $BottomBar/BugReportButton
-@onready var office_cat = $ContentArea/MiddlePanel/CoreZone/CatZone/OfficeCat
 @onready var tab_manager = get_parent()
-@onready var roster_container = $ContentArea/MiddlePanel/EmployeeRosterZone/RosterScroll/RosterContainer
 @onready var pause_menu = $"../../PauseMenu"
-@onready var getting_started_hint = $ContentArea/LeftPanel/GettingStartedHint
 
 # Reference to GameManager
 var game_manager: Node
@@ -103,12 +116,13 @@ func _ready():
 	# Issue #500: research quality selector (script-instantiated; reparent in editor if preferred)
 	research_quality_selector = preload("res://scripts/ui/research_quality_selector.gd").new()
 	research_quality_selector.quality_selected.connect(_on_research_quality_selected)
-	$ContentArea/LeftPanel.add_child(research_quality_selector)
-	$ContentArea/LeftPanel.move_child(research_quality_selector, 0)
+	plan_screen.add_child(research_quality_selector)
+	# Just under PlanScreen's attention gauge (index 0), above the getting-started hint.
+	plan_screen.move_child(research_quality_selector, 1)
 
-	# #512: doom trend sparkline, inserted just below the doom gauge in RightZones
-	var right_zones := $ContentArea/MiddlePanel/CoreZone/RightZones
-	var doom_meter_zone := $ContentArea/MiddlePanel/CoreZone/RightZones/DoomMeterZone
+	# #512: doom trend sparkline, inserted just below the doom gauge in the instrument column
+	var right_zones := instruments.right_zones
+	var doom_meter_zone := instruments.doom_meter_zone
 	doom_trend_graph = preload("res://scripts/ui/doom_trend_graph.gd").new()
 	doom_trend_graph.custom_minimum_size = Vector2(0, 92)  # taller — playtest feedback (screen1)
 	doom_trend_graph.window_size = 24  # show more time points (screen6)
@@ -228,31 +242,27 @@ func _setup_plan_watch_scaffold() -> void:
 	# Speed dial -> real playback speed.
 	screen_mode.speed_changed.connect(func(secs: float): game_manager.day_tick_seconds = secs)
 
-	# --- sort existing panels into PLAN vs WATCH ---
-	# PLAN (strategy): the hand, upgrades to plan, the planning verbs. Hidden while watching.
-	screen_mode.register_plan_only($ContentArea/LeftPanel)                 # the action hand + research selector
-	screen_mode.register_plan_only($ContentArea/RightPanel/UpgradesLabel)
-	screen_mode.register_plan_only($ContentArea/RightPanel/UpgradesScroll)
-	screen_mode.register_plan_only($ContentArea/MiddlePanel/CommandZone)   # Do-Nothing / pass — a planning verb
+	# --- register the real screens for mode switching ---
+	# The extraction turned scattered per-panel visibility toggles into two real, script-backed
+	# screen subtrees: ScreenModeController now shows/hides PlanScreen and WatchScreen as whole
+	# units. The shared InstrumentPanel (doom / roster / committed-month queue) is registered to
+	# neither, so it stays visible in BOTH modes. Response windows still overlay as dialogs.
+	screen_mode.register_plan_only(plan_screen)     # the whole PLAN screen (hand, upgrades, verbs)
+	screen_mode.register_watch_only(watch_screen)   # the whole WATCH screen (the feed)
+	screen_mode.register_watch_only(watch_bar)      # the playback control strip
+	# The plan-time control-bar verbs live in the shared BottomBar; hide them while watching.
 	screen_mode.register_plan_only(undo_last_button)
 	screen_mode.register_plan_only(clear_queue_button)
 	screen_mode.register_plan_only(reserve_ap_button)
 	screen_mode.register_plan_only(commit_plan_button)
 	screen_mode.register_plan_only(end_turn_button)                        # END TURN == COMMIT THE MONTH
-	# WATCH (tactics): the playback control strip. Doom/feed/queue stay visible in BOTH
-	# (context in PLAN, live instruments in WATCH); response windows overlay as dialogs.
-	screen_mode.register_watch_only(watch_bar)
 
 	# The End Turn button is the PLAN->WATCH commit — relabel it in the plan register.
 	end_turn_button.text = "COMMIT THE MONTH ▶"
 
-	# --- first terminal-styling pass over the default greys ---
-	TerminalTheme.style_panel($ContentArea/RightPanel/QueuePanel, TerminalTheme.RULE, TerminalTheme.PANEL_BG)
+	# --- terminal styling that isn't owned by a screen (screens style their own panels) ---
 	TerminalTheme.style_panel($InfoBar, TerminalTheme.RULE, TerminalTheme.PANEL_BG_DEEP)
-	TerminalTheme.style_feed(message_log)  # the feed: monospace, phosphor text
-	# Amber the two title labels into the terminal register.
 	$TopBar/TitleLabel.add_theme_color_override("font_color", TerminalTheme.AMBER)
-	$ContentArea/MiddlePanel/TitleZone/TitleLabel.add_theme_color_override("font_color", TerminalTheme.AMBER)
 
 	# Start in PLAN (the game opens at the month plan).
 	screen_mode.enter_plan()
@@ -683,6 +693,10 @@ func _on_game_state_updated(state: Dictionary):
 	# Phase A: keep the WATCH day/reserve readout live during month playback.
 	if screen_mode:
 		screen_mode.update_from_state(state)
+
+	# Refresh the PLAN attention gauge (allocated vs reserved pips) from the month plan.
+	if plan_screen:
+		plan_screen.update_reserve_gauge(state)
 
 	# Update resource displays (Issue #472 - enhanced turn display with calendar)
 	var turn_display = state.get("turn_display", "")

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -47,6 +47,7 @@ var doom_breakdown  # #578 colour-coded per-source doom "blow-by-blow" (script-i
 var event_dialog  # #622 L10: event dialog presenter (script-instantiated child)
 var ledger_screen  # #622 L10: Liability Ledger UI (leather palette + summary button + screen builder)
 var employee_panel  # #622 L10: employee roster + staff ID card (becomes L2's assignment surface)
+var screen_mode: ScreenModeController  # Lane 1 / Phase A: PLAN<->WATCH two-screen mode controller
 # EE-7 (ADR-0012 loss legibility): per-resource "last turn" delta chips beside the
 # money/compute/reputation/doom readouts. Snapshot at each turn boundary; a chip shows
 # the change over the last completed turn, green=helped red=hurt (doom inverted).
@@ -158,6 +159,10 @@ func _ready():
 	right_zones.add_child(employee_access_btn)
 	right_zones.move_child(employee_access_btn, ledger_summary_btn.get_index() + 1)
 
+	# Lane 1 / Phase A: PLAN<->WATCH two-screen scaffold + first terminal-styling pass.
+	# Built AFTER all panels exist so it can register them for per-mode visibility.
+	_setup_plan_watch_scaffold()
+
 	# Always-visible DEV BUILD corner badge so a playtester can confirm exactly which
 	# build he's running (version + git stamp). Draws on its own CanvasLayer over the UI.
 	add_child(DevBuildBadge.new())
@@ -189,6 +194,69 @@ func _ready():
 	# Call init on next frame to ensure everything is ready
 	await get_tree().process_frame
 	_on_init_button_pressed()
+
+func _setup_plan_watch_scaffold() -> void:
+	"""Lane 1 / Phase A (BUILD_BRIEF_PLAN_WATCH_UI): stand up the two-screen structure over
+	the existing single UI — a mode controller + banner + WATCH control strip, existing
+	panels sorted into PLAN vs WATCH, and a first terminal-styling pass. The game stays
+	fully playable: COMMIT THE MONTH (the End Turn button) drives PLAN->WATCH; the month
+	review returns to PLAN (see _on_turn_phase_changed / _on_end_turn_button_pressed)."""
+	# --- background: dark CRT phosphor field on its own layer (no layout disturbance) ---
+	var bg_layer := CanvasLayer.new()
+	bg_layer.layer = -10
+	var bg := ColorRect.new()
+	bg.color = TerminalTheme.BG_DARK
+	bg.set_anchors_preset(Control.PRESET_FULL_RECT)
+	bg.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	bg_layer.add_child(bg)
+	add_child(bg_layer)
+
+	# --- mode controller + its owned chrome ---
+	screen_mode = ScreenModeController.new()
+	add_child(screen_mode)
+
+	# Mode banner just under the TopBar.
+	var banner := screen_mode.build_banner()
+	add_child(banner)
+	move_child(banner, $TopBar.get_index() + 1)
+
+	# WATCH control strip (speed dial + day/reserve readout) just above the content area.
+	var watch_bar := screen_mode.build_watch_bar()
+	add_child(watch_bar)
+	move_child(watch_bar, banner.get_index() + 1)
+
+	# Speed dial -> real playback speed.
+	screen_mode.speed_changed.connect(func(secs: float): game_manager.day_tick_seconds = secs)
+
+	# --- sort existing panels into PLAN vs WATCH ---
+	# PLAN (strategy): the hand, upgrades to plan, the planning verbs. Hidden while watching.
+	screen_mode.register_plan_only($ContentArea/LeftPanel)                 # the action hand + research selector
+	screen_mode.register_plan_only($ContentArea/RightPanel/UpgradesLabel)
+	screen_mode.register_plan_only($ContentArea/RightPanel/UpgradesScroll)
+	screen_mode.register_plan_only($ContentArea/MiddlePanel/CommandZone)   # Do-Nothing / pass — a planning verb
+	screen_mode.register_plan_only(undo_last_button)
+	screen_mode.register_plan_only(clear_queue_button)
+	screen_mode.register_plan_only(reserve_ap_button)
+	screen_mode.register_plan_only(commit_plan_button)
+	screen_mode.register_plan_only(end_turn_button)                        # END TURN == COMMIT THE MONTH
+	# WATCH (tactics): the playback control strip. Doom/feed/queue stay visible in BOTH
+	# (context in PLAN, live instruments in WATCH); response windows overlay as dialogs.
+	screen_mode.register_watch_only(watch_bar)
+
+	# The End Turn button is the PLAN->WATCH commit — relabel it in the plan register.
+	end_turn_button.text = "COMMIT THE MONTH ▶"
+
+	# --- first terminal-styling pass over the default greys ---
+	TerminalTheme.style_panel($ContentArea/RightPanel/QueuePanel, TerminalTheme.RULE, TerminalTheme.PANEL_BG)
+	TerminalTheme.style_panel($InfoBar, TerminalTheme.RULE, TerminalTheme.PANEL_BG_DEEP)
+	TerminalTheme.style_feed(message_log)  # the feed: monospace, phosphor text
+	# Amber the two title labels into the terminal register.
+	$TopBar/TitleLabel.add_theme_color_override("font_color", TerminalTheme.AMBER)
+	$ContentArea/MiddlePanel/TitleZone/TitleLabel.add_theme_color_override("font_color", TerminalTheme.AMBER)
+
+	# Start in PLAN (the game opens at the month plan).
+	screen_mode.enter_plan()
+
 
 func _unhandled_key_input(event: InputEvent):
 	"""Handle keyboard shortcuts for dialogs (runs after focus but before _unhandled_input)"""
@@ -547,6 +615,9 @@ func _on_end_turn_button_pressed():
 	# playback (auto-pause on response windows, month review at the boundary). The old
 	# single day-step lives on ONLY behind the DEV MODE overlay ("Day step (dev)").
 	game_manager.end_month()
+	# Phase A: COMMIT THE MONTH is the PLAN->WATCH transition.
+	if screen_mode:
+		screen_mode.enter_watch()
 
 func _on_commit_plan_button_pressed():
 	"""Commit queued actions AND reserve remaining AP (no warnings)"""
@@ -582,6 +653,9 @@ func _on_commit_plan_button_pressed():
 
 	# Commit the plan — the L1 month path (see _on_end_turn_button_pressed).
 	game_manager.end_month()
+	# Phase A: committing the plan is the PLAN->WATCH transition.
+	if screen_mode:
+		screen_mode.enter_watch()
 
 func _on_employee_tab_button_pressed():
 	"""Switch to employee management screen - DISABLED: employee info moving to main UI"""
@@ -608,6 +682,10 @@ func _on_game_state_updated(state: Dictionary):
 
 	if research_quality_selector:
 		research_quality_selector.update_from_state(state)
+
+	# Phase A: keep the WATCH day/reserve readout live during month playback.
+	if screen_mode:
+		screen_mode.update_from_state(state)
 
 	# Update resource displays (Issue #472 - enhanced turn display with calendar)
 	var turn_display = state.get("turn_display", "")
@@ -848,6 +926,10 @@ func _on_turn_phase_changed(phase_name: String):
 		commit_plan_button.disabled = false
 		undo_last_button.disabled = (queued_actions.size() == 0)
 		clear_queue_button.disabled = (queued_actions.size() == 0)
+		# Phase A: reaching the plan phase (game start / after month review) returns to PLAN.
+		# Mid-month window pauses emit "turn_start", not "action_selection", so WATCH is kept.
+		if screen_mode:
+			screen_mode.enter_plan()
 	elif phase_name == "turn_end" or phase_name == "TURN_END":
 		phase_color = "yellow"
 		phase_display = "EXECUTING - Your actions are running..."

--- a/godot/scripts/ui/plan_screen.gd
+++ b/godot/scripts/ui/plan_screen.gd
@@ -1,0 +1,71 @@
+class_name PlanScreen
+extends VBoxContainer
+## PLAN screen (BUILD_BRIEF_PLAN_WATCH_UI Lane 1) — the strategy register: lay out the
+## month before it plays. Owns the action hand, the upgrades list, and the planning verbs
+## (Do-Nothing / pass). Extracted from the main_ui monolith: main_ui drives game logic
+## against the public members below instead of reaching through absolute $ContentArea/...
+## node paths, and ScreenModeController shows/hides this whole screen as one unit.
+
+@onready var getting_started_hint: Label = $GettingStartedHint
+@onready var actions_scroll: ScrollContainer = $ActionsScroll
+@onready var actions_list: VBoxContainer = $ActionsScroll/ActionsList
+@onready var upgrades_label: Label = $UpgradesLabel
+@onready var upgrades_scroll: ScrollContainer = $UpgradesScroll
+@onready var upgrades_list: VBoxContainer = $UpgradesScroll/UpgradesList
+@onready var command_zone: VBoxContainer = $CommandZone
+
+# The reserve/allocation gauge (ADR-0011 attention pips) — a header strip built in code
+# and mounted at the top of the screen. Refreshed each state tick via update_reserve_gauge.
+var _reserve_gauge: RichTextLabel
+
+
+func _ready() -> void:
+	# Amber the upgrades label into the PLAN (strategy) register.
+	upgrades_label.add_theme_color_override("font_color", TerminalTheme.AMBER_DIM)
+	_build_reserve_gauge()
+
+
+func _build_reserve_gauge() -> void:
+	"""Header attention gauge: allocated pips vs reserved pips (BUILD_BRIEF PLAN element 1 /
+	ADR-0011). A cheap, data-driven readout of the month-plan attention budget — the honest
+	scarcity made visible before you commit. Read-only view; the real numbers come from
+	game_state.month_plan via update_reserve_gauge()."""
+	var panel := PanelContainer.new()
+	panel.name = "ReserveGauge"
+	TerminalTheme.style_panel(panel, TerminalTheme.AMBER_DIM, TerminalTheme.PANEL_BG_DEEP)
+	_reserve_gauge = RichTextLabel.new()
+	_reserve_gauge.bbcode_enabled = true
+	_reserve_gauge.fit_content = true
+	_reserve_gauge.scroll_active = false
+	_reserve_gauge.add_theme_font_override("normal_font", TerminalTheme.mono_font())
+	_reserve_gauge.text = "[color=#a87a28]ATTENTION —[/color]"
+	panel.add_child(_reserve_gauge)
+	add_child(panel)
+	move_child(panel, 0)
+
+
+func update_reserve_gauge(state: Dictionary) -> void:
+	"""Refresh the attention gauge from the live month plan. allocated ● vs reserved ○ pips
+	(ADR-0011 ~20/mo). Degrades gracefully to a dash row when no plan data is present yet."""
+	if _reserve_gauge == null:
+		return
+	var mp: Dictionary = state.get("month_plan", {})
+	var total := int(mp.get("attention_total", 0))
+	var spent := int(mp.get("attention_spent", 0))
+	var reserved := int(mp.get("attention_reserved", 0))
+	if total <= 0:
+		_reserve_gauge.text = "[color=#a87a28]ATTENTION — plan the month[/color]"
+		return
+	var allocated: int = clampi(spent, 0, total)
+	var held: int = clampi(reserved, 0, total - allocated)
+	var free_slots: int = max(0, total - allocated - held)
+	# Cap the pip render so a large budget can't overflow the strip.
+	var cap := 24
+	var pips := ""
+	if total > cap:
+		pips = "%d/%d" % [allocated, total]
+	else:
+		pips = "[color=#ffb833]%s[/color]" % "●".repeat(allocated)
+		pips += "[color=#5cec78]%s[/color]" % "◒".repeat(held)
+		pips += "[color=#3a4a3a]%s[/color]" % "○".repeat(free_slots)
+	_reserve_gauge.text = "[color=#a87a28]ATTENTION[/color]  %s  [color=#a87a28]· %d/%d allocated · %d reserved[/color]" % [pips, allocated, total, held]

--- a/godot/scripts/ui/plan_screen.gd.uid
+++ b/godot/scripts/ui/plan_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://bhyj73o6n8abx

--- a/godot/scripts/ui/screen_mode.gd
+++ b/godot/scripts/ui/screen_mode.gd
@@ -1,0 +1,176 @@
+class_name ScreenModeController
+extends Node
+## Plan/Watch two-screen mode controller (BUILD_BRIEF_PLAN_WATCH_UI Lane 1 / Phase A).
+##
+## The model (ruled): TWO screens with a mode switch between them.
+##   PLAN  = strategy — lay out the month before it plays (the hand / queue / team).
+##   WATCH = tactics  — the committed month plays out in day-ticks (feed / doom / windows).
+##   COMMIT THE MONTH transitions PLAN -> WATCH; month-end review returns to PLAN.
+##
+## Phase-A scaffold approach: this does NOT reparent the existing widget tree (main_ui.gd
+## is heavily coupled to absolute node paths — moving nodes would break it). Instead it
+## REGISTERS the existing panels as plan-only / watch-only and toggles their visibility,
+## plus owns two NEW pieces of chrome it builds itself: the mode BANNER and the WATCH
+## control strip (playback speed + day/reserve readout). Follow-up lanes promote this into
+## genuinely separate PlanScreen/WatchScreen scenes once the widget coupling is untangled.
+
+enum Mode { PLAN, WATCH }
+
+signal mode_changed(mode: int)
+signal speed_changed(seconds: float)   # WATCH speed dial -> game_manager.day_tick_seconds
+
+var current_mode: int = Mode.PLAN
+
+# NEW chrome this controller owns (built here, mounted by main_ui).
+var banner: PanelContainer
+var watch_bar: PanelContainer
+var _banner_label: RichTextLabel
+var _day_label: Label
+var _reserve_label: Label
+
+# Existing panels toggled per mode (registered by main_ui).
+var _plan_only: Array[Node] = []
+var _watch_only: Array[Node] = []
+
+# Speed presets for the WATCH playback dial (seconds per visible day-tick).
+const _SPEEDS := {"1x": 0.20, "2x": 0.10, "4x": 0.05}
+
+
+func register_plan_only(n: Node) -> void:
+	if n != null and not _plan_only.has(n):
+		_plan_only.append(n)
+
+func register_watch_only(n: Node) -> void:
+	if n != null and not _watch_only.has(n):
+		_watch_only.append(n)
+
+
+func build_banner() -> PanelContainer:
+	"""The mode banner — a boxed strip naming the current screen + its verb. Amber in PLAN,
+	green in WATCH (the two registers). main_ui inserts the returned node under the TopBar."""
+	banner = PanelContainer.new()
+	banner.name = "ModeBanner"
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 8)
+	margin.add_theme_constant_override("margin_right", 8)
+	margin.add_theme_constant_override("margin_top", 2)
+	margin.add_theme_constant_override("margin_bottom", 2)
+	banner.add_child(margin)
+	_banner_label = RichTextLabel.new()
+	_banner_label.bbcode_enabled = true
+	_banner_label.fit_content = true
+	_banner_label.scroll_active = false
+	_banner_label.add_theme_font_override("normal_font", TerminalTheme.mono_font())
+	margin.add_child(_banner_label)
+	return banner
+
+
+func build_watch_bar() -> PanelContainer:
+	"""The WATCH-only control strip: playback speed dial + live day / reserve readout
+	(brief WATCH header — playback controls + reserve remaining). Play/pause is a clean
+	STUB for a follow-up lane; the speed dial is REAL (drives day_tick_seconds)."""
+	watch_bar = PanelContainer.new()
+	watch_bar.name = "WatchControls"
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+	watch_bar.add_child(row)
+
+	var tag := Label.new()
+	tag.text = "▶ PLAYBACK"
+	tag.add_theme_color_override("font_color", TerminalTheme.GREEN)
+	tag.add_theme_font_override("font", TerminalTheme.mono_font())
+	row.add_child(tag)
+
+	# Play/pause — STUB (follow-up lane owns real pause; auto-pause on windows already works).
+	var pause_stub := Button.new()
+	pause_stub.text = "⏸"
+	pause_stub.disabled = true
+	pause_stub.tooltip_text = "Pause/resume — stub (follow-up lane). Windows already auto-pause playback."
+	pause_stub.focus_mode = Control.FOCUS_NONE
+	row.add_child(pause_stub)
+
+	# Speed dial — REAL: sets game_manager.day_tick_seconds via speed_changed.
+	for key in ["1x", "2x", "4x"]:
+		var b := Button.new()
+		b.text = key
+		b.focus_mode = Control.FOCUS_NONE
+		b.tooltip_text = "Playback speed"
+		b.pressed.connect(func(): speed_changed.emit(_SPEEDS[key]))
+		row.add_child(b)
+
+	var spacer := Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(spacer)
+
+	_day_label = Label.new()
+	_day_label.text = "day —"
+	_day_label.add_theme_color_override("font_color", TerminalTheme.TEXT)
+	_day_label.add_theme_font_override("font", TerminalTheme.mono_font())
+	row.add_child(_day_label)
+
+	var sep := Label.new()
+	sep.text = "·"
+	sep.add_theme_color_override("font_color", TerminalTheme.RULE_BRIGHT)
+	row.add_child(sep)
+
+	_reserve_label = Label.new()
+	_reserve_label.text = "reserve —"
+	_reserve_label.tooltip_text = "Held Attention — the slack available to spend on mid-month response windows."
+	_reserve_label.add_theme_color_override("font_color", TerminalTheme.AMBER)
+	_reserve_label.add_theme_font_override("font", TerminalTheme.mono_font())
+	row.add_child(_reserve_label)
+
+	return watch_bar
+
+
+func enter_plan() -> void:
+	set_mode(Mode.PLAN)
+
+func enter_watch() -> void:
+	set_mode(Mode.WATCH)
+
+
+func set_mode(m: int) -> void:
+	current_mode = m
+	var is_plan := m == Mode.PLAN
+	for n in _plan_only:
+		if is_instance_valid(n):
+			(n as CanvasItem).visible = is_plan
+	for n in _watch_only:
+		if is_instance_valid(n):
+			(n as CanvasItem).visible = not is_plan
+	_refresh_banner()
+	mode_changed.emit(m)
+
+
+func update_from_state(state: Dictionary) -> void:
+	"""Refresh WATCH readouts (day / reserve) from the live game state each tick."""
+	var cal: Dictionary = state.get("calendar", {})
+	if _day_label != null and not cal.is_empty():
+		var months := ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+		var mi: int = int(cal.get("month", 1)) - 1
+		var mname: String = months[mi] if mi >= 0 and mi < 12 else "?"
+		_day_label.text = "day %d — %s %d" % [int(cal.get("day", 0)), mname, int(cal.get("year", 0))]
+	if _reserve_label != null:
+		var mp: Dictionary = state.get("month_plan", {})
+		var total := int(mp.get("attention_total", 0))
+		var spent := int(mp.get("attention_spent", 0))
+		var reserved := int(mp.get("attention_reserved", 0))
+		# Remaining slack = whatever isn't committed to strategic work this month.
+		var remaining: int = max(0, total - spent)
+		if reserved > 0:
+			remaining = reserved
+		_reserve_label.text = "reserve %d" % remaining
+
+
+func _refresh_banner() -> void:
+	if _banner_label == null:
+		return
+	if current_mode == Mode.PLAN:
+		if banner != null:
+			TerminalTheme.style_panel(banner, TerminalTheme.AMBER_DIM, TerminalTheme.PANEL_BG_DEEP)
+		_banner_label.text = "[color=#ffb833]▓▓ PLAN[/color]  [color=#a87a28]· strategy · lay out the month, then[/color] [color=#ffb833]COMMIT THE MONTH ▶[/color]"
+	else:
+		if banner != null:
+			TerminalTheme.style_panel(banner, TerminalTheme.GREEN_DIM, TerminalTheme.PANEL_BG_DEEP)
+		_banner_label.text = "[color=#5cec78]▓▓ WATCH[/color]  [color=#369048]· tactics · the month plays out — respond to windows as they arrive[/color]"

--- a/godot/scripts/ui/screen_mode.gd.uid
+++ b/godot/scripts/ui/screen_mode.gd.uid
@@ -1,0 +1,1 @@
+uid://b5mepxoi8j7d5

--- a/godot/scripts/ui/terminal_theme.gd
+++ b/godot/scripts/ui/terminal_theme.gd
@@ -1,0 +1,62 @@
+class_name TerminalTheme
+extends RefCounted
+## First-pass terminal / mainframe styling register for the Plan/Watch scaffold
+## (BUILD_BRIEF_PLAN_WATCH_UI "Aesthetic": amber/green CRT, boxes + rules, lightly
+## modernized — NOT literal retro). This is a THIN static helper: a palette + a few
+## StyleBoxFlat/font builders that the Plan/Watch UI applies over the default greys.
+## Deliberately code-driven (no .tres churn) so Pip can react and a follow-up art lane
+## can promote it to a real Theme resource + scanline shader.
+
+# --- Palette ---------------------------------------------------------------
+# Near-black, faintly green-tinted phosphor background.
+const BG_DARK := Color(0.035, 0.05, 0.043)
+const PANEL_BG := Color(0.07, 0.093, 0.082)
+const PANEL_BG_DEEP := Color(0.05, 0.066, 0.058)
+
+# Amber = PLAN register (strategy, calm). Green = WATCH register (tactics, live).
+const AMBER := Color(1.0, 0.72, 0.20)
+const AMBER_DIM := Color(0.66, 0.48, 0.16)
+const GREEN := Color(0.36, 0.93, 0.47)
+const GREEN_DIM := Color(0.21, 0.56, 0.30)
+
+const TEXT := Color(0.82, 0.86, 0.78)
+const TEXT_DIM := Color(0.50, 0.58, 0.50)
+const RULE := Color(0.20, 0.36, 0.26)          # box borders / hairlines
+const RULE_BRIGHT := Color(0.30, 0.52, 0.36)
+
+
+static func box(border: Color, bg: Color = PANEL_BG, border_width: int = 1) -> StyleBoxFlat:
+	"""A boxed panel in the terminal register — flat fill + a single hairline rule."""
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = bg
+	sb.border_color = border
+	sb.set_border_width_all(border_width)
+	sb.set_corner_radius_all(0)  # terminals have square corners
+	sb.content_margin_left = 8
+	sb.content_margin_right = 8
+	sb.content_margin_top = 4
+	sb.content_margin_bottom = 4
+	return sb
+
+
+static func mono_font() -> SystemFont:
+	"""Best-available system monospace — the 'monospace-ish' the brief asks for, without
+	shipping a font asset. Degrades gracefully to the platform default if none match."""
+	var f := SystemFont.new()
+	f.font_names = PackedStringArray(["Consolas", "DejaVu Sans Mono", "Courier New", "monospace"])
+	return f
+
+
+static func style_panel(node: Control, border: Color = RULE, bg: Color = PANEL_BG) -> void:
+	"""Apply the boxed-panel look to any PanelContainer-like Control (adds a 'panel' stylebox)."""
+	if node == null:
+		return
+	node.add_theme_stylebox_override("panel", box(border, bg))
+
+
+static func style_feed(label: RichTextLabel) -> void:
+	"""The WATCH feed / message log: monospace, dim green-tinted text."""
+	if label == null:
+		return
+	label.add_theme_font_override("normal_font", mono_font())
+	label.add_theme_color_override("default_color", TEXT)

--- a/godot/scripts/ui/terminal_theme.gd.uid
+++ b/godot/scripts/ui/terminal_theme.gd.uid
@@ -1,0 +1,1 @@
+uid://vhqxfetn6fff

--- a/godot/scripts/ui/watch_screen.gd
+++ b/godot/scripts/ui/watch_screen.gd
@@ -1,0 +1,19 @@
+class_name WatchScreen
+extends VBoxContainer
+## WATCH screen (BUILD_BRIEF_PLAN_WATCH_UI Lane 1) — the tactics register: the committed
+## month plays out in day-ticks. Owns the feed (dated event entries / message log). The
+## playback control strip and the mid-month response-window overlays are built in code by
+## ScreenModeController / event_dialog and mounted separately; the shared instruments (doom,
+## roster) and the in-flight queue live in the InstrumentPanel, visible in both modes.
+## Extracted from the main_ui monolith — main_ui logs into message_log via the public member.
+
+@onready var message_log_label: Label = $MessageLogLabel
+@onready var message_scroll: ScrollContainer = $MessageScroll
+@onready var message_log: RichTextLabel = $MessageScroll/MessageLog
+
+
+func _ready() -> void:
+	# The feed reads in the terminal register: monospace, dim phosphor text.
+	TerminalTheme.style_feed(message_log)
+	message_log_label.add_theme_color_override("font_color", TerminalTheme.GREEN_DIM)
+	message_log_label.text = "Feed — the month as it happens:"

--- a/godot/scripts/ui/watch_screen.gd.uid
+++ b/godot/scripts/ui/watch_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dlwoist8i1hg0

--- a/godot/tests/unit/test_plan_watch_screens.gd
+++ b/godot/tests/unit/test_plan_watch_screens.gd
@@ -1,0 +1,53 @@
+extends GutTest
+## Locks the PlanScreen/WatchScreen extraction contract (BUILD_BRIEF_PLAN_WATCH_UI Lane 1):
+## the two screens are real standalone scenes that own + expose their panels, so main_ui can
+## drive game logic against those public members instead of absolute $ContentArea/... paths.
+## Instantiated standalone (no GameManager autoload dependency in their _ready) so the guard
+## stays fast and deterministic.
+
+const PLAN_SCENE := "res://scenes/ui/plan_screen.tscn"
+const WATCH_SCENE := "res://scenes/ui/watch_screen.tscn"
+
+
+func _instance(path: String) -> Node:
+	var scene: PackedScene = load(path)
+	assert_not_null(scene, "scene %s should load" % path)
+	var node: Node = scene.instantiate()
+	add_child_autofree(node)
+	return node
+
+
+func test_plan_screen_owns_its_panels():
+	var plan = _instance(PLAN_SCENE)
+	await get_tree().process_frame
+	assert_is(plan, PlanScreen, "plan_screen.tscn root is a PlanScreen")
+	assert_not_null(plan.actions_list, "PlanScreen exposes the action hand list")
+	assert_not_null(plan.upgrades_list, "PlanScreen exposes the upgrades list")
+	assert_not_null(plan.getting_started_hint, "PlanScreen exposes the getting-started hint")
+	assert_not_null(plan.command_zone, "PlanScreen exposes the command (pass) zone")
+
+
+func test_watch_screen_owns_the_feed():
+	var watch = _instance(WATCH_SCENE)
+	await get_tree().process_frame
+	assert_is(watch, WatchScreen, "watch_screen.tscn root is a WatchScreen")
+	assert_not_null(watch.message_log, "WatchScreen exposes the feed / message log")
+
+
+func test_reserve_gauge_degrades_without_plan_data():
+	# The optional plan-screen payoff must be crash-safe when no month plan is present.
+	var plan = _instance(PLAN_SCENE)
+	await get_tree().process_frame
+	plan.update_reserve_gauge({})  # no "month_plan" key
+	plan.update_reserve_gauge({"month_plan": {"attention_total": 0}})
+	pass_test("update_reserve_gauge tolerates missing / empty plan data")
+
+
+func test_reserve_gauge_renders_with_plan_data():
+	var plan = _instance(PLAN_SCENE)
+	await get_tree().process_frame
+	# ADR-0011 shape: ~20 attention/month, some allocated, some reserved.
+	plan.update_reserve_gauge({"month_plan": {
+		"attention_total": 20, "attention_spent": 6, "attention_reserved": 4,
+	}})
+	pass_test("update_reserve_gauge renders allocated/reserved pips without error")

--- a/godot/tests/unit/test_plan_watch_screens.gd.uid
+++ b/godot/tests/unit/test_plan_watch_screens.gd.uid
@@ -1,0 +1,1 @@
+uid://cr14sf5he61e8

--- a/godot/tests/unit/test_screen_mode.gd
+++ b/godot/tests/unit/test_screen_mode.gd
@@ -1,0 +1,86 @@
+extends GutTest
+## Lane 1 / Phase A: the PLAN<->WATCH mode controller (scripts/ui/screen_mode.gd).
+## The month LOOP itself is covered by test_month_button_path.gd; this guards the UI
+## SEAM — that committing flips plan-only panels off / watch-only panels on, and back.
+
+var ctrl: ScreenModeController
+var plan_panel: Control
+var watch_panel: Control
+
+
+func before_each():
+	ctrl = ScreenModeController.new()
+	add_child_autofree(ctrl)
+	plan_panel = Control.new()
+	watch_panel = Control.new()
+	add_child_autofree(plan_panel)
+	add_child_autofree(watch_panel)
+	ctrl.register_plan_only(plan_panel)
+	ctrl.register_watch_only(watch_panel)
+
+
+func test_starts_showing_plan_hiding_watch():
+	ctrl.enter_plan()
+	assert_eq(ctrl.current_mode, ScreenModeController.Mode.PLAN, "in PLAN mode")
+	assert_true(plan_panel.visible, "plan-only panel visible in PLAN")
+	assert_false(watch_panel.visible, "watch-only panel hidden in PLAN")
+
+
+func test_commit_transitions_to_watch():
+	"""COMMIT THE MONTH: PLAN -> WATCH hides the plan hand, reveals the watch strip."""
+	ctrl.enter_plan()
+	ctrl.enter_watch()
+	assert_eq(ctrl.current_mode, ScreenModeController.Mode.WATCH, "in WATCH mode")
+	assert_false(plan_panel.visible, "plan-only panel hidden in WATCH")
+	assert_true(watch_panel.visible, "watch-only panel visible in WATCH")
+
+
+func test_review_returns_to_plan():
+	"""Month review closes back into PLAN — the loop is closed."""
+	ctrl.enter_watch()
+	ctrl.enter_plan()
+	assert_true(plan_panel.visible, "plan panel back on return to PLAN")
+	assert_false(watch_panel.visible, "watch strip hidden back in PLAN")
+
+
+func test_mode_changed_signal_fires():
+	watch_signals(ctrl)
+	ctrl.enter_watch()
+	assert_signal_emitted(ctrl, "mode_changed")
+
+
+func test_speed_dial_emits_speed_changed():
+	"""The WATCH speed dial drives day_tick_seconds via speed_changed (a REAL control)."""
+	var bar := ctrl.build_watch_bar()
+	add_child_autofree(bar)
+	watch_signals(ctrl)
+	# Find a speed button ("2x") in the built strip and press it.
+	var pressed_any := false
+	for b in _all_buttons(bar):
+		if b.text == "2x":
+			b.emit_signal("pressed")
+			pressed_any = true
+			break
+	assert_true(pressed_any, "found the 2x speed button in the watch strip")
+	assert_signal_emitted(ctrl, "speed_changed")
+
+
+func test_watch_readout_updates_from_state():
+	ctrl.build_watch_bar()
+	var state := {
+		"calendar": {"year": 2034, "month": 3, "day": 12},
+		"month_plan": {"attention_total": 20, "attention_spent": 6, "attention_reserved": 0},
+	}
+	# Should not error and should reflect the day; assert via no crash + label text.
+	ctrl.update_from_state(state)
+	assert_string_contains(ctrl._day_label.text, "day 12", "day readout reflects the calendar")
+	assert_string_contains(ctrl._reserve_label.text, "reserve", "reserve readout present")
+
+
+func _all_buttons(n: Node) -> Array:
+	var out: Array = []
+	if n is Button:
+		out.append(n)
+	for c in n.get_children():
+		out.append_array(_all_buttons(c))
+	return out

--- a/godot/tests/unit/test_screen_mode.gd.uid
+++ b/godot/tests/unit/test_screen_mode.gd.uid
@@ -1,0 +1,1 @@
+uid://djgh8h1cento7


### PR DESCRIPTION
## What

Turns the Phase-A plan/watch **scaffold** (PR #658, which this branch builds on and **supersedes** — its diff = scaffold + extraction) from a visibility-toggle-over-one-screen into a **genuine scene split**. The single `ContentArea` column-soup (`LeftPanel`/`MiddlePanel`/`RightPanel`) is now three real, script-backed screens, each owning its own panels:

| Screen | File(s) | Owns |
|---|---|---|
| **PlanScreen** | `scenes/ui/plan_screen.tscn` + `plan_screen.gd` | action hand, upgrades, planning verbs (Do-Nothing/pass), + a new **attention reserve/allocation gauge** |
| **WatchScreen** | `scenes/ui/watch_screen.tscn` + `watch_screen.gd` | the feed (message log) |
| **InstrumentPanel** (shared, visible in BOTH modes) | `instrument_panel.gd` (node in `main.tscn`) | P(DOOM) gauge, staff roster, committed-month queue (the throughline between planning and watching) |

- **ScreenModeController** now shows/hides the two real screen roots as whole units, replacing the scattered per-panel visibility flags. PLAN↔WATCH commit + month-review return unchanged.
- **Coupling untangled:** `main_ui.gd` drives game logic against the screens' **public members** (`plan_screen.actions_list`, `watch_screen.message_log`, `instruments.doom_meter`, …) instead of the 32 absolute `$ContentArea/<column>/…` node paths. Each screen owns its own terminal styling.
- **Optional plan-screen payoff wired:** the attention gauge renders allocated ● vs reserved ◒ pips from `game_state.month_plan` (ADR-0011, ~20/mo — confirmed live in-boot); read-only, degrades gracefully with no plan data.

## Layout note (for playtest)
The two screens are now side panels either side of the shared instrument column. In PLAN you see `[Plan tools | Instruments]`; committing hides the plan tools and reveals `[Instruments | Feed]`. This is a deliberate, coherent change from the old scattered-visibility layout — please react to it.

## Playability guard
**Fully playable at every commit.** Guarded with (a) the month-loop smoke `test_month_button_path.gd` (plan→commit→day-ticks→window→review→next-plan) and (b) a headless boot of `main.tscn` confirming clean load + hand population, run after **each** stage. Both green throughout. Added `test_plan_watch_screens.gd` locking the extraction contract.

- **Fast gate:** 366 tests / 0 failures / 40 files (was 362/39).
- Month smoke: green (ran within each of 3 quick-gate passes + standalone).

## Drive-bys
**Done:** removed a stray `_populate_upgrades()` that rebuilt the entire upgrades list on *every keystroke* (merge artifact); moved each screen's terminal styling into the screen scripts (decoupling); extracted the shared instrument panel rather than duplicating.

**Noted for later (deliberately not done — would balloon):** promoting `InstrumentColumn` to its own `.tscn` (it embeds instanced sub-scenes — office cat, doom meter); migrating the ~3000-line rendering bulk (`_on_actions_available`, `_populate_upgrades`, submenus, hover/press callbacks) out of `main_ui.gd` into the screen scripts — that cluster is tightly interconnected and is a project unto itself, so `main_ui.gd` stays the orchestrator (3270→3281 lines; ownership + coupling moved, behavior did not); noisy per-keystroke debug `print()` in `_unhandled_key_input`.

## Do not merge yet
Pip reviews + **playtests** first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)