### PR TITLE
feat(hiring): Phase A -- hire data model (hidden appetites/quirks + reveal level + candidate card)

### DIFF
--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -539,6 +539,11 @@ func get_researcher_count_by_spec(spec: String) -> int:
 
 func add_researcher(researcher: Researcher):
 	"""Add a researcher to the team"""
+	# Phase A hiring model: an employed person is fully known on their card (skill,
+	# appetites, loyalty-risk all revealed) and marked EMPLOYED. The QUIRK deliberately
+	# stays hidden until an exposure event -- employing someone does not surface it (A2).
+	researcher.set_reveal_level(Researcher.MAX_REVEAL)
+	researcher.hire_state = Researcher.HireState.EMPLOYED
 	researchers.append(researcher)
 
 	# Update legacy counts for backward compatibility

--- a/godot/scripts/core/researcher.gd
+++ b/godot/scripts/core/researcher.gd
@@ -27,6 +27,70 @@ var jet_lag_severity: float = 0.0  # 0.0-1.0, productivity penalty during jet la
 var traits: Array[String] = []
 
 # ============================================================================
+# HIRING PIPELINE — HIDDEN ABILITY LAYER (Phase A)
+# Spec: docs/game-design/BUILD_BRIEF_HIRING_PIPELINE.md "Phase A" + WORKSHOP_2_BACKLOG
+# "Hiring pipeline RULED" (A1/A2/A3); appetites/quirks per ADR-0011 section 8; pay-to-see
+# per ADR-0004 ("Simulate everything; gate only the view").
+#
+# GUARD (ADR-0004): the MODEL stores the TRUE values below. Only the CARD VIEW hides
+# them by reveal_level (get_card_data). The sim never lies -- interviewing REVEALS, it
+# never fabricates. Physical identity (appearance_id, name) is DECOUPLED from ability.
+# ============================================================================
+
+# Hire lifecycle (WORKSHOP_2 "Hiring pipeline RULED"): pool -> offered -> employed ->
+# departed. DEPARTED is terminal. Transitions are guarded (see can_transition_to).
+enum HireState { CANDIDATE_IN_POOL, OFFERED, EMPLOYED, DEPARTED }
+
+# The five appetites (ADR-0011 section 8) -- the negotiation/retention currency. Each is
+# a 0..1 hunger strength; feeding it (or minting a ledger promise) retains, starving bites.
+const APPETITE_KEYS := ["compute", "prestige", "mentees", "money", "mission_purity"]
+
+# Reveal ladder (A1/A2). 0 = uninterviewed: only lane + rough seniority show. Each
+# interview step (Phase B) peels back one layer. The card hides everything above the
+# current level behind HIDDEN_PLACEHOLDER; the underlying values are always real.
+const REVEAL_UNINTERVIEWED := 0   # name, lane (specialization), rough seniority band
+const REVEAL_SKILL := 1           # + true skill, compensation expectation
+const REVEAL_APPETITES := 2       # + the five appetites
+const REVEAL_DEEP := 3            # + loyalty-risk
+const MAX_REVEAL := 3
+
+# Field -> minimum reveal_level at which the card shows the TRUE value.
+const REVEAL_REQUIREMENTS := {
+	"name": REVEAL_UNINTERVIEWED,
+	"specialization": REVEAL_UNINTERVIEWED,
+	"seniority_band": REVEAL_UNINTERVIEWED,
+	"skill_level": REVEAL_SKILL,
+	"salary_expectation": REVEAL_SKILL,
+	"appetites": REVEAL_APPETITES,
+	"loyalty_risk": REVEAL_DEEP,
+}
+
+const HIDDEN_PLACEHOLDER := "??? (interview to reveal)"
+
+# Identity assets are combinatorial (WORKSHOP_2 "Character sprite system"): a base-body
+# id drawn from a pool, deliberately UNCORRELATED with ability.
+const IDENTITY_POOL_SIZE := 24
+
+# Rare quirk riders (ADR-0011 section 8): philosophical stances etc. Stay hidden until an
+# EXPOSURE event flips quirk_known (ADR-0003 machinery) -- NOT revealed by interviewing.
+const QUIRK_CHANCE := 0.15
+const QUIRK_POOL := [
+	"secret_successionist", "doom_absolutist", "e_acc_sympathizer",
+	"publish_everything", "secrecy_maximalist", "empire_builder"
+]
+
+# --- Identity (ability-UNCORRELATED) ---
+@export var appearance_id: String = ""     # sprite/appearance handle; diverse, not a stat tell
+
+# --- Hidden ability layer (TRUE values; the card gates their visibility) ---
+var hire_state: int = HireState.CANDIDATE_IN_POOL
+var reveal_level: int = REVEAL_UNINTERVIEWED
+var appetites: Dictionary = {}             # appetite_key -> 0..1 strength (ADR-0011 section 8)
+var quirk: String = ""                     # rare quirk rider ("" = none)
+var quirk_known: bool = false              # true once an exposure event surfaces the quirk
+var loyalty_risk: float = 0.0              # 0..1 hidden flight predisposition (NOT live loyalty)
+
+# ============================================================================
 # SPECIALIZATIONS
 # ============================================================================
 
