### PR TITLE
feat(art-review): keyboard-driven asset browser (verdicts + sweep)

### DIFF
--- a/tools/art_review/build.py
+++ b/tools/art_review/build.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 """Build the P(Doom)1 style-review tool: a self-contained HTML page from
 manifest.json + the committed PNGs. Rows = style directions, columns = subjects,
-so a whole style reads across many subjects at once. Plus an era-ladder strip.
-Pick a winner per matrix, note per cell, jot global style dials, and Export the
-verdicts to paste back for the next generation round.
+so a whole style reads across many subjects at once. Plus an era-ladder strip,
+an office gallery, and (when present) the overnight generation sweep.
+
+It's a keyboard-driven asset browser: arrow keys move a focus ring between
+review cells, K/M/R stamp a keep/maybe/re-roll verdict, N/Enter edits the note.
+Verdicts + notes + picks persist to localStorage and are seeded from
+verdicts.json so they survive across sessions/machines.
 
 Convention for image files (relative to <repo>/<image_root>/<batch.dir>/):
   matrix cell : "<style.key>__<subject.key>.png"
   ladder step : "<step.key>.png"
+  gallery item: "<item.key>.png"
+Sweep images live at <image_root>/sweep/<category>/<key>_<roll>.png (roll=1..N).
 Missing files render as a 'pending' placeholder (regenerate + re-run to fill).
 
 Usage:  python tools/art_review/build.py   ->  writes tools/art_review/style_review.html
@@ -19,7 +25,24 @@ import pathlib
 HERE = pathlib.Path(__file__).resolve().parent
 REPO = HERE.parents[1]
 MANIFEST = HERE / "manifest.json"
+SWEEP = HERE / "sweep_prompts.json"
 OUT = HERE / "style_review.html"
+
+# Category keys in sweep_prompts.json carry tool hints in their name
+# (e.g. cats_body_type_quadruped_template_cat, ui_filler_map_object). Once one of
+# these marker tokens appears, the rest of the key is a tool hint, not a label.
+TOOL_HINT_MARKERS = {
+    "use",
+    "create",
+    "map",
+    "object",
+    "body",
+    "type",
+    "template",
+    "quadruped",
+    "character",
+    "overlays",
+}
 
 
 def datauri(path: pathlib.Path):
@@ -32,15 +55,27 @@ def esc(s):
     return (s or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-def cell(item_id, label, uri):
+def controls(label):
+    """Verdict tri-state (keep / maybe / re-roll) + note input for a review cell."""
+    return f"""<div class="verdict" role="group" aria-label="Verdict for {esc(label)}">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for {esc(label)}">"""
+
+
+def stage(label, uri, pending="pending<br>regen &amp; rebuild"):
     if uri:
-        img = f'<div class="stage"><img src="{uri}" alt="{esc(label)}"></div>'
-    else:
-        img = '<div class="stage pending"><span>pending<br>regen &amp; rebuild</span></div>'
+        return f'<div class="stage"><img src="{uri}" alt="{esc(label)}"></div>'
+    return f'<div class="stage pending"><span>{pending}</span></div>'
+
+
+def cell(item_id, label, uri):
     return f"""
       <div class="cell" data-item="{item_id}" data-label="{esc(label)}">
-        {img}
-        <input type="text" class="note" placeholder="note..." aria-label="Note for {esc(label)}">
+        {stage(label, uri)}
+        {controls(label)}
       </div>"""
 
 
@@ -81,18 +116,13 @@ def build_ladder(b, root):
     steps = []
     for i, st in enumerate(b["steps"]):
         uri = datauri(root / f'{st["key"]}.png')
-        img = (
-            f'<div class="stage"><img src="{uri}" alt="{esc(st["label"])}"></div>'
-            if uri
-            else '<div class="stage pending"><span>pending</span></div>'
-        )
         steps.append(
             f"""
         <div class="cell ladder-step" data-item="{b['id']}:{st['key']}" data-label="{esc(st['label'])}">
           <div class="era-idx">{i+1}</div>
-          {img}
+          {stage(st['label'], uri, 'pending')}
           <h4>{esc(st['label'])}</h4><p class="era-note">{esc(st['note'])}</p>
-          <input type="text" class="note" placeholder="note..." aria-label="Note for {esc(st['label'])}">
+          {controls(st['label'])}
         </div>"""
         )
     return f"""
@@ -107,17 +137,12 @@ def build_gallery(b, root):
     cells = []
     for it in b["items"]:
         uri = datauri(root / f'{it["key"]}.png')
-        img = (
-            f'<div class="stage"><img src="{uri}" alt="{esc(it["label"])}"></div>'
-            if uri
-            else '<div class="stage pending"><span>pending</span></div>'
-        )
         cells.append(
             f"""
       <div class="cell" data-item="{b['id']}:{it['key']}" data-label="{esc(it['label'])}">
-        {img}
+        {stage(it['label'], uri, 'pending')}
         <h4>{esc(it['label'])}</h4>
-        <input type="text" class="note" placeholder="note..." aria-label="Note for {esc(it['label'])}">
+        {controls(it['label'])}
       </div>"""
         )
     return f"""
@@ -126,6 +151,68 @@ def build_gallery(b, root):
       <p class="batch-note">{esc(b['note'])}</p>
       <div class="gallery">{''.join(cells)}</div>
     </section>"""
+
+
+def sweep_label(cat_key):
+    """Clean display label from a tool-hinted category key."""
+    words = []
+    for w in cat_key.split("_"):
+        if w in TOOL_HINT_MARKERS:
+            break
+        words.append(w)
+    if not words:
+        words = [cat_key]
+    return " ".join(words).title().replace("Ui", "UI")
+
+
+def build_sweep(root_img):
+    """Render the overnight sweep: one section per category, one row per asset,
+    that asset's rolls side by side as review cells. root_img is <image_root>."""
+    if not SWEEP.is_file():
+        return ""
+    sw = json.loads(SWEEP.read_text(encoding="utf-8"))
+    default_rolls = int(sw.get("default_rolls", 3))
+    sections = []
+    for cat, entries in sw.items():
+        if not isinstance(entries, list):
+            continue  # skip _comment / style_suffix / default_rolls / view
+        subdir = root_img / "sweep" / cat
+        rows = []
+        for e in entries:
+            key = e["key"]
+            n = int(e.get("rolls", default_rolls))
+            rolls = []
+            for r in range(1, n + 1):
+                uri = datauri(subdir / f"{key}_{r}.png")
+                item_id = f"sweep:{cat}:{key}:{r}"
+                label = f"{key} roll {r}"
+                rolls.append(
+                    f"""
+          <div class="cell sweep-cell" data-item="{item_id}" data-label="{esc(label)}">
+            <div class="roll-idx">#{r}</div>
+            {stage(label, uri, 'pending')}
+            {controls(label)}
+          </div>"""
+                )
+            desc = esc(e.get("desc", ""))
+            rows.append(
+                f"""
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>{esc(key)}</h4><p>{desc}</p></div>
+        <div class="sweep-rolls" style="--cols:{n}">{''.join(rolls)}</div>
+      </div>"""
+            )
+        sections.append(
+            f"""
+    <section class="batch" data-batch="sweep:{cat}">
+      <div class="section-label">Sweep &middot; {esc(sweep_label(cat))}</div>
+      <p class="batch-note">One row per asset; rolls side by side -- keep the best roll, re-roll the rest.</p>
+      <div class="sweep">{''.join(rows)}</div>
+    </section>"""
+        )
+    if not sections:
+        return ""
+    return '\n    <div class="section-label big">// overnight sweep</div>\n' + "\n".join(sections)
 
 
 def main():
@@ -140,14 +227,15 @@ def main():
             sections.append(build_ladder(b, root))
         elif b["kind"] == "gallery":
             sections.append(build_gallery(b, root))
-    body = "\n".join(sections)
+    sections.append(build_sweep(img_root))
+    body = "\n".join(s for s in sections if s)
 
     vpath = HERE / "verdicts.json"
-    verdicts = (
-        json.loads(vpath.read_text(encoding="utf-8"))
-        if vpath.is_file()
-        else {"picks": {}, "notes": {}, "styledir": ""}
-    )
+    verdicts = json.loads(vpath.read_text(encoding="utf-8")) if vpath.is_file() else {}
+    verdicts.setdefault("picks", {})
+    verdicts.setdefault("notes", {})
+    verdicts.setdefault("verdicts", {})
+    verdicts.setdefault("styledir", "")
 
     html = (
         TEMPLATE.replace("{{TITLE}}", esc(m["title"]))
@@ -172,6 +260,11 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
     --field:#fffaf0;--shadow:rgba(80,55,20,.18);}}
   :root[data-theme="dark"]{--ground:#17120e;--panel:#211a14;--panel-2:#2b221a;--ink:#ece0cf;--ink-dim:#a9977f;--ink-faint:#6f6250;--amber:#e8a33d;--amber-deep:#c07a1f;--win:#6fae86;--line:#3a2e22;--checker-a:#201811;--checker-b:#180f09;--field:#120d09;--shadow:rgba(0,0,0,.45);}
   :root[data-theme="light"]{--ground:#efe6d6;--panel:#f7efe0;--panel-2:#fbf5e9;--ink:#2b2116;--ink-dim:#6b5b45;--ink-faint:#9a876c;--amber:#b9741a;--amber-deep:#8f5710;--win:#3f8a5c;--line:#ddccb0;--checker-a:#e6dac4;--checker-b:#ded1b8;--field:#fffaf0;--shadow:rgba(80,55,20,.18);}
+  /* verdict colours -- var(--win)/(--amber) are late-bound so they track theme */
+  :root{--keep:var(--win);--maybe:var(--amber);--reroll:#d8695a}
+  @media (prefers-color-scheme:light){:root{--reroll:#c14a3a}}
+  :root[data-theme="dark"]{--reroll:#d8695a}
+  :root[data-theme="light"]{--reroll:#c14a3a}
   *{box-sizing:border-box}
   body{margin:0;background:var(--ground);color:var(--ink);font-family:ui-sans-serif,system-ui,"Segoe UI",Helvetica,Arial,sans-serif;line-height:1.5;-webkit-font-smoothing:antialiased}
   img{image-rendering:pixelated;image-rendering:crisp-edges;max-width:100%;height:auto;display:block}
@@ -185,6 +278,7 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
   .direction textarea{width:100%;min-height:64px;resize:vertical;background:var(--field);color:var(--ink);border:1px solid var(--line);border-radius:8px;padding:.6rem .7rem;font-family:ui-monospace,Consolas,monospace;font-size:.83rem;line-height:1.5}
   .section-label{font-family:ui-monospace,Consolas,monospace;font-size:.74rem;letter-spacing:.2em;text-transform:uppercase;color:var(--ink-faint);margin:2.6rem 0 .6rem;display:flex;align-items:center;gap:1rem}
   .section-label::after{content:"";flex:1;height:1px;background:var(--line)}
+  .section-label.big{color:var(--amber);font-size:.82rem;margin-top:3.4rem}
   .batch-note{max-width:78ch;color:var(--ink-dim);font-size:.9rem;margin:0 0 1.3rem}
   .gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:.9rem}
   .gallery .cell{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:.9rem}
@@ -204,12 +298,25 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
   .pick input:checked+.pick-dot{border-color:var(--win);background:var(--win);box-shadow:inset 0 0 0 3px var(--panel)}
   .pick input:focus-visible+.pick-dot{outline:2px solid var(--amber);outline-offset:2px}
   .mx-cells{display:grid;grid-template-columns:repeat(var(--cols),1fr);gap:.7rem}
-  .cell{display:flex;flex-direction:column;gap:.4rem}
+  .cell{display:flex;flex-direction:column;gap:.4rem;border-radius:8px;scroll-margin:80px}
+  /* verdict border ring (box-shadow needs no pre-existing border on matrix cells) */
+  .cell.v-keep{box-shadow:0 0 0 2px var(--keep)}
+  .cell.v-maybe{box-shadow:0 0 0 2px var(--maybe)}
+  .cell.v-reroll{box-shadow:0 0 0 2px var(--reroll)}
+  .cell.focused{outline:2px solid var(--amber);outline-offset:2px}
   .stage{background-color:var(--checker-a);background-image:linear-gradient(45deg,var(--checker-b) 25%,transparent 25%),linear-gradient(-45deg,var(--checker-b) 25%,transparent 25%),linear-gradient(45deg,transparent 75%,var(--checker-b) 75%),linear-gradient(-45deg,transparent 75%,var(--checker-b) 75%);background-size:14px 14px;background-position:0 0,0 7px,7px -7px,-7px 0;border:1px solid var(--line);border-radius:8px;padding:.7rem;display:grid;place-items:center;min-height:130px}
   .stage img{width:auto;max-height:150px}
   .stage.pending{color:var(--ink-faint);font-family:ui-monospace,Consolas,monospace;font-size:.7rem;text-align:center}
   .note{width:100%;background:var(--field);color:var(--ink);border:1px solid var(--line);border-radius:6px;padding:.35rem .5rem;font-size:.76rem;font-family:ui-sans-serif,system-ui,sans-serif}
   .note:focus-visible{outline:2px solid var(--amber);outline-offset:1px}
+  /* verdict buttons */
+  .verdict{display:flex;gap:.25rem}
+  .vbtn{flex:1;font-family:ui-monospace,Consolas,monospace;font-size:.62rem;text-transform:uppercase;letter-spacing:.03em;padding:.28rem .1rem;border-radius:5px;border:1px solid var(--line);background:var(--field);color:var(--ink-dim);cursor:pointer;transition:.1s}
+  .vbtn:hover{color:var(--ink);border-color:var(--ink-faint)}
+  .vbtn:focus-visible{outline:2px solid var(--amber);outline-offset:1px}
+  .vbtn.on[data-v="keep"]{background:var(--keep);border-color:var(--keep);color:#12251a}
+  .vbtn.on[data-v="maybe"]{background:var(--maybe);border-color:var(--maybe);color:#2a1e08}
+  .vbtn.on[data-v="reroll"]{background:var(--reroll);border-color:var(--reroll);color:#2a1210}
   /* ladder */
   .ladder-scroll{overflow-x:auto}
   .ladder{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(190px,1fr);gap:.9rem;min-width:min-content}
@@ -217,6 +324,18 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
   .era-idx{position:absolute;top:.6rem;left:.7rem;font-family:ui-monospace,Consolas,monospace;font-size:.7rem;color:var(--amber);border:1px solid var(--line);border-radius:50%;width:1.4rem;height:1.4rem;display:grid;place-items:center;background:var(--ground)}
   .ladder-step h4{margin:.5rem 0 .1rem;font-size:.95rem}
   .era-note{margin:0 0 .5rem;font-size:.76rem;color:var(--ink-dim)}
+  /* sweep */
+  .sweep{display:flex;flex-direction:column;gap:1rem}
+  .sweep-row{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:.9rem;display:grid;grid-template-columns:180px 1fr;gap:.9rem;align-items:start}
+  .sweep-rowhead h4{margin:0 0 .25rem;font-size:.9rem;font-family:ui-monospace,Consolas,monospace;word-break:break-word}
+  .sweep-rowhead p{margin:0;font-size:.75rem;color:var(--ink-dim)}
+  .sweep-rolls{display:grid;grid-template-columns:repeat(var(--cols),minmax(130px,1fr));gap:.7rem}
+  .sweep-cell{position:relative;background:var(--panel-2);border:1px solid var(--line);padding:.6rem}
+  .roll-idx{position:absolute;top:.45rem;left:.5rem;z-index:1;font-family:ui-monospace,Consolas,monospace;font-size:.62rem;color:var(--amber);background:var(--ground);border:1px solid var(--line);border-radius:4px;padding:0 .3rem}
+  /* keyboard legend */
+  .kbd-legend{position:fixed;top:10px;right:10px;z-index:50;display:flex;flex-direction:column;gap:.28rem;background:color-mix(in srgb,var(--panel) 92%,transparent);border:1px solid var(--line);border-radius:9px;padding:.55rem .65rem;font-family:ui-monospace,Consolas,monospace;font-size:.66rem;color:var(--ink-dim);pointer-events:none;box-shadow:0 2px 12px var(--shadow);backdrop-filter:blur(4px)}
+  .kbd-legend b{color:var(--amber);font-weight:400}
+  .kbd-legend kbd{display:inline-block;min-width:1.1em;text-align:center;padding:.05rem .32rem;margin-right:.12rem;border:1px solid var(--line);border-bottom-width:2px;border-radius:4px;background:var(--field);color:var(--ink);font-size:.62rem}
   /* export bar */
   .exportbar{position:sticky;bottom:0;margin:2.5rem -1.4rem -6rem;padding:1rem 1.4rem;background:color-mix(in srgb,var(--ground) 88%,transparent);backdrop-filter:blur(8px);border-top:1px solid var(--line);display:flex;align-items:center;gap:1rem;flex-wrap:wrap}
   .tally{font-family:ui-monospace,Consolas,monospace;font-size:.78rem;color:var(--ink-dim)}
@@ -235,9 +354,16 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
   .modal-body p{margin:0 0 .7rem;color:var(--ink-dim);font-size:.85rem}
   #exporttext{width:100%;min-height:320px;resize:vertical;background:var(--field);color:var(--ink);border:1px solid var(--line);border-radius:8px;padding:.8rem;font-family:ui-monospace,Consolas,monospace;font-size:.76rem;line-height:1.5;white-space:pre}
   footer{margin-top:3rem;padding-top:1.4rem;border-top:1px solid var(--line);color:var(--ink-faint);font-size:.78rem;font-family:ui-monospace,Consolas,monospace}
-  @media (prefers-reduced-motion:reduce){*{transition:none!important}}
-  @media (max-width:760px){.mx-headrow,.mx-row{grid-template-columns:1fr}.mx-headrow .mx-corner,.mx-headrow .mx-col{display:none}.mx-cells{--cols:2!important}}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;scroll-behavior:auto!important}}
+  @media (max-width:760px){.mx-headrow,.mx-row{grid-template-columns:1fr}.mx-headrow .mx-corner,.mx-headrow .mx-col{display:none}.mx-cells{--cols:2!important}.sweep-row{grid-template-columns:1fr}}
+  @media (max-width:640px){.kbd-legend{display:none}}
 </style>
+
+<div class="kbd-legend" aria-hidden="true">
+  <span><kbd>&larr;</kbd><kbd>&rarr;</kbd> move focus</span>
+  <span><b>K</b> keep &middot; <b>M</b> maybe &middot; <b>R</b> re-roll</span>
+  <span><kbd>N</kbd>/<kbd>&crarr;</kbd> note &middot; <kbd>Esc</kbd> back</span>
+</div>
 
 <div class="wrap">
   <p class="eyebrow">P(Doom)1 &middot; art direction &middot; repo tool</p>
@@ -254,6 +380,7 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
 
   <div class="exportbar">
     <div class="tally" id="tally">picks: <b id="ct">0</b></div>
+    <div class="tally" id="vct"></div>
     <div class="spacer"></div>
     <button type="button" class="btn ghost" id="clearbtn">reset</button>
     <button type="button" class="btn" id="exportbtn">Export my picks &rarr;</button>
@@ -271,9 +398,51 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
   "use strict";
   var KEY="pdoom_style_review_v1",DKEY="pdoom_style_dir_global_v1";
   var SEEDED={{VERDICTS}};
-  var st={picks:Object.assign({},SEEDED.picks||{}),notes:Object.assign({},SEEDED.notes||{})};
-  try{var ls=JSON.parse(localStorage.getItem(KEY)||"{}");if(ls.picks)st.picks=Object.assign(st.picks,ls.picks);if(ls.notes)st.notes=Object.assign(st.notes,ls.notes);}catch(e){}
+  var st={
+    picks:Object.assign({},SEEDED.picks||{}),
+    notes:Object.assign({},SEEDED.notes||{}),
+    verdicts:Object.assign({},SEEDED.verdicts||{})
+  };
+  try{var ls=JSON.parse(localStorage.getItem(KEY)||"{}");
+    if(ls.picks)st.picks=Object.assign(st.picks,ls.picks);
+    if(ls.notes)st.notes=Object.assign(st.notes,ls.notes);
+    if(ls.verdicts)st.verdicts=Object.assign(st.verdicts,ls.verdicts);
+  }catch(e){}
   function save(){try{localStorage.setItem(KEY,JSON.stringify(st));}catch(e){}}
+  function reduceMotion(){return window.matchMedia&&matchMedia('(prefers-reduced-motion:reduce)').matches;}
+
+  // ---- verdicts (keep / maybe / re-roll) ----
+  function applyVerdict(c,v){
+    c.classList.remove('v-keep','v-maybe','v-reroll');
+    if(v)c.classList.add('v-'+v);
+    c.querySelectorAll('.vbtn').forEach(function(b){b.classList.toggle('on',b.getAttribute('data-v')===v);});
+  }
+  function setVerdict(c,v){
+    var id=c.getAttribute('data-item');
+    if(st.verdicts[id]===v){delete st.verdicts[id];v=null;}
+    else{st.verdicts[id]=v;}
+    applyVerdict(c,v);save();tally();
+  }
+
+  // ---- keyboard navigation ----
+  var CELLS=[].slice.call(document.querySelectorAll('.cell'));
+  var cur=-1;
+  function setFocus(i,scroll){
+    if(i<0||i>=CELLS.length)return;
+    if(cur>=0&&CELLS[cur])CELLS[cur].classList.remove('focused');
+    cur=i;var c=CELLS[cur];c.classList.add('focused');
+    if(scroll)c.scrollIntoView({behavior:reduceMotion()?'auto':'smooth',block:'nearest',inline:'nearest'});
+  }
+  function move(d){
+    var i=cur<0?0:cur+d;
+    if(i<0)i=0;if(i>=CELLS.length)i=CELLS.length-1;
+    setFocus(i,true);
+  }
+  function focusNote(){
+    if(cur<0)setFocus(0,true);
+    var c=CELLS[cur],n=c&&c.querySelector('.note');
+    if(n){n.focus();if(n.select)n.select();}
+  }
 
   // restore + wire winner radios
   document.querySelectorAll('.mx-row').forEach(function(row){
@@ -288,20 +457,54 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
       tally();
     });
   });
-  // restore + wire notes
-  document.querySelectorAll('.cell').forEach(function(c){
-    var id=c.getAttribute('data-item'),inp=c.querySelector('.note');
-    if(!inp)return;
-    if(st.notes[id])inp.value=st.notes[id];
-    inp.addEventListener('input',function(e){st.notes[id]=e.target.value;if(!e.target.value)delete st.notes[id];save();});
+
+  // restore + wire notes, verdicts, click-to-focus on every review cell
+  CELLS.forEach(function(c,idx){
+    var id=c.getAttribute('data-item');
+    var inp=c.querySelector('.note');
+    if(inp){
+      if(st.notes[id])inp.value=st.notes[id];
+      inp.addEventListener('input',function(e){st.notes[id]=e.target.value;if(!e.target.value)delete st.notes[id];save();});
+    }
+    applyVerdict(c,st.verdicts[id]||null);
+    c.querySelectorAll('.vbtn').forEach(function(btn){
+      btn.addEventListener('click',function(){setFocus(idx,false);setVerdict(c,btn.getAttribute('data-v'));});
+    });
+    c.addEventListener('mousedown',function(){setFocus(idx,false);});
   });
+
+  document.addEventListener('keydown',function(e){
+    var t=e.target,tag=(t.tagName||'').toLowerCase();
+    var typing=tag==='input'||tag==='textarea'||t.isContentEditable;
+    if(typing){ if(e.key==='Escape'){t.blur();e.preventDefault();} return; }  // never fire shortcuts while typing
+    if(e.ctrlKey||e.metaKey||e.altKey)return;
+    var k=e.key;
+    if(k==='ArrowRight'||k==='ArrowDown'){move(1);e.preventDefault();}
+    else if(k==='ArrowLeft'||k==='ArrowUp'){move(-1);e.preventDefault();}
+    else if(k==='k'||k==='K'){if(cur>=0){setVerdict(CELLS[cur],'keep');e.preventDefault();}}
+    else if(k==='m'||k==='M'){if(cur>=0){setVerdict(CELLS[cur],'maybe');e.preventDefault();}}
+    else if(k==='r'||k==='R'){if(cur>=0){setVerdict(CELLS[cur],'reroll');e.preventDefault();}}
+    else if(k==='n'||k==='N'||k==='Enter'){focusNote();e.preventDefault();}
+    else if(k==='Escape'){if(cur>=0){CELLS[cur].classList.remove('focused');cur=-1;}}
+  });
+
   var dir=document.getElementById('styledir');
   try{dir.value=localStorage.getItem(DKEY)||SEEDED.styledir||"";}catch(e){dir.value=SEEDED.styledir||"";}
   dir.addEventListener('input',function(e){try{localStorage.setItem(DKEY,e.target.value);}catch(x){}});
 
-  function tally(){document.getElementById('ct').textContent=Object.keys(st.picks).length;}
+  function tally(){
+    document.getElementById('ct').textContent=Object.keys(st.picks).length;
+    var k=0,m=0,r=0;
+    for(var id in st.verdicts){var v=st.verdicts[id];if(v==='keep')k++;else if(v==='maybe')m++;else if(v==='reroll')r++;}
+    var el=document.getElementById('vct');
+    if(el)el.innerHTML='keep <b>'+k+'</b> / maybe <b>'+m+'</b> / re-roll <b>'+r+'</b>';
+  }
   tally();
 
+  function labelFor(id){
+    var c=document.querySelector('.cell[data-item="'+id.replace(/"/g,'')+'"]');
+    return c?c.getAttribute('data-label'):id;
+  }
   function buildExport(){
     var L=["# P(Doom)1 style review -- Pip's picks",""];
     var sd=(dir.value||"").trim();
@@ -310,12 +513,23 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
     var pk=Object.keys(st.picks);
     L.push(pk.length?pk.map(function(b){return "- "+b+": **"+st.picks[b]+"**";}).join("\n"):"_(none picked)_");
     L.push("");
-    var ns=Object.keys(st.notes);
-    if(ns.length){L.push("## Notes");ns.forEach(function(id){
-      var c=document.querySelector('.cell[data-item="'+id.replace(/"/g,'')+'"]');
-      var label=c?c.getAttribute('data-label'):id;
-      L.push("- "+label+" ("+id+"): "+st.notes[id]);
-    });L.push("");}
+    // verdicts grouped keep / maybe / re-roll (with notes inline)
+    var groups={keep:[],maybe:[],reroll:[]};
+    Object.keys(st.verdicts).forEach(function(id){
+      var v=st.verdicts[id];if(!groups[v])return;
+      var note=st.notes[id]?(" -- "+st.notes[id]):"";
+      groups[v].push("- "+labelFor(id)+" ("+id+")"+note);
+    });
+    var titles={keep:"Keep",maybe:"Maybe",reroll:"Re-roll"};
+    ["keep","maybe","reroll"].forEach(function(g){
+      if(groups[g].length){L.push("## "+titles[g],groups[g].join("\n"),"");}
+    });
+    // any remaining notes not attached to a verdict
+    var extra=Object.keys(st.notes).filter(function(id){return !st.verdicts[id];});
+    if(extra.length){L.push("## Other notes");
+      extra.forEach(function(id){L.push("- "+labelFor(id)+" ("+id+"): "+st.notes[id]);});
+      L.push("");
+    }
     return L.join("\n");
   }
   var dlg=document.getElementById('exportdlg'),txt=document.getElementById('exporttext');
@@ -330,10 +544,11 @@ TEMPLATE = r"""<title>{{TITLE}}</title>
     this.textContent=ok?"copied":"select+copy";var b=this;setTimeout(function(){b.textContent="copy";},1500);
   });
   document.getElementById('clearbtn').addEventListener('click',function(){
-    if(!confirm("Clear all picks and notes?"))return;
-    st={picks:{},notes:{}};save();
+    if(!confirm("Clear all picks, verdicts and notes?"))return;
+    st={picks:{},notes:{},verdicts:{}};save();
     document.querySelectorAll('.mx-row').forEach(function(r){r.classList.remove('won');var rr=r.querySelector('input[type=radio]');if(rr)rr.checked=false;});
     document.querySelectorAll('.note').forEach(function(n){n.value="";});
+    CELLS.forEach(function(c){applyVerdict(c,null);});
     tally();
   });
 })();

--- a/tools/art_review/style_review.html
+++ b/tools/art_review/style_review.html
@@ -11,6 +11,11 @@
     --field:#fffaf0;--shadow:rgba(80,55,20,.18);}}
   :root[data-theme="dark"]{--ground:#17120e;--panel:#211a14;--panel-2:#2b221a;--ink:#ece0cf;--ink-dim:#a9977f;--ink-faint:#6f6250;--amber:#e8a33d;--amber-deep:#c07a1f;--win:#6fae86;--line:#3a2e22;--checker-a:#201811;--checker-b:#180f09;--field:#120d09;--shadow:rgba(0,0,0,.45);}
   :root[data-theme="light"]{--ground:#efe6d6;--panel:#f7efe0;--panel-2:#fbf5e9;--ink:#2b2116;--ink-dim:#6b5b45;--ink-faint:#9a876c;--amber:#b9741a;--amber-deep:#8f5710;--win:#3f8a5c;--line:#ddccb0;--checker-a:#e6dac4;--checker-b:#ded1b8;--field:#fffaf0;--shadow:rgba(80,55,20,.18);}
+  /* verdict colours -- var(--win)/(--amber) are late-bound so they track theme */
+  :root{--keep:var(--win);--maybe:var(--amber);--reroll:#d8695a}
+  @media (prefers-color-scheme:light){:root{--reroll:#c14a3a}}
+  :root[data-theme="dark"]{--reroll:#d8695a}
+  :root[data-theme="light"]{--reroll:#c14a3a}
   *{box-sizing:border-box}
   body{margin:0;background:var(--ground);color:var(--ink);font-family:ui-sans-serif,system-ui,"Segoe UI",Helvetica,Arial,sans-serif;line-height:1.5;-webkit-font-smoothing:antialiased}
   img{image-rendering:pixelated;image-rendering:crisp-edges;max-width:100%;height:auto;display:block}
@@ -24,6 +29,7 @@
   .direction textarea{width:100%;min-height:64px;resize:vertical;background:var(--field);color:var(--ink);border:1px solid var(--line);border-radius:8px;padding:.6rem .7rem;font-family:ui-monospace,Consolas,monospace;font-size:.83rem;line-height:1.5}
   .section-label{font-family:ui-monospace,Consolas,monospace;font-size:.74rem;letter-spacing:.2em;text-transform:uppercase;color:var(--ink-faint);margin:2.6rem 0 .6rem;display:flex;align-items:center;gap:1rem}
   .section-label::after{content:"";flex:1;height:1px;background:var(--line)}
+  .section-label.big{color:var(--amber);font-size:.82rem;margin-top:3.4rem}
   .batch-note{max-width:78ch;color:var(--ink-dim);font-size:.9rem;margin:0 0 1.3rem}
   .gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:.9rem}
   .gallery .cell{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:.9rem}
@@ -43,12 +49,25 @@
   .pick input:checked+.pick-dot{border-color:var(--win);background:var(--win);box-shadow:inset 0 0 0 3px var(--panel)}
   .pick input:focus-visible+.pick-dot{outline:2px solid var(--amber);outline-offset:2px}
   .mx-cells{display:grid;grid-template-columns:repeat(var(--cols),1fr);gap:.7rem}
-  .cell{display:flex;flex-direction:column;gap:.4rem}
+  .cell{display:flex;flex-direction:column;gap:.4rem;border-radius:8px;scroll-margin:80px}
+  /* verdict border ring (box-shadow needs no pre-existing border on matrix cells) */
+  .cell.v-keep{box-shadow:0 0 0 2px var(--keep)}
+  .cell.v-maybe{box-shadow:0 0 0 2px var(--maybe)}
+  .cell.v-reroll{box-shadow:0 0 0 2px var(--reroll)}
+  .cell.focused{outline:2px solid var(--amber);outline-offset:2px}
   .stage{background-color:var(--checker-a);background-image:linear-gradient(45deg,var(--checker-b) 25%,transparent 25%),linear-gradient(-45deg,var(--checker-b) 25%,transparent 25%),linear-gradient(45deg,transparent 75%,var(--checker-b) 75%),linear-gradient(-45deg,transparent 75%,var(--checker-b) 75%);background-size:14px 14px;background-position:0 0,0 7px,7px -7px,-7px 0;border:1px solid var(--line);border-radius:8px;padding:.7rem;display:grid;place-items:center;min-height:130px}
   .stage img{width:auto;max-height:150px}
   .stage.pending{color:var(--ink-faint);font-family:ui-monospace,Consolas,monospace;font-size:.7rem;text-align:center}
   .note{width:100%;background:var(--field);color:var(--ink);border:1px solid var(--line);border-radius:6px;padding:.35rem .5rem;font-size:.76rem;font-family:ui-sans-serif,system-ui,sans-serif}
   .note:focus-visible{outline:2px solid var(--amber);outline-offset:1px}
+  /* verdict buttons */
+  .verdict{display:flex;gap:.25rem}
+  .vbtn{flex:1;font-family:ui-monospace,Consolas,monospace;font-size:.62rem;text-transform:uppercase;letter-spacing:.03em;padding:.28rem .1rem;border-radius:5px;border:1px solid var(--line);background:var(--field);color:var(--ink-dim);cursor:pointer;transition:.1s}
+  .vbtn:hover{color:var(--ink);border-color:var(--ink-faint)}
+  .vbtn:focus-visible{outline:2px solid var(--amber);outline-offset:1px}
+  .vbtn.on[data-v="keep"]{background:var(--keep);border-color:var(--keep);color:#12251a}
+  .vbtn.on[data-v="maybe"]{background:var(--maybe);border-color:var(--maybe);color:#2a1e08}
+  .vbtn.on[data-v="reroll"]{background:var(--reroll);border-color:var(--reroll);color:#2a1210}
   /* ladder */
   .ladder-scroll{overflow-x:auto}
   .ladder{display:grid;grid-auto-flow:column;grid-auto-columns:minmax(190px,1fr);gap:.9rem;min-width:min-content}
@@ -56,6 +75,18 @@
   .era-idx{position:absolute;top:.6rem;left:.7rem;font-family:ui-monospace,Consolas,monospace;font-size:.7rem;color:var(--amber);border:1px solid var(--line);border-radius:50%;width:1.4rem;height:1.4rem;display:grid;place-items:center;background:var(--ground)}
   .ladder-step h4{margin:.5rem 0 .1rem;font-size:.95rem}
   .era-note{margin:0 0 .5rem;font-size:.76rem;color:var(--ink-dim)}
+  /* sweep */
+  .sweep{display:flex;flex-direction:column;gap:1rem}
+  .sweep-row{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:.9rem;display:grid;grid-template-columns:180px 1fr;gap:.9rem;align-items:start}
+  .sweep-rowhead h4{margin:0 0 .25rem;font-size:.9rem;font-family:ui-monospace,Consolas,monospace;word-break:break-word}
+  .sweep-rowhead p{margin:0;font-size:.75rem;color:var(--ink-dim)}
+  .sweep-rolls{display:grid;grid-template-columns:repeat(var(--cols),minmax(130px,1fr));gap:.7rem}
+  .sweep-cell{position:relative;background:var(--panel-2);border:1px solid var(--line);padding:.6rem}
+  .roll-idx{position:absolute;top:.45rem;left:.5rem;z-index:1;font-family:ui-monospace,Consolas,monospace;font-size:.62rem;color:var(--amber);background:var(--ground);border:1px solid var(--line);border-radius:4px;padding:0 .3rem}
+  /* keyboard legend */
+  .kbd-legend{position:fixed;top:10px;right:10px;z-index:50;display:flex;flex-direction:column;gap:.28rem;background:color-mix(in srgb,var(--panel) 92%,transparent);border:1px solid var(--line);border-radius:9px;padding:.55rem .65rem;font-family:ui-monospace,Consolas,monospace;font-size:.66rem;color:var(--ink-dim);pointer-events:none;box-shadow:0 2px 12px var(--shadow);backdrop-filter:blur(4px)}
+  .kbd-legend b{color:var(--amber);font-weight:400}
+  .kbd-legend kbd{display:inline-block;min-width:1.1em;text-align:center;padding:.05rem .32rem;margin-right:.12rem;border:1px solid var(--line);border-bottom-width:2px;border-radius:4px;background:var(--field);color:var(--ink);font-size:.62rem}
   /* export bar */
   .exportbar{position:sticky;bottom:0;margin:2.5rem -1.4rem -6rem;padding:1rem 1.4rem;background:color-mix(in srgb,var(--ground) 88%,transparent);backdrop-filter:blur(8px);border-top:1px solid var(--line);display:flex;align-items:center;gap:1rem;flex-wrap:wrap}
   .tally{font-family:ui-monospace,Consolas,monospace;font-size:.78rem;color:var(--ink-dim)}
@@ -74,9 +105,16 @@
   .modal-body p{margin:0 0 .7rem;color:var(--ink-dim);font-size:.85rem}
   #exporttext{width:100%;min-height:320px;resize:vertical;background:var(--field);color:var(--ink);border:1px solid var(--line);border-radius:8px;padding:.8rem;font-family:ui-monospace,Consolas,monospace;font-size:.76rem;line-height:1.5;white-space:pre}
   footer{margin-top:3rem;padding-top:1.4rem;border-top:1px solid var(--line);color:var(--ink-faint);font-size:.78rem;font-family:ui-monospace,Consolas,monospace}
-  @media (prefers-reduced-motion:reduce){*{transition:none!important}}
-  @media (max-width:760px){.mx-headrow,.mx-row{grid-template-columns:1fr}.mx-headrow .mx-corner,.mx-headrow .mx-col{display:none}.mx-cells{--cols:2!important}}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important;scroll-behavior:auto!important}}
+  @media (max-width:760px){.mx-headrow,.mx-row{grid-template-columns:1fr}.mx-headrow .mx-corner,.mx-headrow .mx-col{display:none}.mx-cells{--cols:2!important}.sweep-row{grid-template-columns:1fr}}
+  @media (max-width:640px){.kbd-legend{display:none}}
 </style>
+
+<div class="kbd-legend" aria-hidden="true">
+  <span><kbd>&larr;</kbd><kbd>&rarr;</kbd> move focus</span>
+  <span><b>K</b> keep &middot; <b>M</b> maybe &middot; <b>R</b> re-roll</span>
+  <span><kbd>N</kbd>/<kbd>&crarr;</kbd> note &middot; <kbd>Esc</kbd> back</span>
+</div>
 
 <div class="wrap">
   <p class="eyebrow">P(Doom)1 &middot; art direction &middot; repo tool</p>
@@ -104,14 +142,29 @@
         <div class="mx-cells" style="--cols:3">
       <div class="cell" data-item="2026-07-16-style-matrix:baseline__desk" data-label="Baseline / Desk">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAAel0lEQVR4nO2deXwUVbbHv91V3Z1OQkgiS0JCCGEn7JuCIuDgCIIrMiAKAoqMsvgEl3HeMOJjRkdc2QREHQcVcRjFAX0iKovggLLIFnYSloQkrFm7011V3e+PSlXv2QiB5OX3+eSTrqpb1bfq/M6555x76jbUox71qEc96lGPetSjHvWoRz3qUY961KMe9aj7MFzrDtRGRFu7uv33yS4ZgCJHWq16prWqszWBoaNn+wjXoDhwCxb9M0C/0WODnrtt7Tds/vSDWkUC8Vp3oCZx+5hXdeFKTt9jJrP6XwYGjLirzOv8Z/2vQfe7DFFX1L9rgTpHgDtHvuDWNBY8GmxQHPTzE6xDcflsWwSjvn/XD3tDfodJdNDt6PKA/buSR15J168Jah0BIi2p7l53jQt5vN/osrV3x4btSLIl6LF+mR8AYAH6ldOP52a19Nn+65wMZNlczlnXH2oVAaKtXd3dho0hrEEstwy/GfBosUUw4lBcIc2zBpMIvdOXBe43CwA8u/AOfZ/hzKHq6vp1i1pFAM3THvS737Dxnz9gNIcHtNG0uCw8++6dFfo+d/MO+ue6SoZaRQCAozt+IqxBLODRZE17NTz3fFLI872FWhlo59U1ItQ6AlisVp/t//Ybi0OhqoIPdp26RIJaR4DKQLG2xdhIKL9hJVGXSFCrCCAafbsrGU1lti9L+IbGN4U85j6/vdy+1BUS1CoCVAahTH5ZgvdvUx4R6gIJ6hwByhrrgwnfX8jebSpKhNoM47XuQGWghYFVgb/w3ee3BxVssP1lDhfV5FxeK9QqAvj7AP6oqNmv0Bhfh7XeG7WKAFWxAFURfkWuU1dQZ3yAYNp/pcJ3n99+VQQfqp7gWkwj1xkClIdgwq8u61AWIi2pAcK+MLwbstOBaPadlGr0leiuaSL8vyHA1UJZYWCkJdW9/abutJt/KwDKG78g2iWAAOGDSgyAhG8M7mLJXSNEqFU+wPUG6YSt3DbnS0rY+vh6AMQ/Dq7QdU98+QA5X48Maj2qG/UWoAyUN/6bzafKvcaa0+fVD4+vp/8/HoA5Q5Ff/h7RLiFbTQgz++htNaLw3wcAWNutA3ftwX01LUE9AUpRbtbvCv2DNafPs2bQYl4Y2IyYPwzCDQh4Cf0a4f8NAQyNbwoQYllC9db+oA5kFVPAr2w6y4OnN1IsSwHHpjl95y4WmJUqfUdlUGcIYDhzKCAU9A/jgpEg6LVqIOb3FzZAUusU/fPp4+lXvQ9QhwgQCsFIoO33R0XmCqD6ikK8BR4MBfZq+ZoyUecJAMETOhXR8oA5gWqe+aspLS8LdYoAwYYBDd7CLE/4V1PrvZGUeIP+Oeu8g27PP6dv7/qfP1f79wVDnSIAlE0CDZX16EMJ/69zMoDAmsSK4pOnc/XPt//Rgm31pxQ54cyRmqsxqHMEAI/ArnSqNmu/jRVLtwQ9ZpON7E58yGff9pULEY1i0Fx/MOx5wSu8N0DG0aMACJZIFEcRl0uqPv1dUdRJAmjw1tzyyGDMzePVOT8DIDk94dfPfkLWIIpOti5/W9/u/8k6+g4bEtBu2UNDeDg2BiuBVmKG0/N+2rftTUTZVN4UhNu47XCZ3a021CoC+NcDmFyBsXQoGM4cYsH8swDY7YGaZZON7G42GqM5HJfTN8W7feXCgPbapE2kJdU9bM123r85eH3iyE/WsXLscCZER/v2HTsjlnreJXwX+M9rzUsvDsX2+jAwALJLRjCFldtOG5s1aGP01iaj1R0NAs8R3AVsXfF20OuFSsVqufozxesZk9acMdGJAKzIy9TbpG1dE7SOQcLKqukWFEeR116P0COsUFzsCjivulGrCCAaRRSpRN82mQXmvnpa37bJ6tyWNjYH0+atK94OWllUkWlY77FddskMjLeyKdsTrHsLviLYYLxIuCjTX4iixKEOO1pu4ND+dOySS//ePPveqzIfUKsIkGffa5AzZDdAu76DPRrtB39N9hZspCXV3ah1N/1YYruOAOxcu9xn9k07x3vfLU29zbznc+4vJ2h0X/OAfuz5dI3+2Y4S4AcMsFvYbIUmCS0ANS+g5QYirIC6HAFfjG7B3SvU+67uiaErIkC0tatbdsmq5zs+nuzN6cQPSOHCB2f0NtXd4SJHmkE8Jbq3nwruJQXTZK2fwdB7yG3s2bABgAEPTtT3b/70A7doFP2EHgSdDcRHJ5G2ehOp9w3Ud6et3kTH+27n4OrvEI0iH1+6zMOxMQGnD7BbEM6cY2xuLsVu30ULikv/OwRYNbYVACM/wi0aRarLIlSJAJpWbEtty6z8U9w/MJ4Jm1WPO3tzOodWjWHLp9sYPH4Q7e7+qNqZW9Gb1/rZqHU3feg4n3GgQt/x9EefAfDW2FEMjLeGbrjfDQ9Am6E3krZ6k767zdAbAbi0eDUPxzcly2FnZV4ho6NVB+SDcHW4+iBdVZbZly4HvbwmeO9tSTAy5sPqsQiVPjnSkup+/Y5mFJuNbPqpgC156hgru2SkVqpX3uKs+tZurMvIE8MaY3cLPLP6VJU7G6owoqzrRVpS3XFtewU9Ziu4THiUqo1hEQ1I7tyB7rcPCGinvXL+1thRDEmKAKCkdFwe2VfN4k35IpNGE5vT7PZJ+nlRNzQCYN/y9RR8/CVrxqhC/Mv6s+y+5Bu5aBZ0+ajmmMTQ9TlS6eIVS842w2IRcThkPlwwjbYd1GGwqhahUhYg0pLqntg9low8iUU/q4UOg2LVUGbjpQK9XWKESITLxMZLBUz5IpOB8VZyvh5J3LDKFTdEWlLdr9/XgjH/NQCj4KuFb8/+N3/7Xr1eMII0btkp4Hp97rtP/9yqU+uA494rhAAc3HuUtPVrAVg8MlJv53BZsBgdmAQD9jua8YcPs3E6d5d7P3/6bTMATLKnu5KoPg5HiGTikpxYJEM4JrcNyRDOhwumoRhLn4XLztFDK5n8zGK+WytXqXCkUidoAvnDv7PoHx1OsVHSGS27ZOhsQLI5sWaoHewf7Xl/f16DG2i+6m5i+syrkCWItKS6/3V/Fwa/eA+39JkbcHzr5jHM++t3vLg2M8BEb8q2E9e2F+16diGyUTwAQnjgWgLgIYJFMPL4TZ64XFFkbrv/FQDO7N9K5nNx+rESBMJQvXZJceOU3LSbfw7w5Co0zf5idIug3+tPAo0AkuxiSXFn/dj7b0zGYlR9g6jzqlNZIptx2ov1NnLSvQB07jSSytYSVpoAi+5PZMSMYcTdshSAPo3Uh//LBU84pO3bfUnSY+C87RP45ztbeHz58QoTIG/vrKDCB7hkdLH7u4l6P7xJsCnb7mMBWrRKZvDER3zOdygupt0cDajCBnhz/XnWv7fEp92JX7dz+OkkXeNLSj35MBQkJXTGNyMvghxFwKS4sFSgrsObAC/uNdKsSUMWL3gBU1g4jS/+K6B9QaGEaDYiO1VrJSfdS4nTzbQZc/nhux0VJkGlCTAkKYK+XWOYMH0gACl3rFQ74OVla1qQ1i8Vq8VK1F87sPqtTRzILuKNH8+X2zlLx7Zu0wkTy25vxcjXxzD6rjdRuvrO4K36Sz/s0z+n1fadnLipF/GbDwaQANShICwyGgDJUYI/2qSq6wucPJ6NIJpQZAmzqN7LiV/VSaPjzyUgKDKKIKKUqBbPbDIw/uwwAFwlhez+6l/sfbqZbhlAtRTp9iheO9kMhyHC9x7dxTwefVInh/8Q8EVaEWv2n2P/gVUAxF7+OuizspXmD2SnC9FspLjZKASXvcK+QaUJoH2e2D2Wni3DGUos4TP6BrS1mNWMncESxf++tZJ3v81kU7Y9ICb3PifcYiM/0cS8Lq15ZvUpHo6NoVtvK4/OCVx9S/nzBiS752GbrAKN1u0PSgINoZxCgDCxhJMHfSOEw08nIZoUhFILMeH8CNxeiSg5Q507+PAj1Up17TSIfU+18SHBI782Z8Gb6jRvmFm99RKnetsPPfQsL7dX/Y4iS6AoThXJ/G1DHtt2rsBidNLg4iYMrgKfNhoB9D45Xbo1WDRrDkvXHCwzyVWlKGBIUgTrTqtj0MxbGyMZTSTFmCiWfTtjt8scOm3n6+PF3NLUxKZsu08W7tOHPOOjJLsY+Ys6G/Zxr7ZM+CyDSbGqN33n+BaIG9Roo2+c53zJrtB8y1Fkl8yFIZ1ptG6/z1j90zGZxdvVftokfDxwbYz2/p85pRlSmHoPDpeFx090w1ia3gWIik+gePeXyJKCaBJY8s5sAKY/NYc3Xp1JnmRicN/fsvvJ9kSa1HE7cW4OUXGt6N6+IaJJYNnC532eUdsOo1k/IYmLzkBRFDldXHS6eGb1KUaPHcqSZ1QClxSeI0x0IskSJtGEJEtIim8EISfeh8Nl5skZb3ILR3hxbWZQElSZABrWnS7WH2AoeKdM/eNaDZLsm/ce86lKADsKWMyMaqquC+RNgBY/HGD7zPZ0/tshsgd0JH7zQQ4/naQ//GBjtMPleSFD026npLabnPcAAILZY0Xk4xt9zn9v2RxAFTqAzeYkPFxdHm7RW89Q4nTTq9cw0qa2xCQYSJybQ3LHTjw7rKF+jaGPPQ3A7k/m8cD/bGHNmFZBo4CRH53w2fZWnsy19yE0tBB2+RDFxhScZgui2UhJ3N1qA1MDRtw7GYBne6jJrHHLMwKswRWngj1kCL723phB6lCw6R929UZDXEeLgSXZhaOUC3bNlDqcIc6Cm944zIUhHq/ZYnSg8dokqP8lxY0iiLopF00KsiQw8XBPXJEpiKJ6fSF7R8D1/TX990+qn2VJQS5xENesEXNemoopLJwppaQ4fPBb2ne8g31PtSFjZlPavHWY1yz9EbATpeRgP/cSAMktohGNIg5Bve9xn3kyqLJLpnnnW0Led9ywVYhGkfRjq/R9xS4zHdrdo58/sXssg9s3BIeMSTSyfFRzsIiMWy7qcwtXbAHKwl29YhjzVE/WfrCVcf+4GJLp3lj0vTpluynb7pM6HZWkmnZvC+CNRuv2c2R6E4Qwle1hKLrHDvDoGXX9P6dTxmxWrxETHc7lQ//R23hr9/x5swB4bNIsRJN6HW8izJ83iz88P5e8Qs9kk3b890/OZtnC5+nU5U6OPpWCpLhp+YZa/ZPcfRACdt3B9EZZAveH5CjhwvE9+rY2lC0b2RxLGe97fX84H4APfr2kptUr8mVl5dKDtm9g5p5+Ivjpe0WFXxGIZguNvtqD7JKJMBnImNkURVBvR3PCZElg8q+qH/GXzasxf/oazgefZfZgNfYvvOAr9McmqUIXTYKu6X//4BWmTH2RRQtfYsLEF3Qy/P7J2Sx48zlMYeGqwJf+hSlTXwTAbBKYNPVVDhzaQtsO/dkysQ27nkjgxqW5ZO5VK4wqI2xvnD99Uv8c3qQFtnPq20l/H9XSR/CaFbUY4ad07yln+PG4J4cQlAD+3vk/J3qyZve/V3apyiN3BCZcTGajPn5ZlOBEeO2bs4R7zbsMjLfycXbwCRSA6DU7yZjZVI/Nvd1PTfM7zTvLzaMGI2f8zKRuSTRd8g7yjc1YVuqVz3z+DR9tB4/A58+bxfSn5jBp8p8AmDL1RRYveIFpM+b6aLoGrZ12DGDCxBf4ftt6eva4F6ic0L0FHQpOu4OYFu25fOqwLnyHC7YczdfbpOfYuWj39YV6t4nm+G7VIgWdNfvisfYoDtVjFiwm5n/teQduU7adsoYAfwIMebifzxAAwQkgyS7e3ZQTsN8/ctBz5+PU+P3WJoUAPuZeQ/vXc2nRtRfJPW9Gcdpxn97Oe8vm6A7cooUvYTEqjJv0Ikvemc30p+bglFQqmU0Cb7w6E1NYONOfmsOihS/pGg7glBTMJoFFC9XxXFFkH0IAKPG92bT8HQA69L+HoryLIZ8bVEzowdA4KZkz+7cyOlVVlvTcEuxemcbeLcOxOd2Emw3YSkPQlWmXKXKkGXxi8ln94ujfM4aiUsZ4C15DdRAAAkmgRQH+JLBJ+FiG6cN8U6vdG6qzaKYSgUkZSdhsqkP3Yc8sHC4L7d9SC0YGjnsSAOuF3Sx66xkApjz9OksXPM/kaa+q91tqCbSwbtoM3yykt3ZLJTamzZirh4SypCC2HqQfV5xq1LNp+Tt06K86Zt4EqKqwQ6EkP5PO0arDnZrgiWI0oafnlvhka7VIwIcAnaPDSE2wMvG2OP706UmfB++NskgQbAiQnC7G/eMiq8a28kmLlucTaBAswTuyODcBhyECi7sYhyGC999Qw54nZ7yJwyHzp3bnSBKL6TTvLLJLJrn7IFJv6UfR/m8QTQJ/X/JHXfiahmuabbM5fSIAUE2+2STglBRd4IrTjmC26v+7DOhDSekrPYunjK8R4YNKAG8LoAnbe26izDxApCXVPTo1hrQsO1bRwO96xvDVvuBz1Ftz1Rx/MBL4E0Byuvj9yjO892BXPS/uEEL7AsGgEeDt0031WTGADxdM82knnv7SJxaeNPVVlnZXHcv8Qui5OItW3W8isX1HXCWFmItO+ph+udT8a46ht0nXjnlrOUCXAerr3drUMag1BBr8Tf/VED6oBPAXcKQl1a1lRv2zsBp8CNCnkZWUpmGkZans6d0ynPSc0C+oBSOCNwEe+/ACDkVg+biWmJTyCxwX5HqybtOaqvV1kuxiaXYMMR368dqMofpxwaX2q8H5L4Neyx4/AofLzKNT5rKoxzkipUv6rF3jlp3o8ps7CLOG6dbAX9N1tLjV57ph1jA69+2mb29ft5GtH7+rb8sumSPTm9Bu/rkAp+9qCR+CE+CBNn10R2Dd6eKKZQL7Nu3pTmmiJnXSzzmwigZu69aQ7Wn5/k11+OfcNax4sGXIIgdJdvH+hUY++7SwCtT4e3JyIThkxn12BougsOfgVwguO+Hnv0OgGJNowm2M4lzOJZo2Eck9p4aqsbHqfRc2vheACZNf5v0+uYShkFso0HNxFgC9Bg+nYXI75OMb9fDObBJwNrtZ71PEDbF07NpW33YoLhY88pCe+ZzVL46HbjRjUNQ5AiHMROu56vW9CXA1hQ9lE6BVfDiLfg4+CRcyEdS3aU93aoJVHxIeuzOBglwbFxRXmWR4fGBcUKFLgpElZ5tBWEMsbjUOXfr6Ez5twnJK57vj7kYUBR5+4m1+3+wsOGS+P5zPZwcus+fgV1iMTqzZn+vnmRqoEYHbUUBh/kWimrQEeyY2h6IPB1Oefp3ZHRXCxSKsrgKUEol288/pJND74KfhW7/6SX8vQBO6Fn5qqWYt41iCgCwJtH/rdI1qP4QmwOAOagr6mW/PVn4u4LaEXu5Oza3syFCzXVbRwLNDmwXk7YNBI4G3Wf9wwTRE0TPwi5mrMQpW8i95smkNGqpd0iYzxo99jintnVwusJN+wcGSbRfKJAF4iKAjZQSyrDBh8ssAvN9HjYE1Yd362wH0Gz8VQC8B84Y2HQygCKJPllHbr5HgsZWFrDtdXKPaD1eJAADdGvVw90pSzXJalp2UJhYevlE13eURYWl2DOYGMSx9/QlEUcCcvQ6Xog4XhflumrZIBlSBGVwFYE1EKlRf6pAUI3KiWsI19tE5TE4uxKS42H6qQCeBIIg0OPuR3j48OrD6xpbnCWWLm43CYnQyedqrLOh0hjAUiktcpC68BHg0PPO5OCTFrQs1GEoQEBSZ17d6nsGOE0W6911nCAAqCWItRlKahrHztA2rYOC3XRrQMyGyzPMcLpjwWYbPpIWYudqnTXh0Cw8BALcxCrv9MibBpZNA097JyYU47DIHsotYsu0CAIcOfwHpn2O1gmhWCzW958y1YUAUBRwuM9MmzcBOBJ/0UaODYDOG2sSRdwWQtv3n7zwTU2cvOth33rPdu3k4/z6aX+PmH64yATTcltDL7R0lpDSxMKpnbLnn/ZRexKKfz3Ps2NdYjE4fSwBgtcboQrM5FMKjW+iWAFSPHqBHj/G8fE9jYtyq0L45cJnPDlzm6LGvCT+1VG9fmDhe/ywbwmnbWq3csQgK0wY0ZWoP3/751/gBevXP/J89BNlxokjPsNkVN1bB4JN0sUuu64oAw5N7uYd3UXMDoQhQqengDVk7DXbZN0pY/tM5xt3cpMzzbk5RLUW3jsPVEqf4IVizP9eLGOz2y7r5NskZSIUZXLpkoGkTEUmWsGZ/jj1+BL/88r5uCUyKS53qBNq2GcbRY56SKdklkJJyB6JRxCIozBqWQN9ktR4/xVoAXsI2CQa9vm/hDu8hzUnaSRtZBb5FLt4C15CWZWdb7q6AN4ng2gm/oqh0PcC23F2Gbbm+UcIr32TTu2W4LpBg6JWskqBTlzvZe2AjxI/Qq1xBHau9x/DYWLde8VJQKGFP+4KmLZJ5b5k6J/9oQh4mYHD7hiRYzSQke34JTDSKrBjfhjAvhzNJLNYLRbyxcLf6OrhkNLFxX2B007ulb2LL5nT7CLy2o8oFIdtydxnsiuogpmXZ2ZFhw+Z0c3eX6KDtLUaVBJmX4+naaRAH9v0vBY3v1klgElxgz9RLnJR8B06zBcVZhLlhLKQM4ZJXydnSkw2Y2jwfk2ikS6sIVrTwRAEm0QiKC7wIYFBKKFbwMekA3x4swOrl7GkTJ+DJo9clgfvjiiqC9lzYbbAKqiUA1RSm55bwxG/ighYlWIxwb/dYbogQSGn3AAf3rwIvEmgwiSacqWOQXQKCUcHhEvRxXKt0Gdopxu+cwC9UHBJbzthR7BI/AD8eKQxoo0U44WaPfNNzS9iQtbPGBd7p1tv0zwd+3FDh88r7HYUyz63ymaUINiS8+W02t7ZrQK/kyKBE6N+2IVazQO8ev+PQ4S8oaHw35sMrsLcfgVD6u7+K4qBz+/spLq3Xe+muRNpEqnMCQRNNsguTaOSbA575iwNn7D7TolD+GH4liLSkuqta6OEtfIARf57NJzMfI6xhYogzqgfV9nq4+gB7ujulNORAej4/Hikk87IzIErQCKE5hkmt7uPYsa8RUieQknK33m5y7xjG92ikt/NcQERyqPH6riy10qWktPBox4kiLjlcukn3H781HDhjrxENr6wD2HuISoId6zaw9rVXKnSOXJhzRW8KV+v6ABoJvIeEdzfl8MitwYeEm1MiadBAoFvH4QAsH9caHMFLzxwu2HnSU9qUedlJ+rnAEtNbW/vOUKbn2MkscrHnwu7regzfuXY5R3f8pG8X5Jwoo7UHV/I7SnAVFojwHhJ6twxnR4aNxT/khPQLujS2suyBZHXDT/j+Gh5sDE9NsOrjt91gArdUYxpeF3DVVgjRooRbW0ewI8NWrl8AnopVq1kg7XQRF+1uPeGiIdgYviPDVuu99MYtO+Gw+86qXu3xH67yEjF7Luw2xFp66c7hj0cKCbNAz4RIHC44clG94XMX1fhcm3TS4D2G25xuDBYz1jqq4YIpjLadehARKfLTZ8srJHy5MOeKF4i46msEadlDjQT//rWArIuqqd95unSWMYSG25xuci6VXPdjeKQl1e3/dlRVM4C/btxcTb2qGGpkkSjNLxie3MsdF2vV5xKsgiGop14bNNx7xbD4VPXN5ey06vnRKdkl19jqXTW6SthXJ3cabpN6ub2zbTanm/d2b72uhQ2+OX7RKOpC98aVeuSVwZWGfxpqfJm4DVk7DbHhfdwVean0WkMTuiZwbf0AQfRUKStBfvmjKtCWq9O+ryzEpbQhc2/gOxT+CDOV/5tg12SdQO3V8h6xJsDEhqxr0YvQ0MZ0by3XhO5PAu1/dRGhPDROSiZz75Zru0zclcJ7EQdbzTy3CiPa2tWd2LV/0GOa4L0tgDdEo8iZ/Vur/N6fhlA+gNlq4cz+rVeU+/fHNV8pNNTLJ9cr/IcADYJo0oez6qwBKMlXy+NFo0hJfuV+VVRb0k47Pxiu6Q9HatUq1xNkl0zWkX1Bj5Wl/VD1N379oQo7k5L8TJK7D9KFdzV+P/CaEWB4lxisEdfnD5fGtepATvqxSo/rGjk0ra0qtNfYkrurbyEldu1/1Zzl61MC1xjnT5+kcVIyOScOochSpYigWYFQJJALc5ALc3QN1/7KQk76sYp3vpK4Zj7A9ar9RY40A/m4z5+GhHZdyDqyD8FkJS6lTYXOF0STToIz+7cGHNeOadFEqHYatO+/UoSyINfcCbweoZEgJx2im8YTEd2YrCP7SGjXpULna8LVTLg3/EPIUNbFGhlFxr5dCCYrDWKjr3hYCYV6AoSARoKS/EwKGyZyQ2JLso7swxoVTcPG8WU6g0C5x6Hs3MHxXVt1zT+fceCq/ZR8PQHKgP7Q83HnATcktuRiZgb2grwKW4Ng8BZ8zolDQUM0a1Q0tnOnKvRLJqFw3WYCaxs0a2CzWrBGRWMvyNNDxaoQIeeE+tsKgsmKNSqaAlvg0jEFOSeuWOu98wChUE+ACqLIkWYgBzdAVJxnqZvK+AY56cdQJDvWqGh9n70gL/T31QDqCVAJ6ELxIoI1KtonTFMke0ivvUFsNA67pcL1fjWB/wO3cBnch36e4QAAAABJRU5ErkJggg==" alt="Baseline / Desk"></div>
+        <div class="verdict" role="group" aria-label="Verdict for Baseline / Desk">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Baseline / Desk">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:baseline__monitor" data-label="Baseline / Monitor">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAFJUlEQVR4nO2cz2sUSRTHv72d2ctcNBBCYth1Dln66GUVFsGTKCLoaY8eBM/+QYJnT0sW9iq4CIHNwuJxMAcjSEII5CC4HuIwHuIbyuqq7q7qqlfVk/cBCdPTP8bv+1HVr34AgiAIgiAIgiAIgiAIgiAIF4Ei9Q/Iicm4mjd9/+7TNLheK6FvmAttYpp4dOceVkYj43f/f/6IFy8xD22EQUSAq5iP7z/wes7uP//Wjs1m54/ePz1aHAtpBLYI8PFIoskzbZCYs9kcZVks/tpQv287dzKugkUCSwSQ+D5CAudiTk8OUa1tdr6GPNeEKq5JbNVohBoBRAgjRDfAZFzNKSWYQpzQhWjyQhKmzaNt6OKq97JdZzIA0N8IP/S52AVV/NlsXvtHx+mvSST1XNt99HNM2L5vu85En9QKRG4DJuNq/ujOvZr4TZiM0YbNO315fP8BXu/uBb2nDdZuqEnMsiwwPTnk/BkLtlc3ammM+7ckeQ/w9djt1Q0A+K5X45M2dFwb+JCwG4DEV73PR4CyLHDj6c3F54P3BwCAqz9fbbyOzlNZxxb+fra3MDAnbAZQPbVa26x9BoD1h1ud76cL3SZ8G7eeXMfxzode9/AhWSmiLAsnwQGzyAfvDzqLb/J+G6HSWxssBjC9zvcV30VMn/M5xAcSREC1ttkr1QDd8716rgtfzs4A8ERBNAPQG3DT228bTV7v09h2hcolpsgNDVsENJUNdPp6vS8kuEsE9C1FJOkFNWHzehfhfb3fVJSLTfRaUFtpV8UmMof4Kj4VW+9nxX5A14asr+eHED4FyYckQ+T70OJTG8BBdAPYvN8mbqwXq1xhiwC1K5eql9OVP16+wtblSwDiN8RsAzJd4G5sbfx+9zYAnl5Q8kY4db7XoQGkQZciTCNhOpz9+y4c73zA9OQQ13Et2jNMJOkFuTS06jXLSFZtgA1u8bnSD8D0JqyTS9qx4VK36gtrCnIZdkydcrgGZNhTkDqOayO1+CoxS9EAUwS4hHQq8fUJX1xEi4CV0chpchWQj+d3dZgQc0OjGcC1oJWL+MCSRIALOYnPTdJy9EUWnmCJAOpJcIa2K5x9fxXWCKD/ZI6en8o5okXA3n9vjF6Vo/gpCW4Amg9kWyiRYv6lK5zpKFoElGWRZJqHDymdIlobYJqOsliMsXP+2XV+aEh00dWSA6ejRG2EdSPo6wByTUdchTggsgH2T49qix5SLUfqAufaMCKaAcqyWIjvu3Kdmz4TiX1heQ/QB7lNK9dNn12xpY4uK+UJU9TGJIoBvpyd1cq76kJoU5U0RNevbf1vF6NyrxOL0uH96ccr82r9l9pxzsbNB5P3x1ohT0R5D7h95RKmx29rx3MWvyyL73poZVlEHw0DmPaKiP0MbkJuVzOI/YKIHIx5ITds0glliBhbkLmSxYjYRWaQBsjBc0MxSAMAy2OEwRpgWRi8AVLscBKSwRpA7Qltr24M1hBZ5lGXbibtO2SqK7mWvlO0K8kM0CSyvp+QCbVMYPJ+MkqockIs47AbgIQ37demYtpW0rZ5hm6ALnt++hDDCKwGoLVjK6MRXu/utQrTlNd900xfBl2KmIyrOVUcf7vxq/W853/9aTweY2M900BNk1GXxgBNI1RNxglNl0hUCW0A9sm5JPz+6ZHVoznHZlPNCSVYDfDNexaNsG3/5i64bIPTdp+UJJmerhrCRFOuJ+FDeW5T+uF4Lxj8i1gIlqWwJwiCIAiCIAiCIAiCIAiCkC9fAXkF5zl9TFVxAAAAAElFTkSuQmCC" alt="Baseline / Monitor"></div>
+        <div class="verdict" role="group" aria-label="Verdict for Baseline / Monitor">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Baseline / Monitor">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:baseline__character" data-label="Baseline / Character">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFwAAABcCAYAAADj79JYAAAKSUlEQVR42u2cfWxV5R3HP+c559yX3lbbwmprO2ItYEGsCkwCtqVdWTI3kUzjy4wJCcGQGAxjS4y6v+cSsoQYWaLRkC1BB2vMxiarSUHaUmUwBQUyS6ErUZoOhLZwe1/P2/443NN7em+hvvxxWJ5v0vSe55zn5Nzv+T3f5/t7nuc+ICEhISEhISEhISEhISHxXUIJ+gOqYc2ZXqZbGqpiIjQd2zR85xKGqUjCvwFiuuYITWepfSsAYQQAGWwAPjIvskqrKjh3Wr9KStO4MnE1kN9NC+JD6apwlou5hG3hlWWwCSM4T4IvzIRXHkZ45wCajHIyhk1/OOlYmeBFuwjaA1VX1DnztJh3fN/Gtb7z5YRZv3ilL7Jz/1dsXOcdNzNXSspspWRjx4/59ODHAJwnQUK3uJxKu5quhHhm0TL+NHCEahH1RXuZonOPWgHAgoUN7Bk6RTx5RZGSMgPKolFnw+oOwg21LBgZ5/jgaR5uX817B3u5S6vy5COHOmLU5bWG3Pn72pcDsKG2hZ29B5x4KqVISSna3kIAjPWd4vjgaa/44fbVPlL/+O/DZO0p3Qa4r305i9qXAtB/8J8F95SSUiS6c44khxUb15EZGgHgrQPvk7VtyhSduONaQVsT3Gqp1KtlTJDxXsx7B3tpoAyAy2Q5G80GxrUEhnBdFU6TVgnACXOMdq3ak4fEyDh/GjjCa08/VLTu8+90sVzM9dnDk9a4p+fHxBWCIiuBkZSQEJSiMSgSnr/O4b3h4zOSDfDa0w9xWr/qRTTAPWoFR6yJwLmUwNnCfIQR7On/gFce67jhta881sEQceYQCvJXCg7hWdv2EQ3QZ43NiuwcHtv4NEPEvWPLycpMc8Yxk2tuwjAcUF0dtpwsm3btIySETz7ysWnPQVTTRFVM76U1aGVF3E9KEl4MJbhjVf1c4oVli1mwqP6617/xZLvv+Mznw2z7bIAOqggJ4bOOkvAiMHRBxrYRpk2y8g627u0lmb4mN0aSkrJStq9z7d+Wzj5i4TISmThp22JOtJxXHrkfPhvwJUgESFoCR3jaUb3PO3sPIMI6o19dAqCmvAQ7YxTUGb5wAYAlNZVs+fP+PA3X/MRLwv04T8KTiI927SNpG1z4cpxtd7m6PTqRpOH7U5YxJgxOfXGWF1d1UHk5xKnRMeqrXO+9/qkfsB547u1udBGc4ZRACdyIZXgRqiohIjcIzpTmxsvtQxeJTJx3s0/TQJhuxa17e1EVU0b4TCiPCBLW1ARPWsC2F7ew+e1fuJIxb76n3wDb161mybz5HN33e/b/4S3+tvlxsrbtuZpkfJImrZJBEnIsZToiWsRpVSsZIs6lqIKdMXj1iTVs2rWPSCjsWjsny6tPrPHV27q3l8xklnBpyHsJz7/ThdBjVFk2dcQCldoHJsItJ0sGl6BzqUvolsaZz4d545mfFlx75vNhABYsqvdFvK/ztS3qKJWZ5o0Sn2Piijdbs+PkUNFrFyyqn9Gfb93bS1rAKqeUI9ZE4Hx4YMdSDNUknc3wm909vvKB7kkGuic51znAuc4B37mX3z3AZCrpK5O28DqSkp/agzvenXMuOe1u/FFOJhoLyJ5I217d6eMyMsJnkJTpJBmqSdI2eHZ314x1n93dxVdGFkM1A0t0IF3KCrXcI6vPGvMRCO4CoFpVJ6FbXlk8k/XZyBw6qPKWTxwW49KlFMMkJqW46Xg+2blExiLLE/fO99XZfuzs1DCsKFzHEjQND1S7K0XzZmlyJEdsdzaou2YZISE8h5L7K8FhR2yBd22+pHxsXZYafqNO09KmGt2B791PWsC+2+7ng7GJovUqVFf7u2uWAdDMXJqZSwbbm2yWhBeBrbmP0u7cwkfmReZEIyy+O8YdRFl8d4zNLbW+xCeX/JQT5mcra1h8d4wHRRWdbY2ctMY5Yk2wSquStnC2OPHgAx6hNT39jLY1Uy2ibOns84Zj6yrKyXW0D/WcoqttievVO1ZSu7/Pk5akbcgInwn5Efl4zwCDqsFoWzNNHx7lcNsyYmKKvBIcOtsaaTp6lq62JTQcOs7Knk8K7lcidBnhBRqeMZWT2rhTr/rnI/Vs2ov4mp5+SoTOthe3uB5dFzQdPcuJB1znks7EadCqfa5nRE8Sn5RL3Yqn87r7OJFQGIDOtkavDGC0rdkvD0rIIxtcN7OrbaH3GSBh64FqwYEiPJ5KKYOqwVDrCgBW9nxCle1vhL9W69n++ptsf/1NfpcXza7T0Xi8xx1fGf5hM8NWPHCrZwOn4bYxNVnwQvh2xq0sfzk86pVtbqklJASRkOtO8lGCw+ppkhQ0BM6lhPMmkUfMKS+dT7rlaGAa7Dg0Qq2Wl10qVsGx9OGz1HGPYL2EX6b84+LvV99Doyj3kftS8hyWozFi2l7d/NVckvAiKItGHRGe6uR+mxlCNU1+pRdONkyQ8R1vDs1DVUy2Zb8suKeUlOvgzIqlBSl/rSYK9JoefGU7Do0gNJ2wMRXVI2taafrwaN5qQxnh/g7TnH1GmD9EC1Cria9VXxI+DS8lz6EqId/ERA41Pf2+cfDpfcBzmSFJ+NdO8RULQ3VXxU6Xk9G2Zp+b8RFuODLCvwlu5DDyM1CY0nNDNX3j4vkLi2SnWYTk2v192JqYMRJq9/fRXbOsqF5bjkbENj3ZAQI1cBU4wkNCeAvun93dhW5plJXNpbb3YyKKRdI2GF3T6l58ofBFRMJl2IZJWsCbT7n3efndA4FyKYFCTNecnevXOreW3+LsXL/Wqa6ocxoWPuo0LHzUiemaE9EiTkzXHF0VjhrWnJiueccNCx91Ghf/3Kmcs8LZuX6tUxaNev9lhM/UoWhu87ezCs+93U3tnT9B18IYZobq+kcAGL88Qvja9RVzagvuUXXbnWza83ciAd0nI3CPFdEijh4KY2QzHuEAhpnxCJ9OcEHyNNTp6XeQfvYdyEwzbaaVtJkmprsb0+SIzkd84l9TK2q5E8PMeC8mn+g4ZuAiPNC/0yzILr86SubqJxiWrcRTKQUny8TooW+VsUrCr4PymhafP7dNg/KaFl905/cFkvCvAcspVLti8nKzIbCE67pSELkj//mHt37FKxv+6031IgIvKfmkq4pJ/j5WCcNU9GvDsfmkSw3/BsgnbXqkzzSmcjNEemAJn97xTfff12sNstP8FjDMjPuXPFF0E8h4KqVc/LJLavh3RfZsdPlmmOm5KTvN2bYGSfi3jHJdCxf15TN+qXBwNTywe8/qkVJHNU10XfEkY6aNfHP71KYdFdU00UPhwC1xC3SE66pwIkJl05o1PDl/KcvFXN8PpqYja9ustCtY5ZTyzCL3lxARLeJIwmcJVQmxobWFe29T+GJw+MaeXZva8LeydQkbWlvQ9WA23kASbjlZEiPjDHRPAnBMTXG9nZKtjKl8Gk1ymSxjfacC3ScFMgwiWsQpjwiyaYtQROW/k8lZPWdZNOpU2RoXhfuzccOyA78hvYSEhISEhISEhISEhISEhISEhISEhMT/I/4HewkrJdgaGMwAAAAASUVORK5CYII=" alt="Baseline / Character"></div>
+        <div class="verdict" role="group" aria-label="Verdict for Baseline / Character">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Baseline / Character">
       </div></div>
       </div>
@@ -123,14 +176,29 @@
         <div class="mx-cells" style="--cols:3">
       <div class="cell" data-item="2026-07-16-style-matrix:futurepunk__desk" data-label="+ Futurepunk / Desk">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAARNElEQVR4nO2deXgUxbbAfz3dM0kIi0IuCoKEzSCrFzQmQRAuPkAMSN6TRQEFRN9lcwHNg+ASVLiALBcRuVfDBSSiLI+ggCC8CMgihEUW2ZeAIHgRkCUwzPTM1PujmaUzk4VkkgzQv+/jY7qquqq6z6mqU6eqOmBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgYHB7IpV1BcqSrGtWUZL5x5aLCPn3q5R1BcqK3qtOiF9/3KYLMysmVIcrz3tyx7uvc//v5ugVh6hbQQlpJQjpypUkWdes4uzWHagOF+8OmwKAS1Uxmc24VDXP+0xms+46UFqT2czoya8DsDHrBAATR/YOyXcdkpUqDbKuWcWA+F5c/etYbDgAkBUFp8P7W3H43+dOG3aj83RfuzFftwMQ+dm7vD8tmY1ZJ1idls49zRqyavHkkHvfd+wQcHzDFlyqikMBGYUmvWLYNu9n6r/QGIAqVifTwrzpB5pkAGa4nADYBbzoNOG0aDLNnrOXes82BODIl/sAUJ1Oz/0NHmrCqsUl/lg3jamsK1AW5Db+mvSK4YdvD1L/OU345VQXkyze+KE2UKxOpvoI1Ff4ALVfaET2wkO6sFuBO1IBfLm/Vww7lhyldacYDi77jSpWJ2mywC3HAU6J8xEy08LAImktv4/DFFDQ9/eKAbThwxeHXOKPUWTueAUAqNu1LjvXniY28V6/lh/hEMz2afmDXFJA4R+e93Oe+T/ZrzcHdu4Jap2DxR2rAGZZ1ln0jVrey1SnU9fyrYrkafmgtfxr5sCvrP5zjTm65CiVgApT3uSdvw8na/spVsxKL+EnKR53rAKoTifnkgYB2pj/iUl4unh3y0+TvabCAGfglu/LA53qsO1GT2CW9f1+KM4A4A6cBWRds4rjG7Ywesg4qi1e7Gft95VlZFkwV/E6dPIa83NzqxmAcAf3ADaL1rrdY75daK28EuiEX5iWfytzx/UAbsJdFpZEey2+QS6Ja2YT81xeg6+wLd+XMGEuOFEIccf2AMKhYhfelg/orP2itnyb5HUNn/n1FE/26138ypYgIdMD5Lcy92L6Ofa8XLNE+uFgtXwA2V6ii4slQkgowIhpGWLxzJUB404ePMjdh46VSLl9ZZkqdiefmJyeVZHiCH+u4uLJySm8Py0Z1elk56q1VDN6gPxpVrejWDbjXwHjfFfmRkzLEI6cq0FbVbNZhG4GkNu3fzOUU118Igvi5x7gLm4sE/sMJ6FMmSvAZ3syCkyTPvErlk77Z1DH0+uDJ+m8fnl5+ArC7UMA7wohwIbN2Z7fRw8cLnpFS5gyV4DjG7bors2y7Nd6LGZzUIU/dbcFuZKi8/AVtdtPU7zjvuPG21QdLiw+XsaMOaNDdh5Z5goA8F1m3n70Du0aB60ctxPo0r8mYRs2NijdvpuhNn28PZ9NJaFESCjA3XfdxW/lo/zCI5WSHUf7yjIUYaUud8sfatMcSn8JYt1Ki5BQAIC1dZvQ8vFqXJW8rXHTorO0Y3+JlKeo3nIOz/uZBs804sCivZ49AXkh2wUzZa+n0C18QLeDKDN9fsj7ACBEFKBlbC1inYdhYy5j6V7tP7uq8v1XgbfT7D/n9Jt8Jy48jEOBEy81yLdvrwRsuyH8Q98euynhu51HaWFa8bldAJJya3gEy1wBRg8Zp3tZwhF47HS3pp9HLvWE/fbHNdG+TTfAuzlTOFQibuR39IpDLN9ylleeqJ6nIjTr1pC98/bR/IVGXCqgrm7hD3LdEL6PDdDp6+NETHvTsw/wVqHMFcAtWKV8JI6cq3mmWzl3vl9Y/OwDvD7pY5LiqqLaBcIseSz7jM1nGbLkJIdybNSY8bM4NbCxRwnc+wB2ztnrycv3d148nrv8XNeV8lDeUKbMFWDFrHQkxYxwqH49ge91xz49AH0P8MNLTWkz9whTD1/GhoMwFM9UTHFA51rlWNGngVR7yg4B2kGNjMz1YuxHwyFXe1cdLsYMHQ+A1RFgOzB46pkfZkW/vBKq28HdlLkCfDBjlF9Y7gMWG7NOsGJWup9RldgsEceIv7Ph2Xp8Kqn8JIV7xPrLFwdZ/drLAGS+0IQ62jZ9lq3aRVKnPwcsM3XGyOA8FCDb1FtiKljmCgCwKGNjnnFPd4kDCGhRC6eK0+HALuAnU7guziapVLL7C2Dm+CFSZOSsEl21sZjN7Dq6Utr1jn59o9ZnB0SlMYO58uqHfvf834CmlMUpopBQgGr31SDqT5WKdO+63g14Im03arjXrysrCim1q/BpuXLUnXFA1Kls1r3Yj97pd1Mvuml0O+G0mANa9sKhojhh19GV+ebZrG5H8XukgqtcOZo935SwcG2ouCpJKFYnLefv5z+P2cTiOmGlqgQhoQAAe3YGNsLq3B+HXVV1rlVfLJJmC+QmY/NZZJvK0YH5TwULgyQHdkW7u/h1c/wNVF+aRrcTGVuX0jmuMya7yqeZrwEQZtaUvt2oXdQA5laMoXOjFqLf3u2lpgRlpgDWJcmiVYp2gqZlbC2gli4+93qAe3ft1oHdhf26FjZwzXlUu8CchyvXIcO87s/qunu7Ke9Htrgc2E0KFpeDCJNmCFpdCuO3/xE4/Q2lNIcpZPTs5inH6lJ05UzZ+jvSnFFkbtF8Gbv69+SaaqfNiy0AyBxZL886lTSlPuZ8ndhRtB+gtViX3UnCyL2egxP5WdmftqwIgCUcGneIxmV3Ep+8kyU7VgZUgCdjkwDYkvqAJ8xkyd/v67JrShf71l5ddx+OwOpw+NXPnSZxYH+WTvsnX3TVPFcxCVV1ecYn72TVT0upsPptHOZwrG00w/dkSl9qjp1NxLIUshZrex5OHfqV27YHyOjZTbTvWRv7jX1z7VL38Va9ZrT48gO/tFWSp9By03pkm0rqIxUAaP50tCfeZJH5vHtNuj+WhNXhIEJRdNM3STEjjZ5B/AeveMJcqsrGMZryWXy2brnr02rMESyqnaWbvVPNgujatgffps31KENMQlXswuzJ3610ldalgkVGsV/nZEpfHkiozr0fzsPy+WCyVp+hxX9UAzQFKE1KVQE69qwNaC+/Vco+MhNac37C61R/d7pf2tMTXmehazgLD10htU9PADY/rU8Tk1CVVdFhHN2j76L7Zl6m4YLPmRRdAZ5cAIBZtaOaLSQ0T/Qryy08NWUKNqBzXGdPWG5/hN+9o2do99qu03vs67DsvOe+TeO1Ll6Svfdv+eYIANu/y6YFb/D9Dxd4/Ibwy4JSHQKsS5KFXZhpN2oXGVlLsAu4L+XjfO+5+N7LXHhJmzY9v28r68c21MW77E5PK3PZncSPyWbJmvmYLRJ9HF6nTJgksAmJuYoLu4AUkxZnu+5iWhhMX3mcwR2jGWqDK9fgzNPPM+fRwA4hgH7rrHyzYbFu+LEL7ymicWcktj73NGvejCE+eSfrp8RhkVQuPZ6KatZmLBUz3kAJk9m54iQ21cZDCfeSmbaHbjs2lZpcSl0B4obvZnnCY9g+GYGkBp6Ou3uEi++9jOOVyWw7cpa3LmWzcUxTXdfti8vu5PHUg9RYvwSrIhHhELoDH26G2sCqSKTJQicwu4DlW86SFFeVVl3eYO9fZT+bwWV34rA5aTXxFzI2LCDFZMJ2XXNYTQvTZh5JcVWZtTuHbwb0Zl2qdlg0PnknC5+JotKoWZhWJxNJGA6bk7XzD/DE8408+dvO5dBmwhE+716ThybMLhXZlKoCXMoYJVq/sZ3lCY8RdVd5AGxWu1+6c1OGaXH9xgCBW35uWrx3iu8z01DNFo9gh9rgomwiTPIqmnsBx60IbkVJX3WEHm3q0rVtD34cVTtPg/GRlP002vo1Fx3Ck59dwILV2v3dH0siLTGK+g9X0eURN3w3zjC9YQnojMsIRSEtMYqYhKpEdJ1w+ymAdUmyAGiVso/rSB7r2pcIRSEzoTVXbHae2rQB4VQ93Wcg3C3/woiZ5IS7aPvUPZ64iSLv7/24lcQuYMG60/RuU50OrZ9n6whtPA6kAI+k7Mc69EN+t8js7VHbE56x+SyJzf9UoPK465tX/rr3cDsrwC8b8l8u7fWttirobg0F4WsHuH0L130eLRyhuwa4OPRvPFNLm1oOb12dpNiurEuNKVAw7vIeTT3kacVuCnt/YbgtFWBe92dF0nM1Af+W4BaiO9w3rij4KkUgrtiv0Sn1uKcH2vR2AywVLHmmD5S/bx0LKu9m+Oyddbyye8vtpwBXFwwXM788Q8Uwmcu2st83XzHMK7DLThkc/vZIQBRL4dPeTB6KheOHs2mi5pSaM6hU/QALF5/lpRdqlGaRtwwuu5OZH2zgta51yfzfg6VWbqm7gqf37C+czryNs8Iiy9o8vrh55c5Hlk2FyjPQfbkJFBcob9/4yKP76Lt18+3pBwhE0+h2Hktq9/HMAutzs+lLi+I8R2HvKQnKfDm4TX/vMuvudzILTN/+v/sBsH/XXnYfLzh9aVGU5/A9MlZWzxIS3wfIa63/VsJiNt/Uc9hVlZp1ozl/5kwJ1qpgitUD1E591dONZadOLVIX9lhcbcyyzJqNR4pTlTJH29NAoZ/DrSyxbVuX6eHRYvUA2alTpQ5dqnBX1QiaT0z2c+w/syJV1BowKN/9d7m/pmVQuhR7CLA8+G8qhLmIvA/u+5+BOmHXb2Wj07jwvG41CAGCYgO07OFtxTWGDBAAyVdeE8JymRlRofl9PAONYs8CPoqYLo3MGelp+SLSawjNn+T19vnaC1B0m8EguARlGigsl4lPNHNspz48e+Q/JIDmE5NF7F/Ke8K/++Z8MIo1CAJBUYBxlunSwHPDPC38mRWpYnH8jyTMHyOs568QG1cOAFfYdZZ//ge/jp9htP4QIWh+gBlRk6VhqZV1YSd2nOJRH+F/2misZAg/tChWD5B85TUB8MUH2vdRhkeMkWqnvio2Lz+F2/ZfOl9zdBiCD02KrAAj7IOFywbXFdUj3FoDBons1KlSvcYdxMOfxALwVev3DcGHMEVWgHGW6R7Bnl0wRLR96whV4stTKz5ZnJ6yi1/OhLOpxyhD+CFOsY3A/eecwiXbmL2mL33H7wYgDIlLb69n6Yv/JVq3qUnGR5tLdYnToPAUWwGqfP8qd7d8iopdHmRrF33coTUnyPhoc3GLuKM5dkEV7684zqxe9f0a0Kbj10RCdLliNaxiK0DV7h9LjRueEL5n5tzHtBQnCGdkSK3b30qM/XKLWLbjd+7xOTHu/muk3x3+Q9SMshRbCYLiB1jeV5v+ZS3Tr4RZKlYg0iLxxPFglKKR31Hx24m/LftFACTFVSV97WlA6w0E0GvIONGh/t3SyRxHsXuAoPkBovq8QWxiPR5toy2LPtqmFn9uXpmTBwMfrS4qd4LwAUYm3i/1SNDOKPRIqMaxC6owW7SPYDXu+BwANcsX/4siQd0RdF/rG+fc15bcZ9JiW9Qga/upEss/lMj9ZZNjF1QhzMEdTYPWA4SdWIKo+TAASRM6Ur3Tg8HKWsfttH/AvYkkP0YsOiJO5jiE+4OYC9Zpw8HJHIcYsehIsb91FLQeQI6qrPszynJU5TzTFoct+84R26IGu7fuKJH8S4uWsbU4mH2R2BY18t0RNLhjNOmrjrDiH5M9YRf/fY506zX2Hsr/u0SFIahDgHRym+f3nGfnctkmqBDMAoBxQ5NuixlFUrtWhX6O3u3rAcN0YZd+3c/eoYH/ysrNEJQhYM3CgyzqP08X1rZbDA3rVeCKXOYbj0sFs2Ly+0hkMFDtgne+zqZ3+3qef8uOXaBL5w5ByT8o0nF7+WYP1X+4uTDev1t9M6ibVesOlUi+dSqbpZM5DpG+9jSR4Zq45vZ/xM9ANDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMNDz/32h2uJ+xun6AAAAAElFTkSuQmCC" alt="+ Futurepunk / Desk"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Futurepunk / Desk">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Futurepunk / Desk">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:futurepunk__monitor" data-label="+ Futurepunk / Monitor">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAPZElEQVR4nO2cfXQV5Z3HP/fOnSEJrlhTSQGt2nVlQcSDVSmFFUJDQ1O3YAWxgCBY6h45anuAZuNSgQVBQPCtuLWhvkDkxcImIORgySEBmwPaNlmyIamCG1BExPJOSDJzZ2b/mDxz574kubncmzuU+z2Hw9y5z5155vv9vT0vE0ghhRRSSCGFFFJIIYUUUkghhSsJnmR3IFr0zsgz43WtYxdLXfPcrulIKLKUHJtwyaew/aV36ebzxnStFr8R9Hn0zFz7urpfRfIpQHKEcaUAvTPyzBcfL2JvzS5UU435Ot/qNYAfZN8OhIsAYDTpFG3bCoBqqhRXFtnfdZUYvq64SWfQOyPPfP5nawAYMnAk/gjERYs/1VWwal0tikdps82U8ffbnvW3c6dpvHgGAP0j1QT4Ui1LqBCu8wBh/U5cigjt4U91FbaHzZz4EwCeWr6QY58fpnefmwCoObQnoSK4zgME/H6D8uptAGzdW9RB62CImL5k2hpkue12d/cfAUDlgT/wy5WLI7YZeMu9HDismIkKSa4VYMvejQCU1xVz+pGNmBmd66rnop+CNx6O+F2oMENv+z5Hjr9Gi67H3N9Y4VoBAN7/3+2cnryR6SuvolnpvAGmrSy2j383txkAb9YFChZOAQJC+HzepJAPEFtd10XQ/Spmhi8m8gGaFQ8bmo6y4fxhJi1LZ9KydNInXWTUmRIa//oSc9Y8hC+K0lb3x16JdQTXekBFdXHHjTpAyckGAMZm3hw4/sbNl3zdeMK1AvhNnXPTNjFpWXqnfxtE/PEj9jFAydnPrEZyYiqrzsK1IcjnkWL6nSA/N6sXJcePMPYbNwa+E+R3EqKqSgRcK4Df7HxSFASPzbyZ945+GTX5iRpnRAPXCtBZlJxsAL/fDjtB5Ld6RST4/UZUiThRcG0OkNKiD0ElJxvA52Nsjxsihx1f+4/ZkQcksgpyrQfozdGFIDvsRCK/Hct3C1wngLC2aJJwaLXTWcsHogo/V2QS7gh2tZN5XWyWrwUevSMRrqgQFI21lZxsAM1LblYv3vvyi5gsPzUO6ABmt8jnRczPvT7LKjUzAyPbTsV8zR2P7o5eRImSs5/ZpWbEOj8ayxdIeUD78LQEfxZ1fm5WL0pONlx21U5bcK0AzhBk1/nC8p1hx2n5fn8X9/LS4VoBhAcI8sVxu5bfmRDkwO79O2L6XTzgWgGcHjC2xw127BfodMx3KVwrgBMlJxtir3ZcDtebkJN4SIzlt7dtJdG4LDxA4O/J8gVcKYDfb+DTg60yrpbv99Pt1pn8+rF3ANrdfZfofUGuFACsHQvXFT3Mf/ccze7jn8f34q1CJnMhRsCVOcCvnUWWe/D8z9agaVDwz1PoLr6TVDIOFHJabsNqo/QS4WF+v4GqJm6yrcN+JO3ObeDYxVLPnELVXDZjA7IMsgxir6imWW2cgoAlikCTZOA9WNjhfZy/UZTkJWHXCQDWhthfFj5kSj7FJh8sMTQtfGfb7N9O4fkh1onZezW48Yko7hIg/YrygBnD3zQBCnc/0m5i+1It82SRYz6xarx9TizSLJuxwfYGgU0VrSR28zBr3HP2+abm8wD8+Afftc/lzPwhLz5eZOeAK8YDZgx/03xo5AQAFEUxIWB9QpCe/5BjimmIPz/WG4C7XjvGDbf05c91qzx39X7ILHhjStgiSd4gmWZDp7I2PLG2aBdYv/UPAFxoPM+EYdODEnAkD6g5tAf4O9qePnPUOnPwrYP54OMPUDwK9w39of3dhl0bOdfcSEV1sU26E8+ut+r/4nPW/ITf1DmplQf13flGTShGDLrfPh4zZELY9+XV2zj81adA1xEv0CUeIMLOLX1uZE3Fiyx9bAUFr+YjyV40Q+U/J70AQOPFM5z4pzkAvP7uJkCMUl8C4P6rA3PUxefaJjwUzm2OFdXF9p6jSOvOXUW8QMIFmDB4lTktdzLPvP0LFq7/C7pfQ1fBkPwsmrqCp9+YheFRmV+Uj1f3MXvVkwDInnTmT1mOTzH4TeMpAJSP1trXHdMNtjjWDPpfP9Q+rjtaaR/7TR2fR4q40auryY6EhHagd0aeuTZ/M9sqtzP5vh/Z5+cWFtjHmqEyf/JS5hfls3jaCuauzueZqc/y7LpfAaBrBor8dRbMmIOuQn7hkyx8ZCVv7Xgn6F6HPmvAlybhb93O4nPsK7pwsCqsb//nuQAkX4S439wZizcv2Mrm8lIeyM4jvbvlbPmvzUL2KiyasSSqzwWv5rPop0t5+g3rfLPaiOxJJ/8ngTdaNuzaaCflD2r3BfWnd5+buHCwioxefQCoPf4RYHlM3dFK20MgOWLE5YaZcrYJVkzd+9PrAHjl0AM8kJ1Hi+rhtS3LOa+dBSyLXvL4UsDyBEE0wNI3n2P2xH9Haq0K5xYWoBkqi6etAGDeW4H2wot0zeD6zH5M+n7gbZgNuzbax+eaGwHrZY/bbvpOWN+rDpYzvoe1klZ8rltQqPJ5pISLcsk5IEvJMQXpTqimyubyUlRT5efjnrbPb91XTMGr+RhS8PLh7FVP8vzMl+3kvGjGEhbNWIKuWsRrhmXhzs+Lp1k55N/uf4TCd9cFXU+Uu78tfR2AFx8vorD01+0+izPJW/Dz+7PZZiI9JC5J2Bicg1dR4P1S+9ytX/wOgI97Pcrb5YF4fe1VmUHhQ1fhN8VvIvlk5hYWYEh+DEcp7yRbfP6PiQuZX5Rve4rTM4QXzV1tCdnr6r48+C/jWbH1lbB+1xzaw6SvGbQ1JznwmxncBeQOuQ5N1xiy2gqvwktCS+FYcMkXyJSzzdFGd5rQKRh/FZljrGRrqCoVr2yi7uPAkPX8oMlho86puePCrjnvrUCSFmSfOf0V13zN8jSv7kMzm1g642W7vfAQANmr2L8reHAZz21cbn9Xc2iPTaBFfjj69epG7tDMDp/97sLjwKUJERcBFvWXkWXLTXfWePDplkUtWHy33a7i9/v4pCF4xHnuzkfDricE8ate5q+ZgyRb12puvIqFM/KZX5RvjxsWrs+37jPVsv55bxUwe9wi637/s4ehfe8JsvwDh/fRojXZMV/xBix/zoTAYr+mh8xzOCBLclC7gtVnKTObYhYhrkl46R1paJqOLEs0Gzp79ys0YVlb3iAY8YRF7odrtnLxrMonDSotWqALoR4yKftBAHyKZamhlg7YoSm/8EnmTrSE2Va5ndw7vxdEftXBcuuarVY/8JsZAIy85xq7jSzJ7ZIvULrvJO/X+mxD2+FtTK4AAqIE/dUAL2ne8FFmeXXg3ILXA9MDH/yXNeo9dCRA7okBwd6R9fUe5Nyei08x8KvWg89fMwdD8iN7FTRDpeDBZez8yzZGffu+oLBTdbCcZ/oGrP1f7+0Z0/MJ4kORdA9wQniDQI4nnRH9LJcXYQqgtDrQJm8QjJw10f68a8W6sNwB4bOWPx5miZguy7xd/g6KR4lo+YL8WIh/d88JdtcryFI4VWVmE5DkHBCKTDnbfKB1FLqlJfhdr+FGGmARDtjhCsK9w6soNFZX88f3ajnYEJwsWwZPD/osvKNJ03hh00qrja5Tc2gP8/tZ5EeTVAUiWbqmm7YI8SBeICECHHjqHyne+SkV9T67s5Ew2rDWtbIHWSJpmvX/ztqAGCJ3eBWF6vUlnDhynk+PBkT924DgP0fwxanPadF1qg6Ws+B2mbzvdJ54n+7FL1mia7rl0Lu9zUFt40E+JHgyzqd7wQuL+luVwx9rFfySgaab7PY2UyY14zd1ymoswsd0g3v6yoy8Q7dziKbpzJsemM1cWBQgfO9L6zj08VqaVUhT4Mi3JtA94xr2Vm3i5W+nMeTOazrs464Pz7CzRnDZulgvBTzOSXxPwwqBJ7zxW0FLmACqrlsP4sgIwwaoqLrOh/Xp5HhaX8D2QAUqflNnS4vE5v3WAw83JEYN0O3fCcyeHBjxjhuh8PBKK3fsW70J6qwpiB91QL4zxGg6yCH1gtNrBemJQsIEkJTI73gpksSwAaod+zVNx1ebZltdGdbD7/Y2s7uutZMeiREojBpoMvKOQPjZXqGzvWKj/du5P7+D7oNaE4xjVC4QsPbAY4u4/okBDR7r3okm3YmECaCrurX1wwvz6y2CcvQ025qdCdhp4dSn49O9NKFTKWl2Ei8zmyjbbzUZbqQxaoAe9Dtdgnkr6oF6bushM/WFMXgVhdLlax0JNRC2Nd0Muj6e6Ijvh5cTMfDRFrpkRexa3SK6Co2qWouEgZJkl6dOOM/J9Qp4RCKUqZSs0rRS0thdF1jVEt4hqivQmDe9uNUzRKixqhiRf/ACZvTWPlByeHTc/n5jErel1Og6NZ0QAyxBAlVJYKWrjIB3jDa6kz1Ityur0morzNRjcMJUwRsj6QmCK/YFOcUAy83zBgXKUgGnIOm13S0L9wQnzR3eRnbst4TIu1u3rN3EdcQLuEKAUNRjUF8NJ7xWyBFlrBOheUOEmDKzieFGGju8jZRVRU9kV5LuhOsEcNbYPQ2FU5LO3DpLCJF8dQkkh3M4PaOiXuLVX/ThqZePAYGqKhKSRboTrhFAEC/CxClJ54RXxYdkx3pnaSrEaAvfvbUFRZKgPj1sNO4G4gWSKkCotQeda6002vq7QZHE0KVAe8VBco7HEsFNxAskVIDQkbBAqLU7z8UCpxiXG7rEA0LJdYaZWP4yVmcgyla3voqSEAFmvXCcJhQqpXBLh/Awk2jIkgdMgmY53YK42kWmbG3hWPn0DYwaoDOC4BAj/iUaWkvwPYQXuI18iKMAoSthuiPfdQXpbUGWPPaEm1jDdRPiGoLEBqb+z/219bO7LC4eHtDeAlMsiJsAYoXI6QmJTrBdCUH8cCMtbHXsUhD3JOxcqnNu1E2mGJpuxhxsBfH2ApIEmNazxWOrYkLLUGcHQ3NEV0JUQdHCGWYE8fY0tgPxEKHLRsJu9IxQVKBidoPRF7sH5YsKVPzexPQzKVMRXekZzu0kkSDWo8Gawva3GPglo91kG89t60mfjAvd3hEPQZzbC9siPyi2tzaJRLzzPbJEbE9P+jtS7SEWMcQSpZiiFnuMQuO3nVRpu7Tsihc0XC2AQJaSY3YmVxQNv5ai8hY+8hg0eJrs6exoSBeI18arjpD0EBQNOpMzfB6Jvo+OZdhXaxkGVLSulu32BnZXtIWuIt2Jy8ID2oOYfwr1kFfuvZpTp5t4v9ZHja6HTYckOrZHi8teAIHO5otkWHskuKIT8YYYZ0TKG24hPoUUUkghhRRSSCGFFJKI/wecfx+1SVLaSgAAAABJRU5ErkJggg==" alt="+ Futurepunk / Monitor"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Futurepunk / Monitor">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Futurepunk / Monitor">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:futurepunk__character" data-label="+ Futurepunk / Character">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFwAAABcCAYAAADj79JYAAAEWUlEQVR42u2cMWgbVxzGP9mWkQan4AN7N6aoWQLWUENqTV0MMYhCJ0/2lD3gJXOgFLR0cmmx6aCpUAwpdJcacAcFOlQcVBxdMsjwBFYGHRJGHZInvzu9O8mS0v5f/P0Wy3p3h+7z5//73v9OBxBCCCGEEEIIIYQQQggAZFz4kLlcfpg2nkUfAPA2vBF/PiuSP9xabnk4wCo8b2uq7QcqGAJAGPYydPgMrp5W6Dhd5Yt1+9LHJjYAPPAKWMstDyn4f8gAq6DgC3L3072NicfxvC2RLl9xxbFxkeO/n9avnDiPJRfFnnUbCr4gsV0SXZTgZv3uKn8mAZ/ubaCr/FFambRoosMBKBVEUsaLi0u8uLhM3D4+PsAqlAro8GnFfl7ejYjZ8pto+U2r6LbxLPp4Xt4VKbrolKLFfPV7HQDQ8pvYLjyM9E9afssyfvvfkUUfIR0+GdPlJtq9J+VS4uLG3FfaAmhFqrO1aJ8/foI/Xv0KAPissI2Tciki7HbhIVp+czSu3Z1W8/9PRDV4dErRtVeLrsVLcr05flq/Qlf50F1GpQJR3UORgidNoOaqsqv8iNtN8ePHkCS4M0v78QXOhosfXbbDbS5v1L+KjBf3fkl0t0SHixc8KZvHa7pNbAo+o+Bp9TxNbImCL7kgdtzZk94zkdYXd6I9q1Qwyto2fvrxe7G9E6cE112/NLEB4PEXe2j5TSgVjPYxkbTaXJLs6na1hL+/28A/PxQThW/5Taw3jrHeOEanuot2tSTa7WLbs53q7QS5s/MI643jqffvVHfZnl0UR9+cWV+7gnjBKz/fvra53Hxv87BmPYZu5XJpbxCGvYxSwdDztiICPft6fNtPnxxZj9GulsZEfpfDb5jD09Cp4vXrP62OPsifJzre3EdiHRcleBj2Ml3lRybMWWlXS++u9gi7sVN8t3DzsIZ2tTRy7s7OI6ubAWC/co3fnn0i+nycac+aQie9N8Cl+PNwIhbqpNIpnuFl7wgve7eTZqd4NpZmbLWfgk/Bl5XeWFI5yJ+PJk1z4tTb7Feurf8NFNzCWm55aEY7M7GYrh5bWRbPEidOaXfQOlPDD/LnQOPcOnaXZT8Fn4L1w0tk0Ufc/eZ4PItLLSviBdcXJZQKRsIPsIosau9/9gHji1e29iwFn5J4DyTtMporiE0pm4e1yIWDtMtv8bH9yjUdftfMfVIuzXy72km5FMnldPgHROq318QLnuZupYLUuv3tRU3sH0CU4G/Dm4wWK6nLp+8zed8/TzyOFl5at1Ccw03R5+G0fiXy698iS8oihHrz5i9+135eusqPlAh9wcIlnE8p0lPJRx8LKfgCl/YU/AOSy+WHD7xCJA7aJtN4PJT6FAmWFAp+PyZSJwSPx8FJZYUOv2fRjzVcEKIfoxcvG4vcng430LHO87Zwl8fpmdvzMXp3rNnzPLdwnn3vZUmZtTyY+2XRd+JZtIQQQgghhBBCCCGEEEIIIXPzL0ikFgCDeE//AAAAAElFTkSuQmCC" alt="+ Futurepunk / Character"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Futurepunk / Character">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Futurepunk / Character">
       </div></div>
       </div>
@@ -142,14 +210,29 @@
         <div class="mx-cells" style="--cols:3">
       <div class="cell" data-item="2026-07-16-style-matrix:heavy-outline__desk" data-label="+ Heavy outline / Desk">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAAUlUlEQVR4nO1de3gURbb/zXT3TCYBBQMJWYJAYENCXsxHJAiIyLKKD1YWkJcKiOj1slflri76LbufuKx+LO5DF3VzXVEUEMEFEcQnC+GlAYKBhJCIQBSIgUggEEIy/bx/dKrT3dPd0zOZhLD275+kq845VV11zqlTp6oTwIEDBw4cOHDgwIEDBw4cOHDgwIEDBw4cOHDgwIEDBw4cOHDgwIEDBw4cOHDgwIEDBw4cOHDgwMFVCdeV7oARMpOypVA0vCCBpoK7zwsyK6kjdPqfejlm5eHiUHVJhxxTM3S4zqYlZEk05UK3XoPh5nlDGpGmTeuMaPUgvHblmNHpy8+ePgJRaryqlMB9pTtghISkHJw7dTio3GgyjcrM6tw8DzfPK+WhJj8Unbr8fO1JdOuRaimvI8J89K4wrkseiJqT+xWXDkBx1R0RP0kedKW7EBE6nALo192+0+aZ03rc4FnRvmyPfYdnR67YFAAAVG3Mty23o6HDKQCBm+fBCxKu9/dtE/mjs641LN9aeiFsWVUbW9ubK4cOqwBthWhO/H8COmQQ2FZwJj8YPxoPYDT5bTHxHTVINUOHU4BoD6Bj9dbocAoQTbSH1Z84Uqd5jiR7eCXRYRXAKsETCu1l9frJvxrRYRXAbqpXjyth9Vfbuq9Gh1WAcD2AY/WRocMqQDge4EpY/X8Krvo8gDP5rUOH8wB2o2hn4qODDucB7ARUzuRHDx3OA1jhagj0rrYdQbsoQGZStkQGpqKm1NLHmy0B7ZXK/bFYPkGbLwH+ZL80+18z4bk9K2IZ7eXyf2yTD0TgAcidPSD0BcjMpGzpvg3T8N66b+HpEgc2gg46633bIqIlYM6KqXhjxSFkfgaJoSgUnyoOUgR/sl+6f819kCDg4vFq+Hp0Bc/Yv71jBGfio4+wl4CKmlLXyzNXgfJ5wdw9GI9svh/+ZL+kv8pdL7GQvILyTNNMqzrqTH7bIKIYIEak8KsH5TU9/x+lmLn8HszbOEu5z+9P9kv//cFMhb6x9pKGPzMpW0pLyJLSErIkf7JfozgkWFSngqM5+T/Wtd4MESnAoeoS1+Lxy5Tnl2euguABHth0H9ISsiROaLH8t5YeQEJOivKcGp8u8YIE34RcPLn5gZBtRXvyo40BGd3D5iEGYFSXGp9uWtcWiHgXQHMtrJ3HDUH+P0oBAA99dL9S/vHmajTVNsDloZSyRzbOgTgkBQ2nzmHx+GWG8UO00VZWTyY/kjsAY5dNhH6iU+PTJQCgbhmA/j0z2kUJwlKAzKRsqX/PDIl0rn7TXk39Gy/Iz01u2QNcuhhQ6s6+ux3dZ4zGq5PfwDX9EnDdgJ4aJWortJW7V1u+/tsFu1AHxanx6VKnG3MwZMndELZ9jaNVZe1ys8TWLoCs7fM2zoLgAajm/ZzgAZaOXY4mt4Auk4ahsfYSVq/4RuE793UVAKDh+1rQnBs/vL0VsWNyIAR4NK3dY5kUIqeB2+c/Htxp3QciZt8Imn1IYvQtoJ7XCjTlQmWIbxNDYfvm75Tf0xKyJM/tWfivX+fibz9/s11vFdlSAIai0MjyeGVZKSivzCIEeNQVH0fi9BEYMyoBH81ag053+YN447OuR8P3tQCAblNvxtl3tyNGpCxzCCQAtPu1jTpgjPQiiVqOXobV94V62J28mK6dUA+gf88MiYeIhx8ejPc2nATQvh+Y2vLBxaeKXRU1pa7G9UW4uHIXLq7cBQDo4k8Bz3PYtaUK8z95CJe3HAzibfi+FuzHpRAFHueWb8PRqjJXqBck3/DZfolm2lA8Z08fwR/+ugBnTx8JqlNPstnvZvR2kZmULaXGp0ssy+Hi8Wo8veFBAECfh2/FR1tO4fjOcgAIig3aEmEtwhU1pa4jteWuI7Xlrsb1RWhcX4RLqwshBGTv4G6S1zR3k6gsBZTPCwAgfFHuv+0PPc/XnrR81iudSNPYOmEhAKDpJh8CP+sEL3MRn773pkLzm4oy/KaizFY/0xKypE6xPeW2KBrCtq819Sf2HYenpEp5tvOJfDQQlQkh0SsAxN0zFPWb9qLzuCEAgIb3ChU6N0VDFHhYKUJaQpb0k+RBOF97El3je0WjewqI5VOML6TsUBau/8Sc9Lem+qChC09LyJIKCvcgf/YavFO6RCureVzcFA2acuEvs9/HE2/8sl2WglY3kJaQJe0o24/t027Gs2UNQfVKYkfgsSgvBbe89T5GpOWYKkFaQpbUo09uWEtAOH8vIByZVjBrz0wBMpOypd/dvAoM4vCzJV3gionT1AdcLrw57V94YPUkjMm5CSx/2TDY5QUp5IlqOGj1cbAo8Ch7fCImzRiAXxw7g6ZfbQiikV6cCDzyNoqfnokv5txjKa/55SRRaP2EEsuKhI8gXH4r7+biGIAB/j2/DkCdpq709Hb4aC/G5NyER4f8FADg9TIIBDh4vS1p9A+2n8Q13d3S3h8ORkUJWq0AborG/iPnMTyHhis2Br43pwIA2IBqCYuhwefPQE2dhKITwV5Cj2hoeGp8ethK1BYxCgGx5NLT25HV4+ag+kBjPd45ugT7yg/gpkEjwfKXAQTvKtxuH3aW7EVeZq4ywK0Zr1YrQEVNqet1ZEmvLalV1jBA6/r1ltiWAx0p1Fbf1uA5OZHy7YWv0L/bUE0fvpo3CTsKPwYA+Jbdq9QRz/r9gruw7aHJAIAhVAyW7N6O20cOlyLNqEblrX0eGk9nX29J08jJO4Q/H6qypIsWyIQSBSQw8grtNfk040FWj5vBcyxoxhNULwo8LjS4UfDoA7h9kPb2RMwr4/HxAQ+AWIW2QmKxcvKtKHywBwa/li1FEjRG5c2LTxW7Fkis9FxOHwDA+BuCz/1XfwEsPngqagEM2SZZZfw8dCxiO19nS15d/SnL/TdNuVodlfMci/LaL5Eef6PiBYxwxzA3pMuh5e394aDroitL6vZF54j7FDXVJ3l9o8kniEZgB8iTT/bUZqirPwWWvwy23sZIqtClc7JpnT+ZitjV6mHkAYgnYpKuBXAt2GNnotGUdT8iZSTWore+Dfvclkqg5gPsH6So6XhBQvrQ4ZF2PWJ8+fka9O+ZIcWIlO2/I2jloVqLaGQMI1IAf7Jf+t/hg7CrqCWi31FfjlXFZ3Gvv5tSxlFeMEJAwzuyc7ry+6ABFDp1jgEAZbsTCHAaeo4VUFR2AaOGJiplz28rQuU3xyLpequxeEyL4l1u4lBdY+xhkhJiUV1zGcdOyHO0o74cEqN9N3UAGAlEgceh+WnIXFIRcWAdNpM/2S/NzBgAADh8tMXSd9SXB7l4Ev2X/k8fZL38LdwUrVGAHt1b+Hv1iIHXy+D5bUWGFmO0mzCDPugz41Nn4AitXoa+TB9UGrUzNzcH13XxaRQAkMdo4eh34OKYoCWgqPJDvF/5Tyy+Ub48ow8CATQHgTLm7zqCh/vGAwDWflePOpGNSAnC8gBDuudIi8ePAAB4aAqHj34PQH6xHWX78X+vrMOvH58cxDc0KxceD6PQAsBvb8nV0AQCHP62+wB8HhoFXxWCZuSu/WLKfKxf+TwAYPqcZ7H2rUUKz8R7n8K6VX8K+l3PN3H6k/jgvRc15UT+3ffMw7p3/hwkf/LM3+Od158BAEyZtUDTzprlz4FmaNx9zzxF7p23zcEHH+YjLzMXr5ccxvyRg5GUEItjqrzHyM7pWLh1uua99QoY4EIreICTeV4/cQGiwOOv4+W8wtMfMWHvBGwTE7dPXDTHCvj3Vz+glKvC3uLdWLFhJ2ZMHasM7Io1n8DD0JgyYQwAgFe9WF5mrmJZvxsju8E/bpHPDPaVH8CUWQvCeQcFFO2BwAdbDsdLYGiTs39WXqIkt2xdLpGF5PaY0lO0TKduR93uulV/Qt5AP3hBwhPDcgAA+w/VY+v54BNIIyzKkz2AURz18QEPAhyPkzUX8FplLUZ1ke9lul0BZKfK28Pl+w4jnCyh7Qshi27LQxMvorTsOyR0jsOyY98CkCds9fotYDwtEw8A0yaMwbpNBVizfgsAgOV4TJswBjRDY//XBwAAgwcMAgAUFMrRbkrenRprU4NYHmBskVNmLcDatxYplksUcfLM32PNctmS1RautmS9fCtPIPCshk9dP33Os+A5Hr1HTsLJnZvx0p4SzPVnIDs1FgVFNPYcKmoZeCZ46HmOR15mLp7O0e5EGjlK86yefAAQJfnE9fqkazH/jjws/Eyy7QlCEvmT/dLc3Azl+YWd+wHIEw8Ab7/7CerOXcZjcydg9fotmNZs8QCwblMBWI6Hh6ExcdwovP2urBwzpo7F8JwbwAsSfntLLv64pRApeXdizfLnMHH6kxoL5NkAJLcHLjHYsmmPFzwbAO3xBlm52rKNeEmduh21HDW/mTcwAvEQby5biNv8efhL85I5d20BaMqF3Qf3Yd2mAkwcNwqrm42DGMvEcaMAAMNzbgDLcgbSZagn3+0KYHCmNg/AsYJtT2BJ4E/2S0snyesLH+vF/H9+gs/L5Ht/6s6rn+UOyO59xtSxStnq9VvAsTxm338X8gbKN4cW3joUl5s4PL+tCP2GjoPAs0HWr17LaYY2tVwjizICz/GgGVpZkoxiAVJPPIF6+Zoya4GhByDPhA++GJzcuRmPDEoB03wp9qU9JWBZDrsqDuLDjdsUJSBLJfGWE8eNQl5mLnq749DTG5zImv1L6z9KzfLyncy5awtCJt5MK9WTDwCzV3yKvcW74YqJ0wygesD0UGs1QV6mHPw9MSwHHCt39O9FhwAAfXJvC5JBLFL/U18fLqzkkDVdvbabta8H8QDHCjdBFHjkTxujqZ+7tgAANMuBHmQ8h+fcgPwpo8HyAs7Vt2ynz1+Qt55k/IzANu+i8ovLLJXAsCIzKVvKnzIa5d+eVcpe2LkfKXl3yg3zsnDiWonlqL0A0OLapkwYo6z3gLwDSElq+eZv5YeVKLh43PRlzNAWCRazbV6o9ozOHDweBvlTRmvoWF7A3LUFGnqry6uEXz0XSfGdNHQnquVvJ65vHtMmXhtALvys0DSNHVSYGp8u6bW24vhZJeI3AjkF3H1wH4AWy1drMstyyGJ6YuzQHgBk7WU8FNL7dDOUqQYf68U3h6tMNZ7xUIq8fsldlT6b0epR/k0T7rolCQCwr6wGADA8J0lDc7xa+4FKbIy8rY2h3ahu/vKpX3JXeOhg+YA8gaT/rCAhN72HUrf7YLWG1utxIfun8rVzIo+49YrjZ5HQvTNOnb4o11MuJHRviQFKvj4X1Hacj8KykhLDPIHh1SXyO9mq6RMpZokQdb0ZvTphYpRYsTq9szq10/c1FK3+tFDNb9ZXs/7ZOU20SjLZHQc776+Hvt/65SBIoijwGOppdjFqZTZWbADAGU4AXKqPP0UALgaJjAETZfLTrB2Ldk3pQvEY0Tb/PMPJlpbIUMZ9jEb/rPoR4rmBE3EJBsuQ2Xir+AvZS0HFpipFBsIKpEF1w2o+9e+WnQvRrhGvGV2d6qJzF4ho4ERwDI0AZ7yt0ssmz6HeX89H6L0Mgy4QI3p3O4hj3IgLTabpk1X7pgoQbqfr4AbD8SH5rAY2kaGClMlMuYx4AXnS1Yhj3ABEwMb72FU+q/bR3L4dvnCMzIrerC07fTCMDP3JfqmR5YP+jZrZuh0OQh3qWMUXrWnbbiwRrsxwYw2zfpnJCRWHWcUwBFZ/0cX2BtosOAwXoU7TzHgiba8t0RpDiDbIGIV7IhjWl0FDqBj0Fpk2e2lR4DGEisEQKgaiwGsmXt8mqVfTRaP9cORZKSyR0Vtk0FtkQsqN5D0IT2+RQRd38A0jO4h4Jvu6fFAvt/rgySyYSvTEGAs0iVLNXGAoukjuDpjJs+qLXWNwUzR6i4xmzM67BKQ1Zw4bxOYK3SGgHMOYwGTMwkFECiAKPCqhjQe+E+QoW5Tk50q2EUDwACl0BvkAgjOcEFRnZ59rVhcJ7KztVn0ifU70xOAMJyhjpq53u2nsFZpkmVLwciIKPMC2LvYJhbAlJjIUKln5HP9SfZMhDclDe0LcmWN16c9Xi+SvizuFeVHJ7CYS+d2Izm7yxmzw7QR4+j49lpsZsk0CVpBQcaxROec3w4t7DtiWaQTbCiAKvO2kh4dygRUkvFpcBl6QwDMinrrBH5TKJQqiVgSyZNhdD/V0oZ7V1qmfNCOrtrucGCmcm6LDfh9yMAYAD2QMtMUDAGm0B4Vs+H+JMWwPQF7oi/3BOWcASOvnAyCfQj346W6l/KU7RmBEXMs/gSSarfcCiQyliRuiFeAZybNKOwORLy+EXr0EAEDJEfMr6izHoarhNB78vGXMVtz5czwyKEXhNfMGrUk0RbwEpPXzaVw8mcgAK2FFRTkG3v8ovlz5rlKf9uiz2LX0GczJlrXaajBCwU6gZzV5ehqj53AUzyy3T0DGzGgCybi9WnQEA2bP14xZz1lP4e+vP4PHcjORnRqrjFlCNwY1Z80vjISDiD2A2fru9bgwIq4vClYsRc9BtyrlVQeWYpivl8JHPIUaW1VH5FaTq7YwM9iZQLOoPhxePY8Rr52M3+iuqdj6xhL0GnxHC1/pyxjm66UoiXrMrrtWnjr1mEWCqISVejee1s8H8Wg6dhz4TCkbdU0KslNjg2iNIFtMoyWN3RPEUCB8+t1GqBNQ/VKil2kUY7CCZGo4af18wLFUFDSPmSjwGNGpL3IzjP9EPpHXWrRKAdQdKKmQz6ez064BAAzs78ZAZJjSRwtWE2GX32opMHq2GxASJDIUvhNkGVZjkNbPhzRkIMBK8HpaAmQSVBOolai1W8OIY4BPiuUbPAGppTOJLgFflfwAAJpTOSMEJBe8LknzM9yXMcqDm+XGrVy8maWb9SfUfQgjGlHgsbWk0tZ7GUE/XqSstYhIfdwUjQr2YlB5pY5Gj1CWE44C2NnuGdVFsp3T1xvVmSqWKkDXj5lZvBFOFjOc7bkRIvYfyqURHc5IuvN1lyoACtFRkhULB0YDFY2tY6QBptXuw3DMzMbE5qQWClcoFWy3YeIVItmWtQZ2rag90dq8fVvg/wH0dAya0eqW2AAAAABJRU5ErkJggg==" alt="+ Heavy outline / Desk"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Heavy outline / Desk">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Heavy outline / Desk">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:heavy-outline__monitor" data-label="+ Heavy outline / Monitor">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAK7ElEQVR4nO2dfWxV5RnAf+fcL9Kmgi1iJRVYaaFfaItQcbjiFwMTJWEyRKMkOuuyoXEWl0X215LF+cdKRqAYIA7nJhQH1BSiVFd1bA7aQltGSwuUgtAAQwQRi9x77u3ZH5f3cO/pvf24PR8XPb/kJpz3u8/zPs/7dc4LODg4ODg4ODg4ODg4ODg4ODg4ODg4ODh815GsrjAtpUS1uk4juHylxRRZuc0oVE9GarEaUMPtr/vlwwDkLvyJFVWPmEDIzaaNO3n9XVX9srfVcCWYqoCM1GIV4IVFT7Ly75tZVDQVCAv/aM12M6s2DL+i8uQzj/NNn5c1WzFcCaYoQPT4iieWElAUqmq2sSAvF4CJCxbT9u4WKj/uYsW8XDOqN5TKj7v46ZkNPP9COYDhSjBcAWkpJeriB+aTdes4AoqC1+NBDfkBKC/L5vPad3l7z3FGe8J/g19RWbW727D6g8E+3G55xPlfKsvG55FYMS+XDbu7mbBtCz9b+hhrtm4yrK1gkgWM8no4f/EiAA0dHQj/Lygvy8avqDz6xvv94pKF+sNHmDM5hxXzcikvywag54PthrfXFAU0dHQMmsZ3zQJynp4FgOQJN0VVgloaESbCJY87bvxgxMofr16UEF3VTez9/CRVH0sseyBnyPUMF0MVkJFarE6dmINPlvH39Q2Ydt7aD8hZUgpcF8LNJVMpmDNzxO2Q3P17qRpUtXA1GD0Tbq/fC8DF5s5wgMdFzpKZnNp6gNrOo6YqIHFnGQNhnoMJX8PjQvK4ScvJYvavnqJgzkwkt4TklhglyyzPKtJ+gBYX+VueVcQoWY4Ki0VkuL6MwgdnIbldpJcWkl5aqLXt9iemh/8exbyli6EKGAl64S0bXxAVvzyrCF+fREVmIRWZhfj6otNWZBaOqO6BLM/ISYIeSxZicVFCpOVP6hesdxGx0CvISG6enhd2R0rItDoEtlpASFEA+MHsOwGoyCzUfHVlT1tU2qrTh+IKfeXZdlaebTe+gR4XEJ6amoVhFpDoHo87LZWbbkkHoLKnLcoNVfa0MUqW8csqyOFnMR5Eponn928E7HVBOpZnFWk9eXlWEVWnDwFhyxCC1vd0o4Qfs5zvkgvqHcICRghXDLDLxhewbHwBVacP9ev5RiPGHTVovtAjMdQCpk2KP18OBvuo+2IM8275asAyYs1m/LJqjo+PgeR2XVfCtTHATJJiGho569EPvvp4S/kuuSAAJY4gD/2zSfu3fgZUdfqQPYOsBcKHJBuEBVGDrUVdJLITWElSuKDvM5YqwKNzJWPvLbay+kGxegYENo8Bktv8WcZwsKM9tlpAZI9rr2+M2mCzkra6PbbUC0kyCxI0f9JgUUv6owZD2s9KkmoQnn7/3ZbWpwZV2usbLa1Tj+0KED1ODYbY/9F/LK27vX6vLQNvJLYrQD/wtdXtMX0sUINqQn6/7osxhrfFdgWIHigUIbldplvCcBddvaps2rGk5QrQ9yIh+EhXBOZYwkh8/qdf3TzoJCIRksYCYmG0JQifn4jfN0P4YMNe0HAXY8JX3zX3h+GTsWHg65Pwy4n5+0hSpRvgSNJshDUMVRFqUGV/vTELrKuyeWJKCgUMxyU0f9Jg+dRxVF9w8EQJYvsYAMm3J2QltluAfho6WO+2e+FkNLZawMUGa855h4u+Xb2qeWKy3QVdbO401QUNt2yrO4XtCkAJcaGxfUQ7kZGraP0vMn4w9MI/tfVAQu0ZDraMATvPjKZz10bufOTnAExYWnr91fBrh+HitcVb7rtLyxdLQZHCVYOhuMIWr5tIbhcXGtsHPXQ/uaURyeWjfccGnq2oHPofN0xsG4RXra3lwM51AOTNfyZuuuPbWgctyyupMb9c8Urh9UIiX7V07nqLkBJkzYb3KS0qHnb+oWKbAtwuH1Xr6njktkt07tpoVzPisv7ND4FwO83E9mnozjOjYV2d3c3QiDw2NWv/JxLbFZBs6IW+uqYan9vL84+a82G5bbOg1TXVrHtvs13VawRDfta9t7lfW4IhP+t3bKd8RhFLi6ewuqaa4LXPbY3EFgWsrqlmUdFUFhTmxVTC+h3bWb/Dmi/p36itYf7UKcyfOiWqLW/U1vD2kjm8vOo3LCq93bT6DVWATx56ceVl2ZSXZSPpBrnVNdX876VlnPrja6yuqTayeXHxumWe+9HkmHFdb71jat2GKmBf95G4StBv6foVlYkLFuMPBqLCX1y4hFtXVXH7Kyt4ceESI5sXl9/94ZV+YS8uXMLT73yofc8sEFNbozBsEL58pUXKSC1WB/pEtbGtlen5+drzkW1bYqYza8CLhVdSOVa7bcjpjf5S3tDSxCUd+g81Dp7o4u7cPABtUbPuvc1ILh/LFj5myXRvIMR4E0vxwg2K9jcc7TT07iDD3/9ISylRY30pE6mE6fn5KEqQ1sOHcbmiXVYo1IfLJRMK9bckkVbERabTxyWCvi36uowWPph0Y1bkBU16hBL0DCT4oTLS/KKMWLR0dWDGhU2WvA07kEJuFMy6ssx2qVh1h5xZAhwpSbkVcWTzSh57da0hZR080ZW0wofviQUkswJstQBxv5Dg4ImuAb81ToSDJ7oMLc9obD2SjDUw33vHNEPrMHrlajS2mebYm+5Wp2RN0J7N6P2Cw58fNWUKaQS2WYB+D8hMknkKbHrL0lJKVJ/bGyXweGe4VuNze7UrNQOqFNUu4brMthzTBmExu9ny1FyKHl8MwMNP/5ZFcx8EwidPew4089CsWf3y1n66m/mz79Ged+/fz0OzZhG49qaEyF/fsDcq3a7P9rDgvjIAAoqi5RP8Y+9e7TlWvAiPLOf1TZLqlVTTFGGadsWekE+Wcblk/rxyOS6Pm/Vvfsju/fvJGpdOIKjw5aVerihB7r1jGplj03j/X42EQn1MzsrkxJlz3JYxJqrcQFDh3IXLTM7KxB8IRD0f6zmLv68Pnyxr8T3nLgAwLj1NSwdwrOcsAJOzMvF4Uug83q09+wMBLn3zLee/6eW+khms37EdNeQnoEo3xl6Q6P0zsqdEhf9t7asA/OKVP5GXHb4M1e3y0djWyuziEi3dZ60t3D+zlICi8FFTEyketxYvnkU8QEvHIUryC2LmF8/xyhcIiyy76/p7SB81NTF3ZvRlfmu2bjLUGkxVAPRXAsBfVv0agGcrKpl02ziAfr2959wFxqWn8e3VIFf8fjJGp2px5y5cRpX93DpmrBb25aVeLb/o9aK3i7J9Xi/Hes4yLj1Ny5MxOhWv26NZY2R7xAahCDvWcxaXS6alK3wxrRGKME0B0yblaIugWEoQ1rBqbS1w/f2bxrZWpuXkcrDrKADTcnI5duokednZNHd0RB3oAPz7vwcpmDCe9DEZdHZ3U5Qbjg+G/Fr6zu5uvr76FSW5d3A1oHD05AlKi4q1Q/bmjg7tnCIyX3NHh7a7OrMofJFUU1s799wZvk9UnCOc/7ohYTmaqgBBLEW4XDKtx7tprqnCFeMK4tC1q4RFXEh35XBkuMvj7pdeX44+X2T8QHlitU2frmTBcwlbgymzIJ/bG3U2PCN7Cvu6j7Cv+4i22PIRXgssffn3vPZj8+4AtYKRTKlNUcD5rxukfd2BqD2Ay1dapLSUElVYg1BE/sR8/no4ubcLBuLUCPeaTFsH6KdraSklauRCRyhilNfD1YDSv4AbhKuye0T7TbYsR2/U/8gnHsm83e3g4ODg4ODg4ODg4ODgkFz8H10Ivsv9ZvJ+AAAAAElFTkSuQmCC" alt="+ Heavy outline / Monitor"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Heavy outline / Monitor">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Heavy outline / Monitor">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:heavy-outline__character" data-label="+ Heavy outline / Character">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFwAAABcCAYAAADj79JYAAAGGUlEQVR42u2cYWgTZxjH/0kuZxqtDVpUQl3VFhNJSTCmLes+DabSbW4fCqtfRL8KgzGGlCJi92EU6Qc3dN904gpShW6IrIIbE8YoWutGi2Ot2LlaCQ4Ktmq1Xq65fYj38t7lkiVNB8/J84OD3Ht3Ifnnuf/7PM/dBWAYhmEYhmEYhnnN8bjpwyo+r2EfU/0Kni9qHhZ8hQkGVEPL6EgkkgCAxZcaJifuiO36UtYV38Xrlsje2hAVQgNAYJWKRCIJ1a8gEm1yjH4WvEIbSSSSuD81gcWXGsbGfsPiSw1aRrecBSz4CmIXOLBKhepXxLq8jakgws1lVzJlyOuxWNyIxeKWMZ40/6fsxAk3TJxet4odiTaJjKXcH4YFL5IKJhJJi7Dm68Aq1fEHCFTVGCz4MiM7tHqNyEgi0SZLWmgXW9iK9tQV2QpJwWOxuBEMqMauZCpvwgwGVMu6PJFSthaFqtimdWgZHWNjvwEAeg/sdty/u/9Hx/egOIl6qAoeiTZhcuIOVL+Cz/e/XdJxduEpCk7Ww80+yafv7Cr5mK72Vi7tV4K52SevzdxE1lIAoCHVgenxa1gX9OWifV+z4/7HB64DALKeKtTH92BqdJCspZD7QGYbFsj1us+evYTmthYAQLSxLm/iPD5wHeN//g0AGPvrETr3pMQ2ir1ycpaiZXQhqpbRhdgA0P/tdzh28YZYP3bxhhAbABLbNolmVu+B3fBn6TWzyAmu+hXh2YpaDQD48vS53LZNbwAAfp/8J8/XzX1kMl6FBS+FUO1adLW3wmu8wHv7P8FbyVgu4h89AADsjGxEqHYtAODW8Ig4rrPjA5GtzM0+IRnhJKlRvcbR9980FJ/X+PizL4xgQBVL36G9liW8fp1Y+g7tNRSf1+g7tNegWt6TzlIKVZcnr9zC3MIzx4JILn44S1mG4BtCoYLpoJ3BX//A6P00acEVt9nNLzfrxOvq0G3sjGwU6w8eP+fCp9Io15eyHsXnNbraW8VEaWYo5rqZjz9f1DzycSx4BYLLvRK78Ceu3hQCs+AVVpt2IT9qiVv2vTQybhFX9n/uFpZRbdrFbkh1FNw/vH6dQT2ySQvuFNk/DHxluQdFRLRajVOXfhJnBnXRvZTFDgZU42LPdiF01lOFnZGNlsXsoShqNfqPbiPv4WQjPBhQjanLRyxj586cF61Ys8g5d+Z87osYL9DW0oGZoW7SF5FJCl6jeoXYbS0d6D+6DdHGOjS3tSDrqbI0rprbWhBtrLNcGZq6fITsPSokCx+5yzc8MvgqcoHNjXWYuPcQ8R1b4M/qmLj3ENHGOswMdVv2BXJdR31JY8ErYWaoGw07tkDL6NAAi9h2qHYKSV/TPH3qZxGxsl2YIjuJHd3Xm3eWsOAl5uHJ1scYHhks69hvjm0nfZaSEzwYUA05cjt77mJ4ZFAsMvbxzp67ljOBYrZCTnAn75WFdBIeADa/21vwTGHBS8hQyrUSe+SbmQpnKSX6txPyBLra1yvWC/04HOElIEelbCV2Fpacx+VjOMIryL/trPZZI39myNnHWfBiH8bnzeufFJoQi43LmUrDh30GpbuvyEa4aQ2KWg1dewq5Hz6bnsZ8etQyNjU6iJpwCvPpUXT23MXMEOfhy6I+vkcIOz1+DbPpadSG6y3iA7kbP+VxqnioWYp9zOlKz/T4tbyolyPdDqXeODlLMW/8cXqMRI76Ut/n+MB1Ul1Dsh7e1d6KE1dv5llHIWQ7ofwkBEkPP3nllqOgteF6zKdHLYs5bke+MsSC/0fRM7fwbPmn7KtbnAGaj6qQfALCLMvtk6KZDspX9GvCqbwINydOik9AkPNwU6BKr0nqS1kPxUtsrvm/lNn0NBZmJwtucwuu+oMaXXuaN+b0I1BsWrlScHsRU6igofzPQK4TvFDUu8VWXC+423CF4MUmzGL5PAteoXU4eba+lPXMp0fZwxkWnEv7oiWwQ6VZKA0sZ18u7YuQ2hoWr+XnLyvdly3FIWI3hELLPn5DKET2/nCyHn77wmEcObim7OO+//ogbl84zB5eqX+X6+GUfZxhGIZhGIZhGIZhGIZhGIZhGGZF+RfbItAf5IKiJwAAAABJRU5ErkJggg==" alt="+ Heavy outline / Character"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Heavy outline / Character">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Heavy outline / Character">
       </div></div>
       </div>
@@ -161,14 +244,29 @@
         <div class="mx-cells" style="--cols:3">
       <div class="cell" data-item="2026-07-16-style-matrix:warm-grime__desk" data-label="+ Warm grime / Desk">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAAZoklEQVR4nO2deXgUVdb/P93VSxYgJEAIa3aysCiEReSFEQWiDMoOg+MIzug4LrwOzvI6OvOqjyOjvr9XZRQZBBEQUdkdEMXBQQRkM0ECSUhIIGENIUBWSLq6ut4/KtWp7nQnne4OBH79fZ48XXW3unXPueeee865FQgggAACCCCAAAIIIIAAAggggAACCCCAAAIIIIAAAggggABuTehudAf8jfh2CbJeMPi9XZtkRS8YOF5x7JYas5vyZdKikuVrFuXaJlvQ60z2PFGCXrffBoDBYHRZ32oVW/Q8mygDcDY7C6PgvlzO5ZuPOW66DqdGJMtz/us5TCYBi0VyyDOZFOo4pzvnN1dGzWuuPS2WzH8No3DzMcFN1dm0qGR5/seb+N/5fwVAMApIonviCJrpqi3nXE+9b6q8J+mncrLQ11luKiZo9Y4mh8fJAMeunPD5WakRyXLPgYPt980xgHMZlWBaYjvnaeHMFO6glpNEiTOHfripGMD/2pIGaVHJ8vrd3zE2bRSpEcky+FdEFuzdj2iTMep19t+WQq2nKnnuygAIsoSkExyeY5Os9PmPEUiiRFVZhXcvcgPRqgwAsOGF9az/OgOAR6ank0qy7A8mOPnDDwghJs7eN4aopFjKfswmNK4XVecv0S6hK7oaK7HxMeRkHCUsMsKhrsVicbiXTKZGaQAmF+l1kohZaFAug/++koK9+0kYPszXV7ohaFUGyCg5prv2rwXysNkTCW4fypKPv+ChicNIDo+T/bEkiLOnEdszitO5J+k3diQ5GUfp2T+RkoJT9B8+AICHfz/Ro7ZG9xhIsE7gmtywpHx94gAA4+KGsuPsIZf1VpZX02XFWh/f5MZB3xqNpkUly6kRyp+6RA8YHkJZQSlv/+9mh21bS2CTHWdjZK/enD1zjhFpaeiuidjMBs6dPkfcoGQOZ+YwcESsR+2O7zmYYJ2y1gfrBIJ1gp34E+OHuyU+KAzWGnaH6wW/9zw1Qln3z+ZbAXjsobt57KG7Hcp4uwQ4M052Th59U5Mov1ZN7ukiouN60T0yiqrqKubM/alHbY7vObhR2tbCfRjRMTpuCFvP/OBNV28a+F0CiBLk76pgzqy7eXjGKB4d+wyrPt9PVukRVn2+H5vZu9nvCp17dwfgSGEhkV27MqRnIocLchk8Ot6j+u6IDzA+/o4mZ74WHmwU2ixaZQlwB4PJwOo1u+w7Al+R1KUbF6qrCA0OovTCBbbmHGDGrJ94VNeZ+J8X7uXzwr2MjhsCZoPHM3/rmoM0sxNt0/A7A9gkKz+u38DCtzdjNjWsMDkZyvptMPlv1dm5+3tsIToG3NafmMRYj4g/vudgl8Q3omtS2XOF3f/Oo+zUuZtaAvhdByisLtAt//5D+e2pU6izWB3yUtNM5GRYEKXGThvtIHqqI9yWNoDc00UkTRhMEpHNlncp8utn+ui4IR4T/+L+K1zWiwTpDKSm9aPyk40e1WuLaJUloM6iSAFnZO29irlDwyNVAwsouoMowfBpU0kMa36JEG0yZ8ou8tDj93rUp6aI35KZn3ewlIPFBezPPgJAckT3wBKghUq8xd8uabQ9MpgMfPHScgAknUBM/9vo0XcAPfoOYP4/FgBwZJf7tVc70Ea9jokPj/SoT03O/B4DPSb+yuXfYKi2MCqpHwA5xUUcPHPco7ptFX5dAtR9f8eIKC5duYgesNZUcnxDJolTBnF8QybWmkoA+gwdAiiu2SHDBvP8b54hvHs0oOgRrtCStdYV0UEhvFgnMjF+OFvP/OAx8Q/tOcmI6CQ6hISy4dD3AIyITmJv/lG6QLM+ibYKvzFAakSyHNX/Nvt9WGwPoF4S7PoQlinpNslK/LA77OXuGXs3H7/5lsNy4CvcEr9+izcubmiL9verFn9F+u3D2HEqi7SoeEZEJ5FZmEdmYR6W0kq/9PlGwS8MkBweJ//82XmuM8fe7TLZaDQzZc4s7uujME1kz5hmn+NsCWwJthbuY3TcEIJ1QouIf2jPSSK7dmX/xUK6d43ivFxD0fGT9OjZnZOZxzBFdvC6T6Aow2YXO6Pr5VH0CwPodSZ27thlv/fUD59XeBzRJntEfPU5zcF59p8SKzh6KrdFWr6KNZ/sZHTcAHp268jB4gIIUdLNghFjsJlO0d3o0as7l1rUagOSw+PkV95bCIAxyAyAWFsHwGvznpEzSlqfCfzCADbZwsA0ZSYbjZ5b+nbv2OMyXdK5XuwbSYA6K5iVV3Bn1RORW7y/B6g+fA2zqOjI237cj9UiYTAZKCk4Refe3SnILiA6rpfigBJcxxM0heTwOPm5BYuABuJrr+e+sYA3fvuMXzynTcFvOoDRaOLAvoP2e+fgC2claegdQ9AbW/Zu7iSAM/G3Fu5TGMNsYFwLtHwVy9/5goS+CVTYLHyZm0lqn0RqZSsF2QV0T+jNudPniI7rBUCvlFhkWq4EiqKeTZs2Mm/uLxkxcmCj/Gkz5trtJYXVBa3GBK3mxtIOSJNhW3LjPFdp4CgBVKXR1cwXkaFO9GrmH9pzkn79kgEItkJsfAy1srIrMZgESgpO0T2hN6dzT9I3NYnDGVnEtOgJDbslgH9t38vWL3fa87KyjtqvjQL8mDKAvrkGubWikW+oH1ONttVCqqnxyL1q1Ov4ecIwrmiaULV8o9nYov29iuXvfEH/+HhySs8S17snoR06cCz/ODGJsRRkFwAQnRLL6dyTRCX0Jjsnj579E2GT589IDFOIn52SijE5gvEZmQ75+bv32JfALYYwhp8rdbst9geuKwO4WgoknUBIeBhXryjhVEJoKLbLJc22JdpkHu7UnwVlR7kmSw7++5bs7wHEOpEdXyoz70J1FSOik9iTkUHcoGTE2lpOZB6je0JvAIpPnCZhUDInMo/RKyUWywtvIuK5DiDaZFJG3MG9hw/z1b9h87QhDvnH9ufaryfbKulA51aNN/BLy5LNcW3+6KHv+MWqUY3Krf70XWZOfcJ+rzfq3Ip7V9DqACkj7uDk/l38vqtilRMlRWSqexH13lPIEnSrvy4AugI1qyAI5U8VNN2AGjW/Pp7Qm3Cw0CGDmQrwXaFD+jFbpd0gFk44XRN7Ublzd4vb9xR+YQBB37A2C0aBOZ+NBhoTVkt8Lc5mZzncm00Gl2FjwSYlFjB2sLLuxw7zzBR8PXCpuATB5NkOqPz8ZUalN0yQ77Z9Z7/uENaZkPAw+31VWesamvwuAfJ370EvGByidZ2hmoGLMzLY/rcr/HtdEOkPKqd1dGaRqFlbyH71IX72brJsky32kPKMkmO6xLBk+dLxIoTQUH903a8oKzre7NExo15HcMcQ9u8+SHCHYAAmTJ+A0diwFVwy/zVskpXotDRsotz2dQCtBFDXKzV0Wv3VhlYDrPr7e5wo/y0f3vM3ALatViJtJ8wJ4vzyyUT0gC9eriT6iZdJ7fKmXRocrzimSxWSZbGizGVf1MFS+6EdPEknkDLijkZ1tHpJ4f59Ltdcm2TFbDI4OqSEBgeVUcCjc4PqOKjE37xlaaMyz/7u5yR1TKG6tJyQ8LC2rwNoMWrmVLd5pSUXACgrvoAgSxQvepFXMjs76AGvZAoIsgmj0YYo6nlx/Z+ALg7teGsciW+XIOfu2ecQ1+/qXEFrHgAVZIlr5VcxGIxUlVXwh9+/xv/8v+fYs0tRWp1tAlevVLR9CSDWW8yqyirIKctqpnQD8n4wcOLKXPpFvtsws+pf9g8D6vjFotvRJ88hfcX73Dk3QXY+lNGiPtpkJBSJ1CGss8slpPRMEegEYtonyc7P0TKIOovd9cX5kIpWUqh1y89ddFjrnQmvFwwIJhOSxYKkE+xudm8CZ5qCzwwQ0z5JRpYQxZY5aqY9+Ti/XbKILxe9yOHCn6Fvpxjazy9bYV8OBozIBXLZ+SbkX5lMcufNvPVgEgDvb2p+q6hFdtUlJJ2AaJMpv1wCl10Uqt9/C7JESkinFrXvDlPvjadDUBDGeo/BMx9l2/PUrS/Au+98ijlYoec7zytnH8+fyFeko04gJURhlnkzw6kQ2zPx/gfo++CrPpuKfWYAo16HoLd5XT+kXSiXN21uaM8UxIQ5sGW5xB8G1DE/I5gzR67RSQhD0FswClZWbGv5ESxJJxA36HaqS8sB6JrYyyHfamk4Ml6wd79X76LFvJnhAFisFVyTRX6/+gh6nQm9YKCs6Lh9q7dvxwFGpk2x1zt/Ip9ur/2JJx6bwR/nvsCsl57mwwUfkbvoUwD2ZIcBFUxE2RX5Cp8YIDUiWc5e/QJDp73aZLnSwlwi41Pc5nd+aKbDfdmqz5gwR2DLcuUs3oz3w8h/XSG6KBmYMa4bH28+S129XDUbBQ5eUWaYen7P1e/pHw8j2mQEWeLS6UL0ggGbZG1UTi8YyKout7enhVqmb3v3EuKpqZ2pqTNwVVQm53+vz+DoxTw2rv03AM//5hn780HZ+gFUVpRhe3wysx+5nwMnj/PSW39m8T+/JCYxlr9cPMz7a9ey9DevYNTruH/7QvZ+/kduv+8Nn6SAX3SAGpPjXhaULZGKDZUrmdLhYeKH3WG3mFkstXbdoSmohJGO5wBgFKwYsfLoA+H2Mk9/VMgf/+d1Nm/ayP2TJrNp7TomTZ/GprXreHD2L/hs9epG6ZOmT+PLrVuYOm06q1d81KicYBS4f9JkANasXE1wh2AemDSWjWu/Ysy4MSx+5a8sfTSBmLgBVJ76jh8vxREVVgfWWns/X99YyDULduJHRoUzYuRAJk9X4gkzDirv9MhPZzYYrpZs4jlDEHfeM5ihsYnMmzKF97/ewl83rCU0zMRPdi5meHJ/ZvYYQtZ0fI5H9JoBUiOS5exlz7L3200s/XVfZi9S1jZVY91QubJRncL9++jUKx7BZGJPsefWrR3zy4AEl3mipLzCprXrGuVZrSIrP1jGA5MmsHnTRsZPSHf4TU8fw2erVwOwesVHjJ+Qbm8nPX2MnVH0Rh3p6WPYuPYrxk9IZ+uWbXZ7ff6JQqAH3ULLkGnPNVnRZZ7/5AhZpQqhv/lqL8YgMyNGDrQTHSBtSCoZB3NYtH4lI0YOZM+uQ9TW1PLMY09zYsUG/vzz8fS+axA11RYef+A+3nhnNWdOlpKVf4Yx+zbSZ/AMpg3owY5CvI4d8DooVMt5v1x8iHVXlrHuyjI2VK50IP77OcqM2FC5ErPJQOmZIs6fyFc0bsCqq0IWL1Ap/Mnlc7b/7QrRT7xMytA8+rePYuk/rzQqY5OsWK5ZGDNuDJs3bWTMOIV494y9m2mzZvHNjp3cP2ky3+zYSXr6GLZt2056+hh7umAUmDR9Gtu2bcccGsT4Cels27bd3t694+9j65ZtjBk3hq1btjF+QjoAFquAiRpM1CBjtM/+5z85wp4Tims842AO99w7HLG2joyDOaQNSbX/ZWcVkjYkleheMWRnFdp3Al/t2s6CVWswL9nEmVl/wVJ2lX/u2ctL837Fc7+aRVneeZa9vgKjXkd0z07U1HkfKeX12pEYliznr3iWp97YyLas42yoXMn7ObX8OjWIFSevMjs2pNFv5hmR+f0fZ2I/5UjX50fPsXdZGB3vUzR7nbEroOgAW5ZLzM8IttsDBkU0xP0/9kA7ZcCBJ5fnNdvXpgwpWsORqh84w1WAilpu6aOKZLJYlTJPf1TIgeKD7NyhHImfcP8IsrMUe3/fAfHs2XWIoPqgj7QhqZwpusKFi+ft0qD8UgVJycmMHzqKX94ZTW2dzOqMU4Ay6TrPf47zz/0NQZZIH5DIQ6NC+OXiQ15/gMOrSsnhcXLuJy/zry0fUV4bwksbjpG86XVe/I8u/OmbywSZJWJ6hDI7NsReZ8XJq/wldhBDw+8E4P1HYnhvQyVHqkpYM1fZG6ckdYTxd3JhzVo+/SCIxXkhDInsjFjXsMt47IF2AMgYMRtL+NWSCt77fAuLFr6NZLUiGK6fg/PI19tZNCfOIc0iBTNvdQNT2iQrs56Zy8jhyuw+ceYUjz06k4yDOdTW1tln/Z5dh+zX/bok8dS4NACGRl5FCg0CYOnmC+wsLkEvGHjrwSQu1YbSO+wyd901hZRHXvOKCbwaLdX2bzTouVBl5Imx/Vk4cR4XS1Yzsm97xkcps3NricjZSmVmyFY9/yg5wgcXd/BIxEgsVoHZP+3C7rz2TH5T9YhVAduQdOEIssR7cxoOeZbUhBEVVodsrUWUDBgFKxaxE1DBkxMnePMaXsMuEXQCFikYkU6ECmeQMWIUrLz1YBK785TlwFon8tm7i/hkQcNu43JZDaGhIcx+ZJJ93b/n3uEADIjsz1Pj0oiNUMT6RasBKhQpNWVUJwZe7kZSlwpkrHQLLQP0EBTs9bu0mGNU5Q/g22+V0z+nKiKovCry96+OsKb8n7x96BxZ+We4s17U/zo1yF5/SoeHAVg0J46rchhhxiqOnm9Pv25VjZ5lsQroEO3iXumwsl+XMaJDxGjQI1od7RBqmnOe0eDbORi1TfVahbYvrvp/vqYzUaEV9v7/58dKcInWvf3ywgW89l+vMGtAKGkJOof28y6G1RPdcRxkQ3tM1HDXXVOwVdbQ58mFtDR8rMUMkBiWLPcKCeKbRU86pB/45nNmLi/gJzsX86t+SVjkYnve4y9+De82KIa//elAnp41tqWPbrM4k7eUnkmPelT28qkDVKJ8subH3DJuT+nMlj0nWfh1Bo+OSOR3j7r3pTSFiU98QHbVpdZngPh2CXLf9p3om9iOC5fqHPJqLfB9yUVWXvqWMMNJ+2zXCwaGRHa2lwvy3ycCmkWtRXleXPcQaupa5/SO8zh4g9p6Rd6bsenayUxB0TUyL5e2mAFarANoNeKuncyN8kuqg/lN1Oj6AE49MwZFt/QRfocoyeQUXVWu62wYze6XAq3CWSdKmOsNV9prLYxmPdHdGo/D9UadlxYhv6vMwxI7UVB0DYCEGO+VE3+h+HydA1EBevdSPIE6q2s3a/F5ZUZrGcVo1tvb0aa3BeIDLpnTE3jFANlVl+hLO7f5N5LwKvM1hVOnaxDrbPZ+FhRdIyEm2E54LZyZB9oO0bXIvFzqVT2v7QDOdnytIwVwGQqmBl6o9n0V7owvLQkY9ba+czk15sBVEIbaZ+17eNMvZ2gDUlyNjza0zt0zvf2SuU++5Ph2CXYqSzqBAe06et1WdlXjE3aSxj/fUnha11dG8xZNeRObg/NY+XJyyGcdwBciObejdcn62qanda838f3JcP6IFfS5BXXWu5rBKrR57jhf62Nvqq2bGZ68nxq51FzMgZqXe9W37xP7xABaDnTHjblXK8irnIPe1hFZLqZP+EafxF9bhL9mdXbVJfJK70RvGopNX05K+Cp7KFhrwW/bQHdf+LBJVkqW/B1Qwr3gOlqBrhN8Jb7ZKNj38ac/+AKj6StEi4RzNHRrwCcGEPQW+sSFYhR05B6uoG9i462huUhg9B8bHjMoIqLR9gsg61A5fRPbIUoyWVnlDvqAVnS2demh7aOzqFffL/vwJfu4aWEuEhijCYvQjpUKbX2A/JyLPvXXJwZQvYIFRdfcSoDoXkHUia7FmPbltLPoRmjlrQFXS0Px6Vq3H8BIiAmmTmxg8DpRQpTkRozi8AybbxLVZwlgFHQkxASTedk10YyCjtSUjvZ7d9Y3d3A3WDcDXDFyU2MFipSQDYYWj5O38IkBnI1B6w6f9ekUiyg5ShFng8jNAOf+upICkk5g4+FT17NbbuFXX0BKSJjXNml3pkxBlhq2RkBWdbnbQ6dqeWciuAvtVq9b0o4rC52D/UInkHu1QkmHRrYNtR1tiBs0duY4j6M2X9UtmloaPIXfnUHquq7OZk862Zz9vq0rfu7QnD0juleQw71R0DU5btnHqx3K+gN+YwCpnvNzDyuGCfWfMDn/MyZt+v8vcKULZF4uJVNzPE17mlk7Pu7SVfg6jn6VAPkrnnWZbqusQd8h1P7rjFcXrmPpvmKHGaDFrWAZdF5OHhkexwtPTXNZtrZ4G0HR6S7zXl24jg/3nmh2d+Ap/MYAgizx/Juf2e+Lz9e5dZuqeQVF14hPaA80/amY1vxMWmtCdZa50jPKr1p5/s3PKD5fR2qMY7SSKMkYzOtd7gRcTRBf4HcdQDXudI802a+1u4MZg6KJ7mZGlGSiewVRWFDVZPzAzUp8ZzTF4DlFV+2TZU1mQyxlU9FUbU4HUGE06+0zPCEmmI1HTnKsbCqyEIZOqqBP+EZmDIq2v4CW+P4Sa20FhdUFOq3LXAv1PVXCi5LMxsOnyL8yGVkIg9p8kiK/b/WQOr8zgLPYF0U9p/6xDKNJuGV9Ac3BE8umyhDnl60AqPcFhDdRwz9o9WM0gyIiGffn+u8GCYp92x1updnvKbT+kEERkfzkdw15zrYCd/V8QaszQEJMMBS5J7oWt9oS4Am0RNT6ApozqPkr7tKvdgB3aK6zoiSjFwyNiH8rKIBN6QGuoHr5oMEw5G5S+GNH4NdtoKe+AK2BqKn/2n2rQtIJDtq+Ck8NZPbg1LZkB5B0An19iF5xNvbcakzhHAWtNW9rxb0nBzz8aRjz6yhnVZd77ct3XkJa81t91xt6wWD//J0Kd1HQnoayO7TtA/zKAD8bEuN13U8PFvmtH20NxyuONdIDpg/17P8bu8L6jIbl44b6AoxGx1Mzaw8UuinZNNTBuNV3Ac7v5814qbPfX2PlUwvqCSGtMtdS0e38X0K9baetQ/ueWk+fr+MFt9ZyGUAAAQQQQAABBBBAAAEEEEAAAQQQQCvh/wCSWYSNMLf25gAAAABJRU5ErkJggg==" alt="+ Warm grime / Desk"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Warm grime / Desk">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Warm grime / Desk">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:warm-grime__monitor" data-label="+ Warm grime / Monitor">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAALy0lEQVR4nO1dXWwU1xX+PDMYp0YiLXSpaciyMcYmVktrrNiSW2KSpkKAkIrsosrw0ObBolaxIMaJkihRaRsVMKRGsSpT+aESNHKMjGQBsVoTjMMqdjH/re1ls6wXAwYHmlABMWZ2tw/Dnb0zOzM7u3tn/7qfZHnmzuy5955z7jnn/g6QRRZZZJFFFlkkBTksiRUVlAfJtegPQOA5qO9FfwAA5Gfq99SI9DwZcE8OM+ObZTUjzFYzXOA5BUMjMZcl8+ny0GmRfmP23VjATJIOW1lwfslCzJ37FH5S8UM5XRD4uOgKggBRFOMtnimIoj+svHTayeFLmJq6h6/ct5i1AoEFEYetLAgAdetXAQD+MXgu7B3/E+3hU8ycRAJd7h//oBQA0OHuhsNWFvROnYtbCEy5IYqizPyRgVHd9/z+gPxn5rn6PXU6/d/M77TyMoLL6YLfH0D/2cuG78UCJgIgdvrk8CUAwBWnC8VVxQDCK0hf8zynYJoWM9TM1UpX01Xfq4WilZeeEAGguKoYLqcLPM+h/+xlpr6AiQlSo7CyKCzN5XRJGSbABBlFTjTzjMpSWFmkMD9EoViDOTfUmsjzXEKZHykfEoVFCn1JmWmfFclUxQImLUCvSfqpigDA0ZaVyOX0KxF4NBOWxs3Ojb+ABvmp6c8EOKze1g9AarXPr1xmWf4AYxOk1hCX0yVr2t/3/QhAAPY1DpZZMofvuBe971fLQhgZGEVxVbHsr1jDUpugZD5Slvm+41752r7GgVwugN73qxVmygrmAxYLgEaymH/xyA0gfwtGPz4f/jB/C8ZOeMLKlsiyMhVAqnWyfMe9WL7p9xDv7sGymgOypnv7PUD+Frg730DJy4VJLSPTfgANnhp4SzQIo+21u+E91gRh3g54jzXBvsYBb78HjrUt8B5rQtE6uyGdRJTfMpW1ymZGwsUjN2Cv/S0AwHusCY7qQrg734Bj7e8gTt+HY20LLh58G47q5Go+ARMBJEvT1XAf9WH5prcg3v1A0vTqQnj7PSja+EeIdz+AMG8HfF3NWP6z75qil4h+S2oZ7TjgPupD0cZ3kTNzGhMf35A13LG2BeLdPRDm7cDFg2+nXCTG1Acky+wAgDBHxMW/bMOVIyfg2PQnKTF/C8Z6Qj7ArOYnEkw7YlZ1VsyAaLw4fR++rmbJDzz4M0peLsRYT1PSox09ZJQPAAAhbw4AwNf1rhRuAinLfMDioYhkIdXsvBEs6wdkCqyuG1MTlGo9YRYQ/QFL65V5HGOIRCyJyQrAAGRpjZW+jbkAMtEMpZUJUmtLKoWo0SLtBuNSJQxljbQyQVlEh4yekGEFnufkP9awfDAukzppKTspn8kdMT2wUqz/H47FAKNVEawipKwAIoAIwarWbcnaUJl4mpskWsvTcl1QOnfCEoX0VtEMQEKWJqYrEjHXnTAOuY/6EpVV3CALu9JuLIgGz3N4tWEDAOCn208jlwukhRC8R1zyEnWB59CwfaOl+TGJggSdZYiCwMNe7oBnyIOXGgfQt7sS3iMuDQqphXVNAwAAe7kDoui3NC8mWy3JLsnnVy4L2wO2qvz7AID21i4WWSUM9Y21AEL73oCQLyCbTljskrS0H+D3B9A3dAFAqEJmEe3+YL33BUGqoiiKmvuAtSCKfvQNXUjI0ApzE6S3OIsIwkyl/BZPhMeavxULz5jvEYtUQCPmRtrOSq5pOkbvqZ9p5aXH6GjKHQ8sNUE8z2FkYFTRQrT8hJHQ9Binvo7mmVG6EZNTdpekHkYGRvHeEjtqW+YCAC43/RcbqE1vBLE07Wh+Q+/U1IvYtGC0Q5JVJ5O5AGjGCDyHe2IQU2/dwcw3eIxBObJIN2s6jb6n0/TyM3qHMH/RiufktK8fTMN5MHy9aGmFE3mLFgAApiduK8qoFjirThpzAWgxoueBADwAZs9Spkdq7qTSesJRtyJ1/p5BNxqb69C6+xAmzl5V0C+tuAVAeY6RwHO4Pz4JAPLv6CMXrIClJkiNR4+DinstbVcLhRZCLE6wdfchNGzfKIejZiCKItr2fqgoD9m0zVoQzDti5JQUojm0/SXpWuZFL/KgYSY60dosrodI/oAuq98fgGfQjcLKotTtiPn9ARRXFcMz6JbT6EMuookwzGp8JB9gdMiGWnBGoauLOgGGJZi2AMC4wqzBwlGbiaZoM0ifg8SiBTA9sowVrXQAC+YDDIejWRUoHcCyrmnBNNK68p5ZYOr96etSDJ8OSpHec4YZgKwAkoy0EEC6T+4bIa1qJghpVVxTSOhQRDQg51BrHTdsFg5bWZC0HpbnPbNEyhSKPvgbCA2SkdHJ++OT0mmHBd82pEMioDmLC6T7J6OaaqSKQJJeCJrxTxd9J+z5nbGbcdGfX7JQcT89HZRHPIHkh6pJzdxhKwsSTQWAuvVViucdbd2ah8BGA8+gW16fRHCoxwlRlMyaOPlFUltD0gVAd65oJ5uXJxXtzthN1G+tiYl+R1u3bMJoEOYDkslKZiuw5AMOek5TdwFXjGGm3kci6PtIyBgT5LCVBcnEhyiKigkQrXuCaCZKtGip6Un3odVs7fsPR6QZrQKwNFlMCBUVlAfrG2shin607z+MxuY6aVZpX6d83d7ahfrGWrTt61SstyTpRte9zmF4hjxobK6Tf9e6+xDqt9ago61bseirb+gCXE6XnAcRRrQfktD6HamfwHPMhBA3EYetLEhstBltMwMzpsrIvAg8JwtFFP0KIfU6hyEIAqpXfA+A5CeIk+4bkg53XV1Vjl7nMHzDXgWdvqHzuHHjPlPHHRcRteYXVhRi3YuVACQNbWyuQ/eJzzB5YRwNr/1CTq/fWoP2/Yfludq2vR9i25ubMfNImoulWwH5HZ1OQJ6LooiTw5fkw8LpFkbKZgSjqUlCq2/oAny+rwCwddwxE6E1/7jzXNiqg3igZgi5X7TiOeQKUpF9w145RCU+wDMkHVFGmx/C/IbtG9Fz6gwmzl6VoyrSMsh7dEsWqOX1APDX7k/la1oAehNRZgUUkwCI5gOQmyrRRLXdJ+ntrV14tWEDBIHX9A0A0Hn8U9StXwVRFNFz6gxeXFGK/LzZ6GjrVuRPf5lJrbm09rft68T8koWw2aSFYVecLiytKpZbCpk+9Qy6FenEhBE/QPcbgFBvW+A5XP7DEul6hQ1caQvuvCAJsWrypikzFbUASLQDQGF66FXIRvAMeVBYIS2K0lrRrE7zDXuxtKoYIwOjmpoLhHxP/dYa2Wm27euMtmoy6PoRu0+DCMBZuhDz1s/BrN+0I/DPRnAvHEDg3014tMeHL74EVp2ZiNgSohIAzXxAueZfrYlaH20j79ELodTQMj00Db179U4WOtpqb+2SfQy9Toi02PqtNegbOh9mwnqdw2HMByQBCDyHUyXS0Mm3Ns9RPP+65yHuPc5hKwA184mGff5Z6JthlzZ/id6HD3Hg5hTGBpZi5Fcz+Ln3Gv51cgmEWfmm8vlk0y38evw2xk4vx0eb/4M3P/fJ+ejRt5c7sLqqXKbR3tplegSVLFnMFXIUUQ8AdHzUH/b+9PXbeH3xs/L9+vxQa31qbkihOm9y2DV+DYCxPzAlgKKC8iCx5YC0a2RkYBSvL34Ws2cpSex0+/BOUfip5HlPXNW0QY6PHgexd+I6Xlv0jEx3p9unyGen24f3lkj03/FOAFBu/iB2/5e1r8hRFR1Jafkk0pLNMN87dS7HYSsLEiHQAiDoeRDqKO4avxafABy2siBxmAREw4zida3nscb3evQAhHXqIvUPIoWbgDHzAYkndCswAhMB0N9Q0fqfTLxSWcbkU4ckiGj/W1/YM3XcT0JPIyHsGr8mC9xIAKYGYkgHJBXRfrUPdvvThu+Y3UvwcPpxWJpep+uTBd/ES09sPKA9nuQsWIiK69cN8zTVAsyux8k0GPV4I5mhvRMS4yP1BVJ2TjjZiDTc4J06l7OX58K+n0z+mx0rMh0FmXkvGYg0RxwLEjlJk/Q54XgRz6Jgvago2ZM0WWSRRRZZZJFFFllkkUVm43+Ysv+Vmx7YrwAAAABJRU5ErkJggg==" alt="+ Warm grime / Monitor"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Warm grime / Monitor">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Warm grime / Monitor">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:warm-grime__character" data-label="+ Warm grime / Character">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFwAAABcCAYAAADj79JYAAAD9klEQVR42u2bsWsTURzHfxdcdDAH5xTwDO0NRXARimOgWhxD0v9AhE6dQrd061YyShd1dDItnYSKwSIIog5uDtfQVugWTAUVXM7B/M5313eXu8uJv0e/Hwik996V9nvffN/vvZdHBAAAAAAAAAAAlIll0h/rVO2gbntUueYQEdHQf0dERKOzsTH/xyXTxD4a+1SfXKvb3uSdH5giesUksVnko7FPR2OfiOjPA7A9cqp2AMFLhkWu214o/F+XI8NLdXiWfibEimWS2KqbVXez800QvWKC2Flig/tIz/KKZLHz5jNnu2TRK9JjJAubK0uRWJHsdLEOL1p9SK9cxE98uPzbXFmKtbilPigMmrHIKBIrELxAPDy8686U5RD8gmPE4lW3PyAiooZbo+XFhcT2LNGDmWbKZIfjwR8eEhGRNzcfEZaFjrer95q0dPvfBN9+0A6cqh04VTv4OhpFXnx9Wjv/DmR4AfZ2d2hvdyf8ueHWIvERb8egWTK6HDcFS2qssJMPTk4jGR0fGLv9QaSd75Ga3+KrlIZbCwdD5uX7zxGnq4Mpt8HhBRxepNTjykWqw0ULPjobW07VDlTRH786Cd/fuPojkufd/iC8B4IXFJx/nuZ0Flt3P6qUnIzOxpYaFWlio0opweHq9YZbi/Q9ODnV9oPDSxxI87ShLMwYIaqITtUO/OEh3bt9n5YX3XMOn7QFH48/WJIrFPEO5zURntjwdwp1rG2sUvvWzUC620VPfFjovd0darbaqX2IiJ68fhOZCMHhOZytCsmi7+8/i0xs+H184cofHorNdfFTe52Y7GDdQ0n6JEDwHLCILGivt6UV2YQl2op0d+dxbLPVFi+6OMF1+R13+rRrknMcu/YQPIo3Nx9uoXFcNFtt+vn2RRg7/JJcDho1aOqqlqefvtNlQ/YxxQqu5nd88Itn9aPt55Fran8ebCclpKgDV8jwix4pag7zpkO83Gu22nT915dz1zqddSIi6nTWw/fSsKRFSvxbVboZJT+Y+HXdw5K2OSF60ORl2qTqQ3c9vrSLSCnInHcntZ2PgaMOnzFisoit9sEptgJ0+4OZvnq8ubJEaZvOELwkTDgGLlJw1aFZ4iT8ZyZbcLN+Qi5MWajLYJ3gPECmtalVCwTPKHwWQZP6YNe+5Prc1KMkWEuB4BBcDLrZpCkzTGMdrma3iTmOSEFZqK/Hk1ydtZ8URK8W6k6szdIPkYIqRS5JOzfTjqNAcAyasgdNPtOjO8uT1Pf42xVST0PA4RnE7vW2qNfbCo9xT4OPfC8vLtDaxqrYnR+Ry7Pxk2pZHJ73HjgcGS5rwpM2mSlyDwAAAAAAAAAAAAAAAAAA/h2/AUqNNOrWnIfJAAAAAElFTkSuQmCC" alt="+ Warm grime / Character"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Warm grime / Character">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Warm grime / Character">
       </div></div>
       </div>
@@ -180,14 +278,29 @@
         <div class="mx-cells" style="--cols:3">
       <div class="cell" data-item="2026-07-16-style-matrix:moody-contrast__desk" data-label="+ Moody contrast / Desk">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAAdjElEQVR4nO2dd3gU1frHP9m+KSSBECCE0JVeQm9KkSIgIngRVMByFb0gildsV7FdFfUqqKAgoFQpFxERaVICRLr0XkJLgSSQkLplduf3x2Rmd5JN3xR/N9/nyZPZmTMzZ+b9nve8533fcwaqUIUqVKEKVahCFapQhSpUoQpVqEIVqlCFKlShClWoQhWqUIUqVKHEqBvaVvxu7gqxoutRhQqAQRMmTpjwppiRYRG/nPlDhZOgZ/cHxZ7dHxQ3bYwWN22MFq0Wm/K3eOEacdXKTeKECW9WeD3LCz5leXGDJkwECA+PYPpn7/Lgg30xmgxlds/EpDTR12xQ7dPrNACsXLEeAIvVBoDJaODQsbOE166JzS4AsCtqNza7QMvWzZk9670yfTeVBWX2kLLwbc54H/l3etYVJjz7CgsXf1Wi+343d4U4fvwI7IIzj2DvpFsxunHLZJSIcOPmLQCSkpMA2LRhm+qamemZRE3rCoDG15fRs04R2aULX81483+CALqyuGhu4cvbAb4NxPSsK/y+aacYl3is2C/466/mERoaCsD585cwGqXqJ95OYfP635VyuhxyrHunH6Yw+RH9AZg+7YMC72H5z5HiVusvDa8TwJPw5f1t2rXlzxMxfPzpO4x7YkSJ7zFz5hwEu5UVk1pKO0Lh/alvl6LWLsjk+V9BmWiA3MKX0aFTey6eOs2gIffx6SfzxC8/n0VJNIFgt7Jz82ulr2gVvEsAgyZM9CR8ufXLiNq+h39MHAvAmp/WivsO/FZkEthsNm9UtUAYy6RZeAdLRnfzOEIZu2JviWwWrz2qrPoLwx97D9GjW0fWrN7Aiy+OB2DEyOHiq689UymMLkFwYhUquhZqWGY+I4pt+2M4+Zuy72hylrKdkHiHtU/dKwb4G+n31ZZivUevcj0/1S/Dmp2B0ezP9u1RAAxumMyj9a4AMGTFNLHl6PcrBQkqE7J3rBI1YjrC/p+wAutPxGEwapmxLgmLLS9T89PC+cErBCjqTU+evECffr2YOiwEAGdGBjUHvwymahD/bLEr//8ZwsxHRQCfnFa/40oSh86ns+7QHQCOZGR45T6lJoBBEybe3bw5J07FF34znYapvU0ABPabpOxPin+WRk22FKpByhqZew9V5O0VWGY+I2b3fhKAmJUfcuDMLeZvv11koRenIZWbuZMQG8+5mP3oLfHgHw5AdsZXaAiqFMIH0JTC+rur0T0iwPmYXaV+DkNoBNrYGG6mnWb9/kTei4or7SXzRbkRIObaQawZi8kmFdyIHBI6rVIIP/vw0WKV7xh5v8rolf0HHYPuFw8d3lji57HMfEbMbNEPc9QstvwRX2LhF1ULlBsB9Gs+gQGPkc0aNAQBfw3hd4y8Xxz1yAjF67h5cxQAgt0OgE6vZ+DA3ljdhg6TJz+TZ0Q07okRRXpOg0mLNjaGfVdvFLn+pUG5EcBv/HxiL0gvqU7Tr3E47JVC+IUh5vwloqKiEex2dHo9X339sXJsT/Q+TGZfACI7tFH2X7wQQ58+nbELTgC2/r6HVSs3iQBffP41Bfk9sgY9gfnXb9l16Bbv/pFUNg/lhnIhgM0Z72MgTAxvurDSCb4w1d+xa0cSbyYCUL16MJNfeIOGjRsg2O189eW7AOzYcYA90fuUwJPNLjBnziIAkpMSVdfT6fJ/5Zuf6ytq4s4y/efToDfkW86bKDcNYHPG++Asr7sVjuxbGpznDxTL8Lt9O4XweuHUrxeOzS7w/kezAAitHszyH1cDcPjQEbRaPQ6H3eM1OnftlO/1e4x5GAA/vZN5u1KLXK/SoBI7PcsW5hpOsoso/NBaoarfRqMOm13AbDATGBiE02EBJOEDVA8OonrNEAIDpQikIAhcvxKrhKQLglPIKrSMN/E/S4CCVH9uXshdAEB4vXBi4xIIr1sHjVbyacj/ZSQlJxVJ2J6wfMZiEpKzuWDNLtH5xUWJCLB2i04cPkCoNP14UZF9+CjmyHaF9vu5YwG5NUBERMMCz9dq9VQPDiIpOYnuvXoq+69dvoYg5B9oWD5jMSaTD/uuFnh5r6JEBAjwNxB9uInYM/LsX5IEhaEgDdCgcf085W8kJSAITsLDI/AL8JOuYTSQlJzEnt3RqrKhtWsUeG+LRWTv7dRC6+gtlCj7YcESLXbhAu99HlBgBHDbHl/xj+N+lSLBsriOHndUrx6s/KWlpHkso9NpiI29xrkzZzh35gzHjx7Lp1z+bW5ptOdrlyVKpAHSUnXMnu3H8xMEtu518sozjjxl1m7RiQA92mR6TUuYtXnv4030fWEV6Mx59ick3FS2a4TU4Nq1y3m6AUFwDXH8ff3JyMqge6+eGPTSKz51/BRJyUkFdgF7b6eSvNla2scoFkpEgPXLU3yGjgkWo/eK3Nc/nQPHo1RCHjomWAwMSmPdOu/amE4PwikKMvceyjPcG/TG5jzlDP6BDHtwKHcy01X760WEK9tZWdkYzCZuJCVQu2YdZb9OpyGyY3ulhR/YdxDBbs3TBRQEmzPe54K1aHkVRblWUcqVWEImg4MTx32IaOhg1/7a4j1dbuS54Yx/p5WJjaDTG4tcdtlPN/juu20IgoBOp1Na4IiRwzEadWi0JmUYB/DfVWuJ3vOLqt7Xr8Uq24GB/hzcc4hO3TuqSCAIzjxq/8C+g8V+tqHhwayPTSn2eSVFkQjwwxqTGOwvvbhjJ8y88890n9WL0nz6PxQkHj9sILK5S/3dMzhY7NRRoE9nR7kbiPcO/ASd3ohgl9SoIAiYzH4MGjxIUcUyzL7+/LT6Z6J2riq0nvUiwhXff1ZWJgCpt+8QVD0QQKUJGjRoQrUgyRBMiI0v9nBw2Zp3qN5tar6OJG+jSAR4coTF5+Hx1USA5ycI7DigFVetCGTBTBM7f4F+PdXOixVLtAVeLyPDIurdsm937DiAyajDf8YGOv5acFaQwWBAsFvp0e/DPAbVI2NG43RY8rRqjdbEsiVLC/TBe8KIiJZiBmoNAODr68epE2doE9mO9PTLNK7vIsCVKxcLva57+py7qs7Y+Y24bcF8JrfxY8aR1OJUtcQochcgt/jpnxkAA2++cYfOPbOY8HB1VbkOkQ52ZTgVIzDA30C/7lnKQ/42+FVx56hpBI2VJmMId0Tce/bEpDQxtGa1fAXVsGEYfxs1XPktC1t2xnhS4a1b9itSvzqhVZc85dZvj0Kr1dOtYV1MjZsCOXaAXsfZEydp2LhBvtfr3bc3UTnpb23atSUtVdIeE1rXx+Zw8sPp66o0en3bUQiLVnKyHEMlJbpT/4eCRACjSTp92+pq9Bx6h52/+NK6Zxpvv2UhwN/A+g0SvyxZOr794rZyr6i/vSfW+fUSAA1S56uuvdl/FMOEtR7r1THyfnHB9zPQG6RAyZo1m3nrrefzfYbWLfuJjZs0Un6v/WWeqqwngedGsK/0DNWMGUp0zt26BxgytD/z5y3l3Jkzyj53gzDxRopKMzzZoh4GrQabw4ldEFh6PoFtUzvQeeqX3NNokFfSvcrUCPz951SfewYHi00a+nA9QVT1V1lpOnbu8iUoWGToYAGNzsqqFVJf+XHQvSLA/p92ui7mO4iXAzqR9f493HhtJaHk330cOrzRp227jcWqa8dOkcr22l/UxwxaVzdkcziV352bSw4ZgEYRfjkl/FjTqhZZaVmMX7UfgC7du9CydXPlGnc3l7bPnTmjxAVkTGwnDRsFh2Qv9WqlJTDAjG+gHxNNjbA7nNhPbSrWs3kDpdI1Bk2YOOARyWe9ZaWZxm2yaN/NQexViVdGo0hgNSdT/ulg9SqtMir4RNNX1fJGGyMACP3nMI5NX0ZX4Sev6MDWLfuJj4x5WJn0CSgC0+qNzPlyFhNa16dXKzXpDEjVq9ckDAAfvV45durkZSwWkZp+WkYtv+zxvg83yOU6DvHDKkC/Ln4ey4fUCKBV/35sXbSSUQsvlOBJ1SjzrOCnmnUQv43+L0F1+rBlpWt/zTAfzp0SORGtHq/XNum5rbnNIHNbcVP2MZ9TPndoKQaqygRN/xslmfIxIqKlCHAuyULTAX1Vx5KTEtm0YRNtI9sp+7Q5Q8jBA+7hrTcnUT+sNU8M7+zx2rLgwyfMwdds4MaN2zRd+AJ2u1TTbVOro8+J22/Ypnbgt2rkChBFNKwFgD5Hw9gdTmVb/u20CszbmFzMpy89SuwH+OXFcSRtfY35Hy3g1d8TANi3yQxuJt2vzzaj9/RVfP38IGYtv+ozyEypnRyvd+4hXkvOxCK4up2NCRnMnTdDVU6eBh4UFOTal52lHJv//VJ+G7YRh8OeRyDtQnw51+8djE4LVo2Jw4eO8+qynax590lGR9fk9KAUDCYtPlo9B29moNdqGNxPihHkJ2T3fbmF37lFO0rf65cMJSLA0vMJnIr3Z9OfCxjRpwanP6xPA7OL8T5aPbZuQwCInvYoERrp2KbsYz47AkaJP2RdKtJ9PBlpKVkCAb5GLGnqcfLfn5pEzyYN6DtuLFNfedrj9Sa/+C6Lv18GgMNhZ8Go+lyPy+JGfDIRjerSdOgkDM06civdQuMAEy0efVc599jiabQd9z7/en4YLb5dx6WRUtfXqZYU8xcddpIzncTZJHd1biHnFrwMvVaDo1pDtq+YV6R34m2UuK81aMLEmkiCndgjgBZNg1THbVbpRcQnZ/PS5j9V9xlkbiv2sbqiYqONEVhEJxF9W3JsywGWtYzH5sg/fcig1dA5x/a6HufyQchWular93QaAItG1QNg8Nyt6HUaduw4AEgRv09X7wJg1sujmfz9Nta8+yQDX53F3rmvc9+Ur5nz4kiefW8O08YO4u2ZP/LltGe579w3+Hi4n/vULXvOs7gT4NLFBAyIbDuVwuf/eor24771Sg5AcdPtSkyAuppGYhKSs8X9hTscdtXvWx90xff1lQUSYLjB5WtPETIVAhi0Gvp1cMuNswoE1PBDyJkS5Rvox5Wr6n6zQf0Q1e86z8xl4KuzOLZ4GgBZ2TZWrviNpk3qMXHeBsDVujd/OonElDTGfryYJW+MY+zHi5VjxxZPo/tzn3Nw/lR27DiAxSJ1Mfff3xPtnCfykCDOHKxsX70gabwLMVKMwWGX3tuhiyIjevrRuH4Qj318slyHfzJKFa2RNUC2UcfwMMn9OqiTa9w9olMElxPTpHWCWtcnJjGNDLvI9ttJ9CFvXHyJ5Ryfaq6zqkNTZV+9eqF5yvno9Yh2qe/OLfDu4ZJjSswZmrZ76VN+/XQy167F88Bbks9h79zX6TZhOps/ncTAV2fRdtz7yvljP17Mr//+O6mZkoD1Og3LXxvF6VNnOTh/KgB9+khGY52QVgDE//te9LlM2CU//qFsn7qS161rMkgjjw5jRrNu1o95jpcXSqUB3H8PbCKp/EGdJBU7smtj5dhL88+j02o4n5Cq7Pv9Zkqe5EmtVk/0m2qL3H0I1vKVhcr2sWOnabN3NgB6bd7xw8n4ZJ6dfYHAzh3R6fWE1gxk8JDBPPhgXzr9/TM+mjCMF2csV7XsFo++y/LXRpGVaaFeaDVEUxA+llRqNZBI/d57XzBr5lzMRiPZVitf9q9BaO0ABjz9JE4hi+UzFgNw/LL0WuNS0rDawagHk07P4skt8tTT0r4nP3+7hNdX3UTWqKVBuXYB7r/dCWBABKOOB9o3QHTYmbrYNUQS3Pp2nVZD/ZrSQzeo60/tsBBVP9nqhU/YezyRbt0lZ86lmFjsNhvNmrm0zI4dB+h/0WVAOWq3RnvjBADmF6VlY1RrE+z6mUsXr/DYW3OY9fJounWP5OzZGDLt0KG167py63ZHHYeD1x8MZeDYv2HK8QR+//kiriaZuJnj5jUZtPgZXd1WTGIav99MYeOkVvRu6ooZiA47lxPTqDNwMBu++5HHl8d4fM/FQUnS7Yt8wqON2ikCX31FSpGSuwDIS4AHujYBpAddf1AigA0fxckio3bD2sp2+1fmYtf5c+jAUYKrBymCvhQTS+NGLjvhUowrOOO+HyD24kUa7PhEuTeA78tRqjLDRg5j0vNPKMSS8dBDz7Bv914APrmvOlq9ibo1NGTbHNw3/hEs6IhetIz0LBuHz2sQHE7iUtKoHxKkus7haynsTD6tererHuupPLjV4cCo1TJo/Cg0Rh3LZyxm4rprlBZeJcC9IS3Ehzq4xvQHLqizcVZfScyXADKGtq7LA7P28OETnT0OgcBlIQP8mNkBgI8+eBmASxevANC4SQP0Bazdcz02GZtN0iSNG4VLq4gJGeiW/FMhgYyAqX8o3c7gB4awecMW5dhXQ+pQp041AHqPHg6AMydDdOrLyzBoNei0Gow6yLRK9Za7tt8SThUcxdSEiVPaB6mifOm3j/PLxOFeaf3gZQLIKr5dLTMje9YE4PP110m1ulqw3GfVxKQQoE9kGGGhAVxNsPHcT+dZNaah4lL1BHmMbHc4aWDW83mqa4rVO++oiQCo1L8nnD0rvUyr1UKLls0AWDB/OZO0UYBLIyVlOnht622+HCoZow89PxanVcBiF9i85L9En5QELAeDEtMs6HU60rOs1Ary89jKC4N7GFir1ZOasINfXhxXuQngjn/0rsE3UbdU+woyXBaMqk+Lu8PzPd4uxFfVQi8nplG3mh9xaZk0qlODf5ysC6BMwZIhdwG5uwV3+8AuOHnz7S8AMJzbw/QB1ZShmuiwY+s0gCxBMh7/M3URmVYnuhwtdTM1kwBfV9bR0WtShs7+tPOljlE0C2srAhxZ9y+Mh7bT7dXtXlvswes2gCcSAHQJN9OqrhmrTZ0I0riWq0toEylFv3K7WGW4C959DC067Pho9arjL1+VDLKeXSMZPKS30h14EvqPy9ZyNU5arOLt6mfQa22cjE+m8SDJM+m0Chxcv561O115fzGJUjbuXXWCVM9TklZeGGQCHF86GcGopc/9H1XI+F9Gof2WvO3e37tjYo8Axj0/BENgCCa9josH9pGZno5eb1C5ST15y5LSJN9BzWr55/jJRLBZHEy5LA0tdXo9X/znX4CrpTty0sA+Cz8rndjrfuUaK2Yu5Mh5KzqtZLjdSs8mwNeohH9lr2PsrYxC+/LSQibAoeUTiFqxlg+WXflrEMAdnsjQJdxMhyZSC5/ywUR8jL4Y9v6Wp1xx4UlTiA47b8RJWiEr28owYbcysdJpFdi7Zi3XbmQp43FAZa3LQ9HjcXe83sILgzsBvBX+hXImgIz8tMLTXaozoGs1ujWq5/G4N5B5dwfV771r1rLpgCunXsgVS5C9kCUR+O7XHhA7DBupTNzU7N2JwSR58mwWRx5Xd0FoFtZWXPhUE27EJ7NuTwZLzycUtzoeUVIClMoV7D4KcMeC/bdZsP82/+gt9bOvDWuq9OueuoKiQHTYyWrRVcnv375oJftOCspw7FZ6NiaDlkBfqS7y8OxKqoVT2ZdK3Mqjp/QVI4eNBMD3zHEArPeNRNZLPoDja5OqoYgOO7qXfvxLTJvzyswN95GAOxnkEcM3UbeYPkpKini0x11AXrvA029bpwHK72WfzeG0m0cRXNa6QauhRoDks/C24ZZq0bF96Y8IVitmgxadQUf9lEQaBUsxCqFGExy1W+NoGKE6T5gpebzy0xDr9lRUBoAaRR4FFNdPnV/3MKKNiWCzL9MeuSuPwC3tXTNpo1asJfrPTKxCXnUuD9cEh5PjcXdUkynLYvWRe0Na5OkKJw6sjtXhICw0gGw7tOvVEYCwtNsAWFp3Vcrevnqey8dO0OuTX3261Gsrfjm+Cd+tvsL+q6lemwZeJjZAfsNAb5FhYo8AXpo+BaeQhUbny/tT5ikOl9hbUgsx6qFucDXlnNwCz43yXn5G9vClWgMwaDUM7SZpIp1BR62c+QKNuvYBpNHI1j9Tmfn1OF56YbHiUvcGypUAMrxBhAu7p/H+lHlYBbianIrVDq3rBQHSPP3D11KKNV26Igjgaf+CUVKKmMUiItpsPP6vyfgYfXl61EesvpLIww1CKwUBvJIPUFQieDIaswSboubrBlfjeNwdvjjkOdvWE9r7S74Gk0F6lJ3Jha9YWh54epXLXnm4QShRY2fyWNdwrwrdG/CKEVhaIhh1MPto0ZfFcBd6s9oBAJy9kU6buoHsLP/E2kKx+koiTY1mjv3smjgSl1b2y94XBaXqAgqCN5IbZDQ1mvHXq3P3W4YFcCk5W9U9TGzXkBmH/6jwLmDpmEZYHQ6VFihrVEgXUBCKqxXcIbdwgLpBeqx2yU8vOJwcuHyLIxkZHDmfoSrrrYBKaSH3/UattkKIUFyU+Sph7v19QWRwF3q7iGDFTz/3hPTyfr+Z4rGsXP7I6fIlwPrnB4gAI+aeVO1/bNhgBL0Z4dJB1p+Q1vmVSXE9LouEdDtzj6eWa10LQrkuE+dJKwwNl7Jn64cEqXz0smr3JOyKRNb0R0SAmb+d9Xh8x77dAAg2gRGdXM6h91eeB/T4astn3n9RUSHrBLoTYeLwusxeG8fso2rLXxZ8y7AA9AUsrFTWmDe8qzi2d2t0ZOKj1WONlMb0L+Ucz72e75Y/pFyFXp3DWX/ctdJ3ZHNpXuCohZVjlCKjQheKlIlwV+0giE2hW/UgAMWyLy5yewxLiyWju4mPjJTiABq75LEzXb1OzNUjNPQPwNZqCLBbdc6HY9upfkstH0w6Ox1aFrxEXElRGt9Hha8UatQKysKMJRV8WSDrj4UiwMqv5yr75DhGQ3+pnsZz2/M9f83BaxiMWiKb+9Hxvh4ArF60mdnDIrySAOotVDgBoHifaTNoNXSaMhWT2ZfdH71X4BSykmLJ6G7ijLdns+dMFhl21yhv/taDyoeaujep6fHcKQuPApBpkVzCjw2owdHd0qdomjSqQVZa+a4FXBgqBQGKgh6vqD8Uufy7+YSWgfABpv+SWGiQ5shRz6OO7efknAQrI9sFs/PgbeVYZHM/Nh287q1qegWVggDua/PKw79eb76jTOeWsWKltMRHctxVzPGJhJZRl5FqFfMNYMnIb0jrTpyfjrquBzB9fzyPNylZPkR+KG3so1IQwB2ySv/mm+8Z+fBDbNwgLZuydbM0y+fxu+pQT6fjLJL7tyzshjhnjA8U7AktiqNLJkNhZCopvBH4qnQEkLFndzR7dkfzZAsprUz+f/aGlGUUGRGM4HASk5jG9uSycQLJRID8yVCQcGVyuJOka6cQTt1IL7Xn0ltRz0pLAFngR6+lYDLosNgE2kUE06x2AGdvpKv8BvLwsSxRFDLkhicv6KTlCXmcWxWJSkcAg1bD8bg7yu/ODWso3cIPp10GVP9akkcw0KxX0sHKC6UhQxKWShO3gEpGAHntPPcQrxwLACkq2LNxSJ7z5DITWuddy7+s4U4GKJwQpQmSyfBm0kulIoC8eqY7+tcKJryGWmWevZGuCgN3qx5Urh9ZKAiFaYfShsm9nfFUKQgguKn49v7+eQI+uQUO6iBRs9oBlYYA7sitHQqbZwFqAecuXxbpbpWCAOAy+mR4auWyF85k0NE4xFyhQaKSwOaM9/FEgvwEWx75jZXmDcozcN0NJFnocr6fHBm056z5bxeEvxwJcqOiP6JZad5ebsHL8BT//6sLvTKhUrxJeaJHacPBVSg+KgUBZFQJvvxRKQhQnEQOOSpoMvuy7YN3yqpKxUZRLHxQr1h2/OixIp9XVrZCpSBAUdDv7feU7W3bd1VgTdSQBXjfwP6q/bdvqScoyN8POH70GHc3b658XML9y6Lyt45A/WEsX18zWzf/Lv6/HQbqPKwgJgs8NTUVkFb6/vtTk1RlnmxRD7sgcCk5O9/rlCUaRXQVm9wlLU8j2O1ccVu+LjPjjscPRskflZBJ4P5ZuZohUpKJn7+0lH5Yvdo89JC00sn1a7GcO4PXSVAgAZKwlFko0x2euoBVq9cq27+tlb4SUpivoLxg0ISJvfv2BlAJHQr/aJT8CZvY67F5jsmEkf9XDwlgyeJV6HQaHhnzMNm2bD7793+8SoJCNUB+c/+9BasjbxXO3khn7+l1gBT/H9M4BIvNkcdNDK6RQ5u6gaqlaMsSdzdvTkLCTdU3goqK554bD4DFYmPUyMcLLOv+2ZnDh45wd/PmOZrDe5rg/wDft5dOiSip1QAAAABJRU5ErkJggg==" alt="+ Moody contrast / Desk"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Moody contrast / Desk">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Moody contrast / Desk">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:moody-contrast__monitor" data-label="+ Moody contrast / Monitor">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAD0UlEQVR4nO3cz0sUUQAH8O/M7EgRQiUFsYF0CCIytqAiLMWDHYKgQych+g8iKYKu0UkkqWsRhNSpQyEEURGFYD9MF/sJHcLIS78sIq2dffM6TLOu7lqzOztv3rPvB2R1due9t+/75r2ZcRUgIiIiIiIiIiIiIiIiIqKlylJV0Vpni1yd3VL6OZOxI+1XLPpVt0fdv55yP0xO4IN4rqRvMioqCX2Zeq6yOiPEG0YUm9IjAABe79+susqabLr5Uml9ygNYbic7tQrHhyPsikddKQ8gCcIJFlS/vyN4fDgCq70TxfD53nvahmB8AMLxIQe6AADWy1dwC7/gte+Z9xo50IUiAEvDIJQHMOvLhkxD5R3f9GQC0p07rXTz+eo79XWjePK2ViEob0mj1gA50BV0vBAo7NgKy4vwVl6Mwu1pKU1ZOtBnKEQkHB/F851w8/mg4x0HAFDYsTXS/tL14fa0JNnEmhgXgN/fsegU4+VykbZL19fmKDAugHDE16JaYJkjqxrQmviMCqB81IajWgpR6uBFF98I5aXFmADCs56KTn44Ai+Xq7nzAWixFhhzHeAIu3RhBcyNdq99T12dD2DeqWtajDkCgMoppt6RrxOjAljI9M4HDJqChOMn0thZX6LJlQmUHI12AXgDwX0cy3EghZh32lkQAk3PnjW0vsy5vZi3Etx41dDy/1m/0toicHuHS2c8C0P41zXA9OTGim2rWt8k0s5G0S4AIDjjwdH7FduF4wN93cCL0ar71drZ8tI3uBgulZ3GTTqjFmFH2JjpvYNCW1vssuSlbxVlp8GoAIDgbqp94kGsMhZ2fpqMCwD4c1F2eTraLegylmdj5uLXZBpVJyMDAIIQ/MHpqgtvufKQvKufE/+ddK20XIRrsfLuKCSCRdTtaSndXrA8G9L1g68/U46j4XgzPoBQeESE0ru0qo1+Q+I/wwBSpjyAWd+UyUGNVNYAhjBH6cfTVdXVCKo+ns41IGXKpqBdu/epqqohhobV/C0Dj4CUGR3A4/ExPB4fS7sZsRgdwFJg9K2Indu2p92E2JQdAUPDZ/W6DfkXKttqRKe0rjlU1zXE5Mdr2r8/rgEpYwApYwApM+Is6OfMp7SbkBhtF6lmKytbN3Qu+j8dospkbEy+vY/vckrL96pdo5qtrASAoVPHsKJpGU7feRurvOMd6/Do3Q+cuXIBALQLQqvGhMIQDh44jNz6bKyy8u+ncH1oEIB+nQ9ougaEHSXyt+TT/Nx213bg+aLisdrzAErf69jxRERERERERERERERERERERERERES09PwG66pCM4ycWfsAAAAASUVORK5CYII=" alt="+ Moody contrast / Monitor"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Moody contrast / Monitor">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Moody contrast / Monitor">
       </div>
       <div class="cell" data-item="2026-07-16-style-matrix:moody-contrast__character" data-label="+ Moody contrast / Character">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFwAAABcCAYAAADj79JYAAAGQ0lEQVR42u2cb2gTZxzHv5c0Sa9NOi49WzWJSbpeZLV7Meda/7waqGMgDH0xwtQXg8GYMIcw2As38I3Md073xrHtVR2U4eqLFcfGwBc6UHSFSdXRYDS0a4kmDWvTXJP28uxFvPPyxzap7fac+30g0Ms9d1y/973v83vuLg9AEARBEARBEATxnCNY7YBbnHZmXnY5RGTmspb5P2xWFtsnycgvqJBa3YwcvgZi9wYDAIDMjAqpTcRoYhy9wQBGE+MAgFxBE8jhq8xoYtwQWxdfPxEUKWsous5fmZSljt0ygucKmqBHSCU9L/dYIk4sl+HmZXN2m08KOXwVhNbFruVunyTXbEuCP6OraznanOFm4UnwZxC7Nxh4qtiVwutXAM9Ot0SnuZzY5na8l4hNViqp3tv6Ijyi3Vje448Yf5/+bYwiZTXiRHd3pdiVHNtVEj82meLa5dxGik+SDbGP7YosKbZZ9PyCSg5fCVKbaDi7EVwOkQY+K40UnySX3TcxR4fOrKrhm5F7NQdEPA6EuOw0cwVN0EUfTYzjgOKH1+MyOkc9zz+/PoZtvoBxFZiFJ4c3SJ8SMuroiJPhemoe/XIzvB6XIewBxQ8AGCsIiDgZvB4Xfrr/N/rlZgzFJixzf4ULDm0Jsj4lxHLTSXbh3BnWFdrLHv4yxbo2bGVHt0fY0e0RJrW6WW46yd5Yt5P9Hp9huekkUzo72aEtQRr4NMpQbAJ7/CJ+OBJCzyuvlq3ziHZ4RDtkdysexGK4590EAPj243eRys5RpKy04/zqgBMA8NGPHQCAdvc83gy/UFYifn9nGgCQzjbjg76Wso6Ux0jhWvBaVQkAJB7mAADBjpaqdevDYXxy/mduqxTuBfdJMt7u8da1TeJhDudvJ4wKh0fBub95FUsmq0S7OSrh5qiEWVUr+/787QT3VQnXDp9vAoq5Jy49uj3CPKIdm5KdRrvbbZM4e21MqHV1UKQ0GCe1BDv++kvMPMqsFJt30S311P7CuTNMz2q947xw7gzTv7cCNqu4eyAqMr0eD3a0INjRUlYeDkRFS4jO/QOIiwftbJ1mQ/cmO9oUpWq9fhLkPxaeej+GHN6A2Pu6bOhXgHZX3sjtWkiygIXPHKzS6byJzqXguYImXI062L6u6sM7dekK1ofDmFU1HDz1NUIVro8qi7h4kN9XJbiKFLMbH9mLhh8yKQZJFuA47Uc678LOTycRe2cbAMBx2g85xZD2NBtXQa398lKtcBsp67TSoQ3Hi5Dkcq3ER7cAACFFMU5GuyuPwVjJP/u6bBiIioxGmnVQzyOykKLg1KUryB73lZ2MqLJIZWGj2Z2ZywoDUZH1K7XbtLvyGDniNzrKSobjRQCA214w9smT07kf+GQ1pyHicgzGmpDVnFSHN0rJnbYy0QdjT9aHsVjm5qW2pUipA70cHIw14fCgKujxoHMfTXD7NyKrOcs+hwdVwbwPHkeflnnVzdwhZlIM2YnJsk7zeozupayIelxZ9DRXdZqlur06XnhzuY1nJ5sz/FmiiQT/H8Ot4MPxIg4PqkKL0870qqSSdN5lfHb4RLQ47Wz/d5qgjzjN9Th1mk/N73Jx55uAvUOV+awCX2y0pMO5r1JsRQkbw7vrapueGEaukK2R/yoJXos/kyGcSAIfvjaOrKahe/Nb7EHi17q3F9AOoCT4iavdpjV3KcOX4ssbAdx4EMBcOo5QcHfd23n9O9C9OcreHypQpKwWc49vzZbs4gYAtLZ3UZWyEk5eviuYH6Hl1WSNI3ZDdDVjavqOgGJ2WbFPXr5Lr0ksxdlrY8KsqtX1m56lmFU17sQu9TMcs0HuY5UOnkvHIToWEZ8aETZ4exhs7iqXzz26VboCKFJWh/jUiADAiBUaaa5Vh5mO19VOdDWT4KuF6FiElbGc4Hqc6ExN3xGKM2Mk+L+JutBEgq9Ffi8VJ/XmOwleL0tUI6JjEVapVqwjuM1dld9luf54mE+C/xeZnp8nwdcyUirLRarD10hkYpWRWt2sTwmxeiYN09sonZ1cT6XH9axusrsVmZnGHo/pE9vQ5AYNit0bDEBqEw0Bl3sD1ry+NxgoTW7D4TTXXP9Os5aY9WzrcojG3Fc0ZwpBEARBEARBEARBEARBEARBEM89/wAn0I5smpQIvwAAAABJRU5ErkJggg==" alt="+ Moody contrast / Character"></div>
+        <div class="verdict" role="group" aria-label="Verdict for + Moody contrast / Character">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for + Moody contrast / Character">
       </div></div>
       </div>
@@ -202,31 +315,56 @@
           <div class="era-idx">1</div>
           <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAALpklEQVR4nO2deXAUVR6Av+6eKyQcAmYREI2orKDLKYqLS4HIoXKoMUDcxXApa+F6oLIsIiXiQYECxaK4Vjh0BUVAQI4kBVKwWihGiCILrsqCrICBYBJyzN37x6QnM5OeIxLMG7q/qilm3vTF/L7+vd973TORZDkNE+MiN/YBmDQupgAGxxTA4JgCGBxTAINjCmBwTAEMjimAwTEFMDimAAbHFMDgmAIYHFMAg2MKYHBMAQyOKYDBMQUwOKYABscUwOCYAhgcUwCDY2nsA4hFi+feVuVmaaQO6BLW3ryFI+o6lzeX4m73aruvTpsdf/D5LOnbmOu/5M0AYF76XYHtpbVn+j1dGbt0QfydC4bwGSAy+PE4XqbGXeY7l1KnzVXPj8KtBM4dv98TbDvnzI+/c8EQXgA9ykqdMd8/HwlcyDynXhN1vZe8GbgVCy5kmr4wN+w9i6cq7n5FIykFaCj0JACCEkSKoAVfQ7Jaw973Wps0/EFeYISsAar2v6IO/+MnFDqsUZcpK3XGrAWOl6kJ1QPfuRTdmkAjTAJ9X4IkYwYQUoAgTk/8ZWJQHwkAUqRAIdjOpgZrgtDiMJQf3TrbPVv5C4+08RC+CziXty/qe/FqAUisHtCoVmWqVZkf3VLw8azrK26pOMkRtxL2uFgQW4CaLkCxyCiWX36ox8vUhEXQskAoA62ndZdVPeeXoURAzC7AWR18KtvsWGUFp1v/w45XC4RSXBmQID01erdQrcphEuRI3aMuG1kEqj5XQschEmJngBpOb/osmAX0skGsrsBuCf8XAiJoMkDds75ajf+xHKtIujkfXZJCANlmp7zgQFibngT2KPksWnuoCJoEKZJftxsIRQu+2QU0MopFxuetDVbxmdruIFrQ9ag9m1Xg4jizEyUpMoBGZBYA/UxgkjhJJUCimBIkjtACyDZ7nbbyggNY5fBxuN4QsfiMKUEiCC1ANEryiuq06Y0Qis84wx4NycUimNAC+N3Rx9Xndh6ukwk0ImXQnpeUuikpdZ/XMWnb0Ms6iiv5RgVCjwL0uoBQSvKKaDbohpjL6AWqpNQdNnpIbx17Iqn4jPO8ZiJFRmgBQGe2LWLsXV5wgFZDugHg8Ue/qhdJaED1soJVVoLbu1iDD4J3AZGoHk+YENrzkrwiSvKKonYJoYQuk8jysfCXV5zX+iIgtACRH7AW8EgJtMfZHQeDo4RowY3MErEkCN1O5DbPVx5REFaANMULgK/k53qvq5cRYgUwXjD1lj296bN6H5eICCvAuRYl9NyxFABfZWKpVusiIjNC6AxitOxQnzO6dHMhAJVznw+22RzCfpQxEb4I1PCV/IzS6pKYy0QWjFqb6vHozh0AwQISoksQua5ss+sOUX3O5LsjKDkEqLk1zFdZgZJav183j3fF7uyOg2HLhUoUa92eWxazO6JNUWMPW0VE+LyldQMAOD31rglCuwTtdSiqx1Pvy7rdP5iPSmptgyMwj+CTku+GEGEzwHszhjPqhU1ArQRf3DYZqC0M43UJkUSTIN7yGr3XzcPt84a1XZt+HQM6tuHusRn4MAVoMJr3mwQ1AmhoItgUS51AFGVNP6/9aQWkFmRbzf3/ofsJnS76V+FRuqZ3YsqI35KV0yYpgw8CCwCQV/AhQwYNAwgGRCPyde918xpkn2teHKHb7uieE3Udz6HlDbLvxkAS8U/GVO2ZowIoLVojZ2T9qvt2yafCXitlX6L+70TC6zfpPjWpbikSOgP4Ss/g2//ar7rPYFXsSAECN4lFQ1HtSVn4hSK0AI1GTfD18DklPlh5PPi62udm2urNnPPKyHJixaVICNkFAJzb86r6wcrjZD7QqnEOIIoEPqdEy9sCxaj21fDchzK5d/RlXH77IkorjiVVFyCsACsefUqVXV7hBFBUO25X+OVjqyTjt/vwOQOxb9rniaSRQNguIGfRPOndx6Y22g8u+JwSewqKsdskXO7EDsNZ7ceRIvzcWhjCCgAwfFT0iZ63l53UbX/ozSVJc/aJgLBdQH1QHBlhp2hoMRb6Ey6ybA17DeBz/tfQwiS9AIojQ72pffQvcAK4vbHn+guPfmhYCZKrw4ogkeAD2CzW4CPadhr62JIFoWuARBjesx12R238XM76n8z7N37dkIeUVCS9AH26paHI4f8Nnz9wAUeRLcHn0XC5VXLbZDLhjbWqEeuBpBeg/ZV6N2Eo+Lxa76af9jtc0yz43O+GCW/Amfy5alrzwPY8qh/FU9tDyjb9/TtufiyppWm0InDTX59Wq5yx7+Nv4lAYMLNHzGUUf10B5G9/jL5CSsD5M4fOAnBpv+s5vetrnC43Pq/MFV1aAqC6vQzL3sYjWV25rI2D+bl7eXPRYO5/eCuvzLiV4hMe1m8/xJyZfQPH+ofkFKHRBLgxY4A6c1QvBo1sq/u+v2ayzetVsVgCn63P6scqycjXXMVP+Ye49Co7fnfg7PSogfc0VuZ+S5erW3L2ZxeOFJm+/dvQ9o4F7H19AgC9/5zL5pljARgyK5ePFzxI56weSKl98f97FUMy1+J0u8h/K3A1cuxjO5kxvhsA83P3MiGzG00cVhb/83OWLxmCbEvObNBoowBVTWX2u4foO3oH7qraIm7hgu8BUNIstL1jAUe+KWPiX3bzn4OlfF9UztDsDfgqyrlnRj4FG06wfesJDu8vpfeIzRTuKuHAp2dZs+IYK7btI72tlcFZHZiydCvbt55gzVNj6DFpKUePVLHmqTEA9OrXivXTx1Jc7CRv3sdc0uJ6APK2jOaHylJGTNyIrYnEeysGMT93L1a7zJMTerN49Rekt7Xy/NO3cGfOBiSbhXN7Xk260USjZYBeVw4L+7B2ru6PVZLpn/kerdPSWLtqBKo7UMCdPuLiyLFSut+UjtvjZtyj23llxq3Mff0gi1/uAwQyRYfhCzm1/XEACneVMOrltXy6JAeA68Yvorjg6bBs4a5SyV35PcOHtA7WDFUVfmx2P26XzFWdmnPvxDxapkrMerw3leWw72AJdw1tB8Dkv+0MHud9OVt4f8WdSDYL9h5TkiYTCCMAwEfLBmCxSIzI2UZqmp0Z47thtct89WUZmdlX8PknP7GnqILOGSm0vMROldPDvJX7AVj/zmDWvXuSdflFACx9sT8HD5QzbuFGNsy6j5OnnExbVsibU3+P3S4xe+keXnt2IKeKK1m65humTuxEx27pdY5TdXsZP3k3J8vP8sCwGxk9ph2SreZ2MZeb7HHbWLV8KFZJ5r6cLaxaPhRXuYfWg6clhQSNOhMYTQKAERM3YsHO6tcHUF0CC5Z/zpyZfZFtsDv/FLlri1i+ZAgAox7cwqSR3Rmc1QEIBE0LUpCa4s9+3WRc+/4ebPsq/wRWu0zfx//B+uljsdvC43ZT/98AMCx7GwDPTOoRNux87o29PDMpUKjOX1nII2N60uWGZjQd0JlmLUYKL4FwAgDsfus2IBBYgGnjbqZdx1bMeXUPk7M6AfDCsiKevL8r6W2tHD5YwbKth3n43s66+3FW134V/O6F77Nt+igAOl7r4OQPgZGI3S7RtkP418SdNZd922W0wJ/elOyRG+nXvQMTFg3EqsTv7j0+CauiktL0bmFFEOJaQKQI9/e7gocmXA1A9pSPgtV3NCIDF4uWt2aENzjir6uE/DTskicKuHNgeFehWOr+rJxWU7QZ9juhM4EQE0HaxRhNhHd2HaPjZU24fUYfVn8yrkH3dXzDAd2A6VE7mQRej5f299Sdk4gVfACHT+zLLUJkgFBCs8Gq528Mtns9sad09bBYw/1ONPChaMH0erx0Hj9b2DP5lyJEBgil8OiHUq8rh6nalTvF4g87oxLlYgzWhUA4AaBWAu21YvFz7Z/MgF4IhOsCTH5dxK5QTC44pgAGxxTA4JgCGBxTAINjCmBwTAEMjimAwTEFMDimAAbHFMDgmAIYHFMAg2MKYHBMAQyOKYDBMQUwOKYABscUwOD8Hyt7AwwalNQIAAAAAElFTkSuQmCC" alt="Startup"></div>
           <h4>Startup</h4><p class="era-note">secondhand beige CRT</p>
-          <input type="text" class="note" placeholder="note..." aria-label="Note for Startup">
+          <div class="verdict" role="group" aria-label="Verdict for Startup">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for Startup">
         </div>
         <div class="cell ladder-step" data-item="2026-07-16-era-ladder:e2_funded" data-label="Funded">
           <div class="era-idx">2</div>
           <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAAG9ElEQVR4nO2dX4wTRRzHv93d9g44OUOCQChHETVGNBcJ3EUfOHv4ZKLCIZ4kakxMfFLjg7lo7rCclICGRHyQRxORF2MChmDgQTGaCBFIhOglBjjKoRe4NIFE4IDuPx/K9Lbr9na27XZm29/npe129zez+5vfb36/mdldgCAIgiAIgiAIgiAIgiAIgiAIgiAIgiAIgiCI5iEmugIAkEylbdNSapJhmwZiqlb1sQy3jFrk+nHl8o/Cr384ZxaAZCptv/7e84GOURJxAIBV0MOoUsPYt8ey/7n0k9BGILTwZCptb373RRw9OimyGkKwC3cBADcv/QGRjUC4B2BcHzspugoNIaZqsE0D9z/cDQCoteurFSkagF24i5iqoe1YFrc07yrNMwx8uHJ2Q9FhAQDiUDAyoVbcz9QA1Zj55JXPcMt2yqm0zfm77ZkhrnIagdAGYOhW2e87igXTo0aqAby/0gZPjxWHgkzOhJmo3AAAlMphiuGVv3PchtleWZ7fNtkQWkUt7u/+VAPILjcB8LnKkQnVV/nVys/kTJhaglu2Gy9P4cxARCC2AwJgGGbpu6mUX1zVADLL+SP9bM4OZHVB5GdyJkwlUXerDivF5EVo6aalQNO8rZXHMlmfDwCjE/FQLF+HhWzORiFRveXLjFAPoCrlMYBqFYqfDbD8ovL5ZIepfNFdgDRhCrsQiUIBIytiiHNaflAF8Sq/2S2fIU0DAIB2SwmU6mVyZmDlFz2Lv+PL5uz/xSRh0PIxgBPePByYCcp4oT7fG+EewJkF+MGsvxoFBbH8VlE+IEED4KVa5ZPlz47wcYAgVGv5zqCxnrKbAWk8QKVgiCmvmOfzy2MB32zZBJPfqsoHJBsHqES1I3x+ymeyW1X5gGRZAKPWPJ8snx+pY4BqlR+G7GZFqAfwGgZttWhf9FCwUA8QUzXPyaCwLF825cuAUA/gDgJ1WFVF+1G0fFkQHgM4RwJ3j8dCmc+XWfktPRcAoNQF2KZRcT2gF1G0fNUA8P3ZsuynpWMAJ0EsIYqWz5QPlHd9Le0BqlkSHVXLt46OQQFgqRp5ACdBZgODLObYPR6TRvnM8i3B1u6F8BpVWhPohncxR8ny2+N1qF1tMOXLqHiG8LkA5gFmc4U8w7u1rBUIA6fly4zwpsk8QKVgKMjq4KBLxMJCdrfvRKgH4AkC/ebznZbfiDV8fgS1/JbOAmabDnamen4zezK4/dIdPxGxfIZ0aSC7kLzKL44eig/4AESiz3cjjQdQFQttRlH7xdXB/t3DznF75nix6TS35cfaxHdTTqTyU3f7RwAA21zbnQ3F6TVUxYKhW9AcF53ta1pK2XcveWwft0yv/au9jz/MR8zUA2lq1pF6QnQVWhLhI4GEWIQ+I2hJ13pbdhfJQy1dBCD2aWHCr/zk5WOwpk6Irkbd2H+e/5JOXhzHF5kvQ6yNP9JkAVEhiIKjQHOdTUBWPL0VAJA7vr3iPs2mcDfNfXYcuPvuZle4GynOVln0VMPjgP3nNWz/aue97w0tusSFM1NiCnYg/Fm1yVTaPnfkLbQ98nJd5Dkb0p5f/+U6pmAaSKha2WeY2LdvYCp/FQf3Hhb6lFBAggYAFBuB+5mB7kfIuf9372voVukpnPWikjzecvz2uzr5s/DrL7wCYbN4aZ/dvXZDVceePfWdFEoKExoJbHGkCALD5rF11Rnx2VN1roiEkAeYhagPUfNADaDFaeoAp5YAkDF25pDwVC1MmvbElnStt9/8YAMKdXghw9efHpDi/T5hEMmTYtPIftRrXIDFAn6yopgyRi7KWdK13n7p7eegaSoMw6x4Z1GQW868YHKdcpxluss2DBMH9yrCXwIVlEgFgclU2n5taACjW/qxdXMfRrf0Y45iIbtpDea1q2Wf9yVi2DXYi86OBLIDq0u/NU1FdmA1OjsS2DXYizlz2z33c8ph27e90I1dg73IblpTPFaxMDTQg6GBHoxu6ccbQwNYvLTP9j8TeYhUa02m0vY7w68CAG7o07AKOuZfKWDVwgUYy1/DMsTx+KMrcOSvc+hdvgwAcHP6Fsby17Bm4SIAwOn8VOn7beg4N2Wge9EcqHMT+G3ib9xqi6Nv/oJSmccvX8KTXUvx54XrWPvQAzidL07gJDs6cDGfx50HO9E5r7O0/2fb9kWqK4hMRZOptD32w0fQ4jP3AAx/8wt2DK4DAOw4eBLDG3s8j03EAfcrBr228WDoOj45/DuGN/bA0HVkDpwo1SERB6andax69uPIZA6RqCRQ7PtfufeCSXf/7uyvee42DhIfePX7lcphcr/9/FBkvEAkKgmgpr7VnQ3Umh3wzBJGpQEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBNFM/AfYuVHYKWhfRAAAAABJRU5ErkJggg==" alt="Funded"></div>
           <h4>Funded</h4><p class="era-note">tidy flat LCD</p>
-          <input type="text" class="note" placeholder="note..." aria-label="Note for Funded">
+          <div class="verdict" role="group" aria-label="Verdict for Funded">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for Funded">
         </div>
         <div class="cell ladder-step" data-item="2026-07-16-era-ladder:e3_scaleup" data-label="Scaleup">
           <div class="era-idx">3</div>
           <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAAKmUlEQVR4nO2ce2wUxx3Hv7O3e2f7iHnkcQZsYadqqFAUgYTN07IKSZ2gtCVqIzdSQhCJIBJ5tCEorYlTSAIVEaVNeNglKU0pakPUqomakiKoiUsajHEEUpOGtgI79bVOoMJIftzdvqZ/jHe9u7d3Z2O8NvbvI63s25vHd2Z+85vf7NwdQBAEQRAEQRAEQRAEQRAEQRAEQRAEQRAEQRAEQRAEQRAEQRAEQRAEQRDE9QQb6QpKiis4AIRkeaSrGjLt7R+ykuIKPha1AULfSNcRSMuLyuYDAJRwBACgqakgqs3KpY6zKC1dzA1dx80lc0dbThqft7UGUk9gpn9q68zhFVA+A+AKwLRhFWNoCqru+wiGrrvuD0tf+YxhaXJi6QvKK0mB1OLBbJ0Ds3XO4DPMnyUGHxB/vZeF33uZ0l4r5s/KXr/3vhOugP/qRne6gBkVA7Ax8nOnsTqYaZmvazi4TfWFgzZOY65n8L1Y2pxarbyaguMPXwTvMXD2cS3Nu3k91EgRuAE4O/fk/hxuzjn4TvxmlDNNpv/7UeRQ2r0jewtwbHchKsuLs2tyaAvJjvI9A2wPvqU3C3fcPgX8YCEMLXgPEFgMYA38idNxu5MXzCvB8V1t+OoTifQM3sG3OtHRySxSk5aNpw6ll+WciUjvZCUcQciUoTjswmydA2n+3/0b43T7rsoVlyaXFqv+/na0rL+MqkVlA2/3GP5ljjCBeoBTZzoACCOwcHaCjd+66pnJGQc/W5DIFfTtyd7kxuYBbb5LgXdJcpTt1cQiNb46AWH8Tk6cjuODdV1ZtY0EgRnAidNxqLr/trapvnDghXfme9wqCz+YsVNZpAYs/KC77DU9wrUyDYYONJ3pTMtnbUs1Ay4v4DRUW5sz7rDoN1CuHhRX6pDrcqUD8O7qL1zFOr3i8UeDNYLAlgCrc7V+T2fNtGULi2HqmggIF9xipzfrpwAApMd6XeVw9WB64R73arl5syGKyvIoTq3vQMWeaTi29hIUKbvNa4bQtmxhMSrLi2G2AtK8NqHNuRz5xSWA7xLlNIIjay5hxcJb0+q1+sOQggn+LAJdAjRDNNBqpPW3alEZzDNlMPrbfmTNJTuP2RBNLyjDlgqAPQDOMhbMK8F7j36BkJnb3jMNQNMjXS5vkgnLQzm9FIvUAEyD2RDFXRWlrvRHW9rtSQEAmmnm1HgtCXwXkJQ4fvn9fPTKGkKm7HKzLesv4/jDF5HHBuGYvG7YutePVUZjcxyNzXHUb1XQK2tZO9iQdLz6YgiGpLtjgTNlqCwXHuGDdV0D0bqj/mzrPQDwvG/Y/1ttbjrZhqTEsb9WcU2MIAnMAJJQ0Str2L+J4Y4ZfajfaKJ7klh7rQ5ZMK8EVYtEZzsNw2yIik73WXcB2H+Pr+qCWT+l3/WLNdXZsa/8MHOknYQKAJg9WcPbL3H0yhoam+PpcQCEoTrrBdPEem/FAN4rdQj8J3+x82uGmPkAcGgzw8LSbuytE5MjaAIzgF+/JGF3rYTDb4pBMBQZP3sCSHIdmiGMwNnZleXF9q4BANjrUZdbB5DmAbw7ihOn49BME1uflvC3T3Uk1RBefsbfu7zyfAhbNnHsek1BfiFH00+FEVjanLpUnaU/6fPRA67YD3wsmk62ARCuPs5DqCwyoEgMZ85zPFTch211IlAed4+CJ0sc778jAXlhsLCOO4tVqAUcSYmje1IKL7/AcSXHc/67Kkrt4BCAKyhzGocqp1D9tc/wg1oN2+oYbpjK0NMTQet7ClaUpnsBJRxBqo/h9FsmbigT24BY2MDuWgm9soYk16HKAwdYleXFOLnusohPfAa9aU2PuB7pAns96jJMNcSwv1bBzhdN/GKrat///JyCxORCRJkYkqCeBAa2C3jjcCGYkgDXOOr25WPH2iQAYP8mBiCE6ptTqN/IEP2RiMCB9L2yC9fDnQFUOYWa5Z0wZB3fiYl7tbt1qGHx2Llul4mlPsWdPMqAvDC6P01gdzyCHWuTMBQN9RsZDEXGXtaJ3x8ptdMvmFeCE6fjqHpsqqscsyEKU79oD3pjc9y1tewrMFB5aw8ABs0ULv/pN6YASIApDO+/I2Gpz5PKkSIwD6BLeeAFU4HJ07BjbRKKxLAyBiyfqWP5TB0JcKgFwu0ebr5g5/OuwY3NcffM4wrMhiiqFk+HKqeworoD3bKO6hhHAhyKxLDtcQZeMFXUHytK06apKWDyNHHFivDCamFUK2PAN78EhCOim1Q55fIEgHuX0vSI2MNXLSpzLWlJriPJdVxhGjp2cnvgFUm4++2rugb0TZ4GTQ/uqeCoHAZtODgdmsnx7IGB2ZMPYRC7a4Wkoy3taGyOp63BlncwG6IwG6J4d/UX6I72oWZ5J2qWi4c81THRwZsPTINmcvz8k6E5urpdJpDIs/XdG1PRLet2He98fB4A7EDT0uI8R7C2dr2yhr11wI7nWL+363/f5HiqIQKtN4JnD93gqt/vrGKkGLWPwmw4ON3X/L5erOGV5xUYioZwn4HvbQ8BhoyjLe24q6I0bQbeuXQmapZ2YvHM9PhBl/JEPUMlVoQNv4NL3/3TGQADmsnxxgYZ0tY2hHSe9lCHTQrhz8c+Q6+sYd8WGQnTsPNrpvBIlgfgBVNFPR7GnQdQwhGws+d837NmWQIcz+zLAyCMYGUMWFHGseM5hiRUhEwZf2htw5q7O+3rtX//B9+65yKWz3QHTHX78sFVf9vOpCPT/ScPFOHJA0X2oAFi2frxd8UsPdx8Aaqcwn3V7bivuh1/PPYvJKFi3xYZ98ZU3D+d2YO/YU/ELsfp/bw6gvQAgXwmsGT2ErSURcHnfiVnetlMYufqKwBEcFRVeQWdfSHceJNud6RNIg9v/k/DmQ8LcNvtCTzwZY66t27xL7gfdvYclnQkceGTgX35YPTJZhLbV3VBkRie/s0k3Ha7OMGMFgo9D80yoZkcv/1nGK0fdwMAuHYTdj7QYy93upSXs/1OfR3xlhEfn0ANAMCgjMCJbCahX7qCVzeK1081ROwdhLNTZVPcy9bJ1izPZACD1WdpikRMbHucIYGBnU0CHJsPTAMiOnRt0pDa6tUXhAGMzY/DOtClPCBWhCcP9N8oADZY50GSJ91VIk4Dfc4ccmhKwaHFq2t4H10MjMANwLnWDtUbDLe+oaYfi/quNaP6mUBn49nZc67rasuz8g6lDOvj6pn0XY0ub1q//JnKC3IXMOpLwGCi8mwz0S//1RjBYMsfiofIpi0XQZ0FBGYAFW29uRNlou2jaycE/svzVem7xrqcBHUWENhXw4ihMy62gWOJwRhjEJ0+lhjdL4YQo86oB4FBUzJ7Scb3Ov7x1wCVjA0mlAcYq18DH00mlAHkiqwnooFMKAMg0plQBpBrhge19x5LTCgDINIhA5jgjLuox/ujT063PpggMNuPRgXxo01Bc903KNuAOxlshO+X35t3PBnCde0BSksX87urv+26l9B0NDW+jbkL78bZ5j+hatlKNDW+DW+6TOTKn9B0oBF8vBjBdd2I0tLFfNbsxfbroM7R/3v+1LjxAtd9I0bjtHGiHRgRBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBEEQBDHW+D99QeMoRiV2lQAAAABJRU5ErkJggg==" alt="Scaleup"></div>
           <h4>Scaleup</h4><p class="era-note">sleek dual widescreen</p>
-          <input type="text" class="note" placeholder="note..." aria-label="Note for Scaleup">
+          <div class="verdict" role="group" aria-label="Verdict for Scaleup">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for Scaleup">
         </div>
         <div class="cell ladder-step" data-item="2026-07-16-era-ladder:e4_megacorp" data-label="Megacorp">
           <div class="era-idx">4</div>
           <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAAGnUlEQVR4nO2da2wUVRTH/9t5bGslsY0QUNGioPBBEB9pRPlg0AR8RYyiMQI1BmulBoWClvIKFGiIoMRE0C9SYoigISgETUhAEqIWG8AmAokoklCIDxYUNkvnseuHZWZnd2e3+5o7M3fO70s7s/fec3bPueeee+fuXoAgCIIgCIIgCIIgCIIgCIIgCILglhALIdXhhgQLOTxydeAPR23kuAPUDhmXWL9mMy79d9lpUdwxYtgwNLfOcNQJHHWA6nBDYm3nx+j7/TcnxXBJSBQBAHcOvwkrVrY65gSiE41a2fbFl7i78QEkNA2HvztoW0bVVUiCBFVXnVbHcezehyRIAJDz/VnrGGUbH50CANi191unVAXAwAEAIKFpOPr9D/i1eS1GDr8VAPBnKJJVTle1iskc0HQAQFgUKtZmJoIkpuksSNkfZ50MxAZpJ2bz/5EVCzBx0oPQ1YGy9cwHEwcwkEdcj3PqXwCAx54dwVK0a/SfiZdUT6+wHrlg5gCqopj/8278Uo3uBlUshemqxr3x/QaTCGBktMa4zCt+6vkGTCJAQksmSk4mZG7jR+MDjIcAwnswcYCgDAF+hOk0kCf8GvIzoSEg4JADlAAvvR8gBwg8zByAhwc9AF+9H6AkcFD6T0VTF1KNe4o4BDnAYHBodCvMVgKN59x+grdwbwclgTkIgvEBcoDAQzlABkHp+QYUASykZfwBgel+AC+S1uM5z/jtYLofgPAezB4H87ISyBuBjgBBS/jsYDY4e2khiAyfInCzAD8Zn0XyzO57AS7nAH4yPEsCFwGIdLw7Qa8Qfu75LJJnZhHAjSTQz8YH2OQA3A4Bfjc+wEkEEKSw0yKy4MH4QDICOP35MYkAJ/qOsxADgB/jq4qC40f6HJfD1aZQXozPEm5zAKIwuHEA6v2l4ft1ADJ8efg6ApDxy8e3DkDGrwxMHaBSvxBCxq8czCPA/t1/l1WfjF9ZmD4LMH5IsVgn6D8TR/+paKCML8kyEzlMZwHK+Su4Y9QtAIB9O88XVEeQRNw7cSgg1AIAojr/TnC05xzGM5LFzAEemTYF0qfLzeu7rv21/oBkLi4gu0eoigJJlguq7zfGyzIenjIZvT3OLwUzc4Denj5Me/oJqLoCScgOb5JUBVWNm/8bGPdKxdquX1B1BYcOHmYii+kQcGD/IZbishFFwKM7lN2CWRJYv3AZK1EF8++iDehv855eLHH8xJDqcEPinvufTPY+g3y90K6XWu8N1ovtdtEUKy9fu3Z6DLZzp4yoc6x3j39PDDFw+8ygWmloyXWjannrFuXi9JlBTHIAp99EPirhfG7q7zS+fRZQDGMmNJZW776HKqyJ9/D94+BCGTOhEf+cPlNw+RtH3eagNt4hEBGAyA23YxtgmYGUgiWzP/bjLm7zAF8NAcUmdGPHTkZL0yxs2rK1NIGahpamWXj/0gWcPImiZPvFYXyhZHW4ISHINehc9kFB5QcUFR1LX8XsuavKkmv9YsaOzz4sWD4ALFn5FqKXT3j+8/W8gkDqBNLtu3aX3Ib1/D1BChd1Hp9RPu+XNDIWup55fKqjJ35WCk8qVztkHLOFI12JQZDZ/TiU16KCp5QBksb/ZPPnOPrLzwCAc80vAAAUPQ5ZSE1aTjctxqgta/I3Fotj9I5U1Dg14ykoMrLb2dQJRQbOzlyI27etT2uifmM3Iq/NBGqyJ0yju79KazcXZ19pBwA0PTcdCxa/7ikn8IwiQOqk8e6dXyMRtzlfSNNyr/Vn3A9VJfcf2raTQahKSC9XQHvGtZVEXE+7b71OxHVA09D04vPoaG/DhSs/eeKz94QSgGWc3/MNAKBuaVfa66quIdq1HHVtnVDEpBEm9ezFvgM9qJv3DpSa68yy0a7kxpO6tk4AQCIcSmvHrGd5/dLqDvPaaD/atRw3dKxO0+PiqncBAPWL1pr3rOWt+l1Zs8QsF1nXbpZvefklvDF/ticigesKAMme/9GGbmzett22F0HTEJLD5mvW3mr2MGUAEMXsugWSr4fbyct8zdArVzvWNvRYFK1z5mD+23NdjwSuO4Bh/E1btppGrp93bWwPF67exfeWoO7NVUXVsSOyrj0pv8B2TLlAQXUi69qhx6K4eeRITJ86Fc2tM1ydKbi+EKQrMcSuxkzjA0Bk4+JUgXx7A6z3rPVKff5+re3I+kXZ8nLtGxBF+/I5yJxOCnIN4OwJ8XlxPQIA7u8XcBOvrxMQBEEQBEEQBEEQBEEQBEEQBEEQBOFX/gcOLo31yBFvlgAAAABJRU5ErkJggg==" alt="Megacorp"></div>
           <h4>Megacorp</h4><p class="era-note">high-tech curved holo</p>
-          <input type="text" class="note" placeholder="note..." aria-label="Note for Megacorp">
+          <div class="verdict" role="group" aria-label="Verdict for Megacorp">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for Megacorp">
         </div>
         <div class="cell ladder-step" data-item="2026-07-16-era-ladder:e5_endgame" data-label="Endgame">
           <div class="era-idx">5</div>
           <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABgCAYAAADVenpJAAAQvklEQVR4nO2de5AURZ7HP9Xd1T0PpjlmdkY4UfFC8VxxA+QEVlFUVkAdYRjYJQB3ZfX2LuLO23/2wrjb2I1wDWPdW40zLjYw9g4VVnmIyDDyFpjleAgyKy6OIAK68hJwYGZgnl1dXVX3R01WV1VXzwuGrmPq+093ZmVmZVdlfvP3++avqiFAgAABAgQIECBAgAABAgQIECBAgAABAgQIECDANQspVyde8VvdcOcZSbM7UtRw5NnTfofor9dvcZcTmPcLKWf3IScnXv6CYUhRg5d/91QuTu8r/OwfFwO5GwQ5Oen8e98xPj+5MRen9iVu++sHWb7vyZzci0guTmqkOhzpr88fIkkiF13JGW4uHZvrLgA5GgB2fHV+PxPj/2KlZWKe5VQUz3xRXkVxfPc63hfIxC6rrhuird3nf+eLQZDzAQDZb3pvytiPe5XtyTn6eu7ettXXAdUfCOW6AwMRV3JAXS58wQBufCc8GQANhXDnxQpJMrqhWmVE2p1vh6ivoXBI2w3AvcpdAER0GTkSY9aM4dQfbeKzM1FalSQACS0MQIeeYLARQtVN+2SbvBOA/7hrFrFCjYYvZbYc/JyPhxxBlZL8etxMCiRQ1BA7P2kHYIO2CYDS9uGcLzh95S7SFYIvGMBOiSoKIUnm/uuuB+D+665HQ2FiWZlnemJZGRqKo7zXp8D0N0cB8OjS2wCI/z5CTA4zbf1gM39tKXlhjcpVxQyRZcqrhgLw8JIRjnaKl8QBqFg+xpFfuqrIzF9d6sifddNDPb8gVxE5cT3mjf+DceTMdiBtBNppcXRkGoDnjHfDnh+SZKuePd/OAONb/5aIXEBElymIDmbqAwXcsHqwtHLoBcNIySQ1s05SM9lADSuoKYWm1vMc/tZpVClpMoCsc8O6uPQraZdxPH6B5lizxQCJZpWPjxi0SbrFAHElTkfUZBJVSrK9+WXLCMylG+gLBrBDsMGEIeYMv6fYnPEi7Z7ZggnuKb4e3VCZMKTMKq+hcE+xkwEqlowDYNrrt6HqCUqXxTk2qcF45IMSQoMMplSXAFC+bhjIEtNXjkCOxJhfPRFVMgeFFtEpXVXE4XEtxtyVEwGQjSgAxcuLkGSdh6tKHOedXfKo+fs62/ALfDEAvIyiD5vqrc8wMT5sqickyeyuN/N31zvT9vKyNMiqt6fx6/R5jCjVC2oBWP+Tg8ihPE7MbuHWHSXSjslN6K0S/zur2TxeeQ5Ug7VzjgNQNevP1k0Op0Kc/34Lt9cWSSvm7LbaD6dCNM5rQW3OY8v0ZiKJ9OV9t2Gj1Qc/wRcDwAtixovPiWVl1gwX+e60mPmq0erJAKqUpHKFyQDli0xbYPiKIo5NajAm1QwhNMjggdXm2l5eNZRQYYTpK0cAULl6DKqUREWxGODA6HZjfvVEq32RH8lPMmVtnGQovWQJBvAbfDsA7DM620y3H7czhdcnmLOvam4tKbWdzU8fQdUTNM5zMsCWigbAZAC9LZXBADIxiwEAllWYDBAJy478rZUNRHXZ+j2CAYIloIdwz3Sx1veEGew2g0gLzK8eR0QuYNrrphdQuirNAFJEZUp1Cak8nUdWdM8AsaiGsAFSmooW0SlebnoBD1eZ7QgEDNAL6IbqmNmQXvO98sHbZrDni7V3WUUtqTaVzU8fAeD899MMYKRktlQ0oLel2DT7rMUAakphWcVuTwYQNoBggMZ5aQaw2wAr2tc5+uEX+GIAeEmj9rVcpAUTuGc8kJUhxKcqJS0bIFIoWzqAmLHCBijfUAKyRPm6YahhxfIC5q6c6KDv0lVFKMmwxQCAxQDCC7AzwJMls67Albry8IUO8GD8X61jKgp3R2b0qJ2ulEEvHUA2otzV9jeQlIkUyuSHBlH+UDGXzip8dSZC0yWdVJ6O3pYCWQLVDOZQwwotLU0cLjxBc6zZUgJbT4V4508HOB6/gJqv8dzoacQKNRIXUuw/ZIqsq0LVQKAD9Bp2K9898+02gbDyvRjASweoXDEOoqqlCJYuixOTw0yqGUIs1qngyRKV64aCLPHIu8PMeqvHWDcQ0kpgBgMsiSPJOlPWxmmX08zWlQ2QzCJlXw34YgB4LQFuK3/nN1878u02gUjby3vpAABVc2uJyAVsfCJtA6Q6omyefMm0AaY3E9VlqqadzdAB7Gic14KSDOOlAxhqKKsO4IWoJGc91t/I+QDQU95bo+413K38ea39wvq3K4KeDAAOGyCSn2RazWCkiMoDm+Kk8nRLCZxZPcKs1+kFQHqtH32gQLJ7AaI9gClr44EX0KMORLy3Ru0MoBuqNeO9mECk7YqhmwGE9V0111QCNz5xBFmLOXQAIyWz43HTet9S0QCqwZoK0wtwK4GNC0zF0M4AAI0Lmrl1R4m0tbKBAjX9295qqbr8i9UPyPkAyAYvf143VGtGu5VA++6gFwOI2WtnADWsULzcqQMI631KdQmhwggzq00vwM0ApcviHBjdbrhtALG38HBVicMG+GFRZX9erj7DFwMg216A25+3r/nZlEK7bZDNBkip7az90UGADAZY/5jJAEIJXFNx3Kw368/ElTiyEbV0gNEHCiS3DnB+vskMbh0gUAK7QDYdwP1pt/7ta797F7A7GyAiF1h7AW4GmLLFZIDyqqEOG6BiuekFiBvo3g0USmDpMtM7CJTAy4R9xts/7buA7uNeNoBgCgHBAOt/0skAnWu5pQROybQBAKrnmV6AsAOyKYHCq/BiAL/NfvDxAHDrAG49wK0LdLU3YIebAcSMdTOAsAHEXoA98kfsBYCHDrC8CDme8GQAv8nA4JMB0F08gNeegJffbz8u0l5egGAAWYtl7gXYGCCSCLFp9lnAZID8ZB6AY63P0AEWNGOoIbZWNjh+T8AAXaA7G6CrOAD3jLczhJcXULHEZIDpb45yegHrhwA4GMDSAzB1gOaYedPta32GDtCpBE5alxkR5EcG8N1eAKRjArNBaP3dpbPuBQARuYC4UcLUSYO41JCw9gJiMVAUzGAONf1gZ2P7OQ4XnqAjmuCFsY9bUcHvfbLfcy8gW0ygGIjBXkAW2GMCxcxWjVbHTA9JsmOmu8uLNNClFyAYQOwFpPLMmSviAcRegBpWLC8A0gxgjwcQ+YIBssUE+g2+GwDCHnDH+GXT/ruKFAJvGwCw4gHsOkCBGrNsgJo5DdZegKzFLBvAbu279wJEe7dsK5WqZ51HT2pWvtsGyCaBX234bgC4o4K78gLc5bw+s+0FZI0IstkAIipYMICAsPYjBa0OBoC0rlCxupRQNGzlu22AbBL41YbvBoCAlxfgVvzc5dzlAW8l0B4RNN/U7jfd24CiYDHA+sfN3UC7FwCmsSd2/UbtKcuMCu7UFbZMb3YwwFstVYEX0Bt0xQD2425lsCd7AZFCOc0AtucCYjGc1n8X8QAiKrireAA7flhU6UsvwLcDINua7lYAvZ4TEMdlaRB7Gr8mTCzDBhBKoPDnRTzAjjnmLp7XcwECWkTPrgN0xgOsfywzKjhggF6gq5g/L0bwUgbF7qGG4ogJhPRzASKyR8QDiF08sRdgjwqGNJO4I4LsUcGSnNYRBAIdwIbL1QG6gzs2UDVaHTpARC4AsGIChd+uKJDK04kkQpYOoIZNo7SlpYm6b/2FlKZaOoBnTKCsk2hW2VtnaggbI1tRpWSgA/QUXjqA1y6g2xtwK4BuW0HAzQBC0Xtkm2kDPPp2qaUDiKhgMPcCUpqKKiWttR68GUAvki0GEDfcrzrANckAAvao4TqtJisD3LB6sPTOiIuG3iplPB0s0Nh+jo+HmJ6DlxJoKYQuBnhP3gCkdYiAAVzIJoh4afzuT681360IZns2UEQF222AdlmhfEMJyZDq8ALUsJJ+MqiTAdx7AZDeJZTyY5RvKKFVTt9Tv0YEXdMMIKAbKnVaDQD36N+z8vNDeTw6QyZ1KsSWj7tX5mpYD8Cvx80kNgzO7pKpPn6QE0VfAPCr8Y8RGwapUyFW1LVRkEyxJ7QNMN8QcjG/3ncM4MtXxBxIbQb6/mYvLwiJeUdogyN/83s9qyv6IhPj57Vr0gdt7v7Pa9dYbytTUSCUPq8fXw8DPhkA9le82dEfL1Oyt+l+tZz7fPa8nvalJ+WDt4S50JN3+akoGe8S6irdm/Pa2+jqeG8h2nP300/IOQPcXDqW7edfznU3rjr88JJI8MEAAP9cjIEIXywBAkdP/7Ffy7tRd7KOz071/aXVfemvV50B/3AomBdn5PDevUtv5PCH+nwDPzu1EembPlUF+t7fkcMfuuyBeyWRE99z9rjXjK/O7u6+4ADBzcMm8m7t3w+c/wsAmDPmbcdfaYSv8CPSWhZaFefJdryrOle6LwCa3Jqzmw85HABXC8V5dzoGWhQztj9Jwvou0nboKYWLqaPX/PXxhRfQn7hrxA9QUm19qrvri99c4d74D9f8CAe475Z/6/W/Tu364jcD4tr4xgvoT9xQcnuvyo+8cUI/9cR/GBADIEB2XPM2gB3HTtd0W+bW4ZOvQk/8gwE1AAbaze0JBoShUyTdaITDed0XtGEguIDggwFw34h/Ny30SA8M9ZStu/byKSmdtn+3IRYptL4rifaenc+r/S7a9cK2z3+Z82vcFXK+BBw7Z4ZMvfL8Pk798RItsQYWvT/XkV74/kwWvVTHlxsuksjr4NXNM1j4Ui1fbrholc+WTkjtvLq9wmqvWW/itZ1zrONN4TMsrlmQLt/Zfrb+iPYEFr5Uy6GNZwAc+f9fkNPRWT7mtwbAR4dXARAOyWh6WjbtLu1Gd8cF3CqgvT5Ah96ScVzUCYdkJCmPsXfOYN+BpY56426fb6bDMTQtHfixZv8/+5YFcs4AYM7+1UsXU/mDp/hs51docgeLaxbwyx/vpP4v35DUFF7bOYdnpq5DNRRUo51F78/lxZ/WcurTM9bxn1XspPHCSav+Pz1YTVJTrPRzT+/l9LGTGWnAUV+kn63c62jv2cq9tLbXc8fkYSxd8irjRz/BvgNLeWaq+Sr42pNvA/C9uxew7U9L0DQFVe9ehZxe9j+O9WVt/T9ctQGTs5E5c+xCQ9Xb2HP4Lcds85rF4ZDsmJW9ZYqeMkN35e0s8N1R5j+f7677bwejfPeOBZ5terFA5U2/N4bf+W0AJk29j2SH086Y+2yo3+9PzhhA1ds4cHQzC5//hGPbz9IRusjimgW8/NxuR/qV5/d5psWsf+X5fRzbc44OtYnFNQv4z1/U8sUHZzLKq9EOFr0/1zou6os1vLvzifov/rSWc8cauWlsMevXvcn40U/wUd1KXnjmA04dPYtqtPPG1h+h6aq1NPzdd+Zk/P5bBs8yht/5bSZNvQ+AFW+9bh2LSjI7D/6BUdGnjIPJN/p1EOSMAWZM+C/jo7qVVlrMOHHRvNLiu9dxL9jr9KR9d3te57SnBQvsPfiG47wi36qnKRkMUCTdaPz4saUZA0ANtbH/0/eYcMc8NE3hQsNpdh1/sd/uU84eDEkaqvWadCmSn4tu9AlGqgNwhnGJ39FlaFdC4t26p63rnU+ZEZHyeHzMK9Qd3MAJdZtntdE3ze/XAZCTJSBpqHx4aPkVa88wEkhS74Seq437Rz3pSHdQL/1VeKRR++VyyIfr8u/2rPfp6dX92q+cMECRdKORMhLdF7yGEJHyaDFOZlzvfMq6VKQ6qPetCxkgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQAA/4/8AgwT3QzN4MU0AAAAASUVORK5CYII=" alt="Endgame"></div>
           <h4>Endgame</h4><p class="era-note">eldritch Bayes-rune AI terminal</p>
-          <input type="text" class="note" placeholder="note..." aria-label="Note for Endgame">
+          <div class="verdict" role="group" aria-label="Verdict for Endgame">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for Endgame">
         </div></div></div>
     </section>
 
@@ -237,47 +375,1564 @@
       <div class="cell" data-item="2026-07-16-office-library:chair" data-label="Office chair">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABoCAYAAAAOy/VVAAAK10lEQVR4nO2dXWwU1xXH/2vPOEvCrlsbHBbs2msW7BBvqUHFqARCrDoByoehQWlRQc1Dwksbqap4oE99aIWqvDVtUYsEklNhECEGhSAoqgtJjWpUe+OOAdusbcgSuwKRwC6hxjPL9mG54zuzs7Oz87kL85NWeGfu3nvnnHvux7nnDoCLi4uLi4uLi4uLi4uLi4uLi4uLy9OAx8nCfd5gysnyCYmpccfk4EjBFb5QiueTThSdFZYtxZeJqO3ysL1AutW/HahAsH6W3VWQcGXkPo7cvQ/SIOy2BlsLo1v+zrnlePONetX0gslWwrClkrzJ90NHx/D+7XsA7LcE2wqiW75c+IHw4oz0nhLGknpMDFyRlDfJjQCQKgGwzxJsV8DWCj9+vmOheF1J+EQodiLwSRzovI5j8TgA+xRQYkchdOtnhNzplZRiNXT3BKS7S1vKtaMQli1FtlnPJDeSFjg/jcmh63ZURxN2zdJsUQB5mO1+P5aFfRn3nehylFgW9oHnUjgRT9hWpi1dECszbzUEPomPzt3AhYsTppV/4eKEpvwY1hZxSLClxHzM+f0Pb2BTWy28sxgcOjpmuOzfd0Qx21+GtrW1OHL8hmpagX9kuLx8sV/lOdi5LS2ovT1fGM6ranUrAGDP+Rg6OqP40Q9rVdM/sRaQDwxbitc3V2Pn3HL86jfrDOV169Nu7Ht3A94OVOQUPuBagAjDluLNN+pNGZwnuRFNwneKglTA04SrAIdxFeAwjiigN3Ir5/1cafItT0uZTuCYBdAPTLudBT6JpkXlYNgSU9YB+ztGwbAl6OXimupiN7a4Igg8pP4tpQdvWxPC7/4YwbF4HNv9fvh9fpz7JKqrvE2bvwMeUew5H0O734eyMhaf9hpfX5iJLS5X4g1t9/vQEvbnTN+0qByD1+6hsdqHoZvG/DItzVXojdzC8qZKDAx/lXOu38vFRV+QHS5pWy1AK4PX0hsjRoUPzFhZ3+Adw3lZgSkKKJToBrNRey6zti4NZ5Cv8LO5pAuBfi4h7ohpxWg3ZcgCiPBzbbALfBJ/6hy31c9uhHa/D+/sCqmmOXR0DEfu3kcFG0oZsQTd01CtwgeAA53XJd/7OW2KaGmuQktzlb4KPv796pYFmtLS01QWHrx3eFQ1KmPntlq0z3oOPJ80tH2pSwF0gTu3pR1dgfDi9KexDoHGOgh8EgKfxHuHR/POv6W5Cvc9Jdj650uG5ui9kVv49R8iYp5qsFRvzCMFRpA2HPHZHj8nw5birR/XpdPzSd3joKGFWLs/3ZfPX7oEkw2bMdmwGTFuFDEuLfQDndfBCOkHIt0PWQuoWcGho2P47T9jeHVWJdrWqHcFarStCWG214u9PV+oLurkdTkRT4j13N+RfhbimSXPGWisA8OWijLQi64xQL7D9fm/OdQ8fAAAiD2+RloPLXytbGsNAN3pf/UuwgDg3CdRvLMrhKrjN7DptXni9FYLJ+IJtPt9YOHB/o5RsbUHBj/QXR8ldFmA0h4v3fKBtOBp4be+3qY5/6GbCSxZPNu0dUCwfpYm4ZNWv27HBgBSSwBmnpF86DEin31vGsPrAKUFDjFpuuWXlbFGi3IEYgkHOq9jxbJyAObunOlSwJeJqMfnDaZOxBMAl3mfhUe12+GRAgsP+rmE42uCXi4uGYCVIEro6b+reA+A7kWZbgtITI17KnyhlJqgg+EQxrnMPpx+YCeV0M8lxLrIHYUE8gzZntPoithQF0QsQX49GM4+c6EHNwLpsgRmJnRRLpBcrTQbxNrof+X5kWvZhEyeR6kxGXVHGN4PSEyNe8iHXGMYBi82v6j6O6UWR8eNsvBIPnohvzWSR4MsVlXpmfXiiDeUWEE2s7cDedl062cY+yYMtingzOHTku+F7Bc61XFS8t1KhThiAWQMoFuh0mAoT5PtmhZyDbaAM43CdgW8u7YGAv9IDANUmlPnGyKYTx5qZbfAb0pIZD7Yuim/b9UCTYuYPedjmJj8GhOTX+dMS+dHBEsLn+Sz53xMkpZWhLyOdmKbBXT/rDlnGrK0/1tTZcaJFb0sb5oDAFi/tlpznt3NVWh97EW1Glss4KOfLtGUbvvBPjz7nBfbD/aZXocfHLyMsjJWs2C1NBgzsNQCxrko9q1agGeeYTB/aVoJqUczk3158G3X7hU4/nEUXbtXmF6Xs7u/jeMfR7MKlj6Xdmd4HNPTPPatWoC9PdGcaxojWKIAQcg8iUcLnhAIL85Qwvq11ap504JSO8o6MXAl49qmNm1R0pUNQduOTdk2BsT6r6Jm2QsZ1+cvXaKonFx4Shjxd3JFpB4Juk9aekoYReVZhWUKEARe/Ltv8A6WN1Ui1n81rzwYttTQaXn57/PJz644IssUIF89FmpglBboxmQ2ls+CLl0tXJdDLrRGbxjB0jFg3Y4N6Dp8Gsiv51ElJaTgYYyHbNL5pIRM94SH8aArHhe3J63C1OBT8jaURc2NAICGcAMA4GznKdtOnpvJxl1bIAg8hrkRCDyP2FD6mKuZQbuWKACY2cSg59B6+1KGYTN+m81DaVZ/TfIf5oYhCIK4GWP262xMD7+md8jUdsaMwjDp3lMQBDAMo7j2MAt6J8zskHVL4t8L8ZVkRrHqRU6WHUB40kLWrTqs4ehbE7WiV5lOvg1RKwV5QkYOed9QTaM2Xw6ZrRQDBd9CaLSMLU69flIvRVNRmmxdUjF0OXKK+qR8TWOt5m6pUClqBTwJFJ0C1GZExTj1LToFABC7ndjQDXHGU6xdUcEMWqT1koMO8tlOYmrco+bmkLsLfN5gKlteJI1ZdTeC45WQTy2JYAVe6lQjLT1byDuQtgK5RTCs1GlnlVNNL44uxHzeYKquaRGAmY18xfMEbKkkRJy4uwnEIXctMoRgOCS6juljQ3IvLQBgCIbO+JpBwf3/ARt3bVG8Lg+YzUU++ThpDY68Pb2msRY1ddWYVx0AAExP5/bhX45cllgHOfSX5NOWc+HkP8R7wXBI3IcoK2Nz5j82PIorvYOSVyw/UW9Pf639J6l51QFEej/DytXfxUOZQO7cvoOx4ZlzvPJ+m0AUEAyHEGwIiteTvICJzydxLTIk3leDYRgsfKEe3/xGORL3H4jXfbOfxUAfh/qGhXjw4AFO/vUvxf+6Gp83mKqomoPWl1ai9aWV6LnUh0jvZ+L9bANqLp6vmiP5fvu/t/PKk4w5ZLBnWBbfX/8yfvmLtwAAXae74fMGU1ZbgqUK8HmDqe+tW4WtG1rxvykeH546i/Hhcd1CNxOlOpxnGMRuTmLjq61Y17oagsDj78fOWjpQ2zIL+lf/fzAyPAb+4XTGg2ebz2drefRYsmrFcgBAz6U+8NOCpt8tam6UbF/S9bkWGcLc5ytx+EgXauu/help3vJgAssVcPFMT8bfREg+bzCl1BKtMHuyOCPjhFJ5Pm8wdfFMD17e8gq+unsP3R+cM7saGVimALql0kog98w6ZZgPauXR9aVnVOSeVXW11ALoVS09szFrDOi5ZO45Aro7pOts5ZhlmzOOYRgxlMQoRCADfRwG+jg8nOah1LUUA5ZHRchbldHoslwuZ6P5ZhukizIqgrgc6BWm0WU/EVRNY61it2ZEUEr1NZpnLiwdA0RBT1EXp5TT5gvDsmI/Lfec6kWxvhZTFGEpSpDxxMyxxQkc94fr4UmKinBxcXFxcXFxcXFxcXFxebr4P6KRGgI3dCKWAAAAAElFTkSuQmCC" alt="Office chair"></div>
         <h4>Office chair</h4>
+        <div class="verdict" role="group" aria-label="Verdict for Office chair">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Office chair">
       </div>
       <div class="cell" data-item="2026-07-16-office-library:bookshelf" data-label="Bookshelf">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAAB4CAYAAAANHffOAAAPrklEQVR4nO2dbWwbx5nH/1qulpJsRwxlyYoSh7Zly5JlWbJs2YodOfU5vaJJ2xQHNL0iaNMW6YfD4b4e0KIo0PZLGxyKXtImCC45oD00aS9o4rzIamr71MixaycOE9mt3ymJpiWLUqL6RQrJ1XJ4H5azOzO7pChpt5aD+QECtM8+88zszM7Mcp9nZgGJRCKRSCQSiUQikUgkEolEIpFIJBKJRCKRSCQSicRzyvww2lhbl3swUoPH23dw8q+/3oeHGmvxtdbtnPyJN/uwb20tusJhAIAG4Efvn0d53RrMToxg31pnmkK25srDTX95/Rok4pfxuQc68Muf/nPRawtv+qandaZ6aQwAvrRhde6v1zLQVAWXrg45zmuKu1wkQ4ByIU2FGgAAECNr6V26OgQNgC6kF/PIEKdcE9Ls2t7IHR95b8z6X0+lcT0t5rJ4PG8AAJjJBqAbBMaeTkuWfeckAEAnBNhryo0soA5EkSGAbthyvT+KoGKmyxA7TTpvq+LIoJ3Z3k7ojC1WTtEYe6wc/Yy+QPTDce5Yq6zA4d535774eeJLAywLmHfoxnUNliw2YNaAbhA0RhoQUMuRNWYRG7Arp7v1TgBAtJ/vAQDQGLFtJZiKY+WxAV5O80ggavUATh98A1RX2dWxvELDxp3/ZB1H33kRX/zHDrz0xh9KqoNS8aUBKNOpNJZXVrjKq1eUu6QoTMrIoVI1h192IDBtrUDWmC2aB21k1o7I9U8M6//ExDUkDv63NeysqQthWU1oXmUuBd+GIABITkyhujGCodEJa/wGgNGrU6hesQLx5N8smaYqDjssY6NX0RhpwPmhMa7QyYkpLK+sKCiPxcdQoQasHkDtUDnLTd0+3rdn3fwueoH42gO0/ihG+qMwABiMvGogigsDUWsSpJXDEhTboz+KBKKoEhUZucJWaF6uAYAasO0JcpY19Q7ruHBuCgAwNDqB8nJx2l48vjYA4Hw6EWEvqe8Xf0SVUoYgFMccUOjS3eS6QTg5MbJWI4tylvGxqwCareN4XEdi4hoA+FL5AFC833vASzMBXL3vi3ymagB9gWV4Z3U710AzW7fjSksXV0n0ztUBHEyz/YiXX+p8gKtQHcBrgWVIIuvQf+/aNYw3d3P2AWB1JMLpRiIa9u1Zh9V1IWiVFdBc5rPF4nsDnPjgHG4c+l+H/K23P0T1ueNcZT/17Mt4+dcvAnAOQRqAV08O4/RMyiHv/XAE2aN/dM1jYkZ32PvNuY8w+X4/AH74S9287noNTc1h9HQ1oKerwfX8YvB1CFLUAJ65fwMA51D0zP0boKgBpJm79rHmlegKhQrao7bEPH7evd4h1wR9dghi9cWGjsd1XIpfcdibndVvvzmAGFmcT2WwsTI4p1w3CHbXhS15hgBTowksY+bJQrZOz6TQtqzSkX8pcpqPppbByAL7vvoDS09Ty6AbuQVde6n4PgmLFVaKXId5Z97T2oHJs++bv5Jd0lC5WyW7yd30aT6nox/g2F+SAICHP9vtaq/34HFX+WLw/GVc+I76XFvnVjTciCOVH16MrHnhs3e3IvzRBUtOz92sXY+GG3EAsM6l6ltsm0yaQrbc5FQ2lz4AvHf8ONo6t+J09AO0dW5FhWY2dlrPcNf39p/6PK0zzxvgv575fQ4AjKxdyWogwB2XwkLSLMYePa8GzDGvkO6//NujS/tt6B8O7ffa5KcaX4Ygr20uJaZujC/tHrA6cq/XJpcUU6fH51aaB77/EJMUx/MeMD0+guX1piuRhboXS5FRFmNjIbK5jv3A8wYIKmYjfHnDKgB5bxaAw8Mj+HzjKktvWjdwKO6ux/qCKbpBcCg+gocaa6Epdsfti7nrUbuinqYoVl4HYiN4MFIDTVWsdOKxWL4zyQlvKiqP5w2w/o4g/nrNfHbeubIGgPlr9UBskpOljSwOxT/mZABweHjS+l9TlDn1+2LJkvT2XzT12kMhVORfgdAybVkZQpAoVrrd4TB0wNXO0wuvGld8mQNmsgHohCDd0450Tzv3nj7d047pXe3WMdWjMtE3ML2L13eTsXnNpYe9nQ69wP18pMQnezqRUeyCuJXBK3x9FbFpxQ0AABuf0FxlesHOzaFHG2LzCqf+lpCtT/WojTN5HZ0QTq9Y/ltCN6x0mqqYx0Thzot2vMK3pyD63sWRYSAAJRBwPeewQdxtEJdfqW6yYvJSdXRCQLLZkuwsBN8aYC4fL4vbBdLXxIUai2SzlgNGUxQogYDDRimVJpaTneD/Hviam1gBC7mbHDYK9CxWjwYFzAWrx475JJvljv3EtzlAUxQM9sUQZMZSNxkAS8ZGKWSIqX+ud5i3q5o2ACDI3D+l2GXz/8aBI2X14btymqLgz72XcCfsvM/1Dlu2aRoAqFbmF0pTCv7NAYTg7Kq7EGvdxsmvtHTh+mfMgCcaQTfZvg3XuvcB4D1UOiEYjtyL5yf4V8KT7dsw2c7bHQjWYqrZfo+vGwRXWrpwZetWzt5AsBbXIs349UM9OSqbat3B3fGx1m3WsU4Ikh17kezY63Die4GvT0EvvnoUAPBk3gWoE4Knn/stNLUMT3avtyLonnr2ZQBwdS3+528OQ1PLgDr7HNVn7fYePI6D6gnOLpsXxdTj83/uhd9xOs+98Dv8eJcdF/SLZ14oWL7F4msDfKUpjJ66Wu7O+dbmWrQLft+vNIWtyGgWTVHwrc21aA7fARBefzejT/VEu49tquH03PLXFAU/++HjMPqOWrInv/so/tb/nm2neaXDtlf4OgnvDodx9uYnnGznyhoMpzJcNMTucBjDKXOYyRAgOZoAYN7ZXaEQxmZmLX3dINgdNn3HFJ0Qy66Y/3lB1hUKOfRa1tt3e0V5EG2bW834JIVPo6ilTe7zwfffAW5OdOr3ZaF6QQXYuKWDmwuK6VPSRhZrXfzMouMfAKc3rRs4+ctf2XZmMzj99P8AgB217ZKfV3jukKkP35XbuKUDd07xvxtT9S0OfzCVAXP7gkUbRpZADShF7RbTM7LE8hPT/EUdN9v7T52/PXzCAIr6WOfj82VteO0rdstHhM1P+oQ/ZUif8DyRPuFbjPQJf8qQDXCLWZJO+WKOesDprGfTZYj9PqkUJ7tou1AefjnoPW+AHatX4t2E6TxnORBzyqijnnW8HB7mnexURitqetxpx80+68Snx0cSTtsHYuYNwzI7YZeL/hCjtpa8U/4fGu7E4OhHAMCtfKcOcPpuRofpgNcJQU+dXSkHYpOWk50YWeh5GX0RTO9uNg11+ovpqFN9fbgaVUoZjiQ+5hzzND83dELQFQ6jQg2A5B39fjhrvA9LIYrlp21+eC0AYOStywDMF1/r8rJzvcOW3prP3cvpsTLRH0DTsI51duG2W7r7Hl5vHeuEOMpViFL1FsOSm4SDSmFfMEvb5la0bW6FkXUutruduCUNMJdTvpSunklNI5OaxsZ1DXOuxFwIfy/f8JLrAaVCl49Op9LFFZc4/kVFFLmDijnl3RZtuzGe/BjTaR3JiSnHivfbCd/XiC2EUuaA2hOn8NGJU64r3m8nfG2AP/deMj1LTLRCoegFMeKAjWhgnTOOLQzAT8JixIQYWcFGRoi2RdyiNbzG16iIma3bkezYy10AGxVB+b+yFbjUtoWTnQitxlRzN7fNgMjBtOFYCX+lpQupHZ/lohwudz6AjEKsvYcm27dZ0RKFbIt6VOY1vvaAp559GbqR4xZMu0Uq9B8dRP/RQU72yut/wptqGX7evd71LlXUAF49eRH1W+/BKmbZqZv9nz31PH66x94NS4yqKFZ+wI6GuC1+iLG4rXx/bFONIwKCRjkoTAAVjV4QHzFZP63bynm36Ij/+N5XrR27CpWr1PJ7jedNykY7dIVCjugFGgFRLMqBpmX1EvHLSI4mrN5AV8iL0OgIdtjb1BSx5h3dIFa5lPwckBxNIBG/bP256fmF5z2A3rHFognminKgYy2r19VtRr0lBo9Zeo6V8IRYURd0D4pp3cDI86+6loFO3u3bdwKwF2VPnn3fVc+POcBzl+QXWjfk6Mr3QlEJxVa1u61op6vZKaWunBdlqfoWVI6fdaRzo1C5XoqeWdouyUf+9ScLWhVPmc8K+2Ln2XNitMNioipeij664LRuyKiIW4yMipgnMiriFiOjIj5lyAa4xXg+BBWKHCgUVVBM7kcZiunQ835vT8DieQPQ7QAoOiE4PDyJ5GgCj6yr4VYlaoqC/RedUQ6aoqAvNrKgRmC3SRChNmnUA6WiPIj0bAb7L9oREux5Vm/JR0UAQPXae6z/J2PmT/tpPQVNDaO28V5UlOe3Nr4Qt/RqG+3J+/qwc9fCUqGvKnItG1Gftb1lNK/p8RHcHVkDIIVVTRGkZ83fBOnhK9Y+F9QGvQ5a3uvD3k7AgA+PoSef+Db3GKrnsnjizT58vnEVvrapC+K5r7/ehwcjNfhOx32WDDA/uLDQHhBUgJ7Vtk1qVysL4Auv9CFcnnWcZ8tDG2Df2lo8vnknd37XC79a2o+hZ8Yuusp1QnBp7CJ0wPHBBU1VcGbsoiVfzO6cQQUI598RDU0McfuSintV0/IUQjdIwevxCs8bgP1oA8B/VOGT/Dm6AfHyY3Y8j7Gn05JXMPL5kiHA1EwKCFc5NtioODYI3cghXM6Xx62stJHE68GBIwsumxueN8CmJnv/5awxizPMe3jxHP3ggm4Q7mMPCfZLGAuA9gA2PwC4nG9YWrkb15kfeaBccMlXLLPXeP474ELMnOzEwuoGwYVYHFlj1vVCzg8x32tZZBmu3kxxZaHQ18p0jI/F7TwLVW6h6/EKz3sA94kQ5gI1VUFTY8S6kFh8jBvr2R6wWO5aYfYANr/zQ2NYLjhWGiMN3Hm3yih0PV7heQPE4mNoaoxwdzSFvSONLDivVSw+xn0hQ/x+wHygc4DYA9zKSpnJGFjFlCeomDfN+aExbGpyvx4v8LwB6FczVNCnHYU7Z/0P8PE8whcyioWLFIN9ChLzE/1Z7Plq4TydJ6oGorh8bBBVPsWf+hcZJxy7bTNj7fejKot69BSZcvEVz4WYf1Cxy+xn8K/vL+P8+fBHYTLE7gFeoagB3xzznjeADqC3sgbx/GdLxCea1wLLMCkEZlFousVcbFDhe8Br+U+lFLL5WmCZVVYRTVWgA3ijPITk/Y8suEzF8HwOoBshfXDyFP699W5848CRssbauhxg3kn97wxi9OoUBk6+W/bbh3pyscmJsqcnJ+ztIH+/3zZWwouv9rYdOQAYPP1uGf2f7QFvvf0hNHUQs+tC2Fu3kktLy3P61AV8v/Vuh206BB3sPwF6PRKJRCKRSCQSiUQikUgkEolEIpFIJBKJRCKRlMr/A8bid2uMZqGrAAAAAElFTkSuQmCC" alt="Bookshelf"></div>
         <h4>Bookshelf</h4>
+        <div class="verdict" role="group" aria-label="Verdict for Bookshelf">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Bookshelf">
       </div>
       <div class="cell" data-item="2026-07-16-office-library:whiteboard" data-label="Whiteboard">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAABoCAYAAAA6sjRJAAAQLElEQVR4nO2da2wU1xXH//jO7NprCI9gCA7m5djseh12MQ83NaKljRI1UtukRUoDEm1UlFYilaiiSPnQD2mVVqgRTUibJqFSSVAhihSplZJCQSArFo8YjB/Ya9Z2zdPBBRMgIhh2Z2a3H5Yznpmd2Z1Zz3hnzf6+2Dt77527c+aee+65594LFClSpEiRIkWKFLGdKfmuwESweGF9UhQk+TPHM5y70HNf/PZJ/yOrKgPJj97eLH+WhDgAYMPW3bh0+cyk//1cvivgJFWVgeTLP1qBjpZu+ZokiACA8GyGmFCTvDoyMKmFPKkFzPEMjOdkoQJAJDoIAJgx3QcMx/JVtQlj0gq4qjKQ3P36Rjz/yocAAElKAABEQQLHM4iChN9tXofff8AlJ7OqnrQC5ngm///8tx6R/59W7oMoSfjrgQgOHvhclW4yYvubu3hhfVL5WdliiGyf7SCT4BgrUX2m1g0Y11f5fS510eajMum6U1rE1ha8eGF9cvfrGwEAjPdg49Zd0FqwjPfo5pWEOE4f78PytY+avl9HSzdWfbcBoiCorhHLHltqeL98IglxbHp5D+hZAcDTv/hb8ssbZ20Xsm0CrqoMJD/4w3No2X8SZaVe3LkbgyhIaDvcAcanbjM0NAwAmDe3AqIkgWPqVsZ4Dm2HO0zfk/EcTh5uB5CyjrUGVUdLxPA+lIc4f2kIkpC49/1YC5eEBKqXLJDL0SsvU/1GrlxTXYsJArw8L39u2X8S7x44g0/+vgVPv/Cu7Va9rS14Cl+CHZ9245X1KxH971CaFTtvbgUAYPDsRTlP9ZIFAMYeut7D16LMbxa6jxJl3aqXLNLNJwliTvdjfAm8Hi/mz58nl6O9JwDs+LQbn+76Fba/9r7le5jBtrelqjKQ/Pm3q/HUhifw4xfewTcXlOHEcBxrFvjg86rf+FLP2Bt8Ny5oi8pKqYdX5dN+1rsX40tw+3ZuwyKj8rW/w8rvOjhwC2sW+DAwfAMAUPlAGY5cugO7W7BthS1eWJ/8yeqHAQDf3/AENm7dBcZKIEmJNKNGD7PpKC2hl0dbFqU3Sqssy0xaK78rG3vf2iy33ubBW+4WsPIBAcD2ba+q0ogZ1K4Z4mJ6fg/Hqa57OGdHfnFRtOUecVHEq6/9EbG7AkbvxMC4lJZzrYDJLQgAoiThz/u6MTDYaVfxkxJ/bQN2b/8p3vnTRwCAA9Ebtgt4/DpGB44xW9TX/YAkxDF87Rbi49RuRtiuz0RJwtDlYTCOz554ggjWNSLS2wp/bQOi/e2m8y0Pr0U8njLM4rFYRo3kr20A43hIooCeyAlwfPZHS8+ojGfw8Bwk0V5nD+BAC75w4QtIQgKSaN46DtY1qv731zZYypstfTwWk/t/K2V3dLYg0tuKrq6jaRpJr5yurqPoiZxAwL/S9D3kOjrUgh3RowsXPmwpPb0MwbpGdHUdRbS/XfUAl4fXwl/boHoR6HpX11GVtvDXNqSlZawEHM9lbL3+2gZDIzAUalLlDdY1QpISqKkOy9ei/e1Yteo7qA+uxplom7kffo87ggSPiRafC7aWSk4Ks54ePUKhJkR6W1XXOjpbdNN2dLbAX9uAzs4j8jUrKpjw1zZAkhKoD65Oy08vnRJS9z2RE2n1EQVRt5xMlPGscPrg8ULqVNkqg3WNkEQBjONVwlc+ZOpn9WAcj5rqMM5E21Dmm5r2fbS/HcvDa9NeJNIC9cHVaffWexGMvstER0sEPp8Ho6Nx03ms4CoBR3pbUTkvgAULHsXl4TOq60YE/CvBWEnGhxrpbYUoiLragdDTEpnuO560ShjPYcZUL4S4KI+F7cRWAacc/ta7daVwlIK1ki8bHM/lLAQnkQQRo7GU9exqKzrmUB8y2TnZ1e9o+bZa0amZkkT2hJMY6outDMdu377rVHXsE7BXMQ2Wy/TaRKMdcmk/54okCpZ87je/GpX/d6IPtl1F6827ZsLsg9W2iEz5/LUNqjGqEXdHR+VyJFEwzLM8vBbBukbdl0IURNV1Gm6ZIR6LoXLOtLG8bu6DlZg1tDINbbQoZ6lqqsOGnrJgXSN6IidkzxMJgf6XyxMFhMNr5PtH+9sN/efk0dLWtavrKEKhprRxcrS/Paur9uD+wwCAkeu3IYgJlJeXursFA8DytUEAwMj1UVO+aGo1ypZTUx1GsK4Ry8NrdfP4axvQ3X0sY5lKIr2tCIWa4K9twKm25rF0knlbgdyhWi1Cwy5li/V4vabLFQUJ5eWl4LmSe3W3vwXbNkzy3vNiiRKZ/OZ80WeibaoHlG2KMXZXQMDfCI5nupMHpCJJgOTgAKDyMDFWgp7ICVmL0EumV6aRllG2fu21XIZkrh8HE7OmlYJx2d9GKzNO1DLOXUxFTRqpd3pBqLUpXxilIOh/KiOfc9fl5aWOle3YONhMCyb1acZhoRVmphZCkwGFgNKKdrWK1mK2ddrtXaqpDoOxkoKMJikYFZ1PCk2wZGA5he1GFgDMmTsbUvSmXUXnHTORIMqIjmh/u2p8rc3bfOgzx+qqxZHXp6zU/FDBDOS4MOv+I6eEFXehNr9eHTIR7W9XdTcUCWIGbdy4neQtMo4eWLYHR3O+RqqXhKkUihxmk8EOyBTBEY/FVOm0E/tG42LtixEKNaXlNcIpf3Te+mCycs1au+Sh0kKtRissPQ8TQREcAf9K3RdHL2heWc9M42Kl0CVRkMf42VS8IDpj9edNwIyVIFjXqHqYFLkBjD0Qis8yilTUtlwAGdNTmdkiQJT1DIWawFhJxr6Y+mD6nqx5I/h7dRPEBEZjkmPGVl6t6K6uoyovVrbIDSDdSjbKY5TezL30QnOy+c21gje6LxlYgkLj+LwMN79KuH8cnBQSGLo8jEVV802Ng80Gp1kNpMsl8C4bExENUjDj4POXhrKmcUIIhQqF7DiB7a5KSUhgUdV8u4qd9Djt6HCsdCsrGwodM8EFgL6DwynrmbivVoiZFQSlNeMo8dc24Ey0LWenipKCiOiYM3d2TvmshO5YEZSy/O7uY6buE6xrNFx+YpTfrbNXtguY9qGygr+2QdcpQeE2ytaRyTgzip0CUt4pTrPjDnmkzAidIk+09WQcbzoGS48Z032KslxuRU+5F4uVy9okisJQjh8p0kIbopMpdsoIUZDSBGE09CH7Qbu9Q0/kRNrQTjuWN2IiJxiU2Bo2Ox6UgXJEsK4RA4OdCIfXqK4bqcNgXaNh33nuYjei/e26a5O06I3ho/3tuisUKWDBrdOUrpkP1nN66MU8AcYtOJszwmwUZ6S3NWM/bOWeZogLomObo9omYBoHW+1/gYnzVE3EYjI99NQz+aLjgojR0Tg80wtkhT8wvvXB9wvCBK3lsr0PHro8bFeRk4KD+w9PmDD1cMzR4aZNWPKBcui15cWX0oTM6xilrl/ZQFjth82OQyltpnAcul5THTa1CIxWUmjrkIszRVmneCyGmuowtrz4EkRB0hUoAMyYOhbe5Po++PTxPkhCAn0D57OmpZAZ2gPDrKtPb42QEuUQSm98qvcynWprTtsaQg8jxwgNzbQRJ2//ZbthPZU4OeHgSMnl5d6skw2SlADHc5BEIS3yQi/myY6N1YJ1jXLLIrTj7JrqMDo7j+jej7ZJ0nqzaAys/R08z2Hnezt0NydXqmyacCgYFW1lulDPaRHpbUW0v31cc8Znom1pdkCktxUerzdtfEshPKIgQhQkBPz6XUYo1ISAf6XuPljZfNFmDC3XR3RYgVoIYyVpu+ropr/3vVI96sVIUXmA/pSlVr2TlqBylGufsuVVovVkKdXzzvd2GOYDxlS0633RVqA3Xs+/q4fZVXs9kRMIhZrk/7NhdN/xODqaD31maFQRyu8FMTH59slS9lt2hu+4dTedTPh8qVku11vRmbbhv1/I16yREba1YLIUre7RMVnIRbAxxR5ZTmGrin7jk04A9gxpColchEtW9b6ea2Acc0Q9AzYKWBQkeEt57H1rM0RBwKaXPjD0BtHhU3ahPUpgIqADrZQL3708Z3lDuMeXzgCQOq/B9cOkXduew5F/HwfHGPa+tRnPbtmJPW8+P64yOZ5XHXylhM5YYjyXdkCWGT4/2IZvPKEe09Lxsx0tEdV12mBGyRvbPoQgal/U1GcKxTGyjpsHb+FJ/0zEBRHNg7fwTGg2Pj51xVL9zWCrgDtaItj2cRueWzUPnqO+e9e65UOr9CDDbPjKCObNrdA9N0l51hDtKE/QeUef/8fcKj6CDriil4T850ZTnSk3bOp39Pedxd24gIpZ5fL3en2pcnsGLdRaD/XdxONLZzgiXMCB/aJ/82wjfrvnGB6//rV83cxKBxLU4NnzAKB7Cpk2/eDZ83J6QruVotboU06E6E2K0LWRa9cx9L/UmUbzH5opf9/T90WWX6JGGVSnhCmiNw713cT6FXMdEbKtJ3zMqahJPulPPYy4IOLYxTt45dmUR4iVZj5DULobt5SOYKUe3bx0TTt0EyUJHT2D2X5KGnFBhIfn5L/Z0hohxEVUzCrHP7uuySoaSAnZibMLbS/wwZlL5NNHs1mHuVqPSpeelfxm70fptH/Nps/l/k4IF3BAwE7x4Mwlyafqx4LqyTgxe87QnIqa5DOhsfwfn7pi+qEqNROxr+eaY0Kxk4IYsGqFO3ztluVj4LQtx4pj/+rIwJR9PepTRJ+qn405FTVJgyyuoSAETJBVOm/2tJxU+2hMwuWrt+yulqspKAHbSa5OBXrJ4oLomPfJTgpWwE7MnZrhjs1H0TtNQQiYcUzlNNjXc832Qxyz8eWNs1MORG8guLgiowPDbbhewFWVgeS/dv4S9UutnabmBJIoYf3PvocV9Yvw8NwH8l0dU7hewMCYfzjfULcwa9YMzK+ch/Ur5qrG/W6kIAQMAGcvjeS7CgBSOwkBKZ/10ppFebMFzFIwAgZSBs6B6I28ORiujgxMWb/1fYQfC+S0yC4fFIyAG5cvxYPTy/JdDQCphe6FssDO1QKuqgwk9765CR0tEXCMOXYEay5QC15XPc3V/bB7nphJ7HIujLfvLLZgm7H7jL9C8ELZgasFzPEMJ5tPIxIdhM/LbDWw7LJ+1z62zNWWtGsFPKeiJrn79Y22qUK7hHB1ZGDKhq275RitwbPnsaaqzLUzS64VMAAwxb5WpR53LihfVDUfvMe9poyrBSwJccfGm+Ppgyk0lmLN3GTda3GtgL08B8Z7wDHmePR/rng9Xtc7PFwp4KrKQPLXPwzLn31ehn8cH5rwGaRsTJ1aLtsIT/pnunI87EoBe0tT/S3FLAf91fmsThpXRwambHp5D9b9oEl13Y3WtGs7j1XrluFk82kAwIUL1mKRjTgQTcU5Yzg2bmGIiol/n5e5NhTIlQKmdUZ9A+dx8+sYHpo1ddwCsVu9K9dWBf3VuHy1087ibcOVKhpITcuNxiQEllQicm4E5T57T1MbL6ImdMfn84x7Q1YncJXRQjyyZFlSkhLyqkH6e+5Cj6vq+8iSZSqjinE8+vpPuaqORYoUKVKkSJEiRRzg//yz9VJE/CWCAAAAAElFTkSuQmCC" alt="Whiteboard"></div>
         <h4>Whiteboard</h4>
+        <div class="verdict" role="group" aria-label="Verdict for Whiteboard">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Whiteboard">
       </div>
       <div class="cell" data-item="2026-07-16-office-library:water_cooler" data-label="Water cooler">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAAB4CAYAAABCQPQeAAAKpklEQVR4nO1da3AT1xX+VlrtCtuCFKeBAAEKBLCFca0CsXkkhcQkJWlnmtBpMplkpp1pQjsNCUzLoy2PlkkIDRAIM6GTtJlpQkMaJoFSBqjBIhgb29gI8IuahxsggHnYWDY42tVK2x/LriWtZK28d1ci6Jvx7HJfe+635957zrl3BZBGGnc1KLMf6LA7Rfk+aGVhCXDKFQAYmkbbzROmyUWb9SBA6nxHdx0AYHldEJwghuV/sW0HAODmupUiJzSZQoKpBABSx/t1e+Guu6zKO1d3HJyv21R5TCWAoXseN23SOOWeF4JgaAv6e2fh0ulmfFm5D5xgjkymEsALAjhBBMf0D0uvOX4aV5qb8ODgbGQPug9fmiiTqQRQGRmoqG0G5+OUNMEvvWqO70ZtdQus/q/NFCm5q0AoeEEEQ1PwBxn4+GPfvFUgM9MlAsDLB6sASOM+FJ+8/gYAoB8Aq5sSAeDWLY/hRBj+APmN56zajFtcsNeyrZ7KsCFwy70LAb9oqEYYSoDD7hRn/fOLXsv4/eHTfe3fN6vK+Cr2oLO9xhBZLUY06rA7xZ/tviLO/dwNGy3CRkcd9prBPlSMt08HxOysfH0NRQFxVrOz8sWLbZWw2Vh8cE6dPzojfh+2762Lmr7hhXzckzERXb5GYnITnQQddqeq8z8fEVmKwsFrfXuRr310Ate8NRiaXSSS8heIMSm/+c3nWQDA/NHh+dG0IRQ3Iyy/lsMnYpbd8EI+7uvvIuI0ESEgOytfvNrpwTsnfJifb1flH7wmgqUt4IQgWFr7tPPJruMx8956djyGZhfpJoHIEPCJViz2BMDSDJbXSUsda5GuXFDucCDi2js4QURj48mY+QtrxoIX9DsMxOaAOQ9YUHq5Z2z/foLUtExIIgh1k2vKD0UtM+HpZxJuNxqIECAHM2T8aaIl7D5RElha0ur6+kZMnzkTXKStUFMDQDKf9YIIAbKbK7+5vrz1aOB83ag4XKn8W+R8AIDJ02cQaR8gOAeEghNEzHlA0oLQYZEoXFOnRU0PAmASmEx7A5FW5CEgq65ZYAg8j5jEmZkuceTS9bCyPctg4LbK9hUXSndETRc5H/y11UScJKKWYE5BrnI/ctA9KpdXiLJsXfXGjgEOajsbM+9wbXUfJFSDKAHTxmYr95IlaEXVjdCXxKjqNHX2i9le3fWCqOnfLnCiYtO6PkoZDkO8wTsJhhPQ1EncgyWKtAaY8ZBU1gJiBAT85naSsrBE2iFGgNVmrhEkBrn4hTQgPQckW4BkI01AsgVINoiawqevSLs6NE1jsTec2+a26N7ijZucUicSNUc9UZ8zoLUdDE0R2UInQoDD7hQ7uqQozeR3jmmqI/h7lz7A+XChvkGVLnI+LHpqOv7lrcGAzEm6T5IQ04DFHinYOb1wAgAyAYvGr68o96FhsQP7j+JyxjAitgDx3WG542tcUpRIDo/J4TKWplRng/oKEraAIdvjcueB8ABporHC8gMHYualVFQ4Eos9AZUGhCJUC3rTCPuAgVHTfd52QpISJmDP3sMAgB88MVWZE2LFCXuLH7I0hYptO+B0FcDi51X5X507T0BaCcQMeIfdKS7a+Rk2bZHUdphrsqpMvJlfRoDz4Vq1GwAgRgmjvbpsIVYXzyZygoSoB+OwO8WXy48pmsBmZQGQOk7b6LBrb2gt2x3271ASXlmzAmuKiogdnyFqCXb5GqlNhd/Fc7MmIJO14FzZPgAAbesZaVq0QBSEsD8Zry5biLXfn0707JAhPqzD7hTXn6zDux/ug7fDi6whqkMCMdFatjus0xRNQxQErN2wAC85HwHpI7SG+AJdvkbq1w/mYaZrPO4dcj9a67VZh7LqUzSt/AGS2v/K9TjxzgMGOkOc0ES9/5Mn8Yu50zAyzwk7+DAiQoeFjEiVB4AXV/wBr7sKDDsyZ2gYx84UiED0aFHALyrpscJpVhsF4fbuklGnxw0/KFn4299h1k9/FLecfJCCE0RUr1+mpB/59N+GyQYQ1ACWzhVDnRPZTicVvIyEGORAWVjd+4O6CZBPgroe/V5C9aw2W9wy1691oLn6JPIezoua31B+SiG6r0NEFwEsnStePvMhNu6Mfq4vEoIQAE1blWskXnxsoirtldVbULq1BI8+Nztmu6VbS/pMgK45gKEpbNxZh0PuCs11An4/rDYbAn6/kiZrwyF3BewOBwBA9HVjyoxCfNVyAQCUK2nongQFQXJ69n3+nm5hQlH89EtE24sF047Ldy9eotxnrHlTUx0Lo95OJw0ihhBrU4/nSHSOG068TRIgpgFtpw7iXOVJjCjKQesZKWDhnPNjJe+S1YJLuSMxsaBQVQ8Arrd2AQA62zsxKncoKbHigugQGFGUAwAYPEaK5Mida2m6iFFFOWhpugiv3QvcTqft/dF6ph2DxwzEvYOlyU++mgViBDy75B9gbVZw/oByBRA228sItQHkVSEUsvoHeXU0iDSIEOAqmhy2voeu86ETWZDne53Y5A7HshOMABEC+EAA7hJJrT37e3ZzKAsLm4UP+yIsNJRNWVjFpA1Ndz3mwqzZj5hCgu5VgKatOFoh7QpFdr6jqwId3XVYvKBY1XlAsue9t2rhKVmJg58uVdI9+z3wVNboFU2b/CQaCfj9YZ0HpM4VvVkGADj17qGYmxi5SyRvr/3jj8PS3dvLMWVGYbQqRGGoIVS7rBgAsGegB88s2BK1zOl1cwEADU9xmPK4NgOJJAzfHm8u26WpXOVnx40VJAYMJ0Drus7e3z9+IQNg2BCgLCwmrZLC4mc3bo9Zrmid5Eke+1tN2NswKpASCVOcIfahYnD7dkTNO7F0HgC1KpI6BRYPhhEgBjk0rVpoVPPEoJsALS5r3sN5sDHxQ2Ch8Oz3KLEGI6GbgHj2uhzPGz76O5rbPH/2f7pkSgSmnBIbnTO2T/W0mMI8r3a2EsEdf0yOSXBoRcJwAhId+wBAD5QCImbMASmpAUO+JU2sd4Q3eKcjTYDeBuKNU8aa2hwbbgpX/acWQC0AaSdJjg6R+PCZBAiFxIJgaAol7r+iX0aG5nruBrXBU115FJyfw54PtLnReqGbAJq2grFawAsiPtpbDoZlYdNgHvt5Hqf+26JKv3pR/StzRkLXAGVoGgVjpB0fysKivLRKU+dljB0/SvkLRfPhBjA0hYIxw5HpiP1lKQno1oAfPjETJVXHUDB1Ejav+Auaq2P/7IUWUBYWU+cUYtjIcXhv6y7caOvUK2Kv0EUALwg4UnUEm1YuxJJ17+OXf5wXpgF+HRsby5+fiifnbdAjniYQmQTr6xrwfHERiaYUrN5WGb8QARAhYJv7CIlmwsBY76CdIS1Yu+htAJItMP+N1zTVMcOIMo2A3/x5QcJ1+ED8Dyy+0fEAMzQgpQnQgpQPiKQ6UpoALXOAXqQ0AXf9HHDXa4AZSBOQbAGSjTQByRYg2UgToKdyqkR29SCtAXoqk/hFx2QjPQSSLUCykbIE8AHjzwYAKUyAVujdh9D92ZyM0DemN6LLBwIoLy2HPyLeF62zer8p1lXZYXeK/iCDsZOlrS2GpcFzAhi2h1c+ys89hebHQ31Zfcw8Eh9U626ApXNNWwpIfCusapNUQ0YRYdZ/upZGGmmkkcbdiP8DGnL/FRHA9XYAAAAASUVORK5CYII=" alt="Water cooler"></div>
         <h4>Water cooler</h4>
+        <div class="verdict" role="group" aria-label="Verdict for Water cooler">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Water cooler">
       </div>
       <div class="cell" data-item="2026-07-16-office-library:plant" data-label="Potted plant">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAABgCAYAAAC+EjQcAAAXdUlEQVR4nO2cXXBT55nHf9I5OpJtYWwJy5ZkywZDoLSBQgvBBEOd0E7SzHbTdEtJ26XJtmmyu51tZ6cXe9Ob3Yvdu/0KXQhpkjIEqJOmNE0okxJo7CYm0JKGTV3AGH9bxsaysYUlHZ2jsxcv50iyZPAnZHb4z3gsnc/3PO/z8X+e99GBu7iL/9coL/AZ5QU+407d336nbjwdhIpDRuCBsjs6ho+tgIJuv1H5VyWM9I/f0XF8LAUUdPuN5bv8hLsiLLm3EFmS7thYPnYCWuGrMh7/8QrsTh1JtpOakNF0/Y6N52MloKDbb2gr4A8fXKOndYRl60p55OvFd3RM8h29ewaCbr9RvUM45M7TERSvnfs2Ft3hUc1AQKHikNE91m1biEFUewLGJ74VYGODHU1L0dhnY8cTQVQ1SeN/DyzELaeNaZuYnkoSdPuNoNs/75zE0GQSJGk+mUCWxZAaX+rjyMFBQmvL7qiTnpGJlT/kFSedsFlC6or0z0mrqj0B41svVQDQfDLB0VfHAAjUlrClvggdlUv753KHuWHGPki1T7Dzx0EA3j46jvaaYQBIdgczNcFqT8DY9XwNoFnbhvuiBFeWUFfvQEelce8gkt0x02HOG6ZtYpLdwaNPlBC/pnHk4CCSYvCFR90U3O/gm89X8vhz5azwVc3I/DTV4HfN1zE0MU+d54YB2LrdZR0Tezc5Y8HPJ2bkg7SUyo6nfQA07h1EV9PjlhSDx/6rgqDbb0xHUEG337j3KaGJv2u+bm2vWeNFV228fjjC64cjs9aeoNtvhIpDhuk3zb+Z5nUzMrHmkwlA+Iee1hHefE3M+On3VerqHUiKQcH9DnY+Xclz30gYAFdig1POvohaDg7tHiCZKLG2N+4LU7NG+LsxRm45rlBxyNBTyaxt3z5YhaHJ6Kj89g0VgP4PRnE7i3BdlA2Ynv+ctoAkuwOHEz670UFLc5KK2mIG2seQnOIesixCtDXAl0O0NCeR90lGXzScM5Dlu/zW8ZJsx+EUkarz3DCSbKeuXmhO+0+mHpMpmKXfXIKOisMpsfE+hXebYpw4NkHD9mIkFMJdAxC34aldzJVjw8iKbdrBZdoC6h7rttme04xNmyuFA1UVTjslelpH6Dw3jMPp5bMbs82hrt7BZ9at4NDfkSWkak/AsDt1Wpp1ttQXITlt9LQKTQmt9LF1u8ua+cmaYQrGJmt843lh7i3NSe6vN/2WsKD7txZwaG9v+py1ZZx/sfemGp0PM0o1ilxu3jmmIaEgKQZ19Q7LJ7WdGUZCsY6VZTuybEdxT/A3+5eSafuaatB5OgII/1NWuQiAHU/5uX+7HVVN8vrhCA6XnOODqj0BQ6mDld/NXwZpOh4HEIHEaaNqdSmhlT46Dw/MWDgwQwG19l+0Xdof5heHBywn+vOXhlCKJCbeUzl5fIyq1aVZTvetI1FAmNxkkmlGLYDxJvFgLc1JPvijypd3VghNytCgak/A2PnjIK7FspWGNO4dtPabJLPvwiiB2hK+9p1yGh5cROfhgVnztRnzIMnu4JHHvDgLxf1Mx11WuYiewxFqdlZgd6azb0/AaX1eusuL9qJuaLrO0rVe+i6M0t8+infJYgo3Kxw5OEigtoRNm50YGrywq4O+aNi2wldlqJrOrudr0BEO1yZrFn1KJSRrLAPtY0g3BPXOMY1L+3vI5wOnixln83oqyen3Vet7Xb3DcqhVOz1c2h+2BgvC9Ew4nBKF69MCC64sYfQ3Met7oLaE+gYnmpbizYNjaLpO0O03Fm1dzK7na4RQMtDSLLTL7tRpOh6nv32UHU/72PG0j433KcwH5lzuMNV663YXDqfEPU/5aN0jhHTi2IQ1m4AlyEwoNQqqpkLchhMHzScTvH44QnfrFUBEu4e+7sIma2hayuJemRET0mb1+9PJLH4mK3PjmLMW0Kn3EmhayhqoOZsAheuddJ6O4HBK6Df2m04bl8F3X15O24uDOdfs+EOEztMRom0aUoeNFU/6ENEufe3GfWFcLqEdpsB7WkfwBt30t4/S1TrKkYODNO4Lc2l/eM654ox9UF80bJN/ajNcWxx0tYLDJZGMC5+jC25ohdTkWrH9/dPX2bTZmTXrJZ8vIBUX89PzSoSSDe6scwHcThcJcsO8IivIsp3jR+LoWsoilQ8/6snStAPv9+acO1PMumD2te+U56h5S3OSZEJHR6X28QraXhygcLOY7VPvJXIKYO2HBlBq0r5iYki1hLPumRDr66GlWUS7+oaAdZzdleLoq2P0vBJh9TN+ALbUF2X5qN+8mvZtc8GsTKzI5ebUewnLbMy/+gYnW7e72Lrdhd2VYtWTlUy8p2JPOEgmRI2nZo0Xm6zxlSemXs5Z+ViQ9fXic129A6VIypqMVNxOzysRgo/4rG02WcPQZDQtRUtzkkW++XHSs9Kg1v6LtuH/9Bn2RIiUM8mmzenIlOm0W5qTrHjSxwd7ulm0NZ2hN59MsKVeaJPaKSLixJBKcUURVztVtn2lAB01K32RUCx+1dU4ROF6JyMjo4yEbRQFHfzs+VHr+up1HfV9fU7h3XqeWZ94o8qXKZzJ2FJfxMnjogD28JeX8etfXM45RqlRLCGZ+F3zdeob0td1uKQs8glQs9Fjfc48FuDoq2OEuTbNJ7k5Zi2gvmjYxj6MaMJ7k6PipOJ2Ctc7+dXey8TOx2G12NP4Uh+Q1qDiiiJGz4yx6slKxocngPRDX+9LUhYUvmjiPeHfQJifLOd6iYcf9bD/jbHZPloW5rSqIdkdSChs2iohKQa6akNSRCSTZTvNJxN0XhjGv9JD+MIIVV/10N8+SkWlN4sgAmgxHU3XuX+7ndcPqxzcPWDleQBOHKQ+EH7N7tQtrZkcKAAkQJHnp449J6LYPdZtO/9iL+82xdBVG+82xdJ8BzHDNWu8OBfbqNnoYfTKBKO/iZGMa8iSlJU8jn6YnvEv7Uybj8mB/nRsgFS53Upjmk8msoRjJqmHdg/wwq4O2gZ75qUKOed1sSuxQVvxq07jtFOiYXsxmpb2J5kED6BqdSmtTeHsAUiStXL63ZeXWzxm8vnLGnx0Xxi0yiIAnefEcd6gm3hc5ecvjVPkVVCZnxAP87Rw2DbYY1N/qhs9rSPoWgpJtlsMejIKVrnofGsIc3r7omGbmeU3HY+z7aH0kJw4SJBk4myCbpdg3lWrS639k50zgGxX2P2ri1nllcnLRjOJbvO2stoV6beFWkIG2Kn5dikND4oaz1tHR0nF7Qz2jaJrKWLn4wQeKGPwnUjONR78YiFvHR3lk+scVK0u5cK5AYq8CrIkWWwZ8ud0mpbit2+otB/qRJYkSjaIJeuRtjF8a4XJjvSPUxpYhNxiMzRVyO9Wwpq2gDJrOZLdkVPpE2VMsfrgfNkw9u5L51rLd/kJ1i6hr/0qhZsVbAU3n8C3Dg9ZAhn6VZSljwQwK4UiSzeyopcpnK7GIcx+InVCY2zgOuU3hHP18jUkl52rl6+xpK4UdULj+miMYJvfuNmS1U0FlFkMf/pwLQDHXhuj/gtOTjXpVm1m0yYPZ05F0faLNbLJDlI64LCEq6d0jG3ia9DtzyrFvvxcD49+3UfjhdGscZRUyVZOZpZa6huc1nJR0/Ex7K78mfvVy2k+VBpYxNXL1xjpH0ePpyj7ZAnU3hjXMX/e2vmUU1ntCRipcjuFZQqqQwzK9C3BlSWAKDGYn1NxO+ELI3hrixh6Y2zKLDro9huarrNkUymjZ8boi4Ztmf7iuy8v58DubmrWeEXFMW4Dl2HdH7L9EEAyodNzOIKnTmw3zddeJbFk2eIsIZV9Uoz3yrF0nUrTdZQahVRPLvueUoO6Iv22kBYyoj0x7n0qSCyRdrrdFwatAQ+0i/CsaylwQZG7kIef9/DCLqFNk29oOmWlMP+tHYodSbbTuidM4WYFb20RLrfMAw8VWseYmgMQi8oc+rs2fNvSpmR+NrFk2WJrn4JM/1uRrHGFikNGojOetwdgWt682hMwAFxbhHMM1JZYjrLpeJyB9jF0LYX6viB7JZ8vYPQ3MZY+EqDjzX6KFzmzzC7o9hvmQ/SfGGLJplKunhpBlkTBLZWQOP9iL2u/72fdp8UCQabPMTQZVU1y4Du9aLrOumdC/OnYrbtAChe7iH50fUrHXO0JGJM1f1pO2jwp9NuQkUjGqaj0WsRsqHeciloRMVLVdroah4ieUK3ZUGoUlIpCghNpGy8slCkol5AT6RmTJclKX8w+ocsfjPDZjYJNa1oqS0gvPdkFCNpw7hWRtlRsyp/2GDGD6JkxLvz50k0VIh/7nhXbDBULQZnEzkTzyQTJhE5vS5oV6/EUxRUic49+OG4Ju7zAZ6x8LMiF18TDmQIyfdS6Z0Jcah3EFyxB1VTicZWRozGLVJasFZMy+uEYBavSlQIAT212V9qVY8OzzuxnlWp0j3XbZEni10fSXMYUDkBlXTGVdcUE1pXkZOomZElCc+b2HpoPkiBJsHYJDpdM+LVrDP0qim+bhyWbSlmyqZToR9eJfnQ9Szh6XPjJSPsYyg3jGD4RmVPZY075StDtN+55Kp1QTiZwTcfj9LaMoQ4lKV1RjKYniX8Ut7Qo6PYb5Q95ibSPkWxLWg9SXuAzCla5SLYlMSOepicZPRO1ri15JZQycT9TY4yYga3AhhEz6D8xlDbbOWBOyWpfNGy7uG+QVELKS/u3bnfx1z+qRFokcfXUCIlxDVu1nLOAmImg22+UrC0mdj5uCQdAlm4EiAfKKFjlonyth9LAIkoDixj60ygAtgIbCjKD70S4Ehu03dGCmYm+aNgmHXAYl/Yn8W3z8BdPF1llT4Ekyx/yWktBQN623lu1uVw9NULBKpfFacz/S5YtFvylU1CP+dCaTMxrY5LJvN0PKFRUennwi4VoKZXmkwkrdBeschE7H7dKHWbIH3wnYpHGkrXFjH44ZmnPSNsY+rAQqkg7BMInBonHNCtYnDg2Qcf+4ZxUaC4Cm9c2YDOfCf02ZFxKhbm0X7DZWyEzN5MlCZQ0Kb16agTJKxF4oAx1QqPjzX5r36onK0nGNWyyxsHdggd98ns+qwxsaDK/ODyAfDww7X6gyZizgELFIQOwZqwvGrZlJn6hPrE/kYyj1CjEzscpWOUi2JbmRUZMuKTyAp9RskE480yYCadZkt32kMyJYxNse0hG0+ycODaBa7HMl3Z6kGU7hiZb9KMsuIjkFp0dTwTZ/x1yiOCtMCsBVXsCVrmg9tulJBM68aiGIivQSJYDNoVV7QkYNtfUMcGxwoF2XpiRGa2unhLFsf4TQwA8/bMaQFAKh1Oy1v8dTon4NS2r0yMfdj1fwwu7jLxJ6VSYkYBMH1OzswIdFQmF+gZxCU1L0XQ8jv+xxSzyOkklJLo/HCL4odAUM7eb7r3M5NH9qSKiH12nekdZVom1vsHJiWMTDPWKXwNNTmAz0d8+yoHd3azY4GX5Lj+Fr8rGdEuy05ZkumUXq8xhphtmV6pZl87M8kf+nGT0jGDWJlN2rHBYvCeTC8XOx628LBN//8o9vPivXVlLPWZvkVk36jwdoWajJ4uLNR2PW619ZrUTwF/toatxaFrOe1oaFHT7DU01OLS3l6rVpVaD99btLt49nuL3p5Nc/iD7ocwEVhsQ5iP7oLzJZwnHRF80bNPe1AX3IZ73/kk1ZZU8zJq0KRizXabzNIwPJ2hpxhpfw/Zi3n4jyubPlZBKSHQcuIqeSuJYmdu5NhVuKcHyAp9hRovBvtEpjzNVvL9dtKGAGOihvb1ITlvWMo9ZEjXrQaZWxc6nBXQlNmgLuv3G0l1CEBIK3RcGLc28f2tB1hKTbBdLzW8dTY+xY3+65pPZuJlJVOdccjWz8u2PutA0HxIKB3Z3A+lZNGe1rt7Bz9vF98efrrRMMVBbQkWll+4Ph5g4m8CxInf2nE4lrwaZWtDXJYTTd2EUSbZz5Ibv2fFEENCElgHVy7w0/3PHTR/e3L7CV2UQzXdExvPfbGe1J2B8e/8yID0zA+0iUihFQnBb6os41DqCwylm8itPlNG4dzCrRQ5goHcYyW2zfEzRpgJrXyazNiekvMBn3POUj7ffiBLuilia8/jfV1jNor8+EuEXhwcYOSq00ySI041S03HUt9Sgk2+Ps6W+yIoWy9aVct9GYTqmrQM5LcAgBGY6xok2nVSPzrgutMQskJUX+IzAA2VZv001GXUqIRHuGrQ0deN9Ck3HY3QfyA7n85la5DzDVDuCbr/xj433cOTNEQ7s7kaS7VTUFt9ohFKtBnKAitrinDVyQ5NpOh4ntNLHxX3hrDqOuYqaqTn5TGzgo1FwpNfkL+4Ti4yzaeedLW6qQUfeHGFLfRE9rSNW9ALNCu8gnKfDmbQ4itn2D9Bx4Co2WbNmuNoTMMwCV6ZDzkSmNqh6Ev9yEZJvp1AyMWVt9hPfCpAgSee5YUvFTZNqOh63iugmm914n8LbR8fpeSVi+ZF8qp8ZsSSvZCWhJRvcRM/G6IuGbdWegOH6lAtVT5L6sz7nPsO5IK8GGZrM5gddvPjvIgE0oxLAsYNxrr41xksHsttLLu5LItkdt5zpvmjYVt0VMDKFMxmaalC4qIDoO7EF9S/TQY6Agm6/sePZGk6+fQ1Jtlsrog7Fzk92XUZTjTkPuivSbyuPCeds5lkgfFK1J2BUP1xO+y8H7rhwYAoNKnBr9LePsny1jwRJ1Bb4yZnLc1J18wcommrkX7q+UTGMx7SsczKPm8mvdOYLeQX06yMR1Os6rT8RfKZ7bOaDmvxwT1VnJ5OyLPEfJ3pzcq+SDW5rpeN7K/zWdk0T5rhHNabNgucDeQWUmpBJfZCie6x3VgNY4asynn28nLNNaR/zbFt2X9DksqtZAzI1Kd85kC20/2kXa/4L+ZPNvFEGZj87oeKQ8be1S9A0XWjJedH3LEsSX12Tno8JTeWX/yuUIVOLzM+Pr8tdBHjlnGYJ9gerKvnEKviHN6/OiD3PFDkVLFmxzUk4L3xZLAM9eynMs21hGlYm+Uwoytpgdtdp77Vx/vLeqW9zcXg46w/gq2tkS3CapvPn8/BfjyyZzVCnjRwTm4sTNH3OhjV2vqf52dMxyMkLDj4TElzJfNDJyPRB5ud7vN6s483Pf+h2W9s2rFn4V4/M+7s7zpxLUbdexrtonJ9+JYgs29n1SrqxQE8JvvQp/1V6r43TsDJ/n/WEZuPDvsXWd03XkSWJn329Snw3+xjPJhf07TDzLiBN02k+rVO33sPnnmsCYD+fs5oPzAf71s+zw7wpgPTDGry8I5jTSWbiYluEa7GS+R5+DhZkXeyZpT7qN6Z/3WMKajp47/sNpJLCedsdNuszQMtZLed4M9ItlJOe94sG3X7jmaXCUd/7KQm3Yrc0RymQSCUN7I7c20auJa1jAZpPJ5BvtKOYETETmqbz7KXwvK+kTsaCXNhsYZElKYu3mKhbL+cIKVNTTGhaijPnUhZJNLGnY9AyyYUmiwsmIFMwk8meqV3Tgcmjvrfcz7OXsq9jblvoMsiCv4FqsgY92xbOm4tNBVmS2NMxyA9WVWZtn6xVC4UFEZCs2Cy/sWGNnTPn0tEnn8nN+j634cVLC8K0uiL9tj0d6brxhjV2NqyxU7denhW5y3fOZKe9UFhQExNmIB5Olu2s/7cmTv9wCxvW2Jn8MhRrQDeimLkvzYOyj71dJragXF2WJc6cy+5Ozfy51OTfvE51XD5B7ukYvC3ljtv6HsU//mjb7bzdvGDBBNQXDdsmh/hP/8s7C3W7BcOCapDZINByVstrJtOBSRanuvZC47aZmCzbOftPW2d13p3EgkYxPZXMm0fNBJM1T9N0MinEQmPBp8d8GLvDxvp/y83qZ2N6mj4/Lw2YDhZUg6zfXmg6774P6g+35D1uKj6kaSlaziZvGynMh9vyNmDzAfM526lhEsVs4ezpGLyt73a9LWpq/jrIfLCZ5GP5fM7tXHG97Uu7Zl+1+bYWs0adNag8K7Afh2Xou7iLu7iLu7iLu/h/hf8DHIdkxZMW5xsAAAAASUVORK5CYII=" alt="Potted plant"></div>
         <h4>Potted plant</h4>
+        <div class="verdict" role="group" aria-label="Verdict for Potted plant">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Potted plant">
       </div>
       <div class="cell" data-item="2026-07-16-office-library:server_rack" data-label="Server rack">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAACMCAYAAADr7S75AAAVGUlEQVR4nO1de3QUVZ7+6tajE8HFByjEsEZWg0AiD2XWszNznMO669FZx5GjyTiM6/yBszPoIjMgcWAmJmGBCY85bFDAx6ijZpGo4Ki7Lj4gK8f1gYEk3SQSBIKEEEKMoDBJ6rl/VN/bVdVV1c90Ojv5zsnpVN1bt6pv3cfvfvf7/RoYwQhGMIIRjGAEIxjBCEaQMLjBKFS4cJYBXYlOICJcz3vBmT/WcZJQzweTrgch5bs7CxxVbADAnXPvgijy7PyaqWdQULkLx1d/P9239AVRVQCAogMFlbvQ/ugcLD90iXlO0SGKBLX/IRrqN/uSqsS0VqAwqtgQxo6D2nMaAFC3bRsAoKS0FAsaLgAALG4cndI9RJHYjhVFj+u6c30yoCtY2nIRAJ0927yf3JNSKyaxs8SGMKrYEC6cZRTNvpFVnijyZhcjIhRFw3+9viPmgyqKFvNeiqLb/uLF6FwJQOSlpgspj4G0y152zRR0H2pl50tKS9n/6X7odIx9zudLdhxMqQIDl95oPPTLGrz51ma0NX4anSFNg/yggIjmZ/j5Ml6Bwqhio2j2jQCA0N6PotLpG14z9QwKHt0JYey4ZG+Vdqg9p+3PV7kLGZ1EhFHFxm0/uNMc1zzgHOwX3v87AMCp4++yc9YxzJmfposiSWisM6/TbBaAomi4avKtAICapx7xvF8ySLgChVHFxtx5i7G9dn1C17351mZIooDPjh5m54iUA13uT/QRQKQc27Hc1eU+VFi6aeGMdkhi2q22xCpQGFVslMybj7oEKo++aFnTcKTjGPIn5Cf0gPGgvasLZYdrXdPWVgehP70ebc1NKLxuunsBKYzTcVcgtfHqap+OTrPYfkMCXcEANNRUt8CQAc60WPBwWTEAgNx9P/SXn/K+nrbUJJDaQEBESHkTE6689gOhhG/V9MR427HER8Y4EBGSYH4VrnE38En4LwNIelAQxo6Dce7PkDuP++Zzjv8Sz+P09FsxW/W/zonp/9JlO5Y1i9GtK5B0Dct+PQXAlEgeYpjJLz81aOZUcrNwAl2Wl+y3kDUN44Kvo6B4ZjK3dgcRsWp1q2vS+D1vApMno/PgwfTdz4KkKjCRLqvJatS5tFYeAGn8eBg769wTL7ggrfdyIjMtkIhs3GvvPRNJ1JWUBvB40Gn5v625Ke3lZ6YF6goWLHkMOWIujh58CwBshi6FmwEsijwjGZzXuJEP1vxWTJj0PeSIuah56pG0WgzptywdoHbgu+8+BwBo7z5lS5e7upAs8iZPhiTYWzCb4XUFeVOKIAkiOk524NrjHb7PlywGvQKtaGtuQsG0InbcHtwP/r7FAAANKniFg6HJ4HiJ5dFEA7wSvUzVRAOdL2yKKq9ryw+BfnP2Hb/oTygonon8CfkINTS4GtIJrhKjkNEKdDMljICIh8uKYQgGZFWHJBD26Yc15Xttx+0HQujacAcknQDh+u/acAerRC+IxP254sWgV2CsN2zIgCEYrEIWlV+PjVXmYE8rd211EAvLpqKmugUAsGR5ka2M9uB+fDHjFkgSD+7bFwJnB4AxAUgffINjN92GK/e8Y9qKLmthRUdKE1lmW6AL6LJradXsSMvbtgWaLJsJZc8BQGSl8fxGcGVPRhcUiHR7jAnY03xaWKotMD2cThywrhxsy7Aw1pfvR011CyRdA+beDwDg710IAFhYNpV9/uuBzTAEI+r6iq/PQCY6sO+8eaLDZHkqu7/xfa5h1wIlnscHXB5mI7KUW/toCOBEQAZWVrYCYbrKCIhYWx1k+Qw5Ug4PAfSVFBTPxDPBPZAe+3tUzB8NfHgWAPDCyxyeOfgRCopneq6/U52FM9YCvcDvrAMxFAi7zZUE/bSmG7L5SdOJoYB/x56voHgmtrS8j2VP9KLisW+wasvXeHj3DhRMK3Jt8ZSkHTazsMTzrKt82wivD8LHpN5ktoXddeAUBeLbtZARqTTx7Vr2aYgiy+9EwbQiPBPcw/ZiCmfcAFnT2PAhK5FlJWWks34WtnaRwuumR20+KceOuF9IRO80C9qD+23XWMHuRURPMnXYjIHt3adQeMUVoBtRgNkiBoNm9yq/7cSJqO2AVJGZCiQi5M7jCMXgDocjMlOBuoJf/foPAICOI2+ntWgvNYOTVLDuykWRCdk8BtJZju7KtZ04YUuPxWh7gojuZEJwPxvT8iZPBgB0nz6FSUeyYFcuGVgnkdDej2zr0vYDIXA/fSSpcomhoPOFGjuZQNfDEg+Z6Bj/89dQOOMGSBPy0db4qW38paB8ZbIY2qWcrsAw+lBW/i2IRIWiC2yVIekaZMKz/xVdwAA0SAIBp3KorvqEFSPxPNoaP0XXhjsQGCNCn5oLfPi1nUwgos2MoaDyt2QxtIY0EcGH3+HqimasWRGErOpYtzKElZWt5goFYPsdG6oasG7p/8IQDHYdYJorp2f+AJLEA39jng/MyoUk8fjib2+3mzppxtCyMeHBWyQqFldFurb+pCkDARGBymehD/TBEAyQQC648CNrcG85eiDcHccEwOWqwIDM7uXJxqSAIV/KUawp34v15fsh6RrIz8xxkftnk2xdWjUbgEkmWCuagYhYYZyDTHSQnnCFnR2A0adjlaoynaIbhhUjDVjIBMu+8KrVraxL/lvFPnBcLkBEcJLJ0hgBEfpAH3gIMALRFVEwrQg1jbuALXOw7KcXQjqmwADQ82E/toTeQ+GMGzw3lLK+Bbq94T4pQkeR+h3gBhRzfatoEOvfYGmGHEkX698AFA38zjpw5/pt+QCTTHj8s49R8fQ5LNt0Fss2nUVh7TsonHGDLZ9zJZL1LdDtDd88cBKyao5/nBJhVsgHr0fIBF1hJAKp32Hmq38VANinExOvKcSW4HusuxZMK4KsaYyNkRWVqcGYdG64sDGA2UpsXYmI3rtyfmkWRPF8lrHOmuYkE4YNG0NBpW3U8HXj6OJFoisKav8d6TgWlTY82BgiQu09Y1clDAaSUDpk/RgIgCkTAODkkXoAkcW+lxLBTblgRSwSwUkmeCkTsn4MFAkAIg66MoFOSkyFZVEmdH7ZgwIPMiHrW6Cigw3SrsqEHy9KuuzOlx6PjKmCaCoTNtzB0uk6OO/SsWhrbkLR9de7P18KyCgb4zrbiTyWlM9y3aqksCoWAHOPeH25fX1rZWK4IglGSEbvprm4ZMF2xgC5kQlZvyvn+4aJCJ0zu+Ca8r1YU76XkQn0DwBqqlsgqzpqqluYOsG6Fm4/EMIX182JKBPGBMxPAMduus0kExwvz7Yrl81mjFWlH4XwgxuCgUXl19vUB0yZsPxZABFlAj7ZDU4tNveF6RfXFeRyETWC3q+D5Pi3DZufyJCJzOOAWwu02oCcZPJ9/76iBetWhkxlQunPAQD8jx4AYJIIsqpjYdlULHz1gUhBli9e1v8VUyaQHMIUCrGUCakiYy2QVpqbMmFlZSvTyKysbDVVCgCM0TmsGwNgLgyGDJYHiCgTRofJBJsyoXWPqUzw4ASzXhtDW6BrF0ZEmUAVCMLuOlaZNJ0bUGz5gGgFQ0HxTNQ074lWJli2EIa/OstHmcApClMm8DvroCOiTKBKBKeCwQmbMgEOMbsHpZ/1dqC1C6ddmUBEd2VCuEuytFjKhGyehQGYX7T7FAouuzyKn5NEgSkI3FqItdulomSQFRXt3afc+cBs7sL0Dcudx9GWhcqEYbMSiaVMoHaZ0zc4VX9hSiiMKBNcQMkCK6xjotXNYdgqE6yIpUwghsKWdk5Y04ihAIqGzpcet00Obc1NETIhh8P4Bf+JwuumI39CPiMThqc6ywsWZYLVzYGqEjiVw0BYyGt1f7AqE6h9SX1EAgEB+tRccA3n0fX722xuDtY9kXRhSHblIncXzS1MmGTChqoGcCrHVAnrqvZBEgg7T5UJAGzKhPbgflOZoBOmTOCKJLsywWOcGx6zsBcsZMJvKmYxbYzxvBlSQAOAqmdZHgDgcnJhCIZdmWCtgDEBs1XkBABYVOl+z5fNSzm3FmglE4ihQFZ1rK5oxtrqIDiVA5m/GNAV8PcuhKRr+E3FLACmE45NmWD54iuMc5BlLeLmEMa6gfOD6hGasRZIxyo3MqGmugUcTJKguuoT1j11TmRKBcPoY+ed6gSmTHhuDip+dhHwgcnA9HzYj5rGXb7KhFSRmRboaAFeygQi9zMFAr1GrH8DxIgoE2h+6Z3trAyJ51E44wY8/tnHTJXgpUyI5/kSQcZ25azdNpYyga9/FZpuIRfC6UyZ4PARoa3bqUzImzzZkwWiyPq1sHUSsXWl8B6unzJBOe5iZFv3fi2e8NbrKKxxErzIBGdMh0SRUWXCpPwrvYPfJIF4VxZ+ygRNVrO7C9MxRu09g7Z0KRPSGGsh6/lAOsbQmAkdR96OS3ngW2YC1yuKhgFVw7XT/gmAB5mQAjLGxrz/Py9CVlQc/arXxianokwQJ050PW8t3xBFcIqCL06e9C4omycRCllRo5UJB0LMJ5hB0QCv1hVO06CC9CtQtm1CQfHMiP5P02xsjJW4CO39yNXNAUB2j4E2eLzpJeWzGGkAgG2eA9Hu/RTry02HGqt51H4ghN5NcwHA9BMJszFu3prxPFc8GPKYCZSi2ljVBCMgYsnyIhZ1TSQqZADrVoawZHkR2+J0q1TqJ8LlEuhTcyE1nEfvY7fbpB2DsSuXNSp9DSq45zdC0jWsq9qHdVX7sLqiGQDADYRJB9l0geBUjpEJsqahrbmJ+YnoU3NBcgi4InNvNJafSNbPwrFg3QPWSudDJjy0F2rME/cuMM+HK4sYCrT7HoJIwl3Rr+uNSYCNSQFDUoESz0ctscrKvwUAEHUVZP5i6E+vBwmYXCH1E6FMjKKGA/GEux4vSVhhnMMy8lcItPRBn5oLQeuBhlysOv9n32jCw64FOtkYQwbWrAiaND1FmG0xZHOy0DkRxFBgBEQm7+AVjk07E68ptPmJ4EMFCiQcelse/n4iTkiiEGFjwoQBkfuZnwip32GLzkHqd4AYCmNhhN3hIBT1r7JWJfG8zU+E/n33v3eyuAnA4OgDM94CZUXFzXCwMQ7/Dy8/Eau0w1ZmuIIuv+oqbGl5n52nfiJ+GB5jIBEhiUJ0V0rVT8SNjbHAz0/Ehmy2AwEAuoLPjh5mbEwiLIpT8pGKtMPKxlBPJQDZvRIZFDYmFVAX2+HiqeTHxjh9PbwYFj/2xS26pZv/ybD1E6GgfiJHv+oFEGFMUmFjrMQEhTWCJV3CdX7Zg8L/FxEsGz+Nknbg3gW2TXIKGtHSD+0WPxEAvn4ioYYGVz8RANk9BsYCDyHKT4RTORiCwT6dES05lcO6qn22co4faouSdvRumotLHnzDtaXakM0b67GgcyKLYEn9RNZWB7FuZQhrq4PMP8TqPwJE+4kcvfY7prRj1iiTTKB+It/9B19TZ3hppJ3QFbaEW1Rudi9JIDY/EcnhJ0K2/wEo22CLHwiA+YlYfUS4XMLuAwwOH5gxaYffikDSNWysajIVCioXFcHy4bJi5ify4MfrMQDNro3RFeYnQlr6zOiVMSJYJira9MLQBp0Iu3qtWt3KCIQ1K4K2CJa0y3IDdu2gWwRL5icyYFbuC9ssESwdnKDNDsxmQjWWOouua/38RGjwCSCyDnYGYSwonomaxl1Y9kQvVm35OmYES9vzZbMhbbOznH4iYfA763z9ROh5a5hQVz+RcEuk96G6GFnTPFtZ1tuBtAVKPI+CaUWDG8GSgvonW+7lJTLK+pUIHWO8/ETihZcfiTWdwiufm7QjVfzl+Yn4hIFKBhmbheONYOnlF+I87+VX4oX8Sf8IICztSCMrlLEKTOfvynld73c86eDhSDdP4+8rZdZPpKEh9rp0kOAVdAJAdtuBNlAvygOhQQ2K6HfvdGPI/ETS/cNU8cBzVy6b18JuKv3T02+N+/r24P60tdZh7bHuGks/DqStpfp5rGfzUs6KgmlFg2LMxgNfj/UUMOgVSOM00/B3k/KvTLgM54+5WIcD6/+xcKTjmLsNmI1dmO67Lm4cjROVc3DFb3eifSh/ARZgIqP2yluw/FB6ihz8tbBIsPTgJTi++vuDfStf0J+o5CUBixtHQ0zTai4jY6Ci6FjcOJoduy3XnEuzWMfJIBLuyVFGNpox1thUddu22T7dKkFRdNv5WMd+8ArOWPviVijGKPYcwDDxlft82RxcvcpeiSnDTTTpI6SkqKt9Gu/+6hY8220eZ72/8MprenH1ql3JXexHPbl9aa+KcJRx8+93+qYngozZgXlTitB9+pRrmpvnkDB2nGt6KucBmGaMrtjVWSkgc6GfwuFJ8ifkAzCXaAXFM3EOIsjFY1n+7sOfR8VGVS8ei+5DrSyMCRVnWs/Te7D8LuV0tobYbyOno/KAIdqVaz8QYt1m+WsP4MvZtwAwK492w6att+Hd2y+GJIjoPmT+HIYkiNgrTERTziTz/OHPWZnv33kZ9r94nVnOoVZWzneeuB8PvbYIsuDzS9cZHQPTQIkXTCtivOCSqmboUg4Egbd9ka9etWw+We7XJxk2jTWFEBBx9rWuqEA8eZsfx5yLo8uxIZNj4Nx7FuLySy/C5prfJn1TKybuMycYp0fH371kRjjqbA3rWsJf8uYB02mQdmOK773SHXVeEkTUNQJ1N22ApCreLS1TZILacxrba82QJL9YuAKbH6tK6OZEykHHyQ5PKp8O+D1nz7J0eo5IOej8sge63M+uF8aOA5FybPmt11jzA4CUNzHqxwhShb8AzwFhVLEtVnHJvPm49NIr42qNeVOK8KMf/hJHD76FAVVDQEjeXzgZjM+fDk66GE8+Vxk96xMR6jf7EqoLioQvclYiiIiSe+5D3dY/msfhFllSWsqktnUvb3c3ei35XUENY7+8sYxnD4N73o/vAgBU/vUpXL1qF9TzwaQqMOExkN6IVaSuoG7rH/GLB8vx3vt/sqkBdmx/BQAw7yf3oPbFrQCAEytuSeY5U0Zfn2Ia9EREyd1z2fNULpuTUrlJ24G2itQVsxsTESWlpWaLA9jbVxQdd869Czu2v4KlBy8BkL4xKBbYD6+E7Sna8tKFlA1p9XyQs7VGy1q35O657H/aGp0EgR+sX9yrsuMhGKx5al/cipLSUpSUlobPnE7JjEmq33tBuHCWkdbtw3jGyTQh2TEwrX0o2ZnMF45AO76tJcmWlGzljWAEIxjBCEYwghGM4C8X/wcuoDdrejXWYwAAAABJRU5ErkJggg==" alt="Server rack"></div>
         <h4>Server rack</h4>
+        <div class="verdict" role="group" aria-label="Verdict for Server rack">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Server rack">
       </div>
       <div class="cell" data-item="2026-07-16-office-library:couch" data-label="Break couch">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABYCAYAAAA9U/+JAAAWo0lEQVR4nO1de3Qc1Xn/zc7O7ENaS7aQvJZsY1uWghTLGCMMGAelwWmaNJwkpD0lJzk2DYaAIYXi9pxAmvhAaNwmdeLQ8IwJxDltIGmhHDgJJSLB1HbwS7axLIFlGYGRtF5ZtqSV9jGzM9M/Rnf2zsyd3dnVruAk+ztHR5rXvd/c77vf635zBZRRRhlllFFGGWWUUUYZZZRRRhlllPEnAW62OwyKTRrPCVA0GTwnQEpr4Pk0AEBRvOD5NMh1AnJMrhPkOmad5zkBsVQP871DvlaN7jcX6PdgPed0Plt7TrSVCt7Z6igoNmkBL7Bl4WL82aq5CEoa5i8QIfhFjE8mUVXpR/TcGPNZn9+PoNcDwS9CTkpIC15IaQ6iV4OU5gA5haDXg5GUB/VVXgyNp9F3fBIAIKsaAEDwcJBVDRKnYfNxaFJaQ0rp5QCd8QDwyudaIQi8fv9UGguXVmb6S0gAgFQyadDk86jgPV6kBS8CvAcJRQWXSsIfDAIAhsZ1oUul0gjXiLgwqRp0WSGrGrZFhtEbadFELzdrgjArndQEm7TXblyD2uWVmHfXdqiJUUz98iEk3oqCSyWRUj2oqvSXpO/O1y8YzBc8HKY0FdsGBwEA/dEEAOClz7ai+SPVWLD1R/CIAgAg+pM74Dk+ZQid4BeLTtvuPWMAMkK6LTIMSVUAAAOjMcSlvpLzx1PqDkK+Vu21G9egvsqL6lvvg5oYBQCMd49g3k2fLynzAWD9tXMB6BoAAESNg+jhTfeEa/zgkxKi996O9OBxRLZsQnD11fDXCiVjPgB0rKtGx7pq4/je8AJsrV8I0cOjubYaQbFJK0nHFEouAABQX2W2NPEfPIiF338Eo88/nzfzuUD+zJBVzfhhIfyV6wAAlVcswsiTO1C37VEoz74OJcaVjPkGbTybJklVoCilt9AlFYCQr1V7pK3ROJ7a8yTGnvguKr/5Q5zfuhkVSiDvNrVpW+wWO149DbU6BrU6hm75ApBF3pSuQcxdvxbnt27Om65C8fAr7xj0GTROo7EuUHItUFIRk9IW2ne/i3kPPozJf/57CAqXNzPdovu9EdNxz0gmMuiOXcC1c4DOMfMzAV6fC6n/2Q/BwTXiAmJRaM5GH4Ho4Q1/oJQomQAExSbt8ZXLIWrmwYzee7sx2AlFRYD3oPu9EaxYXIuh8bTNXOSCdTDdoErwA5gyjuMv70Ul476EogIA+gdHsWJxbUHML4Q+GktqQuiPtmgkYik2SiYAiuI1mE9mjpyU4AXQPThuu58M1Hn7pYLR2Rdzdd9A/zBWLK41CaQTfcXEoTMT+ABSMSbMSh5AqvRgJJJG7TwBb79zbja6zMr8F0eTpuOhsQTmVaVxfvyCwxPFx9BYAmPJ7MyfDTMwKwLw9uEzAIo7u4uJnpE06qtnj/kfJpQsCqBTspHIrCUcAeizywnW2Q8AMpzvLwWGxhJMxw9g01dKlDQMlDg9CpBSJc9nlFEgSiIAIV+r9lRbC0SNw3NjQ1h8ceF2bPvhCB45GrWd/01fFNsPR2zns82uk1PFn+lO9HX2xZjns9HnhMa6AHx8S0lmUUkEIJ8VsGwgA/jpRXNMzH7kaBQ9Eypa53iYg+yEt3M4XfmC0PSxcMBE3/bDERybmMLSCuRFn5P6t6aui4mSGOdipjC/1FgFwC78f95QgUpBwDtTE8Y5t2FfsRDgPfj0ojnMazcsqQaAgumTVAWihy8p84EiaoCg2KT5+BaNqCpi/2eCzavqMJpM4xf95vAhoah4ZXAKk7KMzavqXLX13yNTuW8qhL64hOcGxmzXnhsYw2hcck2fdfbTjCehYMjXqvn4Fo0sXxcDRZmqIV+r1vu1ywEAv983hs3H+7HpyCnsvGw5bgjXA8jP5tFoC4fQFg6ZVGyA9+DzS0Kor3a3lvDiaLJkM6l90Ry0W0zUDUuqsbTG3SJXLq9fUhVj2XrRPL3NM+eTCPlatWLUDMy4gZpgk3Zs01VGQcTv940BgCEAoo/DcDyOy5bNbFVN5PUii30DEbRb1O7xSAxnLdpVRgIvjzq/Hj2wLeFK/Oiq2hnRBwDxVBprPtOG7ld7c9LnJtwjM78/mkBjXcCWGDpzPjnjwpEZmYCQr1U7sbHdyO3v3Tuur7drHHatasLX3nxrJs2bIClxjMUn0FoXRDxl1ijWwQWQk/lWHDqnzpjGoM9rY35nn535bsBiPgDT70Xz/DOODgo2AT6+Rdu96SqkeRkCMgsnNJbUhLDhjT58s30+OvtSWN8UKqivQpy76y0qONeMSw3LwEW+vPsBZk6fE20081/64iXo7p7CyEQmwto+HEFjXQADo01aodVDBQsAz6dRraVNs59A4jRT5c0z703gi7UVpuetg+YkHMXy7K+v8RsDzcqxL5oTRM8ZCa2L+FmnjwgDoY/QJno5bF22EB0rKwA5jeZGAeNd7KLXQlHQkyFfq9b39XYIClvoXrowbMTcjXUB9EcTeDGHE9bZF7MN8myGdaLGoVIVMTQ2yUzUzCZ9oodHb2QSL3S0YMWKCgjTk6wKwPpr/eh8XV+3uDe8APcPvY/GugCA1VrPcFfeWiBvH6Am2GRjPiGIBdr7zqWGS8lwN06XqHGus3TFppU1+4FMoQoNUt8IAFvrFxp/F1I9lLcAJNJwnPkAcCQ6iuNxsz/QEq5Eb0Qvh3a72FHMAXYTarlBsZk+P6TTZqWvNzKJR9oacdECwVYz2Pn6BVttIy0E+SIvAQj5WrWTt11lI4jGxQvstTXWAc7GkM6+WNEGmjW4LBAtRc8sJxSTvp0DzrSJGof+txIYOW8eu/XXzmXSeW9DQ0GVxK59gKDYZCR7suHxwfO2pAsrCfPiaNLmqRcDhSynEgGVVQ0rQnPRHStdbUC+9PUci6F+urTdDZbUhHB2vEkbjbuLClzdRDJ9Vntknf1748N4fQKO6I1MoiVs1hAzFYJ8B5Tk2K2JoC0LwhA1DldcWQ3IKTy1f2hGdBVKW380gV2rmgBkNBL97QABGXvy0QvB/UPvA3D/YUlODUCY7xU5QDF3biKe07Iy38nO0prgxdFkxgma1hr0c8VI57LakFQF24cjWCwouALV+N3+jIonGUUiONnehw4vC6HVyRTt3jNmE4LWS0PoOz5p8wfuqQ3jByMR15ogpwCIvAzFL8Kr6gmIzgNs5h+csq/Ns2AdSMA8U9yYj5mAzrAR9EcTaAlXYvOyJfjfQ2chgEf74lpsPXIGREm6FciZ0JvNGbVWTNdXeTH3aj0lHlUE9L2h11qGBK8hBJIi5Owzq3TUBJu0rjuvhU+VcdG2n2By5y3GtRefvGBU/Uqchu3D2QWAVrl0ajPXMyy4fZZmmpWBtAAAsJkmNzOepsdp5tPns2kHenx+sbrZdl1WNeMzNxIZiKIPc+7/McYfvwk8n2G2InrxsX86CiD3eoHjhaDYpJ3a0QHPGI95d21H7Jm/Ay+xY+S1D3S7YgoJBQFMJy/sYM00+hprQJ2us9qxMp6GE02FwNp/LmGi6WIJAJDxBWReg7pMRN0tD9uYT6CIuraov/UPAACn7wpymoCL/vEhjD9+Ex54YtB2TVZ4fPfORdj37RX4+IO9jKczyIcRHxQ+jDTR2L1nDGs7qgAAdbc8jHM7NkIIcNj66AAAnR8AIPAKZIXHd+5Zih2XL8aWo6cN/80Kx40S3v7hWkPCdjzxPibAGR3QEHgF99++BIoi47ptpxyJp1UcDdHL4ZG2RtsXRMZzlsIS0cdh28Aws30n9UvDLZMb6wK4t6HBRldtcwixWAIpRYU2kUl4SZoXomWVclvETqcTbTRdO69sQYVsvk6cvU/9ZbV+YgGgKDK+9Wh20/ude5bium8fR/+5KaYpcBSAC5NHMLnzFkO6Hjth/jLmto/WQlZ4CLwCTU5g6x3LswpAb2QS1aG5GItdwM7LlpuuiRqHjjUVSAteeGV3qdj9Z1Km4xS1GvndNzPaimUynISA0JWSFMxpEKFFVTReEoAsKxh+R4asaqhtDqG1Wu9LUTO08h4vFDUN3qMr1d0HpgA/wM3JhM4+3mOj0+pUEjO5a1WTKRqQVQ2buk+h78GVuOjun+Hcjo144OmzkFUNz5yO2r7DvPmSsPH3vrFJRwFwNAG0w/fYiRFsaJ5vuv7YibNGJ5wQwPef6EOI53Bg0Bzr0y84Frugx7iWXFXHGn2lkMV86yATtDdYtRGPlKoP9nNLWyB6NezdO27ExTTIAhUNYnc//sk6vPbbKHBOQ8e008UFRCytIf5LhoE0PTTz6XeyngeAtKAfv9C2Em+8OmJoCklVDNokTqO7MiAEOEzuvAXf+qk+81Oc/s5W/jz5VsQkBE5wTAUrohdbHx2AJrNny4bm+fj5qbPG8cujHGIOdoaEWYc2rgagpzM71lQYP4CZ0TR4j9f4yYWDXQkc7Erg6MFx7OuLQfBwxoYLVmeMdvh2XrbcULGv/Vav4l3bHjSuu/ko1EqfoqYd3+nAHyZw4A8T6D2UWdWz0rbpyCmT+SN/Wx2+Z98exhca7Yz+m48sMPHHCVlHVVZ4PHlyEjdfEmZurnDjsjo8duIsbvuoXk5FBpme9WSm3VlTi/oqr5HWFPyibYsUQFfrgofD4mY/Fs5xXqogKpdgz6GUkRWTVQ2IaiClE2SA6S1YaFRwHsMYsrJuctIuACz1Tx9b7yXn9h2KG+8cp2YMoZHWWEZZ3XSVlbXcftfJs/rM1+yqwqeppvttn+pPw/VagDXlyIJTKNh/R7stjTw0nkZTWyVSlOP03skkFiwVsLRGmB5Q8zNkkMlg0nZ3Xbu5T97j1e2wC5D9gwhddMLlnaiepOp/i60J17XnV0V05WpzbWRK9eBgV6btrfULIXEazoTiuL9/yBACAkX04hv/dprZtpVHbgpFXAkAGaBcQsDybHetamKuac+tnD5XmRmQhe36OcJoelbt75JMmqJjTYXBfJaqVdQ01rX7sOdQxlncsiBsbBDFesf1jEWXcI0Ir5zGwjUVjKcyfRH0RFScf98seOvafY7mwOdRccXqAA52JYzxFTUOjaEKiF4OUlrDpEdCpaqPUyrF1orW9DHxDQQ++1J3zuXgDc3z8czpzNct2ZZMaQ3gNtzyymnjh4BWofu7JOzvkrBgqYDFjSIWN4oQPBx2H5jCnkMpxNOqSSMQ7DmUwv4uyUSvqHG4p5btGDm9l5uohPTbE9FV8byFgvEjeDj0RHQaDw3amUELqBVke527D7+XkwbrHkjPvj2MxroAfjuiO6+s/RMBBw0QS/Vw9bdq2obm+cbAPN33Pr7c2JBVAOgwS/Ry6L7ralQ6DKDbcO/K1SL8waBRdOqV01haY3aEWPb3itUeHD2aNA2K4OHgE3lbFlHwcEzbD8DYJo7VHy1wvMeLtnr9GhEEgrZ6ffYGefvYrWv3YX9XkjmuosZh52XLsenIKWw6cgqAFz41t1nbddLs/PVGJpFS2ItCjhqASIysarhxWZ1hT3L5AQTHNrRBmSz8G0Ha85eTkk1LELDCLBrEdOUq9nDarQuAbaewXFFJa9hj/NA2vzXMHm76HiutosZhTQNrAxs29o7pS7Ju09qOAhCX+jha9bOIo2G1/0JYQHW1D1xABBcQIfOa8YMVPPwrBSMepuFfychrO9h4lidOfmjHiqBjYxCixtlovfL+ayCKhZWEW8ESjGwhIaCbOSuyjbWbyiWCgdGY4zoAkMMJjKV6uF0nNdclRsTu83wawpw0Kjf/0Nh5kyA9eBwAkPzNQ6hs4ZB8094OLQRTR92ZCieH8BNfrYKiyEb8TOJpq4/i/6u/wMR/vsCsd+RXNyC5p8/EXELj1NGEKRpx85uA2H9rxk/wcOjYqOchdv8sbqLlum2nsLbarhGsDjp5PyfVT5AzCiDSQ9eaEYKdzMHj7W1Y9s3DOBPIZBPlxPSevfOCSKU88Pn0roV2S8xM/c1LafjXsOvxrXpCsPxeP/2cAuDXT04Cku4MpSTF+OCCDNKy65/C2b3/gIu2/cTWj3T8JQCA+NHLIe1/wXa9YhVRtVYK2L9/99MMQwUPh098VV/cIat3gP7eiiKj8ynd3h8YnGRmL2lYeeF2VzHXeQA6pqQ3YGZB5NJ44dMrsWTLMSMBQcqc89lVm+zyTfomYREA03nrMb37OAst4UqbGWj8xL/g5Pc6mfdn+shdYJELZGaTthRFxq+fziyTOy2KEZC1AqsWcJOnYSGvD0OsHTh2mARaLg5i9PwBxP91Mw4em8IvT47aNIcT0fm+TD73H5ywe9EkRb1kyxFmxowWPPrYej7f67meE70cvtAYZgosHd8XynwgTwFw2xGxs4f/9ibs7xvD+0m7Q8PSHtnusYZzubRQPmgIB3H63Qm89NklWHb3Rjxw66MzbnOmIIkcHyPNC8CI7wH3kRkLeX8Y4jas4lJ6CvW+E+8i7jE7ZvSzTu2xjun7cl2nz1nBWg8I14hobKjBttseK4pQzRQ+TTUxP1vF1UzoLejz8Gw7b9OYTGlQFO+MJJTuk+6bPqZ/Z6PzSiFou4fAK6ex9/CHdCNDZK9JnMn4zniHkA3N8/HYibO2xENK9SBcI0L05tYWbpCtjWxCQHBwYgoHkT2Ltn7NXOx+pXTfJxbiqzgxvj+asNUAFIKSbBK16cgp7PI14apravG9Sxdhy9HT+HJjQ87nZuLMWMFy9gB2VfBgJI5aH/D8q3rVU7FosIJu10ofq6SNRqnqFUu2heeGN/rwcCwNATweuqQJPx5lb7ac68Wd4FSfT3/54wTrYLb/rAu/+OtL8anPzcP+/7JXEBGQNKu1facKZSudhcKJ+cWYMAUJgNuO7zjxTiHNfyD40q+OfdAkfCAo2AnMFglYiz7LmDka6wLMBZ6Z+leuNQC9npyrU7KMuX04UpAKnI1t0t1+9fNhQim2uiuJDyBxGs5MxHFnjXnrNdmvIDVd7/50NHvIle3LGmafDl8SubnXSRhynXf6Mikf+8/qwy3dbiu1sqEkAiBqHK5fF8ba/ziCX11zCUYmZKQkBf9+JuMIupXmfKTerebI1iarjWyfo7lp2yoYpE3r+WzfFTrhA3EC3XRcX+XFzhXLMT6exmeunYdvvPwu2udWY/uPv4KtX/+5LZVLF2Zm64N1DytlbG031/qDm35Y97BS0tZ73fTptMK6d2yipCaqoNXAXJA4DQlFxTXXVOHkiGqUc/k0FffdsQtA9rx/tnO57nE6tqaIaTgJkRta3NKdsyIpj5lcTIFwHQVYiwqzFodqHLwihwDvwaVhr60qONdglwLZ0tdu6XFKN7vtP9uxU1RFdgxnmYFiZFiLZgJMyQo/0DOo4NKwF7/+v/P45BWVzGdZy8NO7bNgVa1uVG2+DLO2aTUp2drMdV+u1LWTQ0nGuhiTJy8Rqgk2aTdczE7p0pWoLeFK/PTzbRgYjeN8j549c8oEErj51t96P8u5cmrP2k62SIDVT7b2aTqKoZ6d2qMnGWsd4ODE1HQFsPv/MZi3DiGbE9O7V3/Yv6v/Y4Q1KZSpAczvH0wWLAC5UKr/dPmnilKNe0E+gFX6cu2/U0ZxkKvWv5Bxz3stgOfTuLm5Djc31zG90/5oojz7S4CU0ssNjMaMsQfgGB3kg4IYVRNs0u5qyziDJ85N4nhcLTN/FlATbNKuqQuh42JdCN6NjuL1CeTt/BEUzCzrPy6S0lqZ+bME1j+NKsb/DyqjjDLKKKOMMsooo4wyyiijjDLKKOOPGP8PbxL1AY6ELk4AAAAASUVORK5CYII=" alt="Break couch"></div>
         <h4>Break couch</h4>
+        <div class="verdict" role="group" aria-label="Verdict for Break couch">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Break couch">
       </div>
       <div class="cell" data-item="2026-07-16-office-library:coat_rack" data-label="Coat rack">
         <div class="stage"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEgAAACACAYAAACoVi+eAAAUUklEQVR4nO1de3QUVZ7+6tHVnYQQksAQCRhCJoQQEYKEp+CAqCCjzjI4c8YHKrLqOuJzI7ueYcVVZ4ZhjkfGGRSVxXHWOcuo6MqoDLtjRllQCRKQR0gCeRACQfIkD/pRj/2j+ta7u6u6q0Ocw3dOn3RX3bp168vv/l731r0Ux9K4hMi4xE4MXCIoBhIiiGNYiXzcapCbCLcrofaxCdxfmjd1Grw0hYAo4bP9+6SgwFMJ1Oc2pO9NLoXHIz/ih19+LgFw3L6EJIgWBCwtuQxeejDxosfSkssSuj5ugjiGhcgw2HqgGQFxUPYwXfs4Jr7OQiVo5rXMDEYxSrh9CemghWUzlR9u6iCOYR3VFS4P6ElwpX0Jm/mlk8bAS1MIN1BrNeL+ZIydCiflgwKP3IlXG68BLQi4pTgnIR2ZiAQpOFXdgI0rboXAh8CwHgCAP6yXHn/jHfx09fPoC/F444WnsXHFrZZ1aMv/aNkt+N26vXhp+Q+U+mJdc9uym7Hh+S/w8l03IwAGAPD7bbuBK3IRCvFxP1tCBJH/jI+m8f6BRuW4yDCgBUH53adpoLZcJHz0178BALYfbolZNhCue1vFLgQFHlsPNCvn/KKoEByWcMdwRYL8ogj/8ebYBQGcDZcLimqDOVrfjGD/BQBAc20DOJqNXjZ8zt/eqavfLSREkNa8HzzfGrP8iILpOHhir+36q3vbbJft7Wg3tWPy0BwAUJzFeOB2LEYZPhhRMN1OOd01O7h+4rdEK6e7pru1Gs+On6ytX0EiOihhTzoKLL3HrLxSRIqNOIaVvn6uFIUVr6HhxSxk24uhpKXZeQCANbUHMWPYKF39Ah+yUUVkJESQU9G9as7smGXqD/dC6GxDzZEM9PBR/wEAID04qgjb2puUA6+PzXHUplhIiCAnIcaeqgPK9yGjJwFmCZP2PTMJXX0U3n5kFeqaRLx04zirckr5/xg7ARtP1+gOvtvah9U5hbbbFQsDkg9K87DoPCmbbIb1mHwb0iWyS+YAAO77oA4AcOMNw0kRS5IaQnoHsLnQmpjBpKQBQKcDJs1QlXSQV5XliILpSrmgwOPEuinIuup2lBR7EKQk3P/xCQDApsUFVreQHhxVhHWnjukOih75cRhBxAtjJ6K6+yy2H265eEo6EoxOWapXlZgJU6cAkJUnCU84iQLn9aL9v/4JEx94Qa0nEMDC76UTi0ZIl8rDXShIqYK1JrcYflH+fn8GZTofL5JmxbLySnW/C0sm4tCXsg+ktSyfPCA/7LYPTgMAWt9erZz781/aMeKGn+GVH08ih6S1OUXwMaxJ96zMEOGjgT7ILD3eeBRrcouxc39lXM9GkBBBIsPYLst4OfU760FHUxUAYNZTb5rKarvVtjVP4YdLRim/OchdSAtOkiWGEyg8nsHghW4B5TmFWJkhlwtcrC4WIUqWtNIz54rxAIArx+VZ1tHx1VtKV3h3Rzuy5z8GLysT7/NyuHt7Lbi5P9Nd82mgV/f7UPF45XuQkbDhzHGsHKY+2qeHqmw/kxGu6CBtrGQFn8+HVK8HV82ZjV1vv6o758magNeuHY1HPpFjqJ49G/GTX7+KCyc/x6qdTTj1qylo2/aoUv4CY26yj5alJ8hIeOysHwCQKojgBArlOYWKhMUDV4JVNxEMBPDNx7Ieqv/FFQhIwK6/dirnP+jp1MVbTROL5OsYCb/tELGtvQnll6nm/qEsGhvOxN8eV4JVY4RtROWx+ojnuJR0AMCGBWNQ/ukZ+LwcgB7ceMNwfFjRAwBY9VE91i+egPIdx6zrECicpySsb63D/Mxc+BgWLO1OnjwhgiysmKJ/OpqqsOC2h2zXlfcdH67PHab4PyB/AWy4dgzmX52C8h36a2omFCld64Ezql6SlbjarQ4Vj0fRMb3Vs4uEdFBzbUPU8xzrjP9lk7NMxzYtLoDPyylethY+Tet3d5zG/MxccxsECmkrUhy1Q4sBH3petPxRnDux1+QnzZ43TPd70+ICkxfNSZSif9bmqLqn8Egt5mSNQjKQVIK0oUUiIN1O6xkTb/mxs37d8YrOFvRBBC/K3b9/hU9blWPFlFSCFkwtcVT+xsUZ5mPhgLX9yG7d8fOUhC0dwLb2JqVrXZ06VFdGuFcmR3qtT5E4p0gqQYFgCPuPn1R+MxY6iebScMsPrYeHv79IJoyTKHhT1GtrJhRht5/C2tYaS72jBfd6XzxNV9uX0NUGaC3Y3Fvvg5eTg9Sao0csyQGAnk9/jlBIQCgk4PDXXTHvQQLVFY3HdORc4x2SYOutkTBBkVKaHg+H7DQv0lN8mrJmnSRKHkgBOWYqKk7XnZv/b9XoN8RdALDhvP43IYcRRKzJLcb61jqwtBonsjQDwcIDt4OECYo0sHfr3Klo7wug54Ls+h/9+qBlOSoYwL791t2gscuPVIZGkJJQ9IQalW88XYOl2XnIpNmIkkOUNMHKDDGukCPpOsgOymbJkuPxqP/185IHY4f5FAmqfFJW+MRbBoArPap0klyBP5yL0kpQIkgaQac7exUdVDSxBL2d3QCsTX/l53JIkbboOeVY+Y5jqO2+oEhO2a+OAIBCzjSPDxygfAjWt9ZhbU4RgozZoq8ePSHiiEokuB6sdjRVYfbNdyvkaPXOV7v36FKwACBxXgD6LmZ0IknuaGl2HjpF3pZCZu7We8+cQIERRMdD0EmToEAwhP/7Wo1/jMQQBAMBXDXTHGIYQfwYLTl3pusVuFERM5v9CXe1pFixa2dOVSSIgGNZcF7OFJ8dquoDTYV0+icSrtR0q3syKLA0g9vD3AZhzjS6gYS7WCQrZqWgJ02bhh1vvqg7RhS0XahSIxP6Vod6LpYp56KetcagS5hFwr3pYri7qJImm3KVFCJBJHFvRDCO+7qig3x05Gq+2r0Hh/bti3je7xeR/3AVmhr7ce7NR7FhwZio9yL+DS8K2NxDIwjzg6eBhvRaYiEGgSsE+UXr/1jZhHEAgAt9ka3U1U/XAgBu31SPWb9sQmqEsSwrZRutywxKP8hKH0WyXgTBkPz/7wlQCIaC6I/g7RK/ZnMPrfNxjH5QLKzJLXbkC7lKkNGi+f1+cCwbdZ5hu8AjSEk44+9Hu8AroxtGcIJMXB9E+EXg1X5W17U4qEraSlmTrpni0BdyVUl3NFVhRMF0VB6rjxi9a0G6WublowEAJ3ZtNzmJRvgFAZOqj2PvQ2Mw5Xcn8XOSWbTRvvszKGzqdpYzG5CU61VzZuOr3XtcyzDue34K6MuyTcej+UHx6qSkmHmt9JDvhCQtMi8fDYZlMbt0CvyBEE7s2h6xziAjgRMo9NEMrvyZOlIahFkHyQGrO0o6YYKsPGmB53UkCTxvIgfQE+nzegznSCwn10900NPZNBqCcsB6jXcIOFib+YjtdZgXSlo+CNAHqrGsmfnakCX5WzpkYkhMZqV7BIZ2rGsiISk6iEiG9m+0MbJzXT2G682z0KzSF4DsYTsx82TGh10khSCr1KoRWgLqGk7AH1ClJZL0ANDlgO5NNz/smtxiPNtSHfXeTjKLAzZwyLCsMss1Wrck503zGAVKl0Yl0XwkxJuDNuKijawS1Fa8ZypjJUFBRsIfeiI3l3SzWCkPOiRi9egJgM1BxKTqoGgQ+BAaP3kfJ9ZNQW3FeyYrZgQdUh/8nvCoqjExbwcszSDFQd7oor4Wrh0y1uogK0TqTkSqYnnS2iyAMRMZDa4PHJ6L8rKKlWQVrD6A8fP/IWbdvCggXaJwe5bc3XhRQD8jpzsuMDQEzQcwdzXRQ2NBSxse6QiiRYourVq46knHUr5GFMy9CQzL2rJ6ALBsGNAUZDCvTrVS0ab68qKgSF7hkVr0rC1BW3Uz8reetP0Gq6ueNPlu9KQjwegv2UWQkpRZ9aKHBh2Ss40be+WnfralGgJDg9VMMg1SEt7YewFediSA81bVWiIpsVhdgzxdpTC/wPHDG9HRVIW1OUXKw77bK/8TftMD/PQBue7NrwCABDAU3uk+B8A8y6w8pxCrPjqOICVhzejYvhJB0pL28jlz9YkSRuBjWLzxipqD/swfOcXKiwIeTgfSMB4CQ19cK5aVVxo1KgdkX4gMBtqF1qSX5xTqJOA/u1pw0t+Fk/4u5ZiVo3hvuoj7Up2lXC7KqEY8UiR6aPAhQRepLxrCIJMV8A2tJvr9gqi8ykmUNEszCsHkhRe7+NYM+9Ah0eRJzzx+NGL5ja11WFlUAAjqCAiBk+A2qQTVNZxAYb7l60yOIZtrCfdkyYOFa3OKTK8kAECAZbDvm2Y8mFMI9v4UiJD1yD+Gz/vDrwQ9tdp0qfV93Wi8FdxSxgRkkFAOOWRpME5iIHpnT9g3+v0v9Io7PRzFLxtm/75JISgrrxS1Fe+hYO5NrtXJ0gzuyQAABnemC7ruRsIMRhAVkiKZcY5h8USb/NfO6Ma3RgcZcWe6rJOMMRiZhrezr1t3/Muu0wBADZrpL4DczYjTKPC87gNYpzrsgFimO9NFJWmmVbyMIGKxLx2LfelIpSikUoP0bR8Scgg8b5rVkT/tOjTs+x9b9ciTEYyTFlSQiQ1buiWTRF3jHQKBoVHRGXsdECskvYsRcp779cu641v++yPbdfgYFiS/RcghOoikLrZESdInMm8oqQSd2LVdUdR/+dKZ5zx83Fi01TciK68U604dgn9EfthJlInR5qN/0wM8HJYit0YzCJIuQQzLIiuvVHnT8Iobb8fpI0eV4WY7yC2dj/WG7rg2/E4dWZtsfStv2zI5wYB0MYb1KGPuhz96C4A6Hh8rNcKwHgT7LyAjp1g51t2qmHCdVTKQIxUPGa4sr+NkJRktBkSCMi9XXxkYPm4sANWCxSIn8/JcdJ5sAZemTtXLyiu1FexyNIsRRWPRU3cyZtlIGJCc9OzSKcr366ZPw3XTpwGQM4oCz0cMRwixWoIB+5lL3cJMcS4TmFQJKph7E2or3tP5O+S7cZoLeWUhEogkOV3uZumkMfhTdy+CsqPoGEkliChoKxAd5CRmGzpqJDpPnnLcDinGkFI0JF0HEZ3jBhiWVepzmnCLF9/a5ZLj1SlOkVSCtMM5hfkFlso43nyRE3/Hm8D6QQMezbuVQBsoDLouZle3hJW/rbgikbUVB4Qgu1KzaPmjyW1IHEh6PiiZ5QcCg66LEbTVN17sJgBIEkEdTVVKmuPbppSNSJoEDcbuEg8GbRcbLLhEUAwknSAyqhEPyOqdFxOuEhTJyYuXpERX8nUDbmtSqqOpynHW3DgFj2E9luQ0fmaaVpP0rSqSYWooWIQAWinSmn4jOQtuewif/PG3Sh6prb5RK5kDvndHsmwx1fjZdmUhW45hMXaeOk5vd9ZHR1OVdmXyiNAsmus6gUl5HQrQNzYo8KiteE8nVY2fscgtnQ86RbeEFsRw6jUsNZHG0nV1fX9YLp7MTMO8umopSCWwqqQFkjpH0QBdw4MCj5aqClNX1BAS6UGlNbnF4NI4PFvzNU69LA8AbH2mx5XVf41ImgTZQZQuoeyuAoCy6kLLWT/uHv9dbPx3eUrvx4EeUyVuIKkv1MUJRQyUdaR5AXcMz1fOLUmhcPeZXixv61cuSmQGRzQkLEH+JGydVTOhCP6HgO+8RCkv0j3Tro7FzzwurxWtnZRwjXcIKlxviQsEeWKsBBwPio7VoPhfhqPYm2Y6d3aKvDTyzY3dWOxTR1vjWbjEDhLuYiGajbp2h0NIZ6eMx9kp41E+XF4/8cnMNAxjOWVriDFVdRh5oBapFIVPA73KLI+nWuNbqzUWEn4yj8hr1+5IaNusFSMLMaaqDmMOWa8eXJ5TiObSQqzJVScyvNrPYm1rDX40eqKxDa7AVUeR7KVjB9oZFytGFiJNFPDP2TSezh6PLR3AH7p7cHXqUGUu9JrcYjw4RMLLrRLuGCbijvQh+NdzfmWy5vqhAv4EgMzosLPXkB24StDo4nzTsYAoKTtpkr+0IGDn/ko0FxaC+mUe+EMt+OMrqjALDK1bdnTVCHkVGV4U8BPNUuzaHVnyjspdbFxJobxNxP5BQlAovNj2khmzLM+Tde8j7RLHPHUKAiPhznQRYrjHrzt1zOT0kXcsXu+Su/P61josmTFLWfSbrG1N9tC4fmpZzOWc7SAugjR7CipYVDQSgN4vIjvWGZ3JEM1i5/5KjKmrs74BBWxesRTbjpzBh19+jpfO1eOlc/oiC8tmYlHRSNMKDdp7vGYmSILDgNcxQRzDSrMmTlJ2GtCa+RDNAgZSyF/tg/hoStnKzwtB2XJPi34+hCUlo7GkxHrLP2P9RpB2ac9PHpqD6r42R5tBOibIKnj00TRef/8Lp1UlFUGRB0fLaxdp3ZBkTySXlsyYha4mdZsBhvXgrqVzXLMaboBYyJU/mGmSsIVlM8FJ9qNaJxvRSkQRn6puwMHzrSgeMhyZKam496Zp6OdFPPHWn12fZRovNq9Yin5exLtfHEd/IIS9TTWYPDQHI4rGAgD+t/ILwIY+ssuOwvipalXxVfe2gU9NwZuVDWBYD168S3m92+7We8n4YNWShQiAwfbDLZC8HuxtUr3sczWNWosaU5Jsi08EM06Rm79/oBF+UcKSGbMcLyjrFjiGlZbMmIXikZl4/0AjAiGeGBOTpGh38Y0Gu11MIl6yxgPWbRt8/dQyBEI8lpfl483KBnx+9FBSUqDR2njNpFIsL8vH1gPNCPZewN9qD5vaqfX2w3ozahsdx2JWE7I5icLO/ZXoajqDABj8uOy7mDd1GuBiTBQD0sKymVhWKm+w1F3fQsgxwakxsU3QwfOt2sr16VNNHnjTO7sAyNNvBxLkfq9u+wKMOuXOKB0UYHqWqLBLkEkRWpUhN91aedxmte6CbH2859xJIEo7EftZFPzdjM3b2UM6Hjjxg+zASucMhKLW3Tf81o8r93WboL87XGInBi4RFAOXCIqBSwTFwCWCYuASQTHw/xKkPhRSK9nzAAAAAElFTkSuQmCC" alt="Coat rack"></div>
         <h4>Coat rack</h4>
+        <div class="verdict" role="group" aria-label="Verdict for Coat rack">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
         <input type="text" class="note" placeholder="note..." aria-label="Note for Coat rack">
+      </div></div>
+    </section>
+
+    <div class="section-label big">// overnight sweep</div>
+
+    <section class="batch" data-batch="sweep:props">
+      <div class="section-label">Sweep &middot; Props</div>
+      <p class="batch-note">One row per asset; rolls side by side -- keep the best roll, re-roll the rest.</p>
+      <div class="sweep">
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>desk_mega</h4><p>a sleek high-end megacorp office desk with a large clean monitor</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:desk_mega:1" data-label="desk_mega roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for desk_mega roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for desk_mega roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:desk_mega:2" data-label="desk_mega roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for desk_mega roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for desk_mega roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:desk_mega:3" data-label="desk_mega roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for desk_mega roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for desk_mega roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>chair_decent</h4><p>a decent modern office swivel chair</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:chair_decent:1" data-label="chair_decent roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for chair_decent roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for chair_decent roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:chair_decent:2" data-label="chair_decent roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for chair_decent roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for chair_decent roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:chair_decent:3" data-label="chair_decent roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for chair_decent roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for chair_decent roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>chair_mega</h4><p>a sleek high-end ergonomic executive office chair</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:chair_mega:1" data-label="chair_mega roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for chair_mega roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for chair_mega roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:chair_mega:2" data-label="chair_mega roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for chair_mega roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for chair_mega roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:chair_mega:3" data-label="chair_mega roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for chair_mega roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for chair_mega roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>monitor_mega</h4><p>a sleek modern flat widescreen computer monitor, powered on with a glowing screen</p></div>
+        <div class="sweep-rolls" style="--cols:4">
+          <div class="cell sweep-cell" data-item="sweep:props:monitor_mega:1" data-label="monitor_mega roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for monitor_mega roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for monitor_mega roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:monitor_mega:2" data-label="monitor_mega roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for monitor_mega roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for monitor_mega roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:monitor_mega:3" data-label="monitor_mega roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for monitor_mega roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for monitor_mega roll 3">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:monitor_mega:4" data-label="monitor_mega roll 4">
+            <div class="roll-idx">#4</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for monitor_mega roll 4">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for monitor_mega roll 4">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>pc_mega</h4><p>a sleek high-end black desktop computer tower with subtle lights</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:pc_mega:1" data-label="pc_mega roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for pc_mega roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for pc_mega roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:pc_mega:2" data-label="pc_mega roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for pc_mega roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for pc_mega roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:pc_mega:3" data-label="pc_mega roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for pc_mega roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for pc_mega roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>server_cluster_mega</h4><p>a large glowing compute server cluster, many blinking racks and cables</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:server_cluster_mega:1" data-label="server_cluster_mega roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for server_cluster_mega roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for server_cluster_mega roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:server_cluster_mega:2" data-label="server_cluster_mega roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for server_cluster_mega roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for server_cluster_mega roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:server_cluster_mega:3" data-label="server_cluster_mega roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for server_cluster_mega roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for server_cluster_mega roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>kitchen_bench_scummy</h4><p>a grimy cheap office kitchenette counter with a sink and clutter</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:kitchen_bench_scummy:1" data-label="kitchen_bench_scummy roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for kitchen_bench_scummy roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for kitchen_bench_scummy roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:kitchen_bench_scummy:2" data-label="kitchen_bench_scummy roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for kitchen_bench_scummy roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for kitchen_bench_scummy roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:kitchen_bench_scummy:3" data-label="kitchen_bench_scummy roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for kitchen_bench_scummy roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for kitchen_bench_scummy roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>kitchen_bench_decent</h4><p>a clean tidy office kitchenette counter with a sink</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:kitchen_bench_decent:1" data-label="kitchen_bench_decent roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for kitchen_bench_decent roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for kitchen_bench_decent roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:kitchen_bench_decent:2" data-label="kitchen_bench_decent roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for kitchen_bench_decent roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for kitchen_bench_decent roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:kitchen_bench_decent:3" data-label="kitchen_bench_decent roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for kitchen_bench_decent roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for kitchen_bench_decent roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>filing_cabinet</h4><p>a grey metal office filing cabinet with drawers</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:filing_cabinet:1" data-label="filing_cabinet roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for filing_cabinet roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for filing_cabinet roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:filing_cabinet:2" data-label="filing_cabinet roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for filing_cabinet roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for filing_cabinet roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:filing_cabinet:3" data-label="filing_cabinet roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for filing_cabinet roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for filing_cabinet roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>printer</h4><p>a bulky office printer and copier machine</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:printer:1" data-label="printer roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for printer roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for printer roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:printer:2" data-label="printer roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for printer roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for printer roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:printer:3" data-label="printer roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for printer roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for printer roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>trash_can</h4><p>an office trash can with some recycling</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:trash_can:1" data-label="trash_can roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for trash_can roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for trash_can roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:trash_can:2" data-label="trash_can roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for trash_can roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for trash_can roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:trash_can:3" data-label="trash_can roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for trash_can roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for trash_can roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>meeting_table</h4><p>a long office meeting table with a few chairs</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:meeting_table:1" data-label="meeting_table roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for meeting_table roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for meeting_table roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:meeting_table:2" data-label="meeting_table roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for meeting_table roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for meeting_table roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:meeting_table:3" data-label="meeting_table roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for meeting_table roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for meeting_table roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>water_cooler_reroll</h4><p>an office water cooler dispenser with a large water bottle on top</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:water_cooler_reroll:1" data-label="water_cooler_reroll roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for water_cooler_reroll roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for water_cooler_reroll roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:water_cooler_reroll:2" data-label="water_cooler_reroll roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for water_cooler_reroll roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for water_cooler_reroll roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:water_cooler_reroll:3" data-label="water_cooler_reroll roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for water_cooler_reroll roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for water_cooler_reroll roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>coat_rack_reroll</h4><p>a standing office coat rack with a couple of neatly hung coats</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:props:coat_rack_reroll:1" data-label="coat_rack_reroll roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for coat_rack_reroll roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for coat_rack_reroll roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:coat_rack_reroll:2" data-label="coat_rack_reroll roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for coat_rack_reroll roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for coat_rack_reroll roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:props:coat_rack_reroll:3" data-label="coat_rack_reroll roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for coat_rack_reroll roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for coat_rack_reroll roll 3">
+          </div></div>
+      </div></div>
+    </section>
+
+    <section class="batch" data-batch="sweep:environment">
+      <div class="section-label">Sweep &middot; Environment</div>
+      <p class="batch-note">One row per asset; rolls side by side -- keep the best roll, re-roll the rest.</p>
+      <div class="sweep">
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>floor_carpet</h4><p>a seamless tileable office carpet floor texture tile</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:floor_carpet:1" data-label="floor_carpet roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for floor_carpet roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for floor_carpet roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:floor_carpet:2" data-label="floor_carpet roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for floor_carpet roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for floor_carpet roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:floor_carpet:3" data-label="floor_carpet roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for floor_carpet roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for floor_carpet roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>floor_lino</h4><p>a seamless tileable office linoleum floor texture tile</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:floor_lino:1" data-label="floor_lino roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for floor_lino roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for floor_lino roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:floor_lino:2" data-label="floor_lino roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for floor_lino roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for floor_lino roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:floor_lino:3" data-label="floor_lino roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for floor_lino roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for floor_lino roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>floor_concrete</h4><p>a seamless tileable bare concrete floor texture tile</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:floor_concrete:1" data-label="floor_concrete roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for floor_concrete roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for floor_concrete roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:floor_concrete:2" data-label="floor_concrete roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for floor_concrete roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for floor_concrete roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:floor_concrete:3" data-label="floor_concrete roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for floor_concrete roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for floor_concrete roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>wall_scummy</h4><p>a grimy dated office wall segment with scuffs</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:wall_scummy:1" data-label="wall_scummy roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for wall_scummy roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for wall_scummy roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:wall_scummy:2" data-label="wall_scummy roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for wall_scummy roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for wall_scummy roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:wall_scummy:3" data-label="wall_scummy roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for wall_scummy roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for wall_scummy roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>wall_decent</h4><p>a clean plain office wall segment</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:wall_decent:1" data-label="wall_decent roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for wall_decent roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for wall_decent roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:wall_decent:2" data-label="wall_decent roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for wall_decent roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for wall_decent roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:wall_decent:3" data-label="wall_decent roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for wall_decent roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for wall_decent roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>door_scummy</h4><p>a dated worn office door</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:door_scummy:1" data-label="door_scummy roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for door_scummy roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for door_scummy roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:door_scummy:2" data-label="door_scummy roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for door_scummy roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for door_scummy roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:door_scummy:3" data-label="door_scummy roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for door_scummy roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for door_scummy roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>door_decent</h4><p>a clean modern office door</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:door_decent:1" data-label="door_decent roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for door_decent roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for door_decent roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:door_decent:2" data-label="door_decent roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for door_decent roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for door_decent roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:door_decent:3" data-label="door_decent roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for door_decent roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for door_decent roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>window_weather_clear</h4><p>an office window looking out on a clear bright sky</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:window_weather_clear:1" data-label="window_weather_clear roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for window_weather_clear roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for window_weather_clear roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:window_weather_clear:2" data-label="window_weather_clear roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for window_weather_clear roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for window_weather_clear roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:window_weather_clear:3" data-label="window_weather_clear roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for window_weather_clear roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for window_weather_clear roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>window_weather_storm</h4><p>an office window looking out on a dark stormy sky with rain</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:window_weather_storm:1" data-label="window_weather_storm roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for window_weather_storm roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for window_weather_storm roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:window_weather_storm:2" data-label="window_weather_storm roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for window_weather_storm roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for window_weather_storm roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:window_weather_storm:3" data-label="window_weather_storm roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for window_weather_storm roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for window_weather_storm roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>window_weather_doomy</h4><p>an office window looking out on an ominous doomy red-purple apocalyptic sky</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:environment:window_weather_doomy:1" data-label="window_weather_doomy roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for window_weather_doomy roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for window_weather_doomy roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:window_weather_doomy:2" data-label="window_weather_doomy roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for window_weather_doomy roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for window_weather_doomy roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:environment:window_weather_doomy:3" data-label="window_weather_doomy roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for window_weather_doomy roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for window_weather_doomy roll 3">
+          </div></div>
+      </div></div>
+    </section>
+
+    <section class="batch" data-batch="sweep:cats_body_type_quadruped_template_cat">
+      <div class="section-label">Sweep &middot; Cats</div>
+      <p class="batch-note">One row per asset; rolls side by side -- keep the best roll, re-roll the rest.</p>
+      <div class="sweep">
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>cat_eldritch</h4><p>an eerie eldritch doom cat, glowing eyes, wisps of smoke, wrong-angled, unsettling</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:cats_body_type_quadruped_template_cat:cat_eldritch:1" data-label="cat_eldritch roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cat_eldritch roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cat_eldritch roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cats_body_type_quadruped_template_cat:cat_eldritch:2" data-label="cat_eldritch roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cat_eldritch roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cat_eldritch roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cats_body_type_quadruped_template_cat:cat_eldritch:3" data-label="cat_eldritch roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cat_eldritch roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cat_eldritch roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>cat_purple</h4><p>a strange purple end-state doom cat, faintly glowing, otherworldly</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:cats_body_type_quadruped_template_cat:cat_purple:1" data-label="cat_purple roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cat_purple roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cat_purple roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cats_body_type_quadruped_template_cat:cat_purple:2" data-label="cat_purple roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cat_purple roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cat_purple roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cats_body_type_quadruped_template_cat:cat_purple:3" data-label="cat_purple roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cat_purple roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cat_purple roll 3">
+          </div></div>
+      </div></div>
+    </section>
+
+    <section class="batch" data-batch="sweep:characters_use_create_character">
+      <div class="section-label">Sweep &middot; Characters</div>
+      <p class="batch-note">One row per asset; rolls side by side -- keep the best roll, re-roll the rest.</p>
+      <div class="sweep">
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>base_worker_restyle</h4><p>a Black woman in her 30s with box braids and round glasses, business casual office worker, AI safety researcher</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:base_worker_restyle:1" data-label="base_worker_restyle roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for base_worker_restyle roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for base_worker_restyle roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:base_worker_restyle:2" data-label="base_worker_restyle roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for base_worker_restyle roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for base_worker_restyle roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:base_worker_restyle:3" data-label="base_worker_restyle roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for base_worker_restyle roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for base_worker_restyle roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>cast_black_woman_young</h4><p>a young Black woman with short natural hair and a smart casual outfit, AI safety researcher</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_black_woman_young:1" data-label="cast_black_woman_young roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_black_woman_young roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_black_woman_young roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_black_woman_young:2" data-label="cast_black_woman_young roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_black_woman_young roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_black_woman_young roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_black_woman_young:3" data-label="cast_black_woman_young roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_black_woman_young roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_black_woman_young roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>cast_woman_lead_older</h4><p>an older woman team lead with grey hair in a bun and a blazer, AI safety researcher</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_woman_lead_older:1" data-label="cast_woman_lead_older roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_woman_lead_older roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_woman_lead_older roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_woman_lead_older:2" data-label="cast_woman_lead_older roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_woman_lead_older roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_woman_lead_older roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_woman_lead_older:3" data-label="cast_woman_lead_older roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_woman_lead_older roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_woman_lead_older roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>cast_wheelchair_user</h4><p>a person using a wheelchair, casual jumper, AI safety researcher</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_wheelchair_user:1" data-label="cast_wheelchair_user roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_wheelchair_user roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_wheelchair_user roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_wheelchair_user:2" data-label="cast_wheelchair_user roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_wheelchair_user roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_wheelchair_user roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_wheelchair_user:3" data-label="cast_wheelchair_user roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_wheelchair_user roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_wheelchair_user roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>cast_eccentric_genius</h4><p>a visibly eccentric genius with wild hair and mismatched clothes, AI safety researcher</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_eccentric_genius:1" data-label="cast_eccentric_genius roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_eccentric_genius roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_eccentric_genius roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_eccentric_genius:2" data-label="cast_eccentric_genius roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_eccentric_genius roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_eccentric_genius roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:cast_eccentric_genius:3" data-label="cast_eccentric_genius roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for cast_eccentric_genius roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for cast_eccentric_genius roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>founder_silhouette</h4><p>a shadowed silhouetted operator figure in a high-backed chair, face hidden, ominous, side view</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:founder_silhouette:1" data-label="founder_silhouette roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for founder_silhouette roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for founder_silhouette roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:founder_silhouette:2" data-label="founder_silhouette roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for founder_silhouette roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for founder_silhouette roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:characters_use_create_character:founder_silhouette:3" data-label="founder_silhouette roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for founder_silhouette roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for founder_silhouette roll 3">
+          </div></div>
+      </div></div>
+    </section>
+
+    <section class="batch" data-batch="sweep:cosmetics_overlays">
+      <div class="section-label">Sweep &middot; Cosmetics</div>
+      <p class="batch-note">One row per asset; rolls side by side -- keep the best roll, re-roll the rest.</p>
+      <div class="sweep">
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>hat_medium</h4><p>a medium fancy formal hat, cosmetic accessory on transparent background</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:hat_medium:1" data-label="hat_medium roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for hat_medium roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for hat_medium roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:hat_medium:2" data-label="hat_medium roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for hat_medium roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for hat_medium roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:hat_medium:3" data-label="hat_medium roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for hat_medium roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for hat_medium roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>hat_sports</h4><p>a sports cap, cosmetic accessory on transparent background</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:hat_sports:1" data-label="hat_sports roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for hat_sports roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for hat_sports roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:hat_sports:2" data-label="hat_sports roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for hat_sports roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for hat_sports roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:hat_sports:3" data-label="hat_sports roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for hat_sports roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for hat_sports roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>lab_coat</h4><p>a white lab coat, worn clothing item on transparent background</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:lab_coat:1" data-label="lab_coat roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for lab_coat roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for lab_coat roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:lab_coat:2" data-label="lab_coat roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for lab_coat roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for lab_coat roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:lab_coat:3" data-label="lab_coat roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for lab_coat roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for lab_coat roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>lanyard_badge</h4><p>a security lanyard and ID badge, small accessory on transparent background</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:lanyard_badge:1" data-label="lanyard_badge roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for lanyard_badge roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for lanyard_badge roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:lanyard_badge:2" data-label="lanyard_badge roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for lanyard_badge roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for lanyard_badge roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:lanyard_badge:3" data-label="lanyard_badge roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for lanyard_badge roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for lanyard_badge roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>headphones</h4><p>a pair of over-ear headphones, accessory on transparent background</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:headphones:1" data-label="headphones roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for headphones roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for headphones roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:headphones:2" data-label="headphones roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for headphones roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for headphones roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:cosmetics_overlays:headphones:3" data-label="headphones roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for headphones roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for headphones roll 3">
+          </div></div>
+      </div></div>
+    </section>
+
+    <section class="batch" data-batch="sweep:ui_filler_map_object">
+      <div class="section-label">Sweep &middot; UI Filler</div>
+      <p class="batch-note">One row per asset; rolls side by side -- keep the best roll, re-roll the rest.</p>
+      <div class="sweep">
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>ui_panel_frame</h4><p>an ornate retro computer UI panel frame border, empty center, on transparent background</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:ui_panel_frame:1" data-label="ui_panel_frame roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for ui_panel_frame roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for ui_panel_frame roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:ui_panel_frame:2" data-label="ui_panel_frame roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for ui_panel_frame roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for ui_panel_frame roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:ui_panel_frame:3" data-label="ui_panel_frame roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for ui_panel_frame roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for ui_panel_frame roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>ui_texture_tile</h4><p>a subtle seamless dark warm UI background texture tile</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:ui_texture_tile:1" data-label="ui_texture_tile roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for ui_texture_tile roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for ui_texture_tile roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:ui_texture_tile:2" data-label="ui_texture_tile roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for ui_texture_tile roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for ui_texture_tile roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:ui_texture_tile:3" data-label="ui_texture_tile roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for ui_texture_tile roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for ui_texture_tile roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>ui_indicator_dot</h4><p>a small glowing status indicator light, single icon on transparent background</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:ui_indicator_dot:1" data-label="ui_indicator_dot roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for ui_indicator_dot roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for ui_indicator_dot roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:ui_indicator_dot:2" data-label="ui_indicator_dot roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for ui_indicator_dot roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for ui_indicator_dot roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:ui_indicator_dot:3" data-label="ui_indicator_dot roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for ui_indicator_dot roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for ui_indicator_dot roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>icon_compute</h4><p>a small compute / server chip resource icon on transparent background</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:icon_compute:1" data-label="icon_compute roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for icon_compute roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for icon_compute roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:icon_compute:2" data-label="icon_compute roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for icon_compute roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for icon_compute roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:icon_compute:3" data-label="icon_compute roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for icon_compute roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for icon_compute roll 3">
+          </div></div>
+      </div>
+      <div class="sweep-row">
+        <div class="sweep-rowhead"><h4>icon_doom</h4><p>a small ominous doom skull resource icon on transparent background</p></div>
+        <div class="sweep-rolls" style="--cols:3">
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:icon_doom:1" data-label="icon_doom roll 1">
+            <div class="roll-idx">#1</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for icon_doom roll 1">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for icon_doom roll 1">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:icon_doom:2" data-label="icon_doom roll 2">
+            <div class="roll-idx">#2</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for icon_doom roll 2">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for icon_doom roll 2">
+          </div>
+          <div class="cell sweep-cell" data-item="sweep:ui_filler_map_object:icon_doom:3" data-label="icon_doom roll 3">
+            <div class="roll-idx">#3</div>
+            <div class="stage pending"><span>pending</span></div>
+            <div class="verdict" role="group" aria-label="Verdict for icon_doom roll 3">
+          <button type="button" class="vbtn" data-v="keep" title="Keep (K)">keep</button>
+          <button type="button" class="vbtn" data-v="maybe" title="Maybe (M)">maybe</button>
+          <button type="button" class="vbtn" data-v="reroll" title="Re-roll (R)">re-roll</button>
+        </div>
+        <input type="text" class="note" placeholder="note..." aria-label="Note for icon_doom roll 3">
+          </div></div>
       </div></div>
     </section>
 
   <div class="exportbar">
     <div class="tally" id="tally">picks: <b id="ct">0</b></div>
+    <div class="tally" id="vct"></div>
     <div class="spacer"></div>
     <button type="button" class="btn ghost" id="clearbtn">reset</button>
     <button type="button" class="btn" id="exportbtn">Export my picks &rarr;</button>
@@ -294,10 +1949,52 @@
 (function(){
   "use strict";
   var KEY="pdoom_style_review_v1",DKEY="pdoom_style_dir_global_v1";
-  var SEEDED={"_comment": "Pip's committed review verdicts. Preloaded by build.py into style_review.html so notes persist in git across sessions/machines. localStorage (live edits) overrides these. Update from Pip's Export paste, then rebuild.", "picks": {"2026-07-16-style-matrix": "warm-grime"}, "styledir": "Winning direction: warm-grime base + heavy-outline heft + deeper shadow, view-locked (symmetrical/straight-on/centered) to fix rotation. Monitors are the weak subject (composition); keep screens clearly powered/glowing.", "notes": {"2026-07-16-style-matrix:baseline__desk": "This is probably my favourite desk but suffers from being a little rotated in the image. I like the clutter and objects.", "2026-07-16-style-matrix:baseline__monitor": "This is one of the weakest monitors, coming across as dull and unpowered. Overall flavour is fine.", "2026-07-16-style-matrix:baseline__character": "This is a good character, good colour identity, professional attire.", "2026-07-16-style-matrix:futurepunk__desk": "This is a little too bright and shiny overall, the potted plant and wastepaper bin are nice touches.", "2026-07-16-style-matrix:futurepunk__monitor": "This is poor composition overall.", "2026-07-16-style-matrix:heavy-outline__desk": "This has a satisfying heft to it that I like, the objects have a good amount of visual distinction from each other.", "2026-07-16-style-matrix:warm-grime__desk": "The clutter and coziness of this desk, combined with the object on the PC tower, are all excellent.", "2026-07-16-style-matrix:warm-grime__monitor": "Good monitor, something weird going on where it looks like the monitor has a CD player coming out of it, but acceptable as a first-pass.", "2026-07-16-style-matrix:warm-grime__character": "The glasses render pretty weirdly on this model, otherwise good.", "2026-07-16-style-matrix:moody-contrast__desk": "The angling of this composition is weird and it has a chair which highlights shadows, but wouldn't work as a single asset. I like the increased shadows and moodiness.", "2026-07-16-style-matrix:moody-contrast__monitor": "Bit of a miss.", "2026-07-16-style-matrix:moody-contrast__character": "I like the expression and tone on this character, a little bit cynical, but more individualistic. Overall I like the shadows and mood tuning.", "2026-07-16-office-library:chair": "Looks a little small compared to the others; otherwise OK. Perhaps a little too modern for a starting chair. [RE-ROLLING: older/cheaper starting chair, larger]", "2026-07-16-office-library:bookshelf": "Looks more like a home than an office bookshelf; don't want much wood -- make it laminate / more office-shelfy. [RE-ROLLING]", "2026-07-16-office-library:whiteboard": "Good!", "2026-07-16-office-library:water_cooler": "Extremely good. Might be slightly too angled / perspective in wrong direction.", "2026-07-16-office-library:plant": "Excellent.", "2026-07-16-office-library:server_rack": "Extremely excellent. Direction and lighting might be slightly wrong, possibly wrong direction. Unclear.", "2026-07-16-office-library:couch": "Excellent.", "2026-07-16-office-library:coat_rack": "Excellent. Shoes might be a bit neater, slightly less domestic; office coatrack should be a bit neater."}};
-  var st={picks:Object.assign({},SEEDED.picks||{}),notes:Object.assign({},SEEDED.notes||{})};
-  try{var ls=JSON.parse(localStorage.getItem(KEY)||"{}");if(ls.picks)st.picks=Object.assign(st.picks,ls.picks);if(ls.notes)st.notes=Object.assign(st.notes,ls.notes);}catch(e){}
+  var SEEDED={"_comment": "Pip's committed review verdicts. Preloaded by build.py into style_review.html so notes persist in git across sessions/machines. localStorage (live edits) overrides these. Update from Pip's Export paste, then rebuild.", "picks": {"2026-07-16-style-matrix": "warm-grime"}, "styledir": "Winning direction: warm-grime base + heavy-outline heft + deeper shadow, view-locked (symmetrical/straight-on/centered) to fix rotation. Monitors are the weak subject (composition); keep screens clearly powered/glowing.", "notes": {"2026-07-16-style-matrix:baseline__desk": "This is probably my favourite desk but suffers from being a little rotated in the image. I like the clutter and objects.", "2026-07-16-style-matrix:baseline__monitor": "This is one of the weakest monitors, coming across as dull and unpowered. Overall flavour is fine.", "2026-07-16-style-matrix:baseline__character": "This is a good character, good colour identity, professional attire.", "2026-07-16-style-matrix:futurepunk__desk": "This is a little too bright and shiny overall, the potted plant and wastepaper bin are nice touches.", "2026-07-16-style-matrix:futurepunk__monitor": "This is poor composition overall.", "2026-07-16-style-matrix:heavy-outline__desk": "This has a satisfying heft to it that I like, the objects have a good amount of visual distinction from each other.", "2026-07-16-style-matrix:warm-grime__desk": "The clutter and coziness of this desk, combined with the object on the PC tower, are all excellent.", "2026-07-16-style-matrix:warm-grime__monitor": "Good monitor, something weird going on where it looks like the monitor has a CD player coming out of it, but acceptable as a first-pass.", "2026-07-16-style-matrix:warm-grime__character": "The glasses render pretty weirdly on this model, otherwise good.", "2026-07-16-style-matrix:moody-contrast__desk": "The angling of this composition is weird and it has a chair which highlights shadows, but wouldn't work as a single asset. I like the increased shadows and moodiness.", "2026-07-16-style-matrix:moody-contrast__monitor": "Bit of a miss.", "2026-07-16-style-matrix:moody-contrast__character": "I like the expression and tone on this character, a little bit cynical, but more individualistic. Overall I like the shadows and mood tuning.", "2026-07-16-office-library:chair": "Looks a little small compared to the others; otherwise OK. Perhaps a little too modern for a starting chair. [RE-ROLLING: older/cheaper starting chair, larger]", "2026-07-16-office-library:bookshelf": "Looks more like a home than an office bookshelf; don't want much wood -- make it laminate / more office-shelfy. [RE-ROLLING]", "2026-07-16-office-library:whiteboard": "Good!", "2026-07-16-office-library:water_cooler": "Extremely good. Might be slightly too angled / perspective in wrong direction.", "2026-07-16-office-library:plant": "Excellent.", "2026-07-16-office-library:server_rack": "Extremely excellent. Direction and lighting might be slightly wrong, possibly wrong direction. Unclear.", "2026-07-16-office-library:couch": "Excellent.", "2026-07-16-office-library:coat_rack": "Excellent. Shoes might be a bit neater, slightly less domestic; office coatrack should be a bit neater."}, "verdicts": {}};
+  var st={
+    picks:Object.assign({},SEEDED.picks||{}),
+    notes:Object.assign({},SEEDED.notes||{}),
+    verdicts:Object.assign({},SEEDED.verdicts||{})
+  };
+  try{var ls=JSON.parse(localStorage.getItem(KEY)||"{}");
+    if(ls.picks)st.picks=Object.assign(st.picks,ls.picks);
+    if(ls.notes)st.notes=Object.assign(st.notes,ls.notes);
+    if(ls.verdicts)st.verdicts=Object.assign(st.verdicts,ls.verdicts);
+  }catch(e){}
   function save(){try{localStorage.setItem(KEY,JSON.stringify(st));}catch(e){}}
+  function reduceMotion(){return window.matchMedia&&matchMedia('(prefers-reduced-motion:reduce)').matches;}
+
+  // ---- verdicts (keep / maybe / re-roll) ----
+  function applyVerdict(c,v){
+    c.classList.remove('v-keep','v-maybe','v-reroll');
+    if(v)c.classList.add('v-'+v);
+    c.querySelectorAll('.vbtn').forEach(function(b){b.classList.toggle('on',b.getAttribute('data-v')===v);});
+  }
+  function setVerdict(c,v){
+    var id=c.getAttribute('data-item');
+    if(st.verdicts[id]===v){delete st.verdicts[id];v=null;}
+    else{st.verdicts[id]=v;}
+    applyVerdict(c,v);save();tally();
+  }
+
+  // ---- keyboard navigation ----
+  var CELLS=[].slice.call(document.querySelectorAll('.cell'));
+  var cur=-1;
+  function setFocus(i,scroll){
+    if(i<0||i>=CELLS.length)return;
+    if(cur>=0&&CELLS[cur])CELLS[cur].classList.remove('focused');
+    cur=i;var c=CELLS[cur];c.classList.add('focused');
+    if(scroll)c.scrollIntoView({behavior:reduceMotion()?'auto':'smooth',block:'nearest',inline:'nearest'});
+  }
+  function move(d){
+    var i=cur<0?0:cur+d;
+    if(i<0)i=0;if(i>=CELLS.length)i=CELLS.length-1;
+    setFocus(i,true);
+  }
+  function focusNote(){
+    if(cur<0)setFocus(0,true);
+    var c=CELLS[cur],n=c&&c.querySelector('.note');
+    if(n){n.focus();if(n.select)n.select();}
+  }
 
   // restore + wire winner radios
   document.querySelectorAll('.mx-row').forEach(function(row){
@@ -312,20 +2009,54 @@
       tally();
     });
   });
-  // restore + wire notes
-  document.querySelectorAll('.cell').forEach(function(c){
-    var id=c.getAttribute('data-item'),inp=c.querySelector('.note');
-    if(!inp)return;
-    if(st.notes[id])inp.value=st.notes[id];
-    inp.addEventListener('input',function(e){st.notes[id]=e.target.value;if(!e.target.value)delete st.notes[id];save();});
+
+  // restore + wire notes, verdicts, click-to-focus on every review cell
+  CELLS.forEach(function(c,idx){
+    var id=c.getAttribute('data-item');
+    var inp=c.querySelector('.note');
+    if(inp){
+      if(st.notes[id])inp.value=st.notes[id];
+      inp.addEventListener('input',function(e){st.notes[id]=e.target.value;if(!e.target.value)delete st.notes[id];save();});
+    }
+    applyVerdict(c,st.verdicts[id]||null);
+    c.querySelectorAll('.vbtn').forEach(function(btn){
+      btn.addEventListener('click',function(){setFocus(idx,false);setVerdict(c,btn.getAttribute('data-v'));});
+    });
+    c.addEventListener('mousedown',function(){setFocus(idx,false);});
   });
+
+  document.addEventListener('keydown',function(e){
+    var t=e.target,tag=(t.tagName||'').toLowerCase();
+    var typing=tag==='input'||tag==='textarea'||t.isContentEditable;
+    if(typing){ if(e.key==='Escape'){t.blur();e.preventDefault();} return; }  // never fire shortcuts while typing
+    if(e.ctrlKey||e.metaKey||e.altKey)return;
+    var k=e.key;
+    if(k==='ArrowRight'||k==='ArrowDown'){move(1);e.preventDefault();}
+    else if(k==='ArrowLeft'||k==='ArrowUp'){move(-1);e.preventDefault();}
+    else if(k==='k'||k==='K'){if(cur>=0){setVerdict(CELLS[cur],'keep');e.preventDefault();}}
+    else if(k==='m'||k==='M'){if(cur>=0){setVerdict(CELLS[cur],'maybe');e.preventDefault();}}
+    else if(k==='r'||k==='R'){if(cur>=0){setVerdict(CELLS[cur],'reroll');e.preventDefault();}}
+    else if(k==='n'||k==='N'||k==='Enter'){focusNote();e.preventDefault();}
+    else if(k==='Escape'){if(cur>=0){CELLS[cur].classList.remove('focused');cur=-1;}}
+  });
+
   var dir=document.getElementById('styledir');
   try{dir.value=localStorage.getItem(DKEY)||SEEDED.styledir||"";}catch(e){dir.value=SEEDED.styledir||"";}
   dir.addEventListener('input',function(e){try{localStorage.setItem(DKEY,e.target.value);}catch(x){}});
 
-  function tally(){document.getElementById('ct').textContent=Object.keys(st.picks).length;}
+  function tally(){
+    document.getElementById('ct').textContent=Object.keys(st.picks).length;
+    var k=0,m=0,r=0;
+    for(var id in st.verdicts){var v=st.verdicts[id];if(v==='keep')k++;else if(v==='maybe')m++;else if(v==='reroll')r++;}
+    var el=document.getElementById('vct');
+    if(el)el.innerHTML='keep <b>'+k+'</b> / maybe <b>'+m+'</b> / re-roll <b>'+r+'</b>';
+  }
   tally();
 
+  function labelFor(id){
+    var c=document.querySelector('.cell[data-item="'+id.replace(/"/g,'')+'"]');
+    return c?c.getAttribute('data-label'):id;
+  }
   function buildExport(){
     var L=["# P(Doom)1 style review -- Pip's picks",""];
     var sd=(dir.value||"").trim();
@@ -334,12 +2065,23 @@
     var pk=Object.keys(st.picks);
     L.push(pk.length?pk.map(function(b){return "- "+b+": **"+st.picks[b]+"**";}).join("\n"):"_(none picked)_");
     L.push("");
-    var ns=Object.keys(st.notes);
-    if(ns.length){L.push("## Notes");ns.forEach(function(id){
-      var c=document.querySelector('.cell[data-item="'+id.replace(/"/g,'')+'"]');
-      var label=c?c.getAttribute('data-label'):id;
-      L.push("- "+label+" ("+id+"): "+st.notes[id]);
-    });L.push("");}
+    // verdicts grouped keep / maybe / re-roll (with notes inline)
+    var groups={keep:[],maybe:[],reroll:[]};
+    Object.keys(st.verdicts).forEach(function(id){
+      var v=st.verdicts[id];if(!groups[v])return;
+      var note=st.notes[id]?(" -- "+st.notes[id]):"";
+      groups[v].push("- "+labelFor(id)+" ("+id+")"+note);
+    });
+    var titles={keep:"Keep",maybe:"Maybe",reroll:"Re-roll"};
+    ["keep","maybe","reroll"].forEach(function(g){
+      if(groups[g].length){L.push("## "+titles[g],groups[g].join("\n"),"");}
+    });
+    // any remaining notes not attached to a verdict
+    var extra=Object.keys(st.notes).filter(function(id){return !st.verdicts[id];});
+    if(extra.length){L.push("## Other notes");
+      extra.forEach(function(id){L.push("- "+labelFor(id)+" ("+id+"): "+st.notes[id]);});
+      L.push("");
+    }
     return L.join("\n");
   }
   var dlg=document.getElementById('exportdlg'),txt=document.getElementById('exporttext');
@@ -354,10 +2096,11 @@
     this.textContent=ok?"copied":"select+copy";var b=this;setTimeout(function(){b.textContent="copy";},1500);
   });
   document.getElementById('clearbtn').addEventListener('click',function(){
-    if(!confirm("Clear all picks and notes?"))return;
-    st={picks:{},notes:{}};save();
+    if(!confirm("Clear all picks, verdicts and notes?"))return;
+    st={picks:{},notes:{},verdicts:{}};save();
     document.querySelectorAll('.mx-row').forEach(function(r){r.classList.remove('won');var rr=r.querySelector('input[type=radio]');if(rr)rr.checked=false;});
     document.querySelectorAll('.note').forEach(function(n){n.value="";});
+    CELLS.forEach(function(c){applyVerdict(c,null);});
     tally();
   });
 })();


### PR DESCRIPTION
Upgrades the local art-review tool (`tools/art_review/`) into a keyboard-driven asset browser. Purely additive -- the matrix winner-pick, notes, verdicts.json preload, localStorage model, and Export flow all still work.

## What's new

**1. Per-cell verdicts (keep / maybe / re-roll)**
- Tri-state verdict on every review cell (matrix, ladder, gallery, sweep), stored in `st.verdicts` keyed by `data-item`.
- Persisted to localStorage AND seeded from `verdicts.json` (new `verdicts` key; back-compat defaulted).
- Cell border ring coloured green / amber / red by verdict.
- Export groups Keep / Maybe / Re-roll with notes inline; a tally shows live counts.

**2. Keyboard navigation (headline)**
- Arrow keys (any direction) move a focus ring over cells in flat DOM order.
- `K` keep, `M` maybe, `R` re-roll on the focused cell; `N`/`Enter` edits its note; `Esc` blurs back to nav.
- Shortcuts are suppressed while a note input is focused (typing never fires K/M/R).
- Focused cell scrolls into view; all scroll/transition honours `prefers-reduced-motion`.
- Fixed keyboard legend (top-right; hidden on narrow screens).

**3. Overnight sweep rendering**
- New `build_sweep()`: when `sweep_prompts.json` exists, renders one section per category and one row per asset with that asset's rolls side by side (`sweep/<category>/<key>_<roll>.png`, roll = 1..N where N = `entry.rolls` or `default_rolls`).
- Absent files render a `pending` placeholder (all pending for now -- the sweep is generating in parallel).
- Category keys with tool hints (`cats_body_type_quadruped_template_cat`, `ui_filler_map_object`, ...) are stripped to a clean display label (Cats, UI Filler, ...); the raw key is the on-disk subdir.
- Images embedded as base64 -- self-contained, CSP-clean, openable offline.

## Verify
- `python tools/art_review/build.py` runs clean, writes `style_review.html` (~293 KB).
- Output contains the keyboard legend, 155 verdict control groups, and all six sweep sections (props / environment / cats / characters / cosmetics / ui filler).
- No external hosts referenced (only `data:` image URIs).

## Keyboard map
| Key | Action |
| --- | --- |
| Arrow keys | move focus ring (flat DOM order) |
| K / M / R | keep / maybe / re-roll focused cell (press again to clear) |
| N or Enter | focus the note input |
| Esc | blur note back to navigation |

Staging was scoped to `tools/art_review/` only.

Do NOT merge -- for Pip's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)