### PR TITLE
fix(hiring): promises cost domain obligations, not a reputation rep-bomb

### DIFF
--- a/godot/data/balance/defaults.json
+++ b/godot/data/balance/defaults.json
@@ -33,7 +33,13 @@
 		"staff_rider": { "principal": 1200.0, "fuse_turns": 88, "interest_rate": 0.001 },
 		"blackmail": { "principal_multiplier": 1.5, "fuse_turns": 22, "interest_rate": 0.02 },
 		"expose": { "rep_per_1000": 2.5, "governance_multiplier": 0.5 },
-		"appetite_promise": { "principal": 2000.0, "fuse_turns": 10, "interest_rate": 0.008 },
+		"promise": {
+			"_description": "fix/promise-currency (Option B): appetite promises cost a FUTURE OBLIGATION IN THEIR OWN DOMAIN, never raw reputation. The old reputation-currency principal vs a starting rep of 50 (death at rep<=0) was an instant-death trap. Magnitudes are small/survivable; interest 0.0 (obligations, not compounding mortality levers). first_authorship->papers, compute_budget->compute, mission/mentorship->governance.",
+			"first_authorship": { "principal": 1.0, "fuse_turns": 10, "interest_rate": 0.0 },
+			"compute_budget": { "principal": 20.0, "fuse_turns": 8, "interest_rate": 0.0 },
+			"mission_charter": { "principal": 6.0, "fuse_turns": 12, "interest_rate": 0.0 },
+			"mentorship": { "principal": 4.0, "fuse_turns": 10, "interest_rate": 0.0 }
+		},
 		"resentment_debt": { "principal": 1500.0, "fuse_turns": 6, "interest_rate": 0.02 }
 	},
 	"hiring": {

--- a/godot/scripts/core/ledger.gd
+++ b/godot/scripts/core/ledger.gd
@@ -125,16 +125,47 @@ static func staff_rider(name: String) -> Entry:
 		Balance.num("ledger.staff_rider.interest_rate", 0.02))
 
 ## Hiring Phase B: a PROMISE made to win a candidate on appetite instead of cash (ADR-0003
-## "every mitigation is a loan"). A first-authorship / mentorship / compute / mission promise
-## mints a reputation obligation that bills LATER unless honoured -- the negotiation discount
-## you took up front is a debt against your standing. `promise` is the appetite id it feeds.
+## "every mitigation is a loan"). Each promise -> a FUTURE OBLIGATION IN ITS OWN DOMAIN, keyed
+## by the appetite it feeds. currency/noun/magnitude live here; Balance overrides per key.
+##
+## fix/promise-currency (Option B): the promise cost was RE-HOMED off raw reputation. The old
+## version minted a reputation-currency principal (~2000, or a money-scaled salary discount)
+## while reputation STARTS AT 50 and death fires at reputation <= 0 (game_state.gd) -- so a
+## single promise's bill zeroed the whole rep bar and instantly killed the player (a real run
+## died on turn 14 this way). Now each promise bills the thing it actually promised:
+##   first_authorship -> a paper / first-author slot OWED (currency "papers")
+##   compute_budget   -> compute committed to this hire (currency "compute")
+##   mission_charter  -> a standing governance/mission constraint (currency "governance")
+##   mentorship       -> a mentee commitment, also a standing governance obligation
+## Magnitudes are small and survivable (ADR-0003: heterogeneous, not an inevitability queue);
+## the discount-to-self_worth_floor negotiation currency (ADR-0011) is UNCHANGED -- only the
+## COST side moved off reputation.
+const PROMISE_SPEC := {
+	"first_authorship": {"currency": "papers", "noun": "first-author paper slot", "principal": 1.0, "fuse": 10},
+	"compute_budget":   {"currency": "compute", "noun": "compute", "principal": 20.0, "fuse": 8},
+	"mission_charter":  {"currency": "governance", "noun": "governance (mission constraint)", "principal": 6.0, "fuse": 12},
+	"mentorship":       {"currency": "governance", "noun": "governance (mentee commitment)", "principal": 4.0, "fuse": 10},
+}
+
 static func appetite_promise(name: String, promise: String) -> Entry:
-	# interest_rate MUST survive JSON print->parse exactly (see the ledger _description GOTCHA);
-	# 0.008 is on the probe-verified-safe list.
-	return Entry.new("promise:%s:%s" % [promise, name], "reputation",
-		Balance.num("ledger.appetite_promise.principal", 2000.0),
-		Balance.inum("ledger.appetite_promise.fuse_turns", 10),
-		Balance.num("ledger.appetite_promise.interest_rate", 0.008))
+	# interest_rate defaults to 0.0 (these are obligations, not compounding mortality levers) --
+	# 0.0 is trivially JSON-print->parse-safe (see the ledger _description GOTCHA). Principals are
+	# integer-valued so they round-trip exactly too.
+	var spec: Dictionary = PROMISE_SPEC.get(promise, PROMISE_SPEC["mission_charter"])
+	return Entry.new("promise:%s:%s" % [promise, name], String(spec["currency"]),
+		Balance.num("ledger.promise.%s.principal" % promise, float(spec["principal"])),
+		Balance.inum("ledger.promise.%s.fuse_turns" % promise, int(spec["fuse"])),
+		Balance.num("ledger.promise.%s.interest_rate" % promise, 0.0))
+
+## Legibility (fix/promise-currency): the one-line COST a ticked promise will incur, surfaced in
+## the offer flow BEFORE the player commits (main_ui.gd) so the obligation is never opaque.
+static func appetite_promise_cost_text(promise: String) -> String:
+	if not PROMISE_SPEC.has(promise):
+		return ""
+	var spec: Dictionary = PROMISE_SPEC[promise]
+	var principal := int(roundf(Balance.num("ledger.promise.%s.principal" % promise, float(spec["principal"]))))
+	var fuse := Balance.inum("ledger.promise.%s.fuse_turns" % promise, int(spec["fuse"]))
+	return "owes %d %s in ~%d turns" % [principal, String(spec["noun"]), fuse]
 
 ## Hiring Phase B: a lowball offer taken RESENTFULLY plants a loyalty debt -- a governance
 ## liability that bills later (the resentment festering into a governance problem, ADR-0003).
@@ -228,6 +259,19 @@ func _bill(e: Entry, state) -> void:
 			var applied: float = _apply_capped_doom(e, e.principal, state)
 			_attribute(e, applied, state)
 			_note(state, "ledger_doom_bill", e.source, {"doom": applied})
+		"papers":
+			# fix/promise-currency: a first-authorship OWED. Honoured out of produced papers when
+			# it lands; a shortfall lapses (no doom/rep teeth) -- a promise is a survivable future
+			# obligation in its OWN domain, never a mortality lever (the rep-bomb is gone).
+			var papers_paid: float = minf(state.papers, e.principal)
+			state.papers = max(0.0, state.papers - e.principal)
+			_note(state, "ledger_papers_bill", e.source, {"papers": -papers_paid})
+		"compute":
+			# fix/promise-currency: compute committed to this hire, drawn from the fleet when due.
+			# Survivable (compute is not a death condition); any shortfall simply lapses.
+			var compute_paid: float = minf(state.compute, e.principal)
+			state.compute = max(0.0, state.compute - e.principal)
+			_note(state, "ledger_compute_bill", e.source, {"compute": -compute_paid})
 		"action_points":
 			state.action_points = max(0, state.action_points - int(e.principal))
 		"equity", "board_seat", "agenda":

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -1817,7 +1817,11 @@ func _show_offer_dialog(candidate_id: String) -> void:
 	var promise_boxes := {}
 	for pid in promise_labels:
 		var cb := CheckBox.new()