@@ -139,6 +203,10 @@ func _init(spec: String = "safety", name: String = ""):
 	base_productivity = 0.5 + (skill_level * 0.1)  # 1.0
 	loyalty = 55
 
+	# Hidden ability layer defaults: neutral appetites, no quirk, uninterviewed. Real
+	# values are drawn only via generate_random(rng) or restored via from_dict.
+	appetites = _neutral_appetites()
+
 func generate_random(rng: RandomNumberGenerator):
 	"""Generate random attributes using provided RNG for determinism"""
 	researcher_name = _generate_name_with_rng(rng)
@@ -156,6 +224,34 @@ func generate_random(rng: RandomNumberGenerator):
 	var variation = 1.0 + (rng.randf() * 0.2 - 0.1)
 	salary_expectation = SPECIALIZATIONS.get(specialization, {}).get("base_cost", 60000) * variation
 	current_salary = salary_expectation
+
+	# --- Hidden ability layer (Phase A). ADDITIVE by construction: the hidden layer is
+	# drawn from a CHILD rng seeded off the main stream's CURRENT state, which reading
+	# does NOT advance. So the main rng.state after generate_random is exactly what it
+	# was before this feature -- the rest of the game's deterministic stream (rival
+	# estimates, events, ...) is byte-unchanged. Deterministic + replay-safe because the
+	# child seed is a pure function of the (reproducible) main state at this point. ---
+	var hidden_rng := RandomNumberGenerator.new()
+	hidden_rng.seed = hash(rng.state)
+	# Identity: deliberately uncorrelated with skill (WORKSHOP_2 "Character sprite
+	# system": diversity is identity, never a stat tell).
+	appearance_id = "body_%02d" % (hidden_rng.randi() % IDENTITY_POOL_SIZE)
+	# The five appetites (ADR-0011 section 8): independent 0..1 hungers.
+	appetites = {}
+	for k in APPETITE_KEYS:
+		appetites[k] = hidden_rng.randf()
+	# Loyalty-risk: hidden flight predisposition (revealed only at deep reveal).
+	loyalty_risk = hidden_rng.randf()
+	# Rare quirk rider: most candidates carry none; when present it stays hidden until
+	# an exposure event (A2) -- interviewing never surfaces it.
+	if hidden_rng.randf() < QUIRK_CHANCE:
+		quirk = QUIRK_POOL[hidden_rng.randi() % QUIRK_POOL.size()]
+	else:
+		quirk = ""
+	quirk_known = false
+	# Freshly-sourced people start uninterviewed, in the candidate pool.
+	reveal_level = REVEAL_UNINTERVIEWED
+	hire_state = HireState.CANDIDATE_IN_POOL
 
 func _generate_name_with_rng(rng: RandomNumberGenerator) -> String:
 	"""Generate a random researcher name using provided RNG"""
@@ -386,6 +482,146 @@ func get_specialization_name() -> String:
 	return specialization.capitalize()
 
 # ============================================================================
