### PR TITLE
feat(leaderboard): remote score sync client (PHP score API)

### DIFF
--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -27,6 +27,11 @@ var fullscreen: bool = false
 # Accessibility Settings
 var colorblind_mode: bool = false  # Adds patterns/symbols alongside colors
 
+# Leaderboard Settings
+# Opt-out for uploading scores to the global leaderboard (LeaderboardSync).
+# Default ON for alpha; players who flip it off keep local scores only.
+var submit_scores_global: bool = true
+
 # Game State
 var current_game_active: bool = false
 var games_played: int = 0
@@ -89,6 +94,9 @@ func save_config() -> void:
 	# Accessibility section
 	config.set_value("accessibility", "colorblind_mode", colorblind_mode)
 
+	# Leaderboard section
+	config.set_value("leaderboard", "submit_scores_global", submit_scores_global)
+
 	# Save to file
 	var err = config.save(CONFIG_FILE)
 	if err != OK:
@@ -131,6 +139,9 @@ func load_config() -> void:
 
 	# Load accessibility settings
 	colorblind_mode = config.get_value("accessibility", "colorblind_mode", colorblind_mode)
+
+	# Load leaderboard settings
+	submit_scores_global = config.get_value("leaderboard", "submit_scores_global", submit_scores_global)
 
 	print("[GameConfig] Configuration loaded successfully")
 	config_loaded.emit()
@@ -199,6 +210,8 @@ func set_setting(key: String, value, save_immediately: bool = false) -> void:
 			apply_graphics_settings()
 		"colorblind_mode":
 			colorblind_mode = value
+		"submit_scores_global":
+			submit_scores_global = value
 		"baseline_mode":
 			baseline_mode = value
 		_:

