### PR TITLE
feat(audio): adaptive doom-band music -- spec + working prototype + catalogue + analysis template

### DIFF
--- a/docs/audio/MUSIC_DESIGN.md
+++ b/docs/audio/MUSIC_DESIGN.md
@@ -1,0 +1,140 @@
+# P(Doom)1 -- Music design spec (adaptive doom-band music)
+
+> Music is the AUDIO expression of the existing doom-intensity spec
+> (`docs/art/PALETTE_AND_DOOM_INTENSITY.md`). Same two axes, same five bands, same
+> "cozy competence sliding toward existential dread" arc. This document is the reference
+> for the musicians composing stems and for anyone touching
+> `godot/autoload/music_manager.gd`. Companion docs: `STEM_CATALOGUE.md` (what audio we
+> own today), `TRACK_ANALYSIS.md` (the taste reference method).
+
+## 1. The model in one paragraph
+
+Mick-Gordon / DOOM-style adaptive music: a small set of MUSIC TIERS (moods), each built
+from LAYERED STEMS that add/subtract as doom rises. The game's doom value (0-100) is
+read -- never written -- by the music system, quantized to the canonical doom bands, and
+mapped to a tier. Tier changes crossfade horizontally (mood shift); within a tier, stems
+stack vertically (intensity texture). Players should be able to close their eyes and
+know roughly where the doom meter sits.
+
+## 2. Axes -> music mapping
+
+The art spec defines two independent axes plus combined bands. Each gets a musical
+dimension:
+
+| Axis (art spec) | Visual expression | MUSICAL expression |
+|---|---|---|
+| A. Catastrophe (amber -> red -> fire) | glow sours, strobes, literal fire | RHYTHM: percussive density and drive. Cosy = sparse/ambient pulse; alarmed = insistent percussion; fire = a dedicated "things are on fire" layer (alarm-adjacent textures, driving low end) entering at high tiers only |
+| B. Weirdness (green -> blue -> violet) | clean -> glitchy -> eldritch glow | TIMBRE: clean/tonal instruments -> detuned, bit-crushed, glitch-stuttered -> dissonant clusters, wrong-scale intervals, reversed/smeared textures |
+| Doom bands (0-4) | which register the office renders in | WHICH LAYERS ARE LIVE + overall mood/key territory |
+
+Discipline rule, borrowed from the art spec's lighting rule ("at most ONE ambient +
+ONE weird glow source"): at most ONE rhythmic driver and ONE weird/timbral accent
+prominent at a time. Do not stack every layer at full volume even at terminal doom --
+terminal reads as oppressive SPACE plus the fire layer, not as maximum loudness.
+Purple is expensive; so is dissonance. Reserve overt eldritch harmony for tiers 3-4.
+
+## 3. Music tiers (the five bands, made audible)
+
+The game's canonical thresholds live in `ThemeManager.DOOM_STATUS_BANDS` (7 UI bands).
+Music collapses them onto the art spec's 5 doom-intensity bands:
+
+| Music tier | Name | UI bands (doom %) | Mood target | Rhythm (axis A) | Timbre (axis B) |
+|---|---|---|---|---|---|
+| M0 | cosy | NOMINAL (<15) | warm competence, focus | soft pulse or none | clean, tonal, warm (amber) |
+| M1 | uneasy | ELEVATED + HIGH (15-52) | something is off | pulse gains weight, occasional stumble | faint detune/flicker creeping in |
+| M2 | spooky | SEVERE + EXTREME (52-80) | shadows lengthen | insistent percussion, darker low end | glitch artifacts, blue-arcing synth |
+| M3 | eldritch | CATASTROPHIC (80-92) | it has gone wrong in a wrong way | percussion fractures/polyrhythm | dissonant, wrong-scale, violet |
+| M4 | terminal | TERMINAL (92+) | apocalyptic; the end is audible | FIRE layer in; driving or collapsed | full eldritch smear + alarms |
+
+Numbers come from `ThemeManager` at runtime -- the music system holds NO thresholds of
+its own, only the band->tier table `MUSIC_TIER_BY_BAND = [0,1,1,2,2,3,4]`. If Pip
+retunes the bands, music follows automatically.
+
+## 4. Layer/stem model (what the musicians compose)
+
+Each tier is a STEM GROUP played in sync. Target stems per tier (a tier may omit some):
+
+| Stem slot | Carries | Axis | Notes |
+|---|---|---|---|
+| BASE | harmony/bed, the mood itself | bands | always on within its tier; must loop seamlessly |
+| PULSE | percussion/rhythm | A (catastrophe) | density scales with tier; absent at M0 is fine |
+| WEIRD | timbral accent (detune/glitch/dissonance) | B (weirdness) | the "one weird glow" -- keep it a single identifiable voice |
+| FIRE | the things-are-on-fire topper | A, high end | ONLY M3/M4 (like purple in the palette: expensive) |
+
+Composition constraints so stems can be swapped/stacked mechanically:
+- Every stem in a tier: same tempo, same key (or deliberate fixed relationship), same
+  length or integer multiple, seamless loop, no reverb tails crossing the loop point
+  (bake tails into the loop musically or keep them short).
+- Adjacent tiers should share tempo or have a planned tempo relationship (e.g. M0-M2 at
+  one tempo, M3-M4 at another) so crossfades between tiers do not churn.
+- Deliver as separate files (wav or ogg preferred; mp3 acceptable), loudness roughly
+  matched (about -16 LUFS integrated per stem; final balance happens in-engine).
+- Names stay in the ML/AI-safety pun family (see `STEM_CATALOGUE.md`).
+
+## 5. Runtime architecture (what is built, Godot 4.5.1 native)
+
+No FMOD/Wwise. Two native primitives, already implemented in
+`godot/autoload/music_manager.gd`:
+
+- **Horizontal (tier moods): `AudioStreamInteractive`** -- one clip per tier, named
+  `cosy/uneasy/spooky/eldritch/terminal`, with an any-to-any crossfade transition
+  (8 beats at a nominal 120 BPM = 4 s). Tier changes call
+  `AudioStreamPlaybackInteractive.switch_to_clip()`.
+- **Vertical (stems within a tier): `AudioStreamSynchronized`** -- each clip's stream is
+  a synchronized group of that tier's stems with per-stem volume offsets. Today most
+  tiers hold a single placeholder track; the `terminal` tier already layers two tracks
+  to keep the synchronized path exercised.
+
+Signal flow (read-only, view-layer):
+
+```
+GameManager.game_state_updated(state)          # existing broadcast, emitted per turn
+  -> MusicManager._on_game_state_for_music     # reads state["doom"], nothing else
+    -> ThemeManager.get_doom_band_index(doom)  # canonical band (0..6)
+      -> MUSIC_TIER_BY_BAND[band]              # music tier (0..4)
+        -> switch_to_clip(tier)                # native crossfade if tier changed
+```
+
+### Hard rules (ADR-0006: the replay string is the canonical run artifact)
+- Audio is a PURE view-layer side-effect. `MusicManager` only LISTENS to
+  `game_state_updated`; it never calls into game code, never touches the seeded RNG,
+  the turn loop, replay, or any state that could perturb determinism.
+- Never block or crash on missing audio: a missing stem is skipped, an empty tier
+  inherits its neighbour's stream, a fully-empty build falls back to the legacy
+  playlist, and no music at all is silence, not an error.
+- `randi()` use for playlist shuffle is the GLOBAL RNG, not the seeded game RNG --
+  keep it that way; never "fix" music shuffle by borrowing the game's RNG.
+
+## 6. Transition rules
+
+Current prototype: single any-to-any rule -- switch immediately, crossfade over 8 beats
+(4 s), restart target clip from its start. Deliberately simple; placeholder tracks share
+no tempo grid, so beat-aligned transitions would be false precision.
+
+Target rules once composed stems exist (all native `AudioStreamInteractive` features):
+- UP-tier (doom rose): transition at NEXT BEAT, short crossfade (1-2 bars). Rising dread
+  should feel prompt -- the ratchet.
+- DOWN-tier (doom fell -- rare, earned): transition at NEXT BAR or phrase end, long lazy
+  crossfade. Relief arrives slower than fear.
+- M3 -> M4 (terminal): consider a FILLER CLIP sting (a one-shot "it is happening"
+  hit) via the native filler-clip transition option.
+- Hysteresis: band quantization already gives dead zones; if doom oscillates across one
+  boundary each turn and audibly churns, add a 1-turn dwell before down-transitions
+  (do NOT add one for up-transitions; the ratchet must feel immediate).
+
+## 7. Where composed tracks slot in
+
+One place: `MUSIC_TIER_STEMS` in `godot/autoload/music_manager.gd` -- an array of five
+stem lists, `{"path": ..., "volume_db": ...}` per stem. Replacing a placeholder track
+with real per-tier stems is a data edit, no logic change. Contexts outside GAMEPLAY
+(menu / victory / defeat) stay on the existing `music_library` playlists; a future
+victory track and a composed defeat sting slot in there.
+
+Menu music stays NON-adaptive on purpose: the menu has no doom.
+
+## 8. Out of scope / anti-goals
+
+- No AI-generated finished music (rights are murky; Pip values owning rights).
+- No per-action stingers wired to game logic (would tempt writes into the turn loop;
+  any future stinger hooks must also be listen-only).
+- No rewrite of the audio bus layout; the Music bus (index 2) is the only one touched.