+# HIRING PIPELINE — REVEAL / HIRE-STATE / CANDIDATE CARD (Phase A)
+# ============================================================================
+
+static func _neutral_appetites() -> Dictionary:
+	"""All five appetites at 0.0 (neutral). Used as the deterministic default so a
+	Researcher.new() before generate_random still exposes every appetite key."""
+	var d := {}
+	for k in APPETITE_KEYS:
+		d[k] = 0.0
+	return d
+
+func get_seniority_band() -> String:
+	"""Rough seniority (A1): visible even uninterviewed. A coarse BAND, not the exact
+	skill number, so lane + seniority read at reveal 0 without leaking true skill."""
+	if skill_level <= 2:
+		return "Junior"
+	elif skill_level <= 4:
+		return "Mid"
+	elif skill_level <= 6:
+		return "Senior"
+	elif skill_level <= 8:
+		return "Staff"
+	return "Principal"
+
+# --- Reveal ladder (interviewing is Phase B; this is the API surface it drives) ---
+
+func reveal_more(amount: int = 1) -> int:
+	"""Raise reveal_level by `amount` (an interview step, Phase B), clamped to
+	[0, MAX_REVEAL]. Returns the new level. Reveals NEVER fabricate -- they only
+	unhide values the model already holds (ADR-0004)."""
+	reveal_level = clampi(reveal_level + amount, 0, MAX_REVEAL)
+	return reveal_level
+
+func set_reveal_level(level: int) -> void:
+	"""Directly set the reveal level (clamped). Used by hire-on (fully revealed) and load."""
+	reveal_level = clampi(level, 0, MAX_REVEAL)
+
+func is_field_revealed(field: String) -> bool:
+	"""True if the card should show `field`'s true value at the current reveal_level.
+	Unknown fields are treated as never-revealed. (Quirk is exposure-gated, not here.)"""
+	var req: int = REVEAL_REQUIREMENTS.get(field, MAX_REVEAL + 1)
+	return reveal_level >= req
+
+func expose_quirk() -> void:
+	"""An exposure event (ADR-0003) surfaces the rare quirk rider. Independent of the
+	interview reveal ladder: a fully-interviewed hire can still have a hidden quirk (A2)."""
+	quirk_known = true
+
+func has_quirk() -> bool:
+	"""True if this person actually carries a quirk (regardless of whether it is known)."""
+	return quirk != ""
+
+# --- Hire-state lifecycle (guarded transitions) ---
+
+func can_transition_to(new_state: int) -> bool:
+	"""Guard the pool -> offered -> employed -> departed lifecycle. DEPARTED is terminal."""
+	match hire_state:
+		HireState.CANDIDATE_IN_POOL:
+			return new_state == HireState.OFFERED or new_state == HireState.DEPARTED
+		HireState.OFFERED:
+			return new_state == HireState.EMPLOYED \
+				or new_state == HireState.CANDIDATE_IN_POOL \
+				or new_state == HireState.DEPARTED
+		HireState.EMPLOYED:
+			return new_state == HireState.DEPARTED
+		_:  # DEPARTED (terminal) or unknown
+			return false
+
+func transition_hire_state(new_state: int) -> bool:
+	"""Apply a guarded hire-state transition. Returns false (no-op) if disallowed."""
+	if can_transition_to(new_state):
+		hire_state = new_state
+		return true
+	return false
+
+func hire_state_name() -> String:
+	match hire_state:
+		HireState.CANDIDATE_IN_POOL:
+			return "Candidate"
+		HireState.OFFERED:
+			return "Offer out"
+		HireState.EMPLOYED:
+			return "Employed"
+		HireState.DEPARTED:
+			return "Departed"
+		_:
+			return "Unknown"
+
+# --- Candidate card (the hire-as-scouting info model, ADR-0004) ---
+
+func get_card_data() -> Dictionary:
+	"""The candidate-card INFO MODEL. Revealed fields carry their TRUE value; hidden
+	fields carry HIDDEN_PLACEHOLDER. Identity (name/appearance/lane/seniority) is always
+	shown; skill/comp/appetites/loyalty-risk gate on reveal_level; the quirk gates on an
+	exposure event (quirk_known), never on the interview ladder (A2)."""
+	var card := {
+		"name": researcher_name,
+		"appearance_id": appearance_id,
+		"lane": get_specialization_name(),
+		"seniority_band": get_seniority_band(),
+		"hire_state": hire_state_name(),
+		"reveal_level": reveal_level,
+	}
+	card["skill_level"] = skill_level if is_field_revealed("skill_level") else HIDDEN_PLACEHOLDER
+	card["salary_expectation"] = salary_expectation if is_field_revealed("salary_expectation") else HIDDEN_PLACEHOLDER
+	card["appetites"] = appetites.duplicate() if is_field_revealed("appetites") else HIDDEN_PLACEHOLDER
+	card["loyalty_risk"] = loyalty_risk if is_field_revealed("loyalty_risk") else HIDDEN_PLACEHOLDER
+	# Quirk: exposure-gated. Once known, "" reads as an explicit "none" (a checked absence).
+	if quirk_known:
+		card["quirk"] = quirk if quirk != "" else "none"
+	else:
+		card["quirk"] = HIDDEN_PLACEHOLDER
+	return card
+
+func get_card_text() -> String:
+	"""A minimal formatted candidate card (Phase A view). See get_card_data for the model."""
+	var c := get_card_data()
+	var lines: Array[String] = []
+	lines.append("%s  [%s]" % [c["name"], c["hire_state"]])
+	lines.append("Lane: %s    Seniority: %s" % [c["lane"], c["seniority_band"]])
+	lines.append("Skill: %s" % str(c["skill_level"]))
+	if c["salary_expectation"] is float:
+		lines.append("Comp expectation: $%.0f" % c["salary_expectation"])
+	else:
+		lines.append("Comp expectation: %s" % str(c["salary_expectation"]))
+	if c["appetites"] is Dictionary:
+		var parts: Array[String] = []
+		for k in APPETITE_KEYS:
+			parts.append("%s %d%%" % [k, int(round(float(c["appetites"][k]) * 100.0))])
+		lines.append("Appetites: %s" % ", ".join(parts))
+	else:
+		lines.append("Appetites: %s" % str(c["appetites"]))
+	if c["loyalty_risk"] is float:
+		lines.append("Loyalty risk: %d%%" % int(round(c["loyalty_risk"] * 100.0)))
+	else:
+		lines.append("Loyalty risk: %s" % str(c["loyalty_risk"]))
+	lines.append("Quirk: %s" % str(c["quirk"]))
+	return "\n".join(lines)
+
+# ============================================================================
 # SERIALIZATION
 # ============================================================================
 