-		cb.text = promise_labels[pid]
+		# Legibility (fix/promise-currency): show the future obligation each promise costs BEFORE
+		# the player commits, so the ledger cost is never opaque (e.g. "owes 1 first-author paper
+		# slot in ~10 turns"). Cost text is data-driven from the Ledger promise spec.
+		var promise_cost: String = Ledger.appetite_promise_cost_text(pid)
+		cb.text = promise_labels[pid] if promise_cost == "" else "%s -- %s" % [promise_labels[pid], promise_cost]
 		cb.add_theme_font_size_override("font_size", 10)
 		cb.focus_mode = Control.FOCUS_NONE
 		cb.toggled.connect(_on_offer_promise_toggled.bind(candidate_id, promise_boxes, read_lbl, band_lbl))

--- a/godot/tests/unit/test_promise_currency.gd
+++ b/godot/tests/unit/test_promise_currency.gd
@@ -1,0 +1,171 @@
+extends GutTest
+## fix/promise-currency (Option B): appetite promises cost a FUTURE OBLIGATION IN THEIR OWN
+## DOMAIN, never raw reputation.
+##
+## THE BUG (confirmed from a real playtest death, turn 14): the old appetite_promise minted a
+## REPUTATION-currency principal (~2000) while reputation STARTS AT 50 and death fires at
+## reputation <= 0 (game_state.gd check_win_lose). A single promise's bill zeroed the whole
+## reputation bar -> instant death. The headline negotiation mechanic was a mis-scaled
+## instant-death trap.
+##
+## THE FIX: re-home each promise's cost onto the thing it actually promises --
+##   first_authorship -> a paper / first-author slot OWED (currency "papers")
+##   compute_budget   -> compute committed to the hire (currency "compute")
+##   mission_charter / mentorship -> a standing governance/mission obligation (currency "governance")
+## Magnitudes are small + survivable; NONE bill reputation. The discount-to-self_worth_floor
+## negotiation currency (ADR-0011) is unchanged -- only the COST side moved.
+##
+## DESIGN GUARDRAIL (Pip): a new player must NOT be able to LOSE within the first ~6 turns via
+## promises used as intended. Reputation must not be instantly zeroable by a single promise.
+
+
+func _new_state(seed_str: String = "promise_currency") -> GameState:
+	var s := GameState.new(seed_str)
+	s.turn = 1
+	return s
+
+
+func _make_candidate(state: GameState, spec: String, skill: int, expectation: float, appetites: Dictionary = {}) -> Researcher:
+	var c := Researcher.new(spec)
+	c.skill_level = skill
+	c.base_productivity = 0.5 + skill * 0.1
+	c.salary_expectation = expectation
+	c.current_salary = expectation
+	for k in Researcher.APPETITE_KEYS:
+		c.appetites[k] = float(appetites.get(k, 0.0))
+	state.candidate_pool.clear()
+	state.add_candidate(c)
+	return c
+
+
+func _advance_and_tick(state: GameState, ticks: int) -> void:
+	for i in range(ticks):
+		state.turn += 1
+		state.hiring.on_tick(state)
+
+
+# --- The rep-bomb is gone -------------------------------------------------------
+
+func test_no_promise_mints_a_reputation_currency_entry():
+	# Every promise id (incl. mentorship) must bill in its OWN domain, never reputation.
+	for pid in Ledger.PROMISE_SPEC:
+		var e: Ledger.Entry = Ledger.appetite_promise("Alice", pid)
+		assert_ne(e.currency, "reputation",
+			"promise '%s' must NOT be a reputation-currency entry (the old rep-bomb)" % pid)
+		assert_eq(e.currency, String(Ledger.PROMISE_SPEC[pid]["currency"]),
+			"promise '%s' bills in its domain currency" % pid)
+		assert_true(String(e.source).begins_with("promise:%s:" % pid),
+			"source keeps the promise:<id>:<name> tag for attribution")
+
+
+func test_promise_bill_does_not_zero_reputation():
+	# Billing a promise (even at its full principal) leaves reputation untouched -- the exact
+	# failure the fix targets. Bill the first-authorship promise directly.
+	var s := _new_state("rep_untouched")
+	var rep0: float = s.reputation
+	var e: Ledger.Entry = Ledger.appetite_promise("Alice", "first_authorship")
+	e.fuse = 0  # due now
+	s.ledger.add(e)
+	s.ledger.tick_and_bill(s)
+	s.check_win_lose()
+	assert_almost_eq(s.reputation, rep0, 0.001, "a promise bill leaves reputation unchanged")
+	assert_false(s.game_over, "no death from a promise bill")
+
+
+func test_promise_bills_in_its_domain_resource():
+	# first_authorship draws a paper; compute_budget draws compute; mission_charter draws
+	# governance -- all survivable, none touching reputation.
+	var s := _new_state("domain_bill")
+	s.papers = 3.0
+	var compute0: float = s.compute
+	var gov0: float = s.governance
+	for pid in ["first_authorship", "compute_budget", "mission_charter", "mentorship"]:
+		var e: Ledger.Entry = Ledger.appetite_promise("Alice", pid)
+		e.fuse = 0
+		s.ledger.add(e)
+	s.ledger.tick_and_bill(s)
+	assert_lt(s.papers, 3.0, "first_authorship consumed a paper slot")
+	assert_lt(s.compute, compute0, "compute_budget drew committed compute")
+	assert_lt(s.governance, gov0, "mission/mentorship charged governance (a standing obligation)")
+
+
+# --- Guardrail: promises cannot lose the game in the first 6 turns --------------
+
+func test_promise_heavy_hire_cannot_lose_within_6_turns():
+	# A promise-hungry candidate hired on ALL promises (as intended), then six turns of ledger
+	# billing. The player must survive -- reputation must not be zeroable by promises.
+	var s := _new_state("six_turn_safety")
+	var c := _make_candidate(s, "safety", 7, 80000.0, {
+		"prestige": 1.0, "compute": 1.0, "mission_purity": 1.0, "mentees": 1.0, "money": 0.0,
+	})
+	var all_promises := ["first_authorship", "compute_budget", "mission_charter", "mentorship"]
+	var promised_floor: float = s.hiring.self_worth_floor(c, all_promises)
+	s.hiring.make_offer(s, c.candidate_id, promised_floor + 500.0, all_promises)
+	_advance_and_tick(s, Balance.inum("hiring.offer.duration_ticks", 2))
+	assert_eq(c.hire_state, Researcher.HireState.EMPLOYED, "the promise-heavy offer was accepted")
+	# Confirm the promises minted domain obligations (not reputation).
+	var promise_entries := 0
+	for e in s.ledger.entries:
+		if String(e.source).begins_with("promise:"):
+			promise_entries += 1
+			assert_ne(e.currency, "reputation", "no minted promise is a reputation entry")
+	assert_eq(promise_entries, all_promises.size(), "each promise minted its obligation")
+
+	# Six turns of ledger billing from turn 1. The player must not lose.
+	var start_turn: int = s.turn
+	for t in range(6):
+		s.turn += 1
+		s.ledger.tick_and_bill(s)
+		s.check_win_lose()
+		assert_false(s.game_over,
+			"promises used as intended must not cause a loss by turn %d" % (s.turn - start_turn))
+	assert_gt(s.reputation, 0.0, "reputation is never zeroed by hiring promises")
+
+
+func test_worst_case_all_promises_bill_immediately_is_survivable():
+	# Stress: force EVERY promise to bill on turn 1 (fuse 0) from fresh starting resources.
+	# Even this worst case must be survivable (defends the guardrail against future fuse tuning).
+	var s := _new_state("worst_case")
+	for pid in Ledger.PROMISE_SPEC:
+		var e: Ledger.Entry = Ledger.appetite_promise("Alice", pid)
+		e.fuse = 0
+		s.ledger.add(e)
+	s.ledger.tick_and_bill(s)
+	s.check_win_lose()
+	assert_false(s.game_over, "all promises billing at once is survivable")
+	assert_gt(s.reputation, 0.0, "reputation survives a full promise barrage")
+
+
+# --- Serialization round-trip ---------------------------------------------------
+
+func test_promise_obligations_serialize_round_trip():
+	var s := _new_state("promise_saveload")
+	for pid in Ledger.PROMISE_SPEC:
+		s.ledger.add(Ledger.appetite_promise("Alice", pid))
+	var before := []
+	for e in s.ledger.entries:
+		before.append({"source": e.source, "currency": e.currency, "principal": e.principal, "fuse": e.fuse})
+
+	var blob := JSON.stringify(s.to_dict())
+	var parsed = JSON.parse_string(blob)
+	assert_not_null(parsed, "state with promise obligations serializes to JSON")
+
+	var s2 := GameState.new("promise_reload")
+	s2.from_dict(parsed)
+	assert_eq(s2.ledger.entries.size(), s.ledger.entries.size(), "all promise entries round-trip")
+	for i in range(before.size()):
+		var e2: Ledger.Entry = s2.ledger.entries[i]
+		assert_eq(e2.source, before[i]["source"], "source round-trips")
+		assert_eq(e2.currency, before[i]["currency"], "domain currency round-trips")
+		assert_almost_eq(e2.principal, before[i]["principal"], 0.001, "principal round-trips exactly")
+		assert_eq(e2.fuse, before[i]["fuse"], "fuse round-trips")
+
+
+# --- Legibility: the cost is surfaced before commit -----------------------------
+
+func test_each_promise_exposes_a_cost_line():
+	# The offer flow (main_ui.gd) reads this to show the obligation BEFORE the player commits.
+	for pid in Ledger.PROMISE_SPEC:
+		var text := Ledger.appetite_promise_cost_text(pid)
+		assert_true(text.length() > 0, "promise '%s' exposes a human cost line" % pid)
+		assert_true(text.contains("owes"), "the cost line names the obligation for '%s'" % pid)