--- a/godot/autoload/leaderboard_sync.gd
+++ b/godot/autoload/leaderboard_sync.gd
@@ -1,0 +1,228 @@
+extends Node
+## LeaderboardSync -- client side of the settled PHP score API
+## (docs/strategy/BACKEND_AND_DATA_ARCHITECTURE.md, server/leaderboard/score_api.php).
+##
+## Registered as an autoload singleton. Provides:
+##   submit_score(entry, seed, version)          -> fire-and-forget POST, emits submit_completed
+##   fetch_board(seed, version, limit, callback) -> async GET, invokes callback(ok, entries)
+##
+## DETERMINISM / REPLAY IS SACRED (ADR-0006). Everything here is a pure view/side-effect
+## invoked ONLY from game-over + the leaderboard screen (both UI). It never touches the
+## simulation, the seeded RNG, turn logic, or replay, and must never be called from any
+## deterministic code path. It also never blocks and never crashes on network failure:
+## all HTTP is async with a timeout; unreachable/unconfigured/malformed -> quiet no-op.
+##
+## No `class_name` on purpose: this is registered as the `LeaderboardSync` autoload, and a
+## matching class_name would collide with the singleton. Callers use the autoload directly
+## (LeaderboardSync.x); tests load the script and call the static helpers.
+
+## Emitted when a submit_score POST resolves (or fails). Fire-and-forget: the caller
+## may connect for a status blip but must not depend on it arriving.
+##   success: reached the server AND it accepted the entry (HTTP 200, ok=true)
+##   added:   the entry landed on the board (server "added"; false for a duplicate)
+##   rank:    1-based rank on the board (0 if unknown)
+##   message: short human-readable status for a non-blocking UI blip
+signal submit_completed(success: bool, added: bool, rank: int, message: String)
+
+const CONFIG_PATH := "res://data/leaderboard_config.json"
+const ENDPOINT_FILE := "score_api.php"
+const REQUEST_TIMEOUT_SEC := 8.0
+const PLACEHOLDER_TOKEN := "CHANGE_ME_set_a_long_random_token"
+
+# Loaded from CONFIG_PATH at _ready. Public so tests can set them directly.
+var enabled: bool = false
+var base_url: String = ""
+var token: String = ""
+
+func _ready() -> void:
+	_load_config()
+
+func _load_config() -> void:
+	if not FileAccess.file_exists(CONFIG_PATH):
+		# Missing config -> stay disabled. Unconfigured builds never error.
+		print("[LeaderboardSync] No config at %s; remote sync disabled." % CONFIG_PATH)
+		return
+	var file := FileAccess.open(CONFIG_PATH, FileAccess.READ)
+	if file == null:
+		return
+	var text := file.get_as_text()
+	file.close()
+	var json := JSON.new()
+	if json.parse(text) != OK or typeof(json.data) != TYPE_DICTIONARY:
+		push_warning("[LeaderboardSync] Malformed config; remote sync disabled.")
+		return
+	var data: Dictionary = json.data
+	enabled = bool(data.get("enabled", false))
+	base_url = str(data.get("base_url", ""))
+	token = str(data.get("token", ""))
+	print("[LeaderboardSync] Config loaded. enabled=%s configured=%s" % [enabled, is_configured()])
+
+## True when the config points somewhere plausible (non-empty url + token).
+## Intentionally light: `enabled` is the real master switch and defaults false.
+func is_configured() -> bool:
+	return base_url.strip_edges() != "" and token.strip_edges() != ""
+
+## Master gate for fetching the global board (read-only; not gated by the opt-out).
+func can_fetch() -> bool:
+	return enabled and is_configured()
+
+## Gate for uploading a score: enabled + configured + the player has NOT opted out.
+## The opt-out lives on GameConfig (default ON for alpha).
+func should_submit() -> bool:
+	if not (enabled and is_configured()):
+		return false
+	# Defensive: if GameConfig isn't present (isolated unit test), treat as opted-in.
+	if typeof(GameConfig) == TYPE_OBJECT and "submit_scores_global" in GameConfig:
+		return bool(GameConfig.submit_scores_global)
+	return true
+
+# --------------------------------------------------------------------------
+# Pure helpers (no HTTP, no state) -- this is where the contract bugs hide,
+# so these are unit-tested directly.
+# --------------------------------------------------------------------------
+
+## Full endpoint URL from the configured base. endpoint = base + "/score_api.php".
+static func build_endpoint(p_base_url: String) -> String:
+	var b := p_base_url.strip_edges()
+	while b.ends_with("/"):
+		b = b.substr(0, b.length() - 1)
+	return "%s/%s" % [b, ENDPOINT_FILE]
+
+## POST body = the ScoreEntry dict PLUS seed + version (game_version), per the frozen
+## contract. entry_dict is exactly Leaderboard.ScoreEntry.to_dict().
+static func build_post_body(entry_dict: Dictionary, seed: String, version: String) -> Dictionary:
+	var body := entry_dict.duplicate(true)
+	body["seed"] = seed
+	body["version"] = version
+	return body
+
+## GET url for a board: <base>/score_api.php?seed=&version=&limit=
+static func build_get_url(p_base_url: String, seed: String, version: String, limit: int) -> String:
+	var n: int = max(1, limit)
+	return "%s?seed=%s&version=%s&limit=%d" % [
+		build_endpoint(p_base_url),
+		seed.uri_encode(),
+		version.uri_encode(),
+		n,
+	]
+
+## Parse a POST response body -> { ok, added, rank, duplicate }.
+## Any malformed/error body degrades to ok=false without throwing.
+static func parse_submit_response(body: String) -> Dictionary:
+	var out := {"ok": false, "added": false, "rank": 0, "duplicate": false}
+	var json := JSON.new()
+	if json.parse(body) != OK or typeof(json.data) != TYPE_DICTIONARY:
+		return out
+	var data: Dictionary = json.data
+	out["ok"] = bool(data.get("ok", false))
+	out["added"] = bool(data.get("added", false))
+	out["rank"] = int(data.get("rank", 0))
+	out["duplicate"] = bool(data.get("duplicate", false))
+	return out
+
+## Parse a GET response body -> { ok, entries }, where entries is an Array of
+## Leaderboard.ScoreEntry objects (the exact shape leaderboard_screen renders).
+## Malformed/error body -> { ok=false, entries=[] } with no throw.
+static func parse_board_entries(body: String) -> Dictionary:
+	var out := {"ok": false, "entries": []}
+	var json := JSON.new()
+	if json.parse(body) != OK or typeof(json.data) != TYPE_DICTIONARY:
+		return out
+	var data: Dictionary = json.data
+	if not bool(data.get("ok", false)):
+		return out
+	var raw = data.get("entries", [])
+	if typeof(raw) != TYPE_ARRAY:
+		return out
+	var entries: Array = []
+	for item in raw:
+		if typeof(item) == TYPE_DICTIONARY:
+			entries.append(Leaderboard.ScoreEntry.from_dict(item))
+	out["ok"] = true
+	out["entries"] = entries
+	return out
+
+# --------------------------------------------------------------------------
+# Async HTTP (fire-and-forget). Each call spins up its own HTTPRequest child so
+# concurrent submit + fetch don't collide, and frees it on completion.
+# --------------------------------------------------------------------------
+
+## Fire-and-forget upload. No-op (emits an "off" status) when not submitting.
+func submit_score(entry, seed: String, version: String) -> void:
+	if not should_submit():
+		# Disabled / unconfigured / opted-out -> pure no-op, no HTTP.
+		submit_completed.emit(false, false, 0, "")
+		return
+	if entry == null or not entry.has_method("to_dict"):
+		submit_completed.emit(false, false, 0, "")
+		return
+
+	var url := build_endpoint(base_url)
+	var headers := [
+		"Content-Type: application/json",
+		"X-PDoom-Token: %s" % token,
+	]
+	var payload := JSON.stringify(build_post_body(entry.to_dict(), seed, version))
+
+	var http := _new_request()
+	http.request_completed.connect(
+		func(result: int, code: int, _headers: PackedStringArray, resp_body: PackedByteArray):
+			var msg := ""
+			var ok := false
+			var added := false
+			var rank := 0
+			if result == HTTPRequest.RESULT_SUCCESS and code == 200:
+				var parsed := parse_submit_response(resp_body.get_string_from_utf8())
+				ok = parsed["ok"]
+				added = parsed["added"]
+				rank = parsed["rank"]
+				if ok:
+					if rank > 0:
+						msg = "submitted (rank %d)" % rank
+					else:
+						msg = "submitted"
+				else:
+					msg = "offline -- saved locally"
+			else:
+				msg = "offline -- saved locally"
+			submit_completed.emit(ok, added, rank, msg)
+			http.queue_free()
+	)
+	var err := http.request(url, headers, HTTPClient.METHOD_POST, payload)
+	if err != OK:
+		http.queue_free()
+		submit_completed.emit(false, false, 0, "offline -- saved locally")
+
+## Async board fetch. Invokes callback(ok: bool, entries: Array[ScoreEntry]).
+## On any failure -> callback(false, []) so callers fall back to local silently.
+func fetch_board(seed: String, version: String, limit: int, callback: Callable) -> void:
+	if not can_fetch():
+		if callback.is_valid():
+			callback.call(false, [])
+		return
+
+	var url := build_get_url(base_url, seed, version, limit)
+	var http := _new_request()
+	http.request_completed.connect(
+		func(result: int, code: int, _headers: PackedStringArray, resp_body: PackedByteArray):
+			var ok := false
+			var entries: Array = []
+			if result == HTTPRequest.RESULT_SUCCESS and code == 200:
+				var parsed := parse_board_entries(resp_body.get_string_from_utf8())
+				ok = parsed["ok"]
+				entries = parsed["entries"]
+			if callback.is_valid():
+				callback.call(ok, entries)
+			http.queue_free()
+	)
+	var err := http.request(url, [], HTTPClient.METHOD_GET)
+	if err != OK:
+		http.queue_free()
+		if callback.is_valid():
+			callback.call(false, [])
+
+func _new_request() -> HTTPRequest:
+	var http := HTTPRequest.new()
+	http.timeout = REQUEST_TIMEOUT_SEC
+	add_child(http)
+	return http