@@ -403,7 +639,19 @@ func to_dict() -> Dictionary:
 		"turns_employed": turns_employed,
 		"traits": traits.duplicate(),
 		"jet_lag_turns": jet_lag_turns,
-		"jet_lag_severity": jet_lag_severity
+		"jet_lag_severity": jet_lag_severity,
+		# --- Hiring pipeline hidden-ability layer (Phase A) ---
+		# Appetites / loyalty-risk are SNAPPED to the repo-wide serialization grid
+		# (DoomSystem.SAVE_QUANTUM) so the save/load round-trip is JSON-parse-stable --
+		# Godot's JSON parse is not correctly-rounded, so an un-snapped double drifts a
+		# ULP and breaks deep-equality (see the SERIALIZATION block in game_state.gd).
+		"appearance_id": appearance_id,
+		"hire_state": hire_state,          # enum -> int
+		"reveal_level": reveal_level,
+		"appetites": DoomSystem._snap_dict(appetites),
+		"quirk": quirk,
+		"quirk_known": quirk_known,
+		"loyalty_risk": DoomSystem._snap(loyalty_risk)
 	}
 
 func from_dict(data: Dictionary):
@@ -424,3 +672,20 @@ func from_dict(data: Dictionary):
 		traits.clear()
 		for trait_name in data["traits"]:
 			traits.append(trait_name)
+
+	# --- Hiring pipeline hidden-ability layer (Phase A). Explicit casts: JSON hands
+	# every number back as float and every enum as float. Missing keys fall back to the
+	# uninterviewed/neutral defaults so pre-Phase-A saves still load. ---
+	appearance_id = String(data.get("appearance_id", ""))
+	hire_state = int(data.get("hire_state", HireState.CANDIDATE_IN_POOL))
+	reveal_level = int(data.get("reveal_level", REVEAL_UNINTERVIEWED))
+	quirk = String(data.get("quirk", ""))
+	quirk_known = bool(data.get("quirk_known", false))
+	# Re-snap on load (idempotent) so the live values sit exactly on the grid, matching
+	# the doom-intermediary convention -- keeps any future sim use deterministic.
+	loyalty_risk = DoomSystem._snap(float(data.get("loyalty_risk", 0.0)))
+	appetites = _neutral_appetites()
+	var appetite_data = data.get("appetites", {})
+	if appetite_data is Dictionary:
+		for k in appetite_data.keys():
+			appetites[String(k)] = DoomSystem._snap(float(appetite_data[k]))