--- a/docs/audio/REFERENCE_TRACKS.md
+++ b/docs/audio/REFERENCE_TRACKS.md
@@ -1,0 +1,80 @@
+# Music reference tracks -- Pip's aesthetic north stars
+
+> Captured 2026-07-17 so they persist beyond any chat. These are the emotional/structural
+> references for P(Doom)1's music direction -- to brief musicians (and the generative-music
+> experiments) on what the game should FEEL like. Not tracks to copy; tracks to learn from.
+> Measured features appended below (local analysis of Pip's own library copies; features are
+> facts and carry no rights baggage -- the audio itself stays out of the repo).
+
+## The most beloved
+**Master Musicians Of Bukkake -- People Of The Drifting Houses** (Totem One). Pip listens
+2-3x/day, ~1.5 years.
+- Delightful to try to dance or walk to.
+- A **ritualistic** core, **bookended by the whole album's build-up and subsequent denouement**.
+- Take-home for us: ritual pulse you can move to; large-scale build-and-release framing the piece.
+
+## The stylistically-relevant top-played set
+- **Braided Hair -- Speech feat. 1 Giant Leap** -- the *intro loops* specifically (looped cells).
+- **Touch Me Not -- Dengue Fever** -- evocative, distinct, **simple instrumental melody**.
+- **Feeling Good -- Nina Simone** -- "one of the best progressive brass lines of all time" (Pip).
+- **Wisely and Slow -- The Staves** -- beautifully, interestingly **harmonised**. Pip: if the game
+  ever has lyrics they will likely be a **pure transliteration of formulae / numbers**, harmonised
+  like this. (Formulae-as-lyrics -- a strong, on-theme conceit for an AI-safety game.)
+- **Philip Glass -- Knee Play 1, and *especially* Knee Play 5** (Einstein on the Beach). Pip's ~2nd
+  favourite song ever. **"Philip Glassmaxxing"** -- progressive patterns + subtle orchestration.
+  For us: slightly more **unsettling** versions of that minimalism.
+
+## The synthesis (what these share -> our direction)
+- **Progressive / minimalist patterns** (Glass), **cyclical, looped cells** (Braided Hair intro).
+- **Ritual build-and-release** at large scale (Bukkake), you-can-move-to-it pulse.
+- **Subtle orchestration + interesting harmony** (Staves, Glass, Nina's brass) over simple,
+  distinct melodic material (Dengue Fever).
+- **Formulae/numbers as lyrics**, harmonised -- the one lyrical idea, and it's thematically perfect.
+- Tilt everything a little **unsettling** as doom rises (per the doom-intensity spec's weirdness axis).
+
+Main theme lives in the title / main menu screen.
+
+## Measured features (2026-07-17, hand-rolled DSP: ffmpeg + numpy)
+
+Caveats: BPM values are dominant-periodicity estimates (can alias to 2x/4x of the felt
+tempo -- Feeling Good's 215 is ~4x of a ~54 BPM ballad pulse); key guesses on drone/modal
+material name a TONAL CENTER, not a functional key; centroid/loudness comparisons across
+different masterings are rough. Good enough to set direction, not to transcribe.
+
+| Track | Dur | BPM~ (conf) | Center (top chroma) | Bright (centroid) | Low<150Hz | Dyn p90-p10 | Loudness arc (8ths, dB rel peak) |
+|---|---|---|---|---|---|---|---|
+| MMOB -- People Of The Drifting Houses | 7.5 min | 83.4 (0.73) | D modal (D,A,C) | 1785 Hz | 10.6% | 11.4 dB | -11,-6,-5,-4,-3,-2,0,-11 |
+| Braided Hair (full) | 4.1 min | 99.4 (0.67) | F-ish (C,D,A) | 2177 Hz | 14.9% | 13.7 dB | -15,-4,-2,-3,-1,-2,0,-13 |
+| Braided Hair (intro 45 s) | -- | 99.4 (0.60) | (C,D,F) | 974 Hz | 25.6% | 17.9 dB | staircase: -20,-10,-9,-10,-4,-3,-2,0 |
+| Dengue Fever -- Touch Me Not | 4.4 min | 66.3 (0.58) | D modal (D,A,C) | 1463 Hz | 22.3% | 10.2 dB | -5,-1,-2,-1,-1,-2,0,-12 |
+| Nina Simone -- Feeling Good | 2.9 min | ~54 felt (alias 215) | D minor (D,G,A) | 1985 Hz | 3.3% | 25.1 dB | -22,-15,-3,-2,-4,-3,0,-14 |
+| The Staves -- Wisely & Slow | 3.6 min | 123.0 (0.69) | Bb major (Bb,G,D) | 1586 Hz | 8.2% | 25.5 dB | -18,-14,-13,-8,-9,-7,0,-8 |
+| Glass -- Knee Play 1 (1976) | 3.9 min | 103.4 (0.63) | C (C,D,G) | 1245 Hz | 24.0% | 5.5 dB | -9,-4,-3,-3,-2,0,0,-2 |
+| Glass -- Knee Play 5 (1976) | 5.5 min | 112.3 (0.51) | C (C,A,G) | 1143 Hz | 33.4% | 4.9 dB | -4,-3,-3,-3,-3,-1,0,-7 |
+
+### What the numbers confirm (measured, not vibes)
+1. **The beloved track's shape is Pip's description, verbatim**: a six-segment monotonic
+   climb (-11 dB -> 0) then a -11 dB denouement. Ritual build-and-release, measured.
+2. **Braided Hair's intro is a loudness STAIRCASE** (-20 -> 0 in steps): additive loop-cell
+   layering -- exactly the vertical stem-stacking model in MUSIC_DESIGN.md section 4.
+3. **Glass sits nearly FLAT** (dyn ~5 dB): hypnosis inside a section, terraces between
+   sections. Within-tier stems should behave like this; the TIER LADDER supplies the build.
+4. **A shared modal center**: beloved + Dengue Fever both center D with A and C prominent
+   (drone fifth + flat-7 -- mixolydian/dorian territory); Glass and the friend-made repo
+   tracks center C with D/G prominent. A C/D modal-drone tonal home, avoiding functional
+   leading-tone cadences, matches BOTH the taste profile and the existing game audio.
+5. **Tempo lanes converge**: beloved 83 BPM; repo gameplay tracks' half-time equivalents
+   ~81-92; Glass patterns ~103-112. Suggests a ~84 BPM "ritual heartbeat" lane for beds
+   and a ~104-112 pattern lane for Glass-cell layers.
+6. **Knee Play 1 is literally sung numbers** -- Pip's formulae-as-lyrics conceit has a
+   direct ancestor in his second-favourite piece. The main theme can lean on this hard.
+
+### Direction distilled (for the music lab and the musicians)
+- Tonal home: C/D modal drone (fifth + flat-7), no functional cadences -- doom never resolves.
+- Pulse: ~84 BPM ritual heartbeat you can walk/sway to; pattern layers may run ~104-112.
+- Structure: flat hypnotic cells within a tier; the doom-tier ladder IS the large-scale
+  build; defeat (Out_of_distribution) and victory serve as the denouement bookend.
+- Arrivals: stems enter as Braided-Hair-style staircase events players can learn to await.
+- Harmony/voices: simple distinct melodic cells; close vocal-style harmony reserved for the
+  title theme; lyrics, if ever, are transliterated formulae/numbers (Knee-Play-1-maxxing).
+- Unsettling tilt scales with the weirdness axis: detune/dissonance budget grows with tier.

--- a/docs/audio/STEM_CATALOGUE.md
+++ b/docs/audio/STEM_CATALOGUE.md
@@ -7,7 +7,9 @@
 
 ## Music tracks (`godot/assets/audio/music/`)
 
-All six full tracks are DJ-session ambient recorded by Pip; **Pip owns full rights**.
+All six full tracks are DJ-session ambient made by a friend of Pip's and given to the
+project; Pip authored the track NAMES. Per the music brief **Pip holds full rights** --
+worth capturing that agreement in writing (even a saved message) before shipping.
 Source dump duplicates live in `sounds/musicdump/20_nov_2025/` (root of repo, not in
 the Godot project) -- treat `godot/assets/audio/music/` as canonical.
 

--- a/docs/audio/STEM_CATALOGUE.md
+++ b/docs/audio/STEM_CATALOGUE.md
@@ -1,0 +1,63 @@
+# P(Doom)1 -- Stem + track catalogue
+
+> Everything audio the project holds today, what it is good for, and the gaps the
+> musicians need to fill. Track names are ML/AI-safety puns and are KEPT -- they are
+> part of the game's voice. Durations measured from the imported streams (Godot) and
+> wav headers (Python) on 2026-07-17.
+
+## Music tracks (`godot/assets/audio/music/`)
+
+All six full tracks are DJ-session ambient recorded by Pip; **Pip owns full rights**.
+Source dump duplicates live in `sounds/musicdump/20_nov_2025/` (root of repo, not in
+the Godot project) -- treat `godot/assets/audio/music/` as canonical.
+
+| Track (pun intact) | The pun | Length | Vibe | Current use | Adaptive slot (placeholder) | Usability / coherence note |
+|---|---|---|---|---|---|---|
+| `PDoom1 Descent gradient.mp3` | gradient descent, inverted | 1:28 | calm, drifting, warm ambient | GAMEPLAY playlist | tier M0 `cosy` | Best fit for low-doom bed; loops acceptably for a non-authored loop (no hard tail) |
+| `PDoom1 Local maxima.mp3` | stuck on a local maximum | 1:12 | ambient with more movement, mild tension | GAMEPLAY playlist | tier M1 `uneasy` | Reads slightly less settled than Descent gradient -- fits the first step up |
+| `PDoom1 Power spike.mp3` | compute/power spike | 1:12 | pushier energy, more insistent | GAMEPLAY playlist | tier M2 `spooky`; also layered at -6 dB inside M4 | The most rhythmic of the set; the natural percussion-adjacent placeholder |
+| `PDoom1 Undetected sandbagging.mp3` | model sandbagging evals, undetected | 1:05 | darker, undercurrent of wrongness | GAMEPLAY playlist | tier M3 `eldritch`; base of M4 `terminal` | Darkest gameplay track; carries high-doom until real eldritch stems exist |
+| `PDOOMN ST1 (safe).mp3` | "(safe)" -- the label every unsafe thing has | 1:12 | neutral-warm menu ambience | MENU playlist | none | Fine as menu bed. Filename typo "PDOOMN" preserved on purpose (it is the shipped name) |
+| `PDoom Out_of_distribution.mp3` | out-of-distribution input; also "you died" | 1:00 | unmoored, wrong-place feeling | DEFEAT | none (defeat stays non-adaptive) | Good conceptual fit for defeat; could later gain a terminal-tier reprise so death sounds related to terminal doom |
+| `PDoom1 seleciton beeyoowee.wav` | selection blip ("beeyoowee") | 0.72 s | UI blip, not music | listed in MENU *music* playlist | none | **Miscatalogued**: a 0.72 s one-shot inside the menu MUSIC rotation -- it plays, ends instantly, and the playlist advances. Should move to SFX duty (typo "seleciton" also preserved in the filename) |
+
+Coherence as a SET: all six sit in the same ambient DJ-session family, so tier
+crossfades between them do not clash stylistically -- good placeholder property. None
+were authored as loops or stems: no shared tempo grid, no separated percussion, no
+intensity-matched variants. They demonstrate the adaptive plumbing; they cannot express
+the axes (rhythm-vs-timbre) by themselves.
+
+## SFX (`sounds/`, repo root -- NOT yet in the Godot project)
+
+`godot/assets/audio/sfx/` currently holds only a `.gitkeep`. These files are not wired
+into the game and their provenance is not documented in-repo -- **verify rights before
+shipping any of them** (the all-caps names read like a downloaded pack; the lowercase
+ones may be homemade).
+
+| File | Length | Reads as | Adaptive-music relevance |
+|---|---|---|---|
+| `WARNINGBEEP.WAV` | 0.04 s | single warning tick | loopable tick could seed the M4 FIRE layer's alarm texture |
+| `SUDDENDEATH.WAV` | 6.0 s | doom hit / death sting | candidate M3->M4 filler-clip sting (see MUSIC_DESIGN.md section 6) |
+| `ROCKETPOWERUP.WAV` | 1.58 s | powerup arpeggio | one-shot SFX only |
+| `ROCKETRELEASE.WAV` | 3.0 s | launch whoosh | one-shot SFX only |
+| `blob.wav` | 1.73 s | soft squelch | UI/feedback SFX |
+| `popup_close.wav` | 1.53 s | UI close (16 kHz mono -- lo-fi) | UI SFX; consider re-render at 44.1 kHz |
+| `zabinga.wav` | 1.54 s | jingle/success hit | achievement/fanfare candidate |
+
+## Gaps to fill (the ask to the musicians)
+
+Per `MUSIC_DESIGN.md` section 4 -- in priority order:
+
+1. **Per-tier stem groups** for the five tiers (BASE + PULSE + WEIRD, shared tempo/key
+   within each tier, seamless loops). This is the core commission; everything above is
+   placeholder for it.
+2. **FIRE layer** (M3/M4 topper): alarm-adjacent, driving; the audio equivalent of the
+   hero image's burning monitors.
+3. **Victory music** -- the VICTORY context playlist is EMPTY today (the win screen is
+   silent).
+4. **Terminal->defeat bridge**: a defeat sting/reprise related to the M4 material so
+   losing sounds like the music finished its sentence.
+5. **Menu bed refresh** (optional): `PDOOMN ST1 (safe)` works; a second menu track
+   would stop the single-track loop from wearing.
+6. Naming: keep the pun register -- e.g. "Mesa optimizer", "Reward hacking",
+   "Treacherous turn", "Sharp left turn" are unclaimed and on-theme.

--- a/docs/audio/TRACK_ANALYSIS.md
+++ b/docs/audio/TRACK_ANALYSIS.md
@@ -1,0 +1,96 @@
+# P(Doom)1 -- Beloved-track analysis (method + template)
+
+> Pip has a track he listens to 2-3x/day. That track is the project's TASTE REFERENCE:
+> decoding *why it grips* gives the musicians a concrete target instead of vibe-words.
+> The track name/link arrives separately; this file is the METHOD and the fill-in
+> TEMPLATE. Nothing below assumes a specific track. Written for a low-music-literacy
+> owner: every step says exactly what to do and needs no theory.
+
+## Method: five listening passes (about 30-40 minutes total)
+
+Do the passes in order, one focus each. Use headphones. Write timestamps as `m:ss`.
+
+### Pass 1 -- Structure map (what happens when)
+Listen once with a notepad. Every time the track *changes* (something enters, drops
+out, gets louder, mood shifts), write the timestamp and one plain phrase:
+"1:12 drums drop out", "2:40 gets huge". No vocabulary needed. You now have the
+track's shape -- this is the single most useful artifact for the musicians.
+
+### Pass 2 -- Pulse and speed (tempo)
+- Tap along with the beat on a tap-tempo site (search "tap tempo", tap 20+ times) ->
+  BPM number.
+- Cross-check by searching "<track name> BPM key" (Tunebat/SongData list most tracks).
+- Note WHERE the pulse lives: kick drum? bassline? a repeating synth? And whether it
+  ever stops.
+
+### Pass 3 -- Key and harmony (the mood machinery)
+- Get the key from the same lookup sites (do not derive it by ear).
+- Answer in plain words: does it feel resolved or endlessly suspended? Does it loop a
+  short chord cycle (count: does the "home" feeling come back every 2/4/8 bars)?
+  Bright or dark? Does the mood shift mid-track or stay in one weather?
+
+### Pass 4 -- Instrumentation and texture (who is speaking)
+List every distinct voice you can pick out (name them functionally: "deep bass",
+"shimmery pad", "clicky percussion", "human voice"). For each: when is it present
+(reuse Pass 1 timestamps), and is it clean or dirty/distorted/detuned?
+Optional: open the file in Spek (free spectrogram) -- a dense bottom = bass-heavy,
+striped top = bright percussion. Screenshot it into this doc.
+
+### Pass 5 -- Production feel + the grip (the actual question)
+- Space: does it sound like a small room, a cathedral, or headphone-internal?
+- Dynamics: does it breathe (quiet/loud waves) or hold one intensity?
+- Then the core: at which exact timestamps do you feel the pull? What JUST happened
+  at each of those moments (check the Pass 1 map)? The grip almost always lives in a
+  repeatable trick: a tension that only half-resolves, a texture change right when the
+  loop would get boring, an entrance you wait for. Name the trick in your own words.
+- Honesty check: is the grip musical, or is it associative (memory/person/game it is
+  tied to)? Associative grip is real but does not transfer to a commission -- say so.
+
+## Translating findings -> direction the musicians can use
+
+| If the analysis found... | Then the ask is... |
+|---|---|
+| Grip lives at entrances/drop-outs | "Stems must create arrival moments: build layer entrances players can wait for" (maps to tier up-transitions, MUSIC_DESIGN.md sec 6) |
+| Endless-suspension harmony, never resolves | "Keep tier beds harmonically open -- avoid full cadences; doom never resolves" |
+| One dirty voice over a clean bed | "One WEIRD stem over a clean BASE" -- confirms the one-weird-glow rule (sec 2) |
+| Slow breathing dynamics | "Long-form volume waves inside each loop so a 2-min stay in one tier does not flatline" |
+| Tempo X, pulse carried by Y | "Tier tempo lanes near X BPM; put the pulse in the PULSE stem on instrument-type Y" |
+| Grip is associative, not musical | Do NOT ask musicians to clone the track; extract only tempo/texture facts |
+
+## Template (fill in when the track arrives)
+
+```
+TRACK: <name -- artist>              LINK: <url>
+LISTEN COUNT / CONTEXT: <when/why Pip plays it>
+
+PASS 1 -- STRUCTURE MAP
+  0:00  <...>
+  <m:ss>  <...>
+  Overall shape in one sentence: <...>
+
+PASS 2 -- TEMPO
+  BPM (tapped): <...>   BPM (lookup): <...>
+  Pulse carried by: <...>   Pulse ever stops?: <...>
+
+PASS 3 -- KEY / HARMONY
+  Key (lookup): <...>
+  Resolved or suspended: <...>   Chord-cycle length (bars): <...>
+  Mood weather: <bright/dark/shifting -- describe>
+
+PASS 4 -- VOICES
+  <voice> -- present <m:ss>-<m:ss> -- clean/dirty: <...>
+  <voice> -- ...
+  Spectrogram notes (optional): <...>
+
+PASS 5 -- PRODUCTION + GRIP
+  Space: <...>   Dynamics: <...>
+  Grip moments: <m:ss> because <what just happened>
+                <m:ss> because <...>
+  The trick, in my words: <...>
+  Musical or associative?: <...>
+
+DIRECTION FOR THE MUSICIANS (3-5 bullets, plain language,
+use the translation table above):
+  - <...>
+  - <...>
+```

--- a/godot/autoload/music_manager.gd
+++ b/godot/autoload/music_manager.gd
@@ -1,5 +1,13 @@
 extends Node
 ## Music Manager - Background music playback with crossfade support
+##
+## GAMEPLAY is doom-band ADAPTIVE (docs/audio/MUSIC_DESIGN.md): an
+## AudioStreamInteractive whose clips are the five music tiers of the
+## doom-intensity spec, switched by a READ-ONLY doom value arriving via
+## GameManager.game_state_updated. Audio is a pure view-layer side-effect
+## (ADR-0006): this node never writes game state, never touches the seeded
+## RNG or the turn loop, and degrades to the legacy playlist (or silence)
+## when audio assets are missing.
 
 enum MusicContext {
 	MENU,      # Welcome screen, settings, etc.
@@ -10,6 +18,45 @@ enum MusicContext {
 
 const CROSSFADE_DURATION = 2.0
 const MUSIC_BUS_INDEX = 2  # Music bus in default_bus_layout.tres
+
+## ---- Adaptive doom-band music (docs/audio/MUSIC_DESIGN.md) ----
+## The canonical 7 doom status bands (ThemeManager.DOOM_STATUS_BANDS,
+## NOMINAL..TERMINAL) collapse onto 5 MUSIC TIERS, named after the 5
+## doom-intensity bands in docs/art/PALETTE_AND_DOOM_INTENSITY.md.
+const MUSIC_TIER_NAMES := ["cosy", "uneasy", "spooky", "eldritch", "terminal"]
+## Band index (0..6) -> music tier (0..4):
+## NOMINAL->cosy, ELEVATED/HIGH->uneasy, SEVERE/EXTREME->spooky,
+## CATASTROPHIC->eldritch, TERMINAL->terminal.
+const MUSIC_TIER_BY_BAND := [0, 1, 1, 2, 2, 3, 4]
+
+## Placeholder stems per tier. These are FULL owned tracks standing in for
+## real per-tier stems (see docs/audio/STEM_CATALOGUE.md); when composed
+## stems arrive, each tier grows to a multi-stem AudioStreamSynchronized
+## group (base / percussion / weirdness / fire layers) and nothing else
+## has to change. "terminal" already layers two tracks to exercise the
+## AudioStreamSynchronized path (deliberate cacophony at world's end).
+const MUSIC_TIER_STEMS := [
+	[{"path": "res://assets/audio/music/PDoom1 Descent gradient.mp3", "volume_db": 0.0}],
+	[{"path": "res://assets/audio/music/PDoom1 Local maxima.mp3", "volume_db": 0.0}],
+	[{"path": "res://assets/audio/music/PDoom1 Power spike.mp3", "volume_db": 0.0}],
+	[{"path": "res://assets/audio/music/PDoom1 Undetected sandbagging.mp3", "volume_db": 0.0}],
+	[
+		{"path": "res://assets/audio/music/PDoom1 Undetected sandbagging.mp3", "volume_db": 0.0},
+		{"path": "res://assets/audio/music/PDoom1 Power spike.mp3", "volume_db": -6.0},
+	],
+]
+
+## The placeholder tracks carry no BPM metadata, so clips are stamped with a
+## nominal BPM to give AudioStreamInteractive a time base for beat-measured
+## crossfades: 8 beats at 120 BPM = a 4 s tier crossfade.
+const ADAPTIVE_BPM := 120.0
+const ADAPTIVE_FADE_BEATS := 8.0
+
+var adaptive_enabled: bool = true
+var _adaptive_stream: AudioStreamInteractive = null
+var _adaptive_build_attempted: bool = false
+var _adaptive_active: bool = false
+var _current_music_tier: int = 0
 
 # Music tracks organized by context
 var music_library = {
@@ -70,7 +117,25 @@ func _ready():
 	# Apply volume from GameConfig
 	_apply_volume()
 
+	# GameManager is declared after MusicManager in the autoload list, so the
+	# doom-signal hookup is deferred until the tree is fully assembled.
+	call_deferred("_connect_doom_signal")
+
 	print("[MusicManager] Music system ready")
+
+## Subscribe (read-only) to game-state broadcasts to track the doom band.
+## Listening to a signal never writes game state -- ADR-0006 safe.
+func _connect_doom_signal():
+	var game_manager = get_node_or_null("/root/GameManager")
+	if game_manager == null or not game_manager.has_signal("game_state_updated"):
+		print("[MusicManager] GameManager not available; adaptive music will idle at tier 0")
+		return
+	if not game_manager.game_state_updated.is_connected(_on_game_state_for_music):
+		game_manager.game_state_updated.connect(_on_game_state_for_music)
+		print("[MusicManager] Doom-band signal connected (read-only)")
+
+func _on_game_state_for_music(state: Dictionary):
+	set_doom_level(float(state.get("doom", 0.0)))
 
 ## Apply music volume from GameConfig
 func _apply_volume():
@@ -96,6 +161,14 @@ func play_context(context: MusicContext, shuffle: bool = true):
 	print("[MusicManager] Switching to context: ", MusicContext.keys()[context])
 
 	current_context = context
+
+	# GAMEPLAY prefers the doom-adaptive stream; anything else (or a failed
+	# adaptive build) falls back to the legacy per-context playlist.
+	if context == MusicContext.GAMEPLAY and adaptive_enabled:
+		if _play_adaptive():
+			return
+	_adaptive_active = false
+
 	var tracks = music_library[context]
 
 	if tracks.is_empty():
@@ -129,16 +202,30 @@ func play_track(track_path: String):
 		return
 
 	print("[MusicManager] Loading track: ", track_path.get_file())
+	_adaptive_active = false
+	_play_stream(stream)
 
+## Start (or crossfade to) an already-loaded stream. Shared by the legacy
+## playlist path and the adaptive gameplay stream.
+func _play_stream(stream: AudioStream):
 	# If nothing is playing, start immediately
 	if not active_player.playing:
 		active_player.stream = stream
 		active_player.volume_db = 0
 		active_player.play()
-		print("[MusicManager] Started playing: ", track_path.get_file())
+		print("[MusicManager] Started playing: ", _stream_display_name(stream))
 	else:
 		# Crossfade to new track
 		_crossfade_to_track(stream)
+
+func _stream_display_name(stream: AudioStream) -> String:
+	if stream == null:
+		return "None"
+	if stream is AudioStreamInteractive:
+		return "adaptive doom stream"
+	if stream.resource_path != "":
+		return stream.resource_path.get_file()
+	return "unnamed stream"
 
 ## Crossfade from active player to inactive player with new track
 func _crossfade_to_track(new_stream: AudioStream):
@@ -177,6 +264,14 @@ func _crossfade_to_track(new_stream: AudioStream):
 func _on_track_finished():
 	if is_crossfading:
 		return  # Don't advance during crossfade
+
+	# Adaptive clips loop internally; if the interactive stream somehow ends
+	# (e.g. a stem that refused to loop), restart it rather than advancing
+	# the legacy playlist.
+	if _adaptive_active:
+		if music_enabled and active_player.stream == _adaptive_stream:
+			active_player.play()
+		return
 
 	# Get current context tracks
 	var tracks = music_library[current_context]
@@ -251,6 +346,160 @@ func _exit_tree() -> void:
 	if is_instance_valid(player_b):
 		player_b.stop()
 		player_b.stream = null
+	_adaptive_active = false
+	_adaptive_stream = null
+
+## ---- Adaptive doom-band music ----
+
+## Map a doom percentage (0-100) to a music tier (0-4) via the canonical
+## band API. Pure read; safe to call from anywhere.
+func music_tier_for_doom(doom_percent: float) -> int:
+	var band: int = 0
+	var theme_manager = get_node_or_null("/root/ThemeManager")
+	if theme_manager != null:
+		band = theme_manager.get_doom_band_index(doom_percent)
+	band = clampi(band, 0, MUSIC_TIER_BY_BAND.size() - 1)
+	return MUSIC_TIER_BY_BAND[band]
+
+## READ-ONLY doom input. The single entry point for game -> music flow:
+## stores the tier and, if the adaptive stream is live, switches clips.
+## Never writes anything back toward game state.
+func set_doom_level(doom_percent: float):
+	var tier: int = music_tier_for_doom(doom_percent)
+	if tier == _current_music_tier:
+		return
+	print("[MusicManager] Doom %.1f%% -> music tier %d (%s)" % [
+		doom_percent, tier, MUSIC_TIER_NAMES[tier]])
+	_current_music_tier = tier
+	_switch_adaptive_tier(tier)
+
+## Debug hook: force a music tier directly (dev overlay / manual testing).
+func debug_force_tier(tier: int):
+	tier = clampi(tier, 0, MUSIC_TIER_NAMES.size() - 1)
+	_current_music_tier = tier
+	_switch_adaptive_tier(tier)
+
+## Start the adaptive gameplay stream. Returns false if it cannot be built
+## (missing module or missing audio) so the caller can fall back.
+func _play_adaptive() -> bool:
+	if not music_enabled:
+		print("[MusicManager] Music disabled, skipping adaptive playback")
+		return true  # Handled: stay silent, do not fall through to playlist
+	if _adaptive_stream == null and not _adaptive_build_attempted:
+		_adaptive_build_attempted = true
+		_adaptive_stream = _build_adaptive_stream()
+	if _adaptive_stream == null:
+		return false
+	if _adaptive_active and active_player.stream == _adaptive_stream and active_player.playing:
+		# Already live (e.g. restart-game re-entry): just re-sync the tier.
+		_switch_adaptive_tier(_current_music_tier)
+		return true
+	_adaptive_active = true
+	_adaptive_stream.initial_clip = clampi(_current_music_tier, 0, _adaptive_stream.clip_count - 1)
+	print("[MusicManager] Starting adaptive gameplay stream at tier %d (%s)" % [
+		_current_music_tier, MUSIC_TIER_NAMES[_current_music_tier]])
+	_play_stream(_adaptive_stream)
+	return true
+
+## Switch the live interactive playback to the clip for `tier`. No-op when
+## the adaptive stream is not currently audible (menu, defeat, disabled).
+func _switch_adaptive_tier(tier: int):
+	if not _adaptive_active or _adaptive_stream == null:
+		return
+	var playback := _adaptive_playback()
+	if playback == null:
+		return
+	var clip: int = clampi(tier, 0, _adaptive_stream.clip_count - 1)
+	if playback.get_current_clip_index() == clip:
+		return
+	playback.switch_to_clip(clip)
+
+## Find the live interactive playback, on whichever player carries the
+## adaptive stream (it may sit on either side of a crossfade).
+func _adaptive_playback() -> AudioStreamPlaybackInteractive:
+	for player in [player_a, player_b]:
+		if player != null and player.playing and player.stream == _adaptive_stream:
+			var playback = player.get_stream_playback()
+			if playback is AudioStreamPlaybackInteractive:
+				return playback
+	return null
+
+## Build the AudioStreamInteractive: one clip per music tier, each clip a
+## looped stem (or an AudioStreamSynchronized stem group), plus a single
+## any-to-any crossfade transition rule. Missing stems degrade: a tier with
+## no loadable stems inherits its neighbour's stream; if NOTHING loads the
+## whole build returns null and the legacy playlist takes over.
+func _build_adaptive_stream() -> AudioStreamInteractive:
+	var tier_streams: Array = []
+	var loaded_any := false
+	for tier in range(MUSIC_TIER_STEMS.size()):
+		var stems: Array = []
+		var volumes: Array = []
+		for stem in MUSIC_TIER_STEMS[tier]:
+			var path: String = stem["path"]
+			if not ResourceLoader.exists(path):
+				print("[MusicManager] Adaptive stem missing, skipping: ", path)
+				continue
+			var stream = load(path)
+			if stream == null:
+				print("[MusicManager] Adaptive stem failed to load, skipping: ", path)
+				continue
+			stems.append(_prepare_stem(stream))
+			volumes.append(stem.get("volume_db", 0.0))
+		if stems.is_empty():
+			tier_streams.append(null)  # Filled from a neighbour below
+			continue
+		loaded_any = true
+		if stems.size() == 1:
+			tier_streams.append(stems[0])
+		else:
+			var synced := AudioStreamSynchronized.new()
+			synced.stream_count = stems.size()
+			for i in range(stems.size()):
+				synced.set_sync_stream(i, stems[i])
+				synced.set_sync_stream_volume(i, volumes[i])
+			tier_streams.append(synced)
+	if not loaded_any:
+		print("[MusicManager] No adaptive stems available; falling back to playlist")
+		return null
+
+	# Fill gaps: forward from lower tiers, then backward for leading gaps.
+	for tier in range(tier_streams.size()):
+		if tier_streams[tier] == null and tier > 0:
+			tier_streams[tier] = tier_streams[tier - 1]
+	for tier in range(tier_streams.size() - 1, -1, -1):
+		if tier_streams[tier] == null and tier < tier_streams.size() - 1:
+			tier_streams[tier] = tier_streams[tier + 1]
+
+	var interactive := AudioStreamInteractive.new()
+	interactive.clip_count = tier_streams.size()
+	for tier in range(tier_streams.size()):
+		interactive.set_clip_name(tier, StringName(MUSIC_TIER_NAMES[tier]))
+		interactive.set_clip_stream(tier, tier_streams[tier])
+		interactive.set_clip_auto_advance(tier, AudioStreamInteractive.AUTO_ADVANCE_DISABLED)
+	interactive.initial_clip = 0
+	interactive.add_transition(
+		AudioStreamInteractive.CLIP_ANY, AudioStreamInteractive.CLIP_ANY,
+		AudioStreamInteractive.TRANSITION_FROM_TIME_IMMEDIATE,
+		AudioStreamInteractive.TRANSITION_TO_TIME_START,
+		AudioStreamInteractive.FADE_CROSS, ADAPTIVE_FADE_BEATS)
+	print("[MusicManager] Adaptive stream built: %d tiers" % tier_streams.size())
+	return interactive
+
+## Duplicate a loaded stream (so loop/BPM tweaks never leak into the shared
+## resource cache the legacy playlist also uses), force it to loop, and stamp
+## the nominal BPM used for beat-measured crossfades.
+func _prepare_stem(stream: AudioStream) -> AudioStream:
+	var stem: AudioStream = stream.duplicate()
+	if stem is AudioStreamMP3 or stem is AudioStreamOggVorbis:
+		stem.loop = true
+		stem.bpm = ADAPTIVE_BPM
+	else:
+		# WAV stems should be authored/imported with loop points; a stem that
+		# does not loop just goes quiet at clip end (finished-signal restarts).
+		print("[MusicManager] Adaptive stem is not mp3/ogg; relying on import loop settings: ",
+			stream.resource_path)
+	return stem
 
 ## Debug: Print music library
 func print_library():

--- a/godot/tests/unit/test_adaptive_music.gd
+++ b/godot/tests/unit/test_adaptive_music.gd
@@ -1,0 +1,111 @@
+extends GutTest
+## Adaptive doom-band music (docs/audio/MUSIC_DESIGN.md).
+## Covers the pure doom->tier mapping, the placeholder stream builder, and the
+## read-only wiring. Audio is a pure view-layer side-effect (ADR-0006): these
+## tests also pin that the music system only LISTENS to game state.
+
+var _saved_tier: int = 0
+
+func before_each():
+	_saved_tier = MusicManager._current_music_tier
+
+func after_each():
+	MusicManager._current_music_tier = _saved_tier
+
+func test_tier_mapping_tracks_canonical_bands():
+	# One probe per canonical ThemeManager band (below: 15/37/52/67/80/92/101),
+	# against the documented band->tier collapse [0,1,1,2,2,3,4].
+	assert_eq(MusicManager.music_tier_for_doom(0.0), 0, "NOMINAL -> cosy")
+	assert_eq(MusicManager.music_tier_for_doom(10.0), 0, "NOMINAL -> cosy")
+	assert_eq(MusicManager.music_tier_for_doom(20.0), 1, "ELEVATED -> uneasy")
+	assert_eq(MusicManager.music_tier_for_doom(40.0), 1, "HIGH -> uneasy")
+	assert_eq(MusicManager.music_tier_for_doom(60.0), 2, "SEVERE -> spooky")
+	assert_eq(MusicManager.music_tier_for_doom(75.0), 2, "EXTREME -> spooky")
+	assert_eq(MusicManager.music_tier_for_doom(85.0), 3, "CATASTROPHIC -> eldritch")
+	assert_eq(MusicManager.music_tier_for_doom(95.0), 4, "TERMINAL -> terminal")
+	assert_eq(MusicManager.music_tier_for_doom(100.0), 4, "TERMINAL -> terminal")
+
+func test_tier_mapping_is_monotonic():
+	# Rising doom must never lower the music tier (the ratchet direction).
+	var previous := -1
+	for doom in range(0, 101):
+		var tier: int = MusicManager.music_tier_for_doom(float(doom))
+		assert_true(tier >= previous, "Tier dropped at doom %d" % doom)
+		assert_between(tier, 0, MusicManager.MUSIC_TIER_NAMES.size() - 1,
+			"Tier out of range at doom %d" % doom)
+		previous = tier
+
+func test_tier_config_shapes_agree():
+	# The band->tier table must cover all 7 canonical bands and only name
+	# tiers that exist in both the name list and the stem config.
+	assert_eq(MusicManager.MUSIC_TIER_BY_BAND.size(), 7,
+		"One entry per canonical doom band")
+	assert_eq(MusicManager.MUSIC_TIER_STEMS.size(),
+		MusicManager.MUSIC_TIER_NAMES.size(),
+		"Stem config and tier names must align")
+	for tier in MusicManager.MUSIC_TIER_BY_BAND:
+		assert_between(tier, 0, MusicManager.MUSIC_TIER_NAMES.size() - 1,
+			"Band maps to a nonexistent tier")
+
+func test_set_doom_level_updates_tier_without_audio():
+	# Nothing is playing in headless tests; set_doom_level must still track
+	# the tier and never crash (never-block-on-missing-audio constraint).
+	MusicManager.set_doom_level(95.0)
+	assert_eq(MusicManager._current_music_tier, 4, "Terminal doom -> tier 4")
+	MusicManager.set_doom_level(0.0)
+	assert_eq(MusicManager._current_music_tier, 0, "Doom relief -> tier 0")
+
+func test_build_adaptive_stream_has_one_clip_per_tier():
+	var stream = MusicManager._build_adaptive_stream()
+	if stream == null:
+		# Audio assets absent (e.g. stripped CI checkout): graceful null is
+		# the contract, not a failure.
+		pass_test("No stems available; builder degraded gracefully to null")
+		return
+	assert_eq(stream.clip_count, MusicManager.MUSIC_TIER_NAMES.size(),
+		"One clip per music tier")
+	for tier in range(stream.clip_count):
+		assert_eq(String(stream.get_clip_name(tier)),
+			MusicManager.MUSIC_TIER_NAMES[tier], "Clip name matches tier name")
+		assert_not_null(stream.get_clip_stream(tier),
+			"Every tier has a stream (gap-filled from neighbours)")
+
+func test_gameplay_context_goes_adaptive_and_takes_tier_switches():
+	# End-to-end through the public surface: entering GAMEPLAY builds and
+	# starts the interactive stream (dummy audio driver in headless is fine),
+	# and doom updates route to it without error.
+	MusicManager.play_context(MusicManager.MusicContext.GAMEPLAY)
+	if MusicManager._adaptive_stream == null:
+		_silence_music()
+		pass_test("No audio assets in this checkout; degraded to playlist as designed")
+		return
+	assert_true(MusicManager._adaptive_active, "GAMEPLAY should engage adaptive mode")
+	assert_not_null(MusicManager._adaptive_playback(),
+		"Interactive playback should be live on a player")
+	MusicManager.set_doom_level(95.0)
+	assert_eq(MusicManager._current_music_tier, 4, "Doom 95 -> terminal tier")
+	assert_not_null(MusicManager._adaptive_playback(),
+		"Playback survives a tier switch")
+	MusicManager.set_doom_level(5.0)
+	assert_eq(MusicManager._current_music_tier, 0, "Doom 5 -> cosy tier")
+	_silence_music()
+
+## Synchronous cleanup so later tests never see leftover playback.
+func _silence_music():
+	MusicManager._adaptive_active = false
+	MusicManager.current_context = MusicManager.MusicContext.MENU
+	for player in [MusicManager.player_a, MusicManager.player_b]:
+		if player != null:
+			player.stop()
+			player.stream = null
+
+func test_doom_signal_wiring_is_listen_only():
+	# MusicManager subscribes to game_state_updated (read-only). It must not
+	# be connected to anything that WRITES game state; the only game-facing
+	# coupling is this one listener.
+	assert_true(
+		GameManager.game_state_updated.is_connected(MusicManager._on_game_state_for_music),
+		"MusicManager listens to game_state_updated")
+	# And the handler tolerates a minimal/malformed state dict.
+	MusicManager._on_game_state_for_music({})
+	assert_eq(MusicManager._current_music_tier, 0, "Missing doom key reads as 0")


### PR DESCRIPTION
Executes `docs/audio/MUSIC_BRIEF.md` -- all four deliverables, one focused pass. Do not merge without Pip review.

## 1. Music-design spec (`docs/audio/MUSIC_DESIGN.md`)
Music as the AUDIO expression of `docs/art/PALETTE_AND_DOOM_INTENSITY.md`:
- **Catastrophe axis -> rhythm** (percussive density; FIRE layer at high tiers only)
- **Weirdness axis -> timbre** (clean -> detuned/glitchy -> dissonant/eldritch)
- **Doom bands -> live layers**: 7 canonical `ThemeManager` bands collapse to 5 music tiers named after the art spec's bands: `cosy / uneasy / spooky / eldritch / terminal` (`MUSIC_TIER_BY_BAND = [0,1,1,2,2,3,4]`). No thresholds duplicated -- music reads the canonical band API, so retuning bands retunes music.
- Stem model (BASE / PULSE / WEIRD / FIRE per tier), transition rules (prompt up-moves, lazy down-moves), and the single slot-in point for composed stems.

## 2. Working prototype (`godot/autoload/music_manager.gd`)
GAMEPLAY context now plays a native **`AudioStreamInteractive`**: one looping clip per tier, any-to-any crossfade transition (8 beats @ nominal 120 BPM = 4 s); the `terminal` tier layers two tracks through **`AudioStreamSynchronized`** to keep the vertical-stem path exercised. Existing owned tracks are the PLACEHOLDER tier stems.

**Read-only doom plumbing (ADR-0006 safe):** `GameManager.game_state_updated` (existing broadcast) -> reads `state["doom"]` -> `ThemeManager.get_doom_band_index` -> tier -> `switch_to_clip`. MusicManager only LISTENS; zero changes to game/core code -- the diff touches only the autoload, tests, and docs.

**Degradation:** missing stem -> skipped; empty tier -> inherits neighbour; nothing loads -> legacy playlist; no assets at all -> silence. Never blocks or crashes.

**Hear it:** run the game, start a session -- gameplay opens on `Descent gradient` (cosy). As doom crosses 15% the music crossfades to `Local maxima` (uneasy), 52% -> `Power spike` (spooky), 80% -> `Undetected sandbagging` (eldritch), 92% -> sandbagging + spike layered (terminal cacophony). Doom relief slides it back down. `MusicManager.debug_force_tier(n)` forces a tier for manual testing.

## 3. Stem/track catalogue (`docs/audio/STEM_CATALOGUE.md`)
All 7 tracks (puns preserved, lengths measured from imported streams) + all 7 root-`sounds/` SFX, with vibe/rights/adaptive-slot/coherence notes. Notable finds: `seleciton beeyoowee.wav` is a 0.72 s UI blip sitting in the menu MUSIC playlist; VICTORY playlist is empty (win screen is silent); root `sounds/` SFX provenance is undocumented -- flagged verify-before-ship.

## 4. Track-analysis template (`docs/audio/TRACK_ANALYSIS.md`)
Five-pass listening method (structure map, tempo, key/harmony, voices, production+grip) written for a low-music-literacy owner, a findings->commission-direction translation table, and the fill-in template. No track invented -- Pip supplies it later.

## Honest placeholder-vs-real ledger
- REAL: the adaptive plumbing, doom-band wiring, degradation paths, tier mapping, docs.
- PLACEHOLDER: the audio itself -- full ambient tracks standing in for per-tier stems; no shared tempo grid, so transitions crossfade on a nominal BPM rather than beat-locking. Composed stems slot into `MUSIC_TIER_STEMS` as a data edit.
- OUT OF SCOPE (per brief): composing/generating finished music; AI music gen; bus-layout changes.

## Verification
- Fast gate: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **421 tests, 0 failures, 45/45 files** (includes new `test_adaptive_music.gd`: mapping, monotonic ratchet, config-shape, headless end-to-end play + tier switch, listen-only wiring).
- Simulation/determinism tier: `python scripts/run_godot_tests.py --simulation` -> **93 tests, 0 failures** (audio touched nothing deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)