### PR DESCRIPTION
## The bug (confirmed from a real playtest death, turn 14)
Appetite-promises (first_authorship / compute_budget / mission_charter / mentorship) minted a **reputation-currency** ledger entry (~2000 principal) while reputation **starts at 50** and death fires at **reputation <= 0** (`game_state.gd` `check_win_lose`). A single promise's bill zeroed the whole reputation bar -> instant death. The headline negotiation mechanic was a mis-scaled instant-death trap.

## The fix -- Option B (blessed): cost a FUTURE OBLIGATION IN ITS OWN DOMAIN
Re-home each promise's cost onto the thing it actually promises, as a survivable Ledger entry (ADR-0003), off reputation entirely:

| promise | now costs (currency) | principal | fuse |
|---|---|---|---|
| first_authorship | a paper / first-author slot OWED (`papers`) | 1 | 10 |
| compute_budget | compute committed to the hire (`compute`) | 20 | 8 |
| mission_charter | a standing governance/mission constraint (`governance`) | 6 | 12 |
| mentorship | a mentee commitment (`governance`) | 4 | 10 |

- Interest **0.0** (obligations, not compounding mortality levers); integer principals -> exact save/load round-trip (determinism, ADR-0006).
- The reputation-currency promise principal is **removed entirely**. The discount-to-`self_worth_floor` negotiation currency (ADR-0011) is **unchanged** -- only the COST side moved.
- New ledger `_bill` arms for `papers` / `compute` (survivable, no doom/rep teeth; a shortfall lapses).
- Magnitudes data-driven in `defaults.json` (`ledger.promise.*`).

## Legibility
The offer flow (`main_ui.gd`) now shows each ticked promise's future obligation **before** the player commits (e.g. "owes 1 first-author paper slot in ~10 turns"), via `Ledger.appetite_promise_cost_text`.

## Guardrail (Pip): no loss in the first ~6 turns
`test_promise_currency.gd` verifies: no promise mints a reputation entry; a promise bill never zeroes reputation; a **promise-heavy hire cannot lose the game within 6 turns**, incl. a worst-case all-promises-bill-at-once stress; domain obligations serialize round-trip; each promise exposes a cost line.

## Verify
- Fast gate: **444 tests, 0 fail**.
- Simulation/determinism tier: **93 tests, 0 fail** (touched economy/ledger).

Base: `feat/hiring-phase-b-pipeline` (do NOT merge to base directly; Pip reviews).

🤖 Generated with [Claude Code](https://claude.com/claude-code)