--- a/godot/scripts/ui/candidate_card.gd
+++ b/godot/scripts/ui/candidate_card.gd
@@ -1,0 +1,45 @@
+extends PanelContainer
+class_name CandidateCard
+## Minimal Phase-A candidate / employee card (BUILD_BRIEF_HIRING_PIPELINE "Phase A").
+##
+## PURE VIEW: it renders Researcher.get_card_data() and never mutates the model. Revealed
+## fields show their true value; fields above the current reveal_level (and an unexposed
+## quirk) render as "??? (interview to reveal)" -- hire-as-scouting made visible (ADR-0004).
+## The data model (Researcher) is the real deliverable; this is a deliberately thin view
+## the Phase-B plan screen can replace or embed.
+
+var _title: Label
+var _body: Label
+var _researcher: Researcher
+
+func _ready() -> void:
+	if _body == null:
+		_build()
+
+func _build() -> void:
+	var vbox := VBoxContainer.new()
+	add_child(vbox)
+	_title = Label.new()
+	_title.add_theme_font_size_override("font_size", 16)
+	vbox.add_child(_title)
+	_body = Label.new()
+	vbox.add_child(_body)
+	if _researcher != null:
+		_refresh()
+
+## Point the card at a Researcher (candidate or employee). Re-render is immediate.
+func set_researcher(r: Researcher) -> void:
+	_researcher = r
+	if _body == null:
+		_build()
+	else:
+		_refresh()
+
+func _refresh() -> void:
+	if _researcher == null:
+		_title.text = "(no candidate)"
+		_body.text = ""
+		return
+	var c: Dictionary = _researcher.get_card_data()
+	_title.text = "%s  [%s]" % [c["name"], c["hire_state"]]
+	_body.text = _researcher.get_card_text()

--- a/godot/tests/unit/test_hiring_data_model.gd
+++ b/godot/tests/unit/test_hiring_data_model.gd
@@ -1,0 +1,197 @@
+extends GutTest
+## Phase A hiring data model: hidden-ability layer, reveal-level gating, hire-state
+## transitions, appetites, quirk exposure, and save/load round-trip of the new fields.
+## Spec: docs/game-design/BUILD_BRIEF_HIRING_PIPELINE.md "Phase A".
+
+func _make_seeded() -> Researcher:
+	# Deterministic candidate via a seeded RNG (WS-0: no global RNG).
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 12345
+	var r := Researcher.new("safety")
+	r.generate_random(rng)
+	return r
+
+# --- Appetites --------------------------------------------------------------
+
+func test_default_appetites_are_neutral_and_complete():
+	var r := Researcher.new("safety")
+	assert_eq(r.appetites.size(), Researcher.APPETITE_KEYS.size(), "All 5 appetite keys present by default")
+	for k in Researcher.APPETITE_KEYS:
+		assert_true(r.appetites.has(k), "Appetite key present: %s" % k)
+		assert_eq(float(r.appetites[k]), 0.0, "Default appetite neutral: %s" % k)
+
+func test_generate_random_populates_appetites_in_range():
+	var r := _make_seeded()
+	assert_eq(r.appetites.size(), Researcher.APPETITE_KEYS.size())
+	for k in Researcher.APPETITE_KEYS:
+		var v: float = float(r.appetites[k])
+		assert_between(v, 0.0, 1.0, "Appetite %s in [0,1]" % k)
+	assert_between(r.loyalty_risk, 0.0, 1.0, "loyalty_risk in [0,1]")
+
+func test_generation_is_deterministic():
+	var a := _make_seeded()
+	var b := _make_seeded()
+	assert_eq(a.appearance_id, b.appearance_id, "Same seed -> same identity")
+	assert_eq(a.appetites, b.appetites, "Same seed -> same appetites")
+	assert_eq(a.loyalty_risk, b.loyalty_risk, "Same seed -> same loyalty_risk")
+	assert_eq(a.quirk, b.quirk, "Same seed -> same quirk")
+
+func test_identity_assigned_and_from_known_pool():
+	var r := _make_seeded()
+	assert_ne(r.appearance_id, "", "Identity assigned")
+	assert_true(r.appearance_id.begins_with("body_"), "Identity from combinatorial pool")
+
+# --- Reveal-level gating ----------------------------------------------------
+
+func test_uninterviewed_hides_skill_appetites_loyalty():
+	var r := _make_seeded()
+	assert_eq(r.reveal_level, Researcher.REVEAL_UNINTERVIEWED, "Fresh candidate uninterviewed")
+	var card := r.get_card_data()
+	# Identity + lane + seniority always shown.
+	assert_eq(card["name"], r.researcher_name)
+	assert_ne(card["seniority_band"], Researcher.HIDDEN_PLACEHOLDER, "Rough seniority shown at reveal 0")
+	# Hidden layer masked.
+	assert_eq(card["skill_level"], Researcher.HIDDEN_PLACEHOLDER, "Skill hidden at reveal 0")
+	assert_eq(card["appetites"], Researcher.HIDDEN_PLACEHOLDER, "Appetites hidden at reveal 0")
+	assert_eq(card["loyalty_risk"], Researcher.HIDDEN_PLACEHOLDER, "Loyalty-risk hidden at reveal 0")
+
+func test_reveal_more_progressively_unhides():
+	var r := _make_seeded()
+	r.reveal_more(1)  # REVEAL_SKILL
+	var c1 := r.get_card_data()
+	assert_eq(c1["skill_level"], r.skill_level, "Skill revealed at level 1")
+	assert_eq(c1["appetites"], Researcher.HIDDEN_PLACEHOLDER, "Appetites still hidden at level 1")
+
+	r.reveal_more(1)  # REVEAL_APPETITES
+	var c2 := r.get_card_data()
+	assert_true(c2["appetites"] is Dictionary, "Appetites revealed at level 2")
+	assert_eq(c2["loyalty_risk"], Researcher.HIDDEN_PLACEHOLDER, "Loyalty-risk still hidden at level 2")
+
+	r.reveal_more(1)  # REVEAL_DEEP
+	var c3 := r.get_card_data()
+	assert_eq(float(c3["loyalty_risk"]), r.loyalty_risk, "Loyalty-risk revealed at level 3")
+
+func test_reveal_more_clamps_at_max():
+	var r := _make_seeded()
+	r.reveal_more(99)
+	assert_eq(r.reveal_level, Researcher.MAX_REVEAL, "Reveal clamps to MAX_REVEAL")
+	assert_eq(r.reveal_more(5), Researcher.MAX_REVEAL, "Cannot exceed MAX_REVEAL")
+
+func test_is_field_revealed_unknown_field_never():
+	var r := _make_seeded()
+	r.set_reveal_level(Researcher.MAX_REVEAL)
+	assert_false(r.is_field_revealed("no_such_field"), "Unknown fields never reveal")
+
+# --- Quirk exposure (independent of interview ladder, A2) --------------------
+
+func test_quirk_hidden_even_when_fully_interviewed():
+	var r := Researcher.new("safety")
+	r.quirk = "secret_successionist"
+	r.set_reveal_level(Researcher.MAX_REVEAL)
+	var card := r.get_card_data()
+	assert_eq(card["quirk"], Researcher.HIDDEN_PLACEHOLDER, "Quirk stays hidden until exposure, even fully interviewed")
+
+func test_expose_quirk_reveals_it():
+	var r := Researcher.new("safety")
+	r.quirk = "doom_absolutist"
+	r.expose_quirk()
+	var card := r.get_card_data()
+	assert_eq(card["quirk"], "doom_absolutist", "Exposure event surfaces the quirk")
+
+func test_exposed_absent_quirk_reads_none():
+	var r := Researcher.new("safety")  # no quirk
+	r.expose_quirk()
+	var card := r.get_card_data()
+	assert_eq(card["quirk"], "none", "Checked absence reads 'none', not the placeholder")
+
+# --- Hire-state transitions -------------------------------------------------
+
+func test_valid_hire_state_flow():
+	var r := Researcher.new("safety")
+	assert_eq(r.hire_state, Researcher.HireState.CANDIDATE_IN_POOL, "Starts in pool")
+	assert_true(r.transition_hire_state(Researcher.HireState.OFFERED), "pool -> offered ok")
+	assert_true(r.transition_hire_state(Researcher.HireState.EMPLOYED), "offered -> employed ok")
+	assert_true(r.transition_hire_state(Researcher.HireState.DEPARTED), "employed -> departed ok")
+
+func test_invalid_hire_state_transitions_rejected():
+	var r := Researcher.new("safety")
+	assert_false(r.transition_hire_state(Researcher.HireState.EMPLOYED), "pool -> employed skips offer")
+	assert_eq(r.hire_state, Researcher.HireState.CANDIDATE_IN_POOL, "Rejected transition is a no-op")
+
+func test_departed_is_terminal():
+	var r := Researcher.new("safety")
+	r.transition_hire_state(Researcher.HireState.OFFERED)
+	r.transition_hire_state(Researcher.HireState.EMPLOYED)
+	r.transition_hire_state(Researcher.HireState.DEPARTED)
+	assert_false(r.transition_hire_state(Researcher.HireState.EMPLOYED), "No resurrection from departed")
+	assert_false(r.transition_hire_state(Researcher.HireState.CANDIDATE_IN_POOL), "Departed is terminal")
+
+func test_offer_can_return_to_pool():
+	var r := Researcher.new("safety")
+	r.transition_hire_state(Researcher.HireState.OFFERED)
+	assert_true(r.transition_hire_state(Researcher.HireState.CANDIDATE_IN_POOL), "Declined offer -> back to pool")
+
+# --- Hiring marks employed + fully revealed (backward compat) ----------------
+
+func test_add_researcher_marks_employed_and_revealed():
+	var state := GameState.new("test_hire_reveal")
+	var r := _make_seeded()
+	state.add_researcher(r)
+	assert_eq(r.hire_state, Researcher.HireState.EMPLOYED, "Hired -> employed")
+	assert_eq(r.reveal_level, Researcher.MAX_REVEAL, "Employed staff fully revealed")
+	assert_false(r.quirk_known, "But quirk still hidden until exposure")
+
+func test_starting_candidates_are_uninterviewed():
+	var state := GameState.new("test_pool")
+	assert_gt(state.candidate_pool.size(), 0, "Pool seeded with candidates")
+	for cand in state.candidate_pool:
+		assert_eq(cand.reveal_level, Researcher.REVEAL_UNINTERVIEWED, "Pool candidates uninterviewed")
+		assert_eq(cand.hire_state, Researcher.HireState.CANDIDATE_IN_POOL, "Pool candidates in pool state")
+		assert_ne(cand.appearance_id, "", "Candidate carries an identity")
+
+# --- Save / load round-trip of the new fields -------------------------------
+
+func test_researcher_new_fields_round_trip():
+	var r := _make_seeded()
+	r.reveal_more(2)
+	r.quirk = "empire_builder"
+	r.quirk_known = true
+	r.transition_hire_state(Researcher.HireState.OFFERED)
+
+	# Full JSON hop, mirroring the save/load path (numbers come back as float).
+	var json_str := JSON.stringify(r.to_dict())
+	var parsed = JSON.parse_string(json_str)
+	assert_not_null(parsed, "Round-trips through JSON")
+
+	var r2 := Researcher.new()
+	r2.from_dict(parsed)
+	assert_eq(r2.appearance_id, r.appearance_id, "appearance_id round-trips")
+	assert_eq(r2.reveal_level, r.reveal_level, "reveal_level round-trips")
+	assert_eq(r2.hire_state, r.hire_state, "hire_state round-trips")
+	assert_eq(r2.quirk, r.quirk, "quirk round-trips")
+	assert_eq(r2.quirk_known, r.quirk_known, "quirk_known round-trips")
+	assert_almost_eq(r2.loyalty_risk, r.loyalty_risk, 0.0001, "loyalty_risk round-trips")
+	for k in Researcher.APPETITE_KEYS:
+		assert_almost_eq(float(r2.appetites[k]), float(r.appetites[k]), 0.0001, "appetite %s round-trips" % k)
+
+func test_pre_phase_a_save_loads_with_defaults():
+	# A researcher dict WITHOUT the new keys (old save) must load cleanly.
+	var legacy := {"name": "Old Hand", "specialization": "safety", "skill_level": 6}
+	var r := Researcher.new()
+	r.from_dict(legacy)
+	assert_eq(r.reveal_level, Researcher.REVEAL_UNINTERVIEWED, "Missing reveal_level -> default")
+	assert_eq(r.hire_state, Researcher.HireState.CANDIDATE_IN_POOL, "Missing hire_state -> default")
+	assert_eq(r.appetites.size(), Researcher.APPETITE_KEYS.size(), "Missing appetites -> neutral set")
+
+# --- Card view --------------------------------------------------------------
+
+func test_card_view_renders_hidden_and_revealed():
+	var r := _make_seeded()
+	var card := CandidateCard.new()
+	add_child_autofree(card)
+	card.set_researcher(r)
+	# Uninterviewed: card text shows the placeholder for skill.
+	assert_true(card._body.text.contains(Researcher.HIDDEN_PLACEHOLDER), "Hidden fields shown as placeholder")
+	r.set_reveal_level(Researcher.MAX_REVEAL)
+	card.set_researcher(r)
+	assert_true(card._body.text.contains("Skill: %d" % r.skill_level), "Revealed skill shown after interview")


### PR DESCRIPTION
## Phase A -- hire/candidate data model + candidate card

The foundation the rest of the hiring pipeline builds on. Extends the existing
`Researcher` model with a hidden-ability layer; the existing roster/hiring keeps
working (purely additive).

**Two things to confirm at the top of review (per the build brief):**
1. **DQ-24 taxonomy** -- not touched here (that's Phase C demands); flagging that
   the appetite set used is the ADR-0011 canonical five, not DQ-24's demand
   categories. Confirm that's the right split for Phase A.
2. **Candidate-card info model** -- what shows at reveal 0 vs what interviewing
   peels back (see below). Confirm the ladder.

### Data model (`godot/scripts/core/researcher.gd`)
- **Identity (ability-UNCORRELATED):** `appearance_id` -- a sprite/appearance
  handle, drawn from its own child RNG so it never correlates with skill
  (WORKSHOP_2 "Character sprite system").
- **Hidden ability layer (TRUE values stored):** `appetites`
  (compute / prestige / mentees / money / mission_purity -- ADR-0011 section 8),
  rare `quirk` rider, `loyalty_risk`. The model holds real values; only the card
  VIEW hides them (ADR-0004 "simulate everything; gate only the view").
- **Reveal ladder:** `reveal_level` 0..3 (0 uninterviewed: lane + rough seniority
  only -> skill/comp -> appetites -> loyalty-risk). `reveal_more(amount)` is the
  API surface Phase B interviewing will drive. Quirk is **exposure-gated**
  (`expose_quirk()`), NOT interview-gated (A2 -- a fully-interviewed hire can
  still carry a hidden quirk).
- **Hire-state:** `HireState` enum
  (candidate_in_pool / offered / employed / departed) with guarded transitions
  (`transition_hire_state`); departed is terminal.
- **Candidate card:** `get_card_data()` / `get_card_text()` render revealed
  fields and hidden ones as `??? (interview to reveal)`. Minimal `CandidateCard`
  view in `godot/scripts/ui/candidate_card.gd` (pure view).

### Determinism / save-load
- Hidden layer drawn from a **child RNG seeded off (but not advancing)** the main
  stream -> the rest of the game's deterministic stream is byte-unchanged. Fully
  additive.
- New float fields snap to `SAVE_QUANTUM` so save/load is JSON-parse-stable;
  `to_dict`/`from_dict` extended both sides; pre-Phase-A saves load with defaults.
- `add_researcher` marks hires employed + fully revealed (quirk stays hidden).

### Scope
Phase A only -- data model + card. NOT built: pipeline stages, sourcing,
interview action, negotiation, onboarding, typed demands, assignment, managers
(later phases).

### Tests
`godot/tests/unit/test_hiring_data_model.gd` (20 tests): reveal-level gating,
hire-state transitions, appetite fields, quirk exposure, determinism, save/load
round-trip. **Fast gate: 399 tests, 0 fail.** Headless launch clean.

Do NOT merge -- Pip reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)