### PR TITLE
docs(art): capture sweep picks + main-screen wireframe

### DIFF
--- a/docs/art/reviews/2026-07-17-overnight-sweep.md
+++ b/docs/art/reviews/2026-07-17-overnight-sweep.md
@@ -1,0 +1,143 @@
+# Sweep review -- Pip's picks (2026-07-17, overnight sweep of 168 assets)
+
+> Verbatim capture of Pip's Export from the art-review tool. Source of truth for
+> re-roll instructions + keeper decisions. Parsed into tools/art_review/verdicts.json
+> so the tool preloads it.
+
+## Style direction
+Winning direction: warm-grime base + heavy-outline heft + deeper shadow, view-locked (symmetrical/straight-on/centered) to fix rotation. Monitors are the weak subject (composition); keep screens clearly powered/glowing.
+
+## Winning styles
+- 2026-07-16-style-matrix: **warm-grime**
+
+## Keep
+- desk_mega roll 1 -- good; check desk shadow vs transparency; monitor game-responsiveness is a maybe-later-UI question
+- desk_mega roll 4 -- second favourite
+- monitor_mega roll 1
+- monitor_mega roll 2
+- pc_mega roll 4 -- keep as default so we can move on
+- server_cluster_mega roll 2 -- good colouring
+- server_cluster_mega roll 3 -- good density and intensity
+- kitchen_bench_decent roll 3 -- nice
+- filing_cabinet roll 1
+- filing_cabinet roll 3
+- printer roll 3 -- nice
+- printer roll 4 -- keep as early-era
+- trash_can roll 1 -- good
+- trash_can roll 4 -- start-era keep
+- meeting_table roll 3 -- dramatic lighting great, want more samples of it
+- water_cooler_reroll roll 3
+- coat_rack_reroll roll 1
+- coat_rack_reroll roll 2
+- floor_lino roll 1
+- wall_scummy roll 3
+- wall_scummy roll 4
+- door_scummy roll 4
+- door_scummy roll 1
+- door_decent roll 3
+- door_decent roll 4
+- window_weather_clear roll 4
+- window_weather_clear roll 1 -- lighting direction maybe weird, good asset
+- window_weather_storm roll 4 / 3 / 1 -- good defaults, needs rework
+- window_weather_doomy roll 3 -- not good but a default for testing while iterating
+- cat_eldritch roll 4 -- keep for baseline
+- cat_purple roll 1
+- base_worker_restyle roll 1 -- best of an OK bunch, rest feel under
+- base_worker_restyle roll 4
+- cast_black_woman_young roll 1
+- cast_woman_lead_older roll 1
+- cast_wheelchair_user roll 4
+- founder_silhouette roll 3 -- all bad but tolerable for testing; WRONG ORIENTATION; should mostly see the chair + silhouette; chair is the visual focus
+- hat_medium roll 3 / 1
+- hat_sports roll 4
+- lab_coat roll 3 / 4
+- lanyard_badge roll 2
+- lanyard_badge roll 3 -- feels advanced/doomy, keep/recycle for that
+- headphones roll 3 / 1 / 2 -- like all; want to see variants ON characters
+
+## Maybe
+- desk_mega roll 3 -- weirdly symmetrical (2 grey + 2 red objects)
+- chair_decent roll 4 / 2
+- monitor_mega roll 3 -- has keyboard+mouse; be explicit whether monitors include them
+- kitchen_bench_scummy roll 2 / 3 -- side boundaries; need clearer architectural/positioning decisions (design/philosophy check)
+- kitchen_bench_decent roll 1
+- printer roll 2 -- check lighting + positioning
+- meeting_table roll 2
+- water_cooler_reroll roll 1
+- coat_rack_reroll roll 3
+- floor_carpet roll 1
+- floor_lino roll 4
+- floor_concrete rolls 1-4 -- Claude check if this is even vaguely a floor
+- wall_scummy roll 1 -- defer to Claude
+- wall_decent roll 3 -- not a wall segment, maybe something else
+- door_scummy roll 3
+- door_decent roll 1 -- lighting weird
+- door_decent roll 2 -- too flat
+- window_weather_clear roll 3
+- cat_purple roll 4 -- keep for playtesting
+- cast_black_woman_young roll 3 -- accentuate or de-accentuate belly/lighting
+- cast_black_woman_young roll 4
+- cast_woman_lead_older roll 3
+- hat_sports roll 2
+- lanyard_badge roll 1
+- lanyard_badge roll 4 -- chunky; standby for a special-access asset
+- headphones roll 4
+- ui_panel_frame roll 4 -- keep in case we want ornate; unsure these generated well
+- ui_texture_tile roll 4 / 3 -- might tile poorly?
+- ui_indicator_dot roll 2 / 1
+- icon_compute roll 4 -- slightly chip-ish; under-specified
+- icon_doom roll 3 -- best artistically, still too human
+- icon_doom roll 1 -- too purple and teethy
+
+## Re-roll (with direction)
+- desk_mega roll 2 -- single-colour screen least interesting vs image screens
+- chair_mega rolls 1-4 -- needs FANCIER; roll 3 over-lit (lower half good); roll 4 too flat
+- chair_decent rolls 1/3 -- must DIFFERENTIATE from chair_mega: no arm rests, more circular, smaller/less backrest, dull green or plasticky office-blue
+- monitor_mega roll 4 -- angle too strong; re-roll as a STARTUP-mode mega monitor = 2 large chunky CRTs
+- pc_mega rolls 1/2/3 -- angle/orientation consistency; roll 1 has plant leaves over it; think about how it sits near other items
+- server_cluster_mega roll 1 -- looks like a city block, no cables
+- server_cluster_mega roll 4 -- too solid
+- kitchen_bench_scummy rolls 1/4 -- size/positioning vs others; side boundaries
+- kitchen_bench_decent rolls 2/4 -- no potplants; roll 4 looks like a desk
+- filing_cabinet roll 2 -- too angly
+- filing_cabinet roll 4 -- lacks shadow depth, boring
+- printer roll 1
+- trash_can rolls 2/3 -- make explicitly RECYCLING, neater
+- meeting_table roll 4 -- too thin
+- water_cooler_reroll rolls 2/4
+- coat_rack_reroll roll 4
+- floor_carpet rolls 2/3/4 -- not tiling (circle, too small, indistinguishable)
+- floor_lino rolls 2/3 -- didn't work as texture
+- wall_scummy roll 2 -- unrequested circular downlight
+- wall_decent rolls 1/2/4 -- not a wall segment
+- door_scummy roll 2
+- window_weather_clear roll 2 -- no windowsill/edging; deliberately call for these
+- window_weather_storm roll 2 -- no frames. Claude: do we want frame + background rendered SEPARATELY?
+- window_weather_doomy rolls 1/2/4 -- doomy needs style-guide input + significant rework, probably mechanically
+- cat_eldritch roll 3 -- needs more Visual Doom. Need a UNIVERSAL intensity/philosophy reference? @Claude
+- cat_eldritch rolls 1/2 -- more glow, maybe collar + emblem
+- cat_purple roll 2 -- too smiley
+- cat_purple roll 3 -- head too big
+- cast_black_woman_young roll 2
+- cast_woman_lead_older rolls 2/4
+- cast_wheelchair_user roll 2 -- too flat
+- cast_eccentric_genius rolls 1-4 -- ALL too generic
+- founder_silhouette rolls 1/2/4 -- weirdly called for + incoherent; Claude rethink all of these
+- hat_medium rolls 2/4
+- hat_sports rolls 1/3
+- lab_coat rolls 1/2
+- ui_panel_frame rolls 1/2/3 -- angled / poorly defined / ew
+- ui_texture_tile rolls 1/2 -- these are objects, wrong prompt/model
+- ui_indicator_dot rolls 3/4
+- icon_compute rolls 1/2/3 -- generic, off-brand; start thinking colour palette?
+- icon_doom roll 2 -- try a ROBOT-flavoured skull
+- icon_doom roll 4 -- too much yellowing/anatomy
+
+## Cross-cutting asks to Claude (extracted)
+1. Floors/walls/UI-textures did not come out as tileable textures -- check + fix the approach.
+2. Windows: do we want the frame and the weather background rendered as SEPARATE layers?
+3. Doom assets (cats, doomy windows): need a UNIVERSAL doom-intensity / philosophy reference to define/modulate intensity.
+4. UI icons: off-brand -- start a colour palette / brand spec.
+5. Founder silhouette: rethink entirely -- chair is the visual focus, silhouette seated, correct orientation.
+6. Asset architecture/positioning: several props have implied side "boundaries"; need clearer decisions on how assets sit in space (relates to prop-only vs tileset room).
+7. Be explicit per-asset about included sub-items (does a monitor come with keyboard/mouse; does a kitchen bench include plants).

--- a/tools/ui_mockup/wireframe.html
+++ b/tools/ui_mockup/wireframe.html
@@ -1,0 +1,135 @@
+<!-- P(Doom)1 main-screen wireframe. Deliberately rough + throwaway (Pip: "I will not
+     get too attached"). Structure + where-art-goes only, not final layout. Open in a browser. -->
+<title>P(Doom)1 -- main screen wireframe</title>
+<style>
+  :root{
+    --ground:#17120e;--panel:#211a14;--panel2:#2b221a;--ink:#ece0cf;--dim:#a9977f;--faint:#6f6250;
+    --amber:#e8a33d;--line:#3a2e22;--doom:#c0492f;--doom2:#7a3b8f;--good:#6fae86;--compute:#5fa9c8;
+  }
+  @media (prefers-color-scheme:light){:root{
+    --ground:#efe6d6;--panel:#f7efe0;--panel2:#fbf5e9;--ink:#2b2116;--dim:#6b5b45;--faint:#9a876c;
+    --amber:#b9741a;--line:#ddccb0;--doom:#bd4e34;--doom2:#7a3b8f;--good:#3f8a5c;--compute:#2f7fa0;}}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--ground);color:var(--ink);font-family:ui-monospace,Consolas,monospace;line-height:1.45}
+  .wrap{max-width:1120px;margin:0 auto;padding:2rem 1.3rem 4rem}
+  h1{font-size:1.5rem;margin:0 0 .2rem}
+  .sub{color:var(--dim);font-size:.85rem;margin:0 0 1.4rem;max-width:70ch;font-family:ui-sans-serif,system-ui,sans-serif}
+  .sub b{color:var(--ink)}
+
+  /* the screen mock */
+  .screen{border:2px solid var(--line);border-radius:10px;overflow:hidden;background:var(--panel);
+    display:grid;grid-template-columns:1fr 300px;grid-template-rows:auto 1fr auto;min-height:560px}
+  .region{border:1px dashed var(--faint);margin:5px;border-radius:7px;padding:.6rem .7rem;position:relative;background:var(--panel2)}
+  .tag{position:absolute;top:-9px;left:9px;background:var(--amber);color:#20140a;font-size:.6rem;font-weight:700;
+    padding:.05rem .4rem;border-radius:4px;letter-spacing:.03em}
+  .region h4{margin:.5rem 0 .3rem;font-size:.8rem}
+  .region p{margin:0;color:var(--dim);font-size:.72rem;font-family:ui-sans-serif,system-ui,sans-serif}
+
+  /* top resource strip */
+  .resources{grid-column:1 / 3;display:flex;gap:.5rem;align-items:stretch}
+  .res{flex:1;border:1px solid var(--line);border-radius:6px;padding:.4rem .5rem;background:var(--panel);display:flex;flex-direction:column;gap:.15rem}
+  .res .ic{width:20px;height:20px;border-radius:4px;display:inline-block}
+  .res .v{font-size:1rem;font-weight:700}
+  .res .l{font-size:.58rem;color:var(--faint);text-transform:uppercase;letter-spacing:.08em}
+  .res .spark{height:14px;border-bottom:1px solid var(--line);position:relative;opacity:.7}
+  .res .spark::after{content:"";position:absolute;left:0;bottom:0;width:100%;height:70%;
+    background:linear-gradient(90deg,transparent,currentColor);opacity:.25;border-radius:3px}
+
+  /* office stage */
+  .stage{position:relative;min-height:320px;display:flex;align-items:center;justify-content:center;overflow:hidden}
+  .floorgrid{position:absolute;inset:8px;border-radius:6px;
+    background:
+      linear-gradient(var(--line) 1px,transparent 1px) 0 0/38px 38px,
+      linear-gradient(90deg,var(--line) 1px,transparent 1px) 0 0/38px 38px,
+      var(--panel);opacity:.5}
+  .token{position:absolute;border:1px solid var(--faint);border-radius:5px;background:var(--panel);
+    font-size:.6rem;color:var(--dim);padding:.25rem .35rem;text-align:center;font-family:ui-sans-serif,system-ui,sans-serif}
+  .worker{width:34px;height:44px}
+  .prop{color:var(--faint)}
+  .window{width:74px;height:52px;border-color:var(--compute);color:var(--compute)}
+  .catbox{width:44px;height:34px;border-color:var(--amber);color:var(--amber)}
+
+  /* right column panels */
+  .side{grid-row:2 / 3;grid-column:2;display:flex;flex-direction:column;gap:0}
+  .tabs{display:flex;gap:.3rem;margin:5px 5px 0}
+  .tab{flex:1;text-align:center;font-size:.62rem;padding:.3rem;border:1px solid var(--line);border-bottom:none;
+    border-radius:5px 5px 0 0;background:var(--panel2);color:var(--dim)}
+  .tab.on{background:var(--amber);color:#20140a;font-weight:700}
+
+  /* action dock */
+  .dock{grid-column:1 / 3;display:flex;gap:.4rem;align-items:center}
+  .act{flex:1;border:1px solid var(--line);border-radius:6px;padding:.5rem;text-align:center;font-size:.66rem;
+    color:var(--dim);background:var(--panel)}
+  .act .k{display:block;font-size:.9rem;color:var(--ink);margin-bottom:.15rem}
+
+  .callouts{margin-top:1.6rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:.8rem}
+  .co{border:1px solid var(--line);border-left:3px solid var(--amber);border-radius:8px;padding:.8rem 1rem;background:var(--panel2)}
+  .co h3{margin:0 0 .3rem;font-size:.85rem}
+  .co p{margin:0;color:var(--dim);font-size:.78rem;font-family:ui-sans-serif,system-ui,sans-serif}
+  .co .n{color:var(--amber);font-weight:700}
+  .legend{margin-top:1.4rem;color:var(--faint);font-size:.72rem}
+</style>
+
+<div class="wrap">
+  <h1>P(Doom)1 -- main screen wireframe</h1>
+  <p class="sub">Rough + throwaway, just to react to. The idea: fill the negative space by giving every edge a job --
+    a <b>resource strip</b> up top, the <b>office floor</b> as the living centre (sprites + cat + window doing the ambient
+    doom-signalling), a <b>tabbed side panel</b> for team/feed/barometer, and a <b>grouped action dock</b> below.
+    Numbers map to the notes underneath.</p>
+
+  <div class="screen">
+    <!-- 1: resources -->
+    <div class="region resources"><span class="tag">1 - RESOURCE STRIP</span>
+      <div class="res" style="color:var(--good)"><span class="l">Money</span><span class="v">$245k</span><span class="spark"></span></div>
+      <div class="res" style="color:var(--doom)"><span class="l">Doom</span><span class="v">34%</span><span class="spark"></span></div>
+      <div class="res" style="color:var(--amber)"><span class="l">Attention</span><span class="v">17/20</span><span class="spark"></span></div>
+      <div class="res" style="color:var(--compute)"><span class="l">Compute</span><span class="v">8</span><span class="spark"></span></div>
+      <div class="res" style="color:var(--ink)"><span class="l">Reputation</span><span class="v">+12</span><span class="spark"></span></div>
+    </div>
+
+    <!-- 2: office stage -->
+    <div class="region stage"><span class="tag">2 - OFFICE FLOOR (living centre)</span>
+      <div class="floorgrid"></div>
+      <div class="token window" style="top:16px;left:26px">3 window<br>(weather)</div>
+      <div class="token worker" style="top:120px;left:90px">worker</div>
+      <div class="token worker" style="top:150px;left:150px">worker</div>
+      <div class="token worker" style="top:190px;left:250px">worker</div>
+      <div class="token prop" style="top:110px;left:210px;width:40px;height:30px">desk</div>
+      <div class="token prop" style="top:220px;left:120px;width:38px;height:28px">server</div>
+      <div class="token catbox" style="bottom:14px;right:20px">4 cat<br>(doom band)</div>
+    </div>
+
+    <!-- side tabs + panel -->
+    <div class="side">
+      <div class="tabs"><div class="tab on">Team</div><div class="tab">Feed</div><div class="tab">Barometer</div></div>
+      <div class="region" style="flex:1;margin-top:0;border-radius:0 0 7px 7px"><span class="tag">5 - SIDE PANEL (tabbed)</span>
+        <h4>Team / Candidate Pool</h4>
+        <p>Roster + the candidate pool (the hiring pipeline lives here -- interview / offer / onboard). Tabs swap to
+          the <b>event feed</b> (ad responses, incidents) and the <b>doom barometer</b> (cat state + window weather + doom trend graph).</p>
+        <h4 style="margin-top:.9rem">6 - Doom trend</h4>
+        <p>A small sparkline/area graph of doom over time -- fills the lower panel, reads at a glance.</p>
+      </div>
+    </div>
+
+    <!-- action dock -->
+    <div class="region dock"><span class="tag">7 - ACTION DOCK (grouped)</span>
+      <div class="act"><span class="k">[$]</span>Fundraise</div>
+      <div class="act"><span class="k">[@]</span>Advertise</div>
+      <div class="act"><span class="k">[#]</span>Research</div>
+      <div class="act"><span class="k">[!]</span>Safety</div>
+      <div class="act"><span class="k">[>]</span>End Month</div>
+    </div>
+  </div>
+
+  <div class="callouts">
+    <div class="co"><h3><span class="n">1</span> Resource strip</h3><p>Money / Doom / Attention / Compute / Reputation, each with an on-brand icon (the UI-filler batch), a big value, and a tiny sparkline. This alone eats most of the top negative space and gives the eye a dashboard.</p></div>
+    <div class="co"><h3><span class="n">2</span> Office floor = the centre</h3><p>Not a spare rectangle -- the living dashboard. Worker sprites walk/work/stress; props dress it; it grows as you hire. This is where all that art lands.</p></div>
+    <div class="co"><h3><span class="n">3</span> Window as a portal</h3><p>Framed window showing outside weather that darkens/reddens with doom. Ambient signal, fills a wall, costs no UI space. (Needs the frame + weather-background split we discussed.)</p></div>
+    <div class="co"><h3><span class="n">4</span> Cat = doom barometer</h3><p>Sits in the office; its form (singed -> spooky -> eldritch -> purple) reads the doom band. Free flavour in otherwise-dead corner space.</p></div>
+    <div class="co"><h3><span class="n">5</span> Tabbed side panel</h3><p>One column, three jobs: Team/Candidates, Event Feed, Doom Barometer. Tabs keep it dense without a wall of panels. Framed with the UI panel-frame art.</p></div>
+    <div class="co"><h3><span class="n">6</span> Doom trend graph</h3><p>Lower side panel -- a small area chart. Turns an empty panel into information + motion.</p></div>
+    <div class="co"><h3><span class="n">7</span> Grouped action dock</h3><p>Actions along the bottom with icons + labels, grouped by type. Replaces a scattered button soup and anchors the bottom edge.</p></div>
+  </div>
+
+  <p class="legend">// wireframe only -- boxes are placeholders for real sprites/panels. Everything here is rearrangeable. React freely.</p>
+</div>


### PR DESCRIPTION
Persist Pip's 168-asset sweep verdicts (review log) + a throwaway main-screen wireframe. 🤖 Generated with [Claude Code](https://claude.com/claude-code)