### PR TITLE
docs(art): double swatches + wireframe upgrade slots + upgrades brainstorm

### DIFF
--- a/docs/game-design/UPGRADES_ASSET_BRAINSTORM.md
+++ b/docs/game-design/UPGRADES_ASSET_BRAINSTORM.md
@@ -1,0 +1,87 @@
+# Upgrades system -- asset brainstorm (pre-mechanics-review)
+
+> Pip asked: "are there suggestions on what we can do that would also require some assets?"
+> This is a BRAINSTORM, not ruled mechanics -- but it doubles as the art-generation target list.
+> The frame: an **upgrade** is a purchasable/earnable thing that (a) drops a new sprite into a
+> reserved office slot (the office visibly grows + gets fancier -- see the wireframe upgrade slots),
+> (b) has a mechanical hook, and (c) usually feeds an existing system/appetite. Most come in
+> era-tiers (scummy startup -> decent -> conspicuously-fancy megacorp), which is free art mileage.
+
+## Why this is a good fit
+- The office-reflects-your-state mechanic already wants tiered props -- upgrades ARE that, made a
+  player choice instead of automatic.
+- Appetites (ADR-0011: compute / prestige-first-author / mentees / money / mission-purity) give
+  each upgrade a "who loves this" hook -- a prestige-hungry hire is happier with the fancy espresso
+  machine; a compute-hungry one wants the GPU wall.
+- Burnout/morale, doom mitigation, and attention all give upgrades numeric effects.
+
+## The list
+
+### Comfort / morale (reduce burnout; feed money/comfort appetites)
+| upgrade | mechanical hook | feeds | art asset | tiers |
+|---|---|---|---|---|
+| Cushions / beanbags | small burnout resistance | morale | beanbag, floor cushions | 1 |
+| Break couch | rest spot; slow burnout recovery | morale | couch (HAVE) | S/D |
+| Standing desks | tiny productivity, "we care" signal | morale/prestige | standing desk | D/M |
+| Nap pod | strong burnout recovery | morale | sleek nap pod | M |
+| Rug / soft-furnishing | ambient cosiness (low-doom register) | flavour | rug | S/D |
+| Potted plants | ambient morale | morale | plant (HAVE) + variants | 1 |
+
+### Kitchen / social (morale; the conspicuous-status axis)
+| upgrade | hook | feeds | art asset | tiers |
+|---|---|---|---|---|
+| Coffee -> espresso -> full cafe bar | escalating morale + a status flex | morale/prestige | drip (HAVE) / espresso (HAVE) / **cafe bar** | S/D/M |
+| Fridge | morale | fridge (HAVE) | S/D |
+| Snack shelf / free food | morale, mild money drain | morale | snack shelf | D |
+| Kitchen bench | enables the above | (host slot) | bench (re-rolling) | S/D |
+
+### Compute (feed compute appetite; enable/scale research)
+| upgrade | hook | feeds | art asset | tiers |
+|---|---|---|---|---|
+| Server rack -> cluster -> exotic | +compute capacity | compute | rack (HAVE) / cluster (re-rolling) / **quantum/exotic rig** | S/D/M |
+| GPU wall | big compute, big power draw | compute | glowing GPU wall | M |
+| Cooling / server cage | compute uptime; mild security | compute/security | AC unit, caged rack | D/M |
+
+### Prestige / status (feed prestige appetite; reputation)
+| upgrade | hook | feeds | art asset | tiers |
+|---|---|---|---|---|
+| Trophy / awards shelf | reputation, recruiting pull | prestige | trophy shelf, framed awards | D/M |
+| Framed published papers | prestige for first-authors | prestige-first-author | framed-paper wall | D/M |
+| Conspicuously fancy espresso | pure flex (Pip's example) | prestige | chrome espresso (HAVE) / **gold-plated** | M |
+| Reception / lobby | reputation; visitor events | prestige | reception desk, logo wall | M |
+| Branded wall art / logo | identity | flavour | logo sign | D/M |
+
+### Research / productivity
+| upgrade | hook | feeds | art asset | tiers |
+|---|---|---|---|---|
+| Whiteboards | +research legibility | mentees | whiteboard (HAVE) | 1 |
+| Bookshelf / library | slow skill growth | mentees | bookshelf (HAVE) | S/D |
+| Extra monitors | per-desk productivity | -- | monitor (HAVE) tiers | S/D/M |
+| Meeting room / war room | unlocks team actions | -- | meeting table (re-rolling) | D/M |
+
+### Security / safety (doom mitigation; DQ-24 tech-infra)
+| upgrade | hook | feeds | art asset | tiers |
+|---|---|---|---|---|
+| Air-gap / red-team corner | doom reduction | mission-purity | isolated terminal | D/M |
+| Monitoring wall | early-warning on incidents | security | wall of status screens | M |
+| Server security cage | leak resistance (vs Loose Lips quirk) | security | caged rack | D/M |
+
+### Ambient / doom-flavour (mostly signal, not stats)
+| upgrade | hook | feeds | art asset | tiers |
+|---|---|---|---|---|
+| Cat furniture | the cat likes it (Cat Whisperer quirk) | flavour | bed (HAVE), box (HAVE) | 1 |
+| Emergency lighting | reads at high doom | flavour | red strobe, exit sign | doom 2+ |
+| The rune wall / shrine | eldritch flavour at high doom | flavour | glowing rune wall (Bayes runes) | doom 3+ |
+
+## How it plugs into the art pipeline
+- Everything marked HAVE is generated. Everything else is a **prompt for a future sweep** -- mostly
+  clean objects (warm-grime-heft, palette-locked, era-tiered), which is exactly what the current
+  pipeline does well.
+- The doom-flavour items pull their glow hues from the doom-intensity spec (rune wall = violet/
+  eldritch band; emergency lighting = red/catastrophe band).
+
+## For Pip / the mechanics review
+- Is an upgrade a one-off purchase, or does it occupy a limited slot count (forcing choices)?
+- Do upgrades tie to appetites strongly enough to matter in hiring/retention? (I think yes -- it
+  makes the office a retention tool.)
+- Which come as era-tiers vs one-shot? (Compute/comfort/kitchen scale well; trophies are one-shot.)

--- a/tools/art_review/palette.html
+++ b/tools/art_review/palette.html
@@ -42,11 +42,15 @@
   <p class="note">Green = computers doing things correctly; blue = acting up / arcing; purple = crossed into ELDRITCH (endgame only). Purple is expensive -- reserve it.</p>
 </div>
 <script>
-  const grounds=[["Void","#0E0614"],["Deep aubergine","#170A1C"],["Ink brown","#14040C"],["Steel","#1C2730"],["Graphite","#0E1318"]];
-  const warm=[["Warm panel","#2B221A"],["Warm line","#3A2E22"],["Cozy amber","#E8A33D"],["Amber token","#F6A800"]];
-  const neutral=[["Chrome/slate","#6B7C8C"],["Off-white","#E9F2F2"],["Teal action","#1EC3B3"],["Teal hover","#0FA5A0"]];
-  const axisA=[["cosy","#F6A800"],["uneasy","#E9752E"],["alarmed","#E24A3B"],["critical","#B31217"],["fire","#DD5F4C"]];
-  const axisB=[["ok","#3F8A5C"],["ok deep","#234C34"],["acting up","#354375"],["arcing","#5C7AC3"],["eldritch","#504673"],["ELDRITCH","#7A3B8F"]];
+  // ~doubled -- more real hero-bg samples per family for eyedropping/tuning
+  const grounds=[["Void","#0E0614"],["Deep aubergine","#170A1C"],["Ink brown","#14040C"],["Steel","#1C2730"],["Graphite","#0E1318"],
+    ["Night blue","#18112A"],["Deep indigo","#181735"],["Blue-black","#0D0B23"],["Violet-black","#150718"],["Pitch","#0B020C"]];
+  const warm=[["Warm panel","#2B221A"],["Warm line","#3A2E22"],["Cozy amber","#E8A33D"],["Amber token","#F6A800"],
+    ["Ember red","#C53A28"],["Brick","#932928"],["Wine","#521824"],["Rose flesh","#DA9997"],["Salmon","#CD7984"],["Warm off-white","#F5DFCE"]];
+  const neutral=[["Chrome/slate","#6B7C8C"],["Off-white","#E9F2F2"],["Teal action","#1EC3B3"],["Teal hover","#0FA5A0"],
+    ["Warm grey","#5B5048"],["Cool grey","#4A5560"],["Olive","#668E4F"],["Pale olive","#A7C270"]];
+  const axisA=[["cosy","#F6A800"],["warming","#F0891F"],["uneasy","#E9752E"],["alarmed","#E24A3B"],["critical","#B31217"],["ember","#DD5F4C"],["fire","#F69168"]];
+  const axisB=[["ok deep","#234C34"],["ok","#3F8A5C"],["ok bright","#668E4F"],["cool","#334A89"],["acting up","#354375"],["arcing","#5C7AC3"],["arc bright","#8EA8EA"],["weird","#504673"],["eldritch","#7A3B8F"],["eldritch pale","#96718F"]];
   function chips(id,arr){document.getElementById(id).innerHTML=arr.map(([n,h])=>
     `<div class="sw"><div class="chip" style="background:${h}"></div><div class="meta"><div class="nm">${n}</div><div class="hx">${h}</div></div></div>`).join("");}
   function lad(id,arr){document.getElementById(id).innerHTML=arr.map(([n,h])=>`<div style="background:${h}">${n}<br>${h}</div>`).join("");}

--- a/tools/ui_mockup/wireframe.html
+++ b/tools/ui_mockup/wireframe.html
@@ -99,6 +99,11 @@
       <div class="token worker" style="top:200px;left:250px">worker</div>
       <div class="token prop" style="top:130px;left:210px;width:40px;height:30px">desk</div>
       <div class="token prop" style="top:230px;left:120px;width:38px;height:28px">server</div>
+      <!-- 8: upgrade slots -- pencilled zones the player fills over time -->
+      <div class="token" style="bottom:14px;left:16px;width:96px;height:54px;border-style:dashed;border-color:var(--faint);color:var(--faint)">+ comfort<br>(cushions, beanbags)</div>
+      <div class="token" style="bottom:14px;left:124px;width:96px;height:54px;border-style:dashed;border-color:var(--amber);color:var(--amber)">+ kitchen /<br>morale (espresso)</div>
+      <div class="token" style="bottom:80px;right:14px;width:84px;height:58px;border-style:dashed;border-color:var(--compute);color:var(--compute)">+ compute<br>wall</div>
+      <div class="token" style="top:150px;left:250px;width:60px;height:40px;border-style:dashed;border-color:var(--faint);color:var(--faint)">empty desk<br>(fills on hire)</div>
     </div>
 
     <!-- side tabs + panel -->
@@ -131,6 +136,7 @@
     <div class="co"><h3><span class="n">5</span> Tabbed side panel</h3><p>One column, three jobs: Team/Candidates, Event Feed, Doom Barometer. Tabs keep it dense without a wall of panels. Framed with the UI panel-frame art.</p></div>
     <div class="co"><h3><span class="n">6</span> Doom trend graph</h3><p>Lower side panel -- a small area chart. Turns an empty panel into information + motion.</p></div>
     <div class="co"><h3><span class="n">7</span> Grouped action dock</h3><p>Actions along the bottom with icons + labels, grouped by type. Replaces a scattered button soup and anchors the bottom edge.</p></div>
+    <div class="co"><h3><span class="n">8</span> Upgrade slots (fill over time)</h3><p>Dashed zones = where the <b>upgrades system</b> drops assets as the player buys them: a comfort corner (cushions/beanbags), a kitchen/morale bar (espresso), a compute wall, empty desks that fill as you hire. The office visibly grows and gets fancier -- every upgrade is a new sprite in a reserved slot. See <b>docs/game-design/UPGRADES_ASSET_BRAINSTORM.md</b>.</p></div>
   </div>
 
   <p class="legend">// wireframe only -- boxes are placeholders for real sprites/panels. Everything here is rearrangeable. React freely.</p>


### PR DESCRIPTION
Doubled palette swatches (real hero samples), pencilled upgrade slots into the wireframe, and an upgrades-that-need-art brainstorm (doubles as a generation target list). 🤖 Generated with [Claude Code](https://claude.com/claude-code)