--- a/godot/data/leaderboard_config.json
+++ b/godot/data/leaderboard_config.json
@@ -1,0 +1,6 @@
+{
+	"_comment": "Remote leaderboard sync config (client side of the PHP score API). Pip: set base_url + token to the real values, then flip enabled to true, BEFORE producing the alpha build. Default enabled=false + placeholder host so an unconfigured build NEVER touches the network and NEVER errors. The token is a low-value shared secret (X-PDoom-Token) -- acceptable to ship for alpha. endpoint = base_url + '/score_api.php'.",
+	"enabled": false,
+	"base_url": "https://api.example.invalid",
+	"token": "CHANGE_ME_set_a_long_random_token"
+}

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -19,6 +19,7 @@ config/features=PackedStringArray("4.5")
 
 ErrorHandler="*res://autoload/error_handler.gd"
 GameConfig="*res://autoload/game_config.gd"
+LeaderboardSync="*res://autoload/leaderboard_sync.gd"
 Balance="*res://autoload/balance.gd"
 SceneTransition="*res://autoload/scene_transition.gd"
 ThemeManager="*res://autoload/theme_manager.gd"

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -15,6 +15,7 @@ var baseline_doom_integral: int = 0
 var baseline_result: Dictionary = {}
 var leaderboard_entry_uuid: String = ""
 var game_start_time: float = 0.0
+var sync_status_label: Label = null  # Tiny non-blocking remote-sync status blip
 
 func _ready():
 	# Initially hidden
@@ -110,6 +111,11 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 
 	# Store entry UUID globally for leaderboard highlighting
 	GameConfig.latest_leaderboard_entry = leaderboard_entry_uuid
+
+	# Remote leaderboard sync (ADR-0006: pure view side-effect, off the deterministic
+	# path). Fire-and-forget; the local save above already succeeded, so a network
+	# failure just leaves the score local. Only runs when enabled+configured+opted-in.
+	_maybe_submit_remote(entry, game_seed)
 
 	# Set title and colors based on outcome
 	if is_victory:
@@ -211,6 +217,38 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 	stats_text += "[center][color=gold][b]⏎ Press ENTER for Leaderboard[/b][/color][/center]"
 
 	stats_label.text = stats_text
+
+func _maybe_submit_remote(entry, game_seed: String) -> void:
+	"""Upload the just-saved score to the global board, if sync is on. Never blocks;
+	shows a tiny status blip that resolves async via submit_completed."""
+	if not LeaderboardSync.should_submit():
+		return
+	_ensure_sync_status_label()
+	sync_status_label.visible = true
+	sync_status_label.text = "Global leaderboard: submitting..."
+	sync_status_label.add_theme_color_override("font_color", Color(0.7, 0.8, 0.9))
+	if not LeaderboardSync.submit_completed.is_connected(_on_sync_submit_completed):
+		LeaderboardSync.submit_completed.connect(_on_sync_submit_completed)
+	LeaderboardSync.submit_score(entry, game_seed, "v" + GameConfig.CURRENT_VERSION)
+
+func _on_sync_submit_completed(success: bool, _added: bool, _rank: int, message: String) -> void:
+	"""Resolve the status blip. Failure is silent-ish: score is already saved locally."""
+	if not is_instance_valid(sync_status_label):
+		return
+	if message == "":
+		message = "saved locally"
+	sync_status_label.text = "Global leaderboard: %s" % message
+	var col := Color(0.6, 1.0, 0.6) if success else Color(0.85, 0.8, 0.55)
+	sync_status_label.add_theme_color_override("font_color", col)
+
+func _ensure_sync_status_label() -> void:
+	if is_instance_valid(sync_status_label):
+		return
+	sync_status_label = Label.new()
+	sync_status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	sync_status_label.add_theme_font_size_override("font_size", 12)
+	var parent: Node = stats_label.get_parent() if stats_label else self
+	parent.add_child(sync_status_label)
 
 func _get_doom_display_color(doom: float) -> String:
 	"""BBCode colour for the final-doom stat — ThemeManager's doom ramp, stroke variant

--- a/godot/scripts/ui/leaderboard_screen.gd
+++ b/godot/scripts/ui/leaderboard_screen.gd
@@ -9,6 +9,11 @@ var all_leaderboards: Dictionary = {}  # seed -> Leaderboard
 var all_entries: Array = []  # All entries across all seeds
 var filtered_entries: Array = []  # Current filtered/sorted view
 
+# Remote/global board (LeaderboardSync). Pure view: fetched async, never on a
+# deterministic path. Falls back to local silently on any failure.
+var showing_global: bool = false
+var global_toggle_button: Button = null
+
 # UI References
 @onready var seed_dropdown = $MarginContainer/VBoxContainer/Filters/SeedDropdown
 @onready var entries_container = $MarginContainer/VBoxContainer/LeaderboardPanel/MarginContainer/VBoxContainer/ScrollContainer/EntriesContainer
@@ -24,7 +29,59 @@ func _ready():
 	ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Leaderboard screen opened", {})
 	_load_all_leaderboards()
 	_populate_seed_dropdown()
+	_setup_global_toggle()
 	_filter_and_display()
+
+func _setup_global_toggle():
+	"""Add a Local/Global view toggle next to the seed filter, but only when remote
+	sync is enabled+configured. When off/unconfigured the screen stays local-only."""
+	if not LeaderboardSync.can_fetch():
+		return
+	if not is_instance_valid(seed_dropdown):
+		return
+	var container = seed_dropdown.get_parent()
+	if container == null:
+		return
+	global_toggle_button = Button.new()
+	global_toggle_button.toggle_mode = true
+	global_toggle_button.text = "View: Local"
+	global_toggle_button.tooltip_text = "Toggle between your local scores and the global (online) board for this seed"
+	global_toggle_button.toggled.connect(_on_global_toggle)
+	container.add_child(global_toggle_button)
+
+func _on_global_toggle(pressed: bool):
+	showing_global = pressed
+	if pressed:
+		global_toggle_button.text = "View: Global"
+		_fetch_and_show_global()
+	else:
+		global_toggle_button.text = "View: Local"
+		_filter_and_display()
+
+func _fetch_and_show_global():
+	"""Async-fetch the global board for the CURRENT (seed, version) and show it."""
+	var board_seed = GameConfig.get_display_seed()
+	var version = "v" + GameConfig.CURRENT_VERSION
+	subtitle.text = "Global board: fetching %s ..." % board_seed
+	LeaderboardSync.fetch_board(board_seed, version, 100, _on_global_board_fetched)
+
+func _on_global_board_fetched(ok: bool, entries: Array):
+	"""Render the global board, or fall back to local silently on failure."""
+	if not showing_global:
+		return  # User toggled back to Local before the request resolved.
+	if not ok:
+		showing_global = false
+		if is_instance_valid(global_toggle_button):
+			global_toggle_button.set_pressed_no_signal(false)
+			global_toggle_button.text = "View: Local"
+		_filter_and_display()  # Silent local fallback.
+		return
+	filtered_entries = entries.duplicate()
+	current_page = 1
+	subtitle.text = "Global board: %s (v%s)" % [GameConfig.get_display_seed(), GameConfig.CURRENT_VERSION]
+	_display_current_page()
+	_update_pagination_ui()
+	_update_stats()
 
 func _load_all_leaderboards():
 	"""Load all leaderboard files from user directory"""
@@ -109,7 +166,13 @@ func _populate_seed_dropdown():
 	seed_dropdown.select(0)
 
 func _filter_and_display():
-	"""Filter entries based on current seed and display current page"""
+	"""Filter entries based on current seed and display current page (LOCAL view)."""
+	# Any local filter action returns us to the local board.
+	showing_global = false
+	if is_instance_valid(global_toggle_button):
+		global_toggle_button.set_pressed_no_signal(false)
+		global_toggle_button.text = "View: Local"
+
 	# Filter by seed
 	if current_seed == "all":
 		filtered_entries = all_entries.duplicate()

--- a/godot/scripts/ui/settings_menu.gd
+++ b/godot/scripts/ui/settings_menu.gd
@@ -14,6 +14,9 @@ extends Control
 @onready var theme_dropdown = $VBox/SettingsContainer/UISettings/ThemeRow/ThemeDropdown
 @onready var colorblind_checkbox = $VBox/SettingsContainer/AccessibilitySettings/ColorblindRow/CheckBox
 
+# Built programmatically (no .tscn row): global-leaderboard opt-out (default ON).
+var global_leaderboard_checkbox: CheckButton = null
+
 # Section header labels for icon integration
 @onready var audio_label = $VBox/SettingsContainer/AudioSettings/AudioLabel
 @onready var graphics_label = $VBox/SettingsContainer/GraphicsSettings/GraphicsLabel
@@ -30,6 +33,9 @@ func _ready():
 
 	# Add icons to section headers
 	_setup_section_icons()
+
+	# Add the global-leaderboard opt-out under Gameplay (built in code, not the .tscn)
+	_add_global_leaderboard_toggle()
 
 	# Connect theme dropdown
 	theme_dropdown.item_selected.connect(_on_theme_changed)
@@ -131,6 +137,29 @@ func _on_difficulty_changed(index: int):
 	"""Handle difficulty dropdown change"""
 	print("[SettingsMenu] Difficulty changed to: ", ["Easy", "Standard", "Hard"][index])
 	GameConfig.set_setting("difficulty", index, false)
+
+func _add_global_leaderboard_toggle():
+	"""Append a 'Submit Scores to Global Leaderboard' toggle to the Gameplay section.
+	Respects the player's choice (LeaderboardSync.should_submit reads this). Default ON."""
+	var gameplay = get_node_or_null("VBox/SettingsContainer/GameplaySettings")
+	if gameplay == null:
+		return
+	var row = HBoxContainer.new()
+	var label = Label.new()
+	label.text = "Submit Scores to Global Leaderboard"
+	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(label)
+	global_leaderboard_checkbox = CheckButton.new()
+	global_leaderboard_checkbox.button_pressed = GameConfig.submit_scores_global
+	global_leaderboard_checkbox.toggled.connect(_on_global_leaderboard_toggled)
+	row.add_child(global_leaderboard_checkbox)
+	gameplay.add_child(row)
+
+func _on_global_leaderboard_toggled(pressed: bool):
+	"""Handle global-leaderboard opt-out toggle"""
+	print("[SettingsMenu] Submit scores to global leaderboard: ", pressed)
+	GameConfig.set_setting("submit_scores_global", pressed, false)
+	NotificationManager.info("Global leaderboard submission " + ("enabled" if pressed else "disabled"))
 
 func _on_colorblind_toggled(pressed: bool):
 	"""Handle colorblind mode toggle"""

--- a/godot/tests/unit/test_leaderboard_sync.gd
+++ b/godot/tests/unit/test_leaderboard_sync.gd
@@ -1,0 +1,167 @@
+extends GutTest
+## Client-side tests for LeaderboardSync (the PHP score API client).
+## We can't exercise live HTTP in GUT, so we test the parts where the frozen-contract
+## bugs actually hide: building the POST body / GET url, parsing responses, and the
+## enabled/opt-out gating (the no-op path). See docs/strategy/BACKEND_AND_DATA_ARCHITECTURE.md.
+
+var SyncScript = load("res://autoload/leaderboard_sync.gd")
+
+
+func _make_entry() -> Leaderboard.ScoreEntry:
+	# score, player_name, level, mode, duration, baseline, doom_integral, baseline_integral
+	return Leaderboard.ScoreEntry.new(42, "Contoso Safety Lab", 42, "v0.11.0", 12.5, 30, 777, 100)
+
+
+# ---- build_post_body: exactly a ScoreEntry dict + seed + version --------------
+
+func test_build_post_body_matches_contract():
+	var entry := _make_entry()
+	var body: Dictionary = SyncScript.build_post_body(entry.to_dict(), "weekly-2026-w7", "v0.11.0")
+
+	# The two contract-mandated extra fields.
+	assert_has(body, "seed", "POST body must carry seed")
+	assert_has(body, "version", "POST body must carry version (game_version)")
+	assert_eq(body["seed"], "weekly-2026-w7")
+	assert_eq(body["version"], "v0.11.0")
+
+	# Every whitelisted ScoreEntry field must survive unchanged.
+	for f in ["score", "doom_integral", "player_name", "date", "level_reached",
+			"game_mode", "duration_seconds", "entry_uuid", "baseline_score",
+			"baseline_doom_integral"]:
+		assert_has(body, f, "POST body missing whitelisted field: %s" % f)
+	assert_eq(body["score"], 42)
+	assert_eq(body["doom_integral"], 777)
+	assert_eq(body["player_name"], "Contoso Safety Lab")
+	assert_eq(body["baseline_score"], 30)
+
+
+func test_build_post_body_does_not_mutate_source():
+	var entry := _make_entry()
+	var src := entry.to_dict()
+	SyncScript.build_post_body(src, "s", "v")
+	assert_false(src.has("seed"), "build_post_body must not mutate the caller's dict")
+
+
+# ---- endpoint + GET url -------------------------------------------------------
+
+func test_build_endpoint_appends_score_api():
+	assert_eq(SyncScript.build_endpoint("https://api.pdoom1.com"), "https://api.pdoom1.com/score_api.php")
+
+func test_build_endpoint_strips_trailing_slashes():
+	assert_eq(SyncScript.build_endpoint("https://api.pdoom1.com/"), "https://api.pdoom1.com/score_api.php")
+	assert_eq(SyncScript.build_endpoint("https://api.pdoom1.com///"), "https://api.pdoom1.com/score_api.php")
+
+func test_build_get_url_encodes_and_limits():
+	var url: String = SyncScript.build_get_url("https://api.pdoom1.com", "weekly 2026/w7", "v0.11.0", 20)
+	assert_true(url.begins_with("https://api.pdoom1.com/score_api.php?"), "GET hits the endpoint")
+	assert_true(url.contains("limit=20"), "GET carries limit")
+	assert_true(url.contains("version=v0.11.0"), "GET carries version")
+	# space and slash must be percent-encoded, not raw.
+	assert_false(url.contains("weekly 2026/w7"), "seed must be uri-encoded")
+	assert_true(url.contains("seed=weekly"), "encoded seed present")
+
+func test_build_get_url_min_limit_is_one():
+	var url: String = SyncScript.build_get_url("https://x", "s", "v", 0)
+	assert_true(url.contains("limit=1"), "limit floored to 1")
+
+
+# ---- parse_submit_response ----------------------------------------------------
+
+func test_parse_submit_response_ok():
+	var r: Dictionary = SyncScript.parse_submit_response('{"ok":true,"added":true,"rank":3}')
+	assert_true(r["ok"])
+	assert_true(r["added"])
+	assert_eq(r["rank"], 3)
+
+func test_parse_submit_response_duplicate():
+	var r: Dictionary = SyncScript.parse_submit_response('{"ok":true,"added":false,"duplicate":true,"rank":5}')
+	assert_true(r["ok"])
+	assert_false(r["added"])
+	assert_true(r["duplicate"])
+	assert_eq(r["rank"], 5)
+
+func test_parse_submit_response_error_body():
+	var r: Dictionary = SyncScript.parse_submit_response('{"ok":false,"error":"bad token"}')
+	assert_false(r["ok"])
+	assert_eq(r["rank"], 0)
+
+func test_parse_submit_response_malformed_never_crashes():
+	for junk in ["", "not json", "[]", "null", "{"]:
+		var r: Dictionary = SyncScript.parse_submit_response(junk)
+		assert_false(r["ok"], "malformed submit body %s -> ok=false" % junk)
+
+
+# ---- parse_board_entries ------------------------------------------------------
+
+func test_parse_board_entries_ok():
+	var payload := '{"ok":true,"seed":"s","version":"v0.11.0","entries":[' + \
+		'{"score":99,"doom_integral":10,"player_name":"Alpha","baseline_score":40,"duration_seconds":8.0,"date":"2026-07-17T10:00:00","entry_uuid":"u1"},' + \
+		'{"score":88,"doom_integral":5,"player_name":"Beta","entry_uuid":"u2"}]}'
+	var r: Dictionary = SyncScript.parse_board_entries(payload)
+	assert_true(r["ok"])
+	var entries: Array = r["entries"]
+	assert_eq(entries.size(), 2, "both entries parsed")
+	# ScoreEntry-shaped: property access is what leaderboard_screen relies on.
+	assert_eq(entries[0].score, 99)
+	assert_eq(entries[0].player_name, "Alpha")
+	assert_eq(entries[0].baseline_score, 40)
+	assert_eq(entries[0].entry_uuid, "u1")
+	assert_eq(entries[1].score, 88)
+
+func test_parse_board_entries_error_ok_false():
+	var r: Dictionary = SyncScript.parse_board_entries('{"ok":false,"error":"whatever"}')
+	assert_false(r["ok"])
+	assert_eq((r["entries"] as Array).size(), 0)
+
+func test_parse_board_entries_malformed_never_crashes():
+	for junk in ["", "garbage", "{}", '{"ok":true}', '{"ok":true,"entries":"nope"}']:
+		var r: Dictionary = SyncScript.parse_board_entries(junk)
+		assert_eq((r["entries"] as Array).size(), 0, "malformed board %s -> no entries" % junk)
+
+
+# ---- gating: enabled=false is a no-op; opt-out respected ----------------------
+
+func _make_sync():
+	# NOT added to the tree -> _ready/HTTP never run; we drive the state directly.
+	var s = SyncScript.new()
+	return s
+
+func test_disabled_never_submits():
+	var s = _make_sync()
+	s.enabled = false
+	s.base_url = "https://api.pdoom1.com"
+	s.token = "realtoken"
+	assert_false(s.should_submit(), "enabled=false must be a hard no-op")
+	assert_false(s.can_fetch(), "enabled=false must not fetch either")
+
+func test_unconfigured_never_submits():
+	var s = _make_sync()
+	s.enabled = true
+	s.base_url = ""
+	s.token = ""
+	assert_false(s.is_configured(), "empty url/token is unconfigured")
+	assert_false(s.should_submit())
+	assert_false(s.can_fetch())
+
+func test_enabled_configured_optin_submits():
+	var prev = GameConfig.submit_scores_global
+	GameConfig.submit_scores_global = true
+	var s = _make_sync()
+	s.enabled = true
+	s.base_url = "https://api.pdoom1.com"
+	s.token = "realtoken"
+	assert_true(s.is_configured())
+	assert_true(s.can_fetch(), "enabled+configured can fetch the global board")
+	assert_true(s.should_submit(), "enabled+configured+opted-in submits")
+	GameConfig.submit_scores_global = prev
+
+func test_opt_out_blocks_submit_but_not_fetch():
+	var prev = GameConfig.submit_scores_global
+	GameConfig.submit_scores_global = false
+	var s = _make_sync()
+	s.enabled = true
+	s.base_url = "https://api.pdoom1.com"
+	s.token = "realtoken"
+	assert_false(s.should_submit(), "opt-out must block uploads")
+	assert_true(s.can_fetch(), "opt-out still lets you VIEW the global board")
+	GameConfig.submit_scores_global = prev


### PR DESCRIPTION
## What
Client side of the settled PHP score API (`docs/strategy/BACKEND_AND_DATA_ARCHITECTURE.md`, `server/leaderboard/score_api.php`). A downloaded build can now upload a run's score on game-over and view the global (online) board, keyed by **(seed, game_version)** per ADR-0002 #5.

## Files
- **`godot/autoload/leaderboard_sync.gd`** (new) -- `LeaderboardSync` autoload over Godot `HTTPRequest`:
  - `submit_score(entry, seed, version)` -> fire-and-forget POST, `submit_completed` signal.
  - `fetch_board(seed, version, limit, callback)` -> async GET, parsed into `ScoreEntry` objects.
  - Pure `static` helpers (`build_post_body` / `build_endpoint` / `build_get_url` / `parse_submit_response` / `parse_board_entries`) -- where the contract bugs hide; unit-tested.
- **`godot/data/leaderboard_config.json`** (new) -- committed config: `base_url`, `token`, `enabled`. **Default `enabled=false` + placeholder host** so an unconfigured build never touches the network and never errors. **Pip sets `base_url` + `token` here** (then flip `enabled` to `true`) before building.
- **`godot/project.godot`** -- registers the `LeaderboardSync` autoload.
- **`godot/scripts/ui/game_over_screen.gd`** -- after the existing local save, submits remotely when enabled+configured+opted-in; tiny non-blocking status blip: `submitting...` -> `submitted (rank N)` / `offline -- saved locally`.
- **`godot/scripts/ui/leaderboard_screen.gd`** -- Local/Global toggle (only shown when sync is configured); fetches the remote board for the current (seed, version); **falls back to local silently** on any failure.
- **`godot/autoload/game_config.gd`** -- `submit_scores_global` opt-out (default ON), persisted under `[leaderboard]`.
- **`godot/scripts/ui/settings_menu.gd`** -- "Submit Scores to Global Leaderboard" toggle.
- **`godot/tests/unit/test_leaderboard_sync.gd`** (new) -- POST-body build, GET-url encoding, response parsing (incl. malformed/error), and the enabled=false / opt-out no-op gating.

## Where Pip configures it
`godot/data/leaderboard_config.json`: set `base_url` (host base; endpoint = `<base>/score_api.php`) + `token` (the `X-PDoom-Token` shared secret), then set `enabled: true`.

## Determinism / replay is untouched (ADR-0006)
All network I/O is a **pure view side-effect** invoked ONLY from the game-over screen and the leaderboard screen (both UI). It never touches the simulation, the seeded RNG, turn logic, or replay, and is never called from any deterministic code path. Every HTTP call is async with an 8s timeout; unreachable/unconfigured/timeout/malformed -> the game plays normally, local leaderboard works, quiet status at most. Only the fields already in `ScoreEntry` (+ seed/version) go up; opt-out honored.

## Verification
- Fast gate: `run_godot_tests.py --quick --ci-mode --min-tests 300` -> **431 tests, 0 failures** (45/45 files, incl. the new test).
- Simulation/determinism tier: `--simulation` -> **93 tests, 0 failures** (proves determinism untouched).
- `godot --headless --path godot --import` -> clean (no parse errors).

Do NOT merge -- Pip reviews first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)