### PR TITLE
audio: music drop-in kit (#682 interface) + reference-track analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,12 @@ generate_icons.py
 # Third-party visual references (Pip mind-dump 2026-07-16) — NOT committed (copyright).
 # Aesthetic notes derived from these live in docs/game-design/WORLD_AND_LORE.md.
 art_prompts/16-july-2-26-dump/
+
+# Music reference tracks -- personal/copyrighted, NEVER committed. Only the
+# numeric JSON profiles (tools/music/profiles/, kept via .gitkeep) are tracked.
+# See tools/music/README.md. Cover both dir spellings + all audio formats.
+tools/music/ref_local/
+tools/music/refs_local/
+tools/music/**/*.flac
+tools/music/**/*.mp3
+tools/music/**/*.wav

--- a/docs/audio/MUSIC_DROPIN_KIT.md
+++ b/docs/audio/MUSIC_DROPIN_KIT.md
@@ -1,0 +1,245 @@
+# P(Doom)1 -- Adaptive-music drop-in kit (for the audio developer)
+
+> **Who this is for:** a professional audio developer new to this repo who wants
+> to replace the placeholder music with real composed stems. It documents the
+> ACTUAL audio interface the game implements, cited to code (`file:line`), plus a
+> step-by-step for swapping a placeholder for a real stem and an honest list of
+> what still needs building.
+>
+> **Provenance / important:** the adaptive interface described here lives in
+> **PR #682 / branch `feat/adaptive-music`** (`godot/autoload/music_manager.gd`).
+> As of this writing that branch is **not yet merged to `main`** -- `main` still
+> carries the older playlist-only `music_manager.gd`. All `file:line` citations
+> below are against the `feat/adaptive-music` version. Check that branch out (or
+> wait for it to land) before wiring real audio. Design rationale lives in
+> `docs/audio/MUSIC_DESIGN.md`; the placeholder audit in
+> `docs/audio/STEM_CATALOGUE.md`; the taste target in
+> `docs/audio/REFERENCE_TRACKS.md`.
+
+Engine: Godot 4.5.1, pure GDScript. The whole music system is one autoload node,
+`MusicManager` (`godot/autoload/music_manager.gd`), registered in
+`godot/project.godot` under `[autoload]` as
+`MusicManager="*res://autoload/music_manager.gd"`. No FMOD/Wwise; two native
+primitives only (`AudioStreamInteractive` + `AudioStreamSynchronized`).
+
+---
+
+## 1. Stem / slot inventory
+
+The adaptive system exposes **5 tier slots** (one clip per doom-intensity band).
+Each slot is a list of stems `{"path", "volume_db"}` in the constant
+`MUSIC_TIER_STEMS` (`music_manager.gd:38`). Tier names come from
+`MUSIC_TIER_NAMES = ["cosy","uneasy","spooky","eldritch","terminal"]`
+(`music_manager.gd:26`).
+
+| Tier | Slot name | Selected when doom band is... | Stems today (placeholder) | Volume |
+|---|---|---|---|---|
+| M0 | `cosy` | NOMINAL (<15% doom) | `PDoom1 Descent gradient.mp3` | 0 dB |
+| M1 | `uneasy` | ELEVATED + HIGH (15-52%) | `PDoom1 Local maxima.mp3` | 0 dB |
+| M2 | `spooky` | SEVERE + EXTREME (52-80%) | `PDoom1 Power spike.mp3` | 0 dB |
+| M3 | `eldritch` | CATASTROPHIC (80-92%) | `PDoom1 Undetected sandbagging.mp3` | 0 dB |
+| M4 | `terminal` | TERMINAL (92%+) | `PDoom1 Undetected sandbagging.mp3` **+** `PDoom1 Power spike.mp3` (layered) | 0 dB / -6 dB |
+
+All stem paths are under `res://assets/audio/music/` (repo dir
+`godot/assets/audio/music/`).
+
+**Real vs placeholder:** **0 of 5 slots have real composed stems.** All are FULL
+owned tracks standing in for per-tier stems (see the comment at
+`music_manager.gd:34-37`). Only **4 distinct audio files** back the 5 slots --
+M4 `terminal` reuses M3's and M2's tracks layered together, deliberately, to
+keep the `AudioStreamSynchronized` (multi-stem) code path exercised
+(`music_manager.gd:44-51`). None of the target layered stems (BASE / PULSE /
+WEIRD / FIRE from `MUSIC_DESIGN.md` section 4) exist yet: every current "stem"
+is a whole track, not a separable layer.
+
+Non-adaptive contexts (unchanged, NOT doom-driven) live in `music_library`
+(`music_manager.gd:62`): MENU playlist (2 tracks), VICTORY (**empty**), DEFEAT
+(1 track, `PDoom Out_of_distribution.mp3`). Menu stays non-adaptive on purpose
+(the menu has no doom).
+
+---
+
+## 2. Doom-band -> cue mapping
+
+Two art-spec axes (`docs/art/PALETTE_AND_DOOM_INTENSITY.md`) map to two musical
+dimensions (per `MUSIC_DESIGN.md` section 2): **Catastrophe (amber->red->fire)
+-> RHYTHM/percussive density**, **Weirdness (green->blue->violet) ->
+TIMBRE/detune-dissonance**. But the RUNTIME selector is single-valued: the game's
+doom % (0-100) is quantized to a doom band, then to a tier.
+
+The music system holds **no thresholds of its own** -- it calls
+`ThemeManager.get_doom_band_index(doom)` for the canonical band (0..6), then
+indexes `MUSIC_TIER_BY_BAND = [0,1,1,2,2,3,4]` (`music_manager.gd:30`) to get the
+tier (0..4). Retuning the doom bands in `ThemeManager` moves the music
+automatically.
+
+Signal path (read-only view layer; ADR-0006):
+
+```
+GameManager.game_state_updated(state)              # per-turn broadcast (existing)
+  -> MusicManager._on_game_state_for_music(state)  # reads state["doom"] only   (:137)
+    -> set_doom_level(doom%)                        # (:367)
+      -> music_tier_for_doom(doom%)                 # ThemeManager band -> tier  (:356)
+        -> _switch_adaptive_tier(tier)              # (:406)
+          -> AudioStreamPlaybackInteractive.switch_to_clip(tier)   # native crossfade
+```
+
+Transition rule (the crossfade): a **single any-to-any** transition added at
+`music_manager.gd:481-485`:
+`CLIP_ANY -> CLIP_ANY`, `TRANSITION_FROM_TIME_IMMEDIATE`,
+`TRANSITION_TO_TIME_START`, `FADE_CROSS`, over `ADAPTIVE_FADE_BEATS` (8) beats.
+With the stamped `ADAPTIVE_BPM = 120` (`music_manager.gd:52-53`), 8 beats = **a
+4-second cross-fade**, target clip restarted from its start. Tier only switches
+when the computed tier actually changes (`set_doom_level` early-returns
+otherwise, `:369-370`). Band quantization gives natural hysteresis (dead zones);
+no beat-alignment is attempted because the placeholder tracks share no tempo
+grid (see `MUSIC_DESIGN.md` section 6 for the intended up/down/hysteresis rules
+once real stems exist).
+
+| Trigger | From | To | What happens |
+|---|---|---|---|
+| doom rises/falls into a new band | any tier | new tier | `switch_to_clip`, 4 s FADE_CROSS, target restarts at 0 |
+| doom moves within same band | tier N | tier N | no-op (early return) |
+| entering GAMEPLAY context | -- | tier for current doom | adaptive stream starts at `initial_clip = current tier` (`:398`) |
+| MENU / VICTORY / DEFEAT | -- | -- | non-adaptive `music_library` playlist, NOT doom-driven |
+
+Debug hook: `debug_force_tier(tier)` (`music_manager.gd:377`) forces a tier
+directly for manual testing.
+
+---
+
+## 3. File format + conventions
+
+**Directory (canonical):** `godot/assets/audio/music/` (`res://assets/audio/music/`).
+SFX go in `godot/assets/audio/sfx/` (today just a `.gitkeep`).
+
+**Formats Godot 4.5 accepts here:**
+- **`.ogg` (Vorbis)** -- `AudioStreamOggVorbis`. **Preferred for looping music
+  stems**: compressed, and the runtime loop/BPM stamping applies to it.
+- **`.mp3`** -- `AudioStreamMP3`. What every current placeholder uses. Also
+  gets runtime loop/BPM stamping. (ffmpeg-free; Godot decodes natively.)
+- **`.wav`** -- `AudioStreamWAV`. Fine for short one-shots/SFX; for looping
+  music it must carry **import-set loop points** (the runtime stamping does NOT
+  apply to WAV -- see below).
+
+**Loop + BPM handling (important, this is done at runtime):** `_prepare_stem`
+(`music_manager.gd:492-497`) `duplicate()`s each loaded stream (so tweaks never
+leak into the shared resource cache the playlist also uses) and, **for MP3/Ogg
+only**, sets `stream.loop = true` and `stream.bpm = 120`. So today a whole
+placeholder track is force-looped end-to-end (no authored loop point -> it wraps
+at the file boundary, acceptable only because these beds have no hard tail). For
+**WAV**, the code does NOT set loop -- it relies on the `.import` loop settings
+(`edit/loop_mode` in the `.wav.import`), else the clip goes silent at its end and
+the `finished` signal restarts it (`:266-272`, `music_manager.gd:498-503`).
+
+**Import metadata:** the per-asset `.import` file is committed alongside each
+audio file (Godot 4 convention -- see repo `CLAUDE.md`). Current MP3 imports have
+`loop=false, bpm=0` (runtime overrides both). WAV import defaults show
+`force/max_rate_hz=44100`, `edit/loop_mode=0`.
+
+**Recommended authoring conventions for real stems:**
+- Deliver **`.ogg` (or `.wav`)**, 44.1 kHz, stereo (mono acceptable for a mix
+  layer). Match loudness roughly to about -16 LUFS integrated per stem; final
+  balance is per-stem `volume_db` in-engine.
+- **Seamless loop:** author the loop so head meets tail with no click and no
+  reverb tail crossing the loop point (bake tails into the loop). The engine
+  will still hard-loop MP3/Ogg, so the FILE boundary must BE the loop point.
+- **Within a tier:** all stems share tempo, key (or a fixed relationship), and
+  length (or integer multiple), so `AudioStreamSynchronized` stacks them cleanly.
+- **Naming:** keep the ML/AI-safety pun register (e.g. "Mesa optimizer", "Reward
+  hacking"); the game's voice depends on it (`STEM_CATALOGUE.md`). Existing
+  filename typos ("PDOOMN", "seleciton") are shipped names -- preserve them.
+
+---
+
+## 4. How to replace a placeholder with a real stem
+
+Aimed at a developer new to this repo. Assumes the `feat/adaptive-music` branch
+(#682) is checked out.
+
+1. **Drop the file in.** Copy your rendered stem (e.g. `bed_cosy.ogg`) into
+   `godot/assets/audio/music/`. Use `.ogg` or `.wav`.
+2. **Let Godot import it.** Open the project in the editor
+   (`godot --path godot`, or `make run`), or run a headless import pass
+   (`godot --headless --path godot --import`). Godot writes a
+   `bed_cosy.ogg.import` (and maybe a `.uid`) next to the file. **Commit the
+   audio file AND its `.import`/`.uid`** -- they are tracked on purpose. Do NOT
+   `git add -A` (it stages ~1200 unrelated `.import` churn); `git add` only your
+   file and its sidecars.
+3. **(Optional) set a loop point for WAV.** If you shipped a `.wav` whose loop is
+   not the whole file, select it in the editor's Import dock, set
+   `Loop Mode = Forward` with begin/end sample points, and Reimport. MP3/Ogg are
+   force-looped whole-file at runtime, so no editor step is needed there -- the
+   file must itself be one seamless loop.
+4. **Register it in `MUSIC_TIER_STEMS`** (`godot/autoload/music_manager.gd:38`).
+   Replace the placeholder path for the relevant tier. Example -- swap the cosy
+   bed and add a second synchronized layer:
+   ```gdscript
+   const MUSIC_TIER_STEMS := [
+       [   # M0 cosy -- now a 2-stem synchronized group (BASE + PULSE)
+           {"path": "res://assets/audio/music/bed_cosy.ogg",   "volume_db": 0.0},
+           {"path": "res://assets/audio/music/pulse_cosy.ogg", "volume_db": -3.0},
+       ],
+       # ... M1..M4 unchanged
+   ]
+   ```
+   Multiple stems in one tier are auto-wrapped in an `AudioStreamSynchronized`
+   with per-stem `volume_db` (`music_manager.gd:461-475`); a single stem is used
+   directly. No other code changes -- this is a **data edit**.
+5. **Test in-engine.** Start a game session (GAMEPLAY context builds the adaptive
+   stream, `music_manager.gd:384`). To move tiers without playing to high doom,
+   call `MusicManager.debug_force_tier(0..4)` from a dev overlay / remote debugger.
+   Watch the console: the manager logs `Adaptive stem missing, skipping`,
+   `Adaptive stream built: N tiers`, and `Doom X% -> music tier N (name)`.
+6. **Run the unit tests** (they cover the wiring, not the audio content):
+   `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`.
+   `godot/tests/unit/test_adaptive_music.gd` asserts tier mapping, clip-per-tier,
+   and listen-only signal wiring. A malformed path just degrades (see section 5),
+   so also confirm your file actually loads via the console log.
+
+**Loop/transition behaviour to expect:** within a tier the stem(s) loop
+indefinitely (whole-file for MP3/Ogg). When doom crosses a band boundary the
+engine cross-fades to the new tier's clip over ~4 s and restarts that clip from
+0. Missing/failed stems never crash -- they degrade.
+
+---
+
+## 5. Gaps / TODO -- what EXISTS vs what the audio dev must still build
+
+**What is ready (plumbing, done):**
+- The full doom-band -> tier -> clip pipeline, read-only and determinism-safe
+  (ADR-0006). Adding real stems is a pure data edit in one constant.
+- `AudioStreamInteractive` (horizontal tier crossfades) AND
+  `AudioStreamSynchronized` (vertical multi-stem stacking) are both wired and
+  exercised (terminal tier layers two stems today).
+- Graceful degradation everywhere: a missing stem is skipped
+  (`music_manager.gd:441-449`); an empty tier inherits a neighbour's stream
+  (`:466-472`); a fully-empty build falls back to the legacy playlist
+  (`:463-465`); no audio == silence, not an error.
+- Per-stem `volume_db`, runtime loop/BPM stamping for MP3/Ogg, 4 s crossfade.
+
+**What is still stubbed / missing (the commission):**
+1. **No real stems exist -- all 5 slots are placeholders (4 distinct full
+   tracks).** The core ask: per-tier **BASE / PULSE / WEIRD** stem groups (and a
+   **FIRE** topper for M3/M4), sharing tempo+key within each tier, authored as
+   seamless loops. Today no tier expresses the rhythm-vs-timbre axes -- they are
+   just five whole ambient tracks. (`STEM_CATALOGUE.md` "Gaps to fill".)
+2. **Loop points are not authored.** MP3/Ogg are force-looped whole-file at
+   runtime; there are no seamless loop points and no shared tempo grid, so the
+   stamped 120 BPM is nominal and beat-aligned transitions are false precision.
+   Real stems must be authored so the file boundary IS a clean loop.
+3. **VICTORY music is empty** (`music_library` VICTORY = `[]`,
+   `music_manager.gd:73`) -- the win screen is silent. Needs a track.
+4. **Transition polish not built:** only a single any-to-any 4 s crossfade
+   exists. The intended up-tier(prompt)/down-tier(lazy) asymmetry, M3->M4 filler
+   sting, and down-transition hysteresis (`MUSIC_DESIGN.md` section 6) are not
+   implemented yet.
+5. **Minor:** `PDoom1 seleciton beeyoowee.wav` (0.72 s UI blip) is miscatalogued
+   in the MENU *music* rotation; SFX in `sounds/` (repo root) are not wired and
+   their rights are unverified. A terminal->defeat bridge and a second menu bed
+   are nice-to-haves. (`STEM_CATALOGUE.md`.)
+
+Bottom line for the audio dev: **the engine is ready; the music is not.** Your
+job is composing the per-tier layered stems (and victory/defeat cues); wiring
+them is dropping files in `godot/assets/audio/music/` and editing the one
+`MUSIC_TIER_STEMS` table.

--- a/tools/music/README.md
+++ b/tools/music/README.md
@@ -1,0 +1,127 @@
+# tools/music -- reference-track analyzer
+
+Turns the dev's beloved reference tracks into NUMBERS the music lab (Fable /
+Strudel / SuperCollider) can compose against, so composed stems match the
+pulse and structure of the north-star tracks (e.g. Master Musicians Of
+Bukkake -- "People Of The Drifting Houses"). It is an offline analysis tool;
+it does not touch the game or CI.
+
+Companion docs:
+- `docs/audio/REFERENCE_TRACKS.md` -- the aesthetic north stars + a prior
+  hand-rolled DSP pass (ffmpeg + numpy). This tool is the repeatable,
+  richer-featured successor.
+- `docs/audio/MUSIC_DESIGN.md` / `docs/audio/STEM_CATALOGUE.md` -- what the
+  numbers are FOR (the doom-band adaptive-music model + stem commission).
+- `docs/audio/MUSIC_DROPIN_KIT.md` -- how a real stem replaces a placeholder.
+
+## IMPORTANT: reference audio stays LOCAL, never committed
+
+The reference tracks are personal and copyrighted. **Never commit the audio.**
+Only the emitted JSON profiles are safe to keep -- extracted features (BPM,
+chroma, section times) are facts and carry no rights baggage.
+
+- Put your local copies in `tools/music/ref_local/` (singular "ref"; this is
+  the dir Pip already uses -- gitignored).
+- `.gitignore` already excludes `tools/music/ref_local/` (and the alternate
+  `refs_local/` spelling) plus any `*.flac` / `*.mp3` / `*.wav` under
+  `tools/music/` so personal audio cannot be staged by accident.
+- If you analyze files from elsewhere on disk, that is fine too -- just do not
+  copy them into the repo except under `ref_local/`.
+
+## Install (local/dev only)
+
+The analyzer needs **librosa** (which pulls in numpy / scipy / numba /
+soundfile). It is intentionally **NOT** added to `requirements-dev.txt` --
+librosa is heavy and this is a local-only tool, so keeping it out of the dev
+requirements keeps CI installs light.
+
+```
+python -m pip install librosa
+```
+
+FLAC loads natively (soundfile); MP3 loads via `ffmpeg`, so **no format
+conversion step is required** -- point the tool straight at your `.flac` /
+`.mp3` files. (ffmpeg on PATH is the only non-pip prerequisite for MP3.) If
+librosa is missing the script prints this same install line and exits
+non-zero (no traceback).
+
+Python 3.11 baseline (repo automation floor).
+
+## Usage
+
+```
+python tools/music/analyze_refs.py path/to/track.mp3 [more.mp3 ...]
+python tools/music/analyze_refs.py --help
+```
+
+One JSON profile per input is written to `tools/music/profiles/<trackname>.json`.
+Useful flags: `--segments N` (target section count, default 8), `--env-buckets N`
+(intensity-envelope resolution, default 32), `--sr HZ` (analysis rate, default
+22050), `-o DIR` (output dir).
+
+Batch the recommended set (assuming local copies live in `ref_local/`; FLAC and
+MP3 both work directly):
+
+```
+python tools/music/analyze_refs.py tools/music/ref_local/*.flac tools/music/ref_local/*.mp3
+```
+
+## Recommended 5 reference tracks to analyze
+
+Pulled from `docs/audio/REFERENCE_TRACKS.md` (the top-played, most
+stylistically-relevant set):
+
+1. **Master Musicians Of Bukkake -- People Of The Drifting Houses** (the most
+   beloved; ritual pulse + large-scale build-and-release).
+2. **Philip Glass -- Knee Play 5** (Einstein on the Beach; progressive
+   minimalist patterns, and Knee Play 1 is literally sung numbers -- the
+   formulae-as-lyrics ancestor).
+3. **Braided Hair -- Speech feat. 1 Giant Leap** (the intro loops: additive
+   loop-cell staircase = the vertical stem-stacking model).
+4. **Dengue Fever -- Touch Me Not** (simple, distinct instrumental melody over
+   a modal bed).
+5. **The Staves -- Wisely and Slow** (close vocal harmony -- the reference for
+   the title theme's harmonized formulae-as-lyrics).
+
+(Nina Simone -- "Feeling Good" is a 6th brass-line reference; add it if you
+want the progressive-brass data point.)
+
+## What each profile contains
+
+Per track, `<trackname>.json` holds:
+
+- `tempo` -- estimated BPM + beat grid (`beat_times_sec`), plus `bpm_half` /
+  `bpm_double` because BPM estimates alias to 2x/4x of the felt tempo (the
+  `~84 BPM ritual heartbeat` vs `~104-112 pattern` lanes from REFERENCE_TRACKS.md).
+- `key` -- Krumhansl-Schmuckler tonic + mode + top-4 candidates (a tonal
+  CENTER, not a functional key; drone/modal material has no cadence to pin it).
+- `tonal` -- normalized mean chroma (12 pitch classes) + the top pitch classes
+  (spot the C/D modal-drone home: fifth + flat-7).
+- `rhythm` -- onset count, onsets/sec density, and onset times.
+- `intensity_envelope` -- time-bucketed arrays: `rms`, `rms_db_rel_peak` (the
+  loudness ARC -- reveals ritual build-release), `onset_strength`,
+  `onset_density`, `spectral_centroid_hz` (brightness proxy for the weirdness
+  tilt budget).
+- `sections` -- structural boundary times (agglomerative segmentation over
+  chroma + MFCC).
+
+## How the JSON feeds the composition loop
+
+The profiles are compact, ASCII, and language-model-friendly. The intended
+loop:
+
+1. Analyze the 5 references -> `tools/music/profiles/*.json`.
+2. Hand a profile (or several) to the composition agent (Fable) with the ask
+   from `docs/audio/MUSIC_DESIGN.md` (per-tier BASE / PULSE / WEIRD / FIRE
+   stems). The agent reads `tempo.bpm_half` for the heartbeat lane,
+   `tonal.top_pitch_classes` for the drone center, `sections.boundary_times_sec`
+   + `intensity_envelope.rms_db_rel_peak` for the build-release shape, and
+   `rhythm.onset_density_per_sec` for how busy the PULSE stem should be.
+3. The agent emits Strudel / SuperCollider patterns whose tempo/key/structure
+   match the reference numbers.
+4. Rendered stems drop into the game via `docs/audio/MUSIC_DROPIN_KIT.md`
+   (the `MUSIC_TIER_STEMS` table in `godot/autoload/music_manager.gd`).
+
+The profiles are just a starting seed -- the doom-tier LADDER supplies the
+large-scale build; within-tier stems stay hypnotically flat (Glass-like), per
+`docs/audio/REFERENCE_TRACKS.md`.

--- a/tools/music/analyze_refs.py
+++ b/tools/music/analyze_refs.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Reference-track analyzer for P(Doom)1 adaptive-music composition.
+
+Turns a personal reference MP3 (Pip's aesthetic north stars -- see
+docs/audio/REFERENCE_TRACKS.md) into a NUMERIC profile a language model can
+compose Strudel / SuperCollider patterns against: tempo + beat grid, estimated
+key/mode, section boundaries, a rhythmic-intensity envelope (RMS + onset
+density over time), a coarse loudness arc, and a chroma/tonal summary.
+
+The audio files are personal / copyrighted and MUST stay local (gitignored --
+put them in tools/music/ref_local/). Only the emitted NUMBERS are safe to
+keep; they carry no rights baggage. See tools/music/README.md.
+
+Usage:
+    python tools/music/analyze_refs.py path/to/track.mp3 [more.mp3 ...]
+
+Output:
+    tools/music/profiles/<trackname>.json  (one per input track)
+
+Dependency: librosa (heavy; intentionally NOT in requirements-dev.txt to keep
+CI light). If it is missing this script prints the install line and exits
+non-zero rather than crashing with a raw traceback.
+"""
+
+import argparse
+import json
+import math
+import os
+import sys
+from datetime import datetime, timezone
+
+# Krumhansl-Schmuckler key profiles (major / minor). Correlating the mean
+# chroma against all 12 rotations of each picks the most likely tonal center.
+# These are a de-facto standard; they name a TONAL CENTER, not a functional key
+# (drone/modal material has no leading-tone cadence to disambiguate) -- treat
+# the estimate as direction, matching the caveat in REFERENCE_TRACKS.md.
+_KS_MAJOR = [6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88]
+_KS_MINOR = [6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17]
+_PITCH_CLASSES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
+
+# JSON schema version -- bump if the emitted structure changes so downstream
+# (Fable / Strudel) consumers can detect stale profiles.
+SCHEMA_VERSION = 1
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog="analyze_refs.py",
+        description=(
+            "Analyze reference audio tracks into JSON compositional seeds "
+            "(tempo, key, sections, intensity envelope, chroma) for the "
+            "P(Doom)1 adaptive-music lab. See tools/music/README.md."
+        ),
+        epilog=(
+            "Input MP3s are personal/copyrighted -- keep them in the "
+            "gitignored tools/music/ref_local/ dir. Only the JSON profiles "
+            "(numbers) are committed/shared."
+        ),
+    )
+    parser.add_argument(
+        "tracks",
+        nargs="+",
+        metavar="TRACK",
+        help="one or more audio files (mp3/wav/flac/ogg) to analyze",
+    )
+    parser.add_argument(
+        "-o",
+        "--out-dir",
+        default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "profiles"),
+        help="directory for the emitted <trackname>.json files " "(default: tools/music/profiles/)",
+    )
+    parser.add_argument(
+        "--sr",
+        type=int,
+        default=22050,
+        help="analysis sample rate in Hz (default: 22050; librosa default, "
+        "plenty for tempo/chroma/structure)",
+    )
+    parser.add_argument(
+        "--segments",
+        type=int,
+        default=8,
+        help="target number of structural sections to detect (default: 8)",
+    )
+    parser.add_argument(
+        "--env-buckets",
+        type=int,
+        default=32,
+        help="number of time buckets for the intensity envelope arrays "
+        "(default: 32; keeps JSON compact)",
+    )
+    return parser.parse_args(argv)
+
+
+def _require_librosa():
+    """Import librosa lazily so --help works without it. Exit cleanly if absent."""
+    try:
+        import librosa  # noqa: F401
+        import numpy  # noqa: F401
+    except ImportError as exc:
+        sys.stderr.write(
+            "\n[analyze_refs] Missing dependency: this tool needs 'librosa' "
+            "(which pulls in numpy/scipy/numba/soundfile).\n"
+            "  Install it into your local/dev Python (it is intentionally NOT "
+            "in requirements-dev.txt to keep CI light):\n\n"
+            "      pip install librosa\n\n"
+            "  On Windows you may also need a working ffmpeg on PATH for MP3 "
+            "decoding (audioread/soundfile backend).\n"
+            "  Underlying import error: %s\n" % exc
+        )
+        sys.exit(2)
+
+
+def _estimate_key(chroma_mean):
+    """Krumhansl-Schmuckler: return (tonic, mode, correlation, ranked list)."""
+    import numpy as np
+
+    vec = np.asarray(chroma_mean, dtype=float)
+    if vec.sum() <= 0:
+        return {"tonic": None, "mode": None, "correlation": 0.0, "candidates": []}
+    vec = vec - vec.mean()
+    major = np.asarray(_KS_MAJOR) - np.mean(_KS_MAJOR)
+    minor = np.asarray(_KS_MINOR) - np.mean(_KS_MINOR)
+
+    def _corr(a, b):
+        denom = math.sqrt(float(np.dot(a, a)) * float(np.dot(b, b)))
+        return float(np.dot(a, b) / denom) if denom > 0 else 0.0
+
+    scored = []
+    for i in range(12):
+        rot = np.roll(vec, -i)
+        scored.append((_PITCH_CLASSES[i], "major", _corr(rot, major)))
+        scored.append((_PITCH_CLASSES[i], "minor", _corr(rot, minor)))
+    scored.sort(key=lambda t: t[2], reverse=True)
+    best = scored[0]
+    candidates = [{"tonic": t, "mode": m, "correlation": round(c, 4)} for (t, m, c) in scored[:4]]
+    return {
+        "tonic": best[0],
+        "mode": best[1],
+        "correlation": round(best[2], 4),
+        "candidates": candidates,
+    }
+
+
+def _bucket(values, n_buckets):
+    """Down-sample a 1-D array to n_buckets means (compact envelope for JSON)."""
+    import numpy as np
+
+    values = np.asarray(values, dtype=float)
+    if values.size == 0:
+        return []
+    if values.size <= n_buckets:
+        return [round(float(v), 5) for v in values]
+    edges = np.linspace(0, values.size, n_buckets + 1, dtype=int)
+    out = []
+    for i in range(n_buckets):
+        seg = values[edges[i] : edges[i + 1]]
+        out.append(round(float(seg.mean()) if seg.size else 0.0, 5))
+    return out
+
+
+def _analyze(path, args):
+    """Compute the full numeric profile for one track. Returns a dict."""
+    import librosa
+    import numpy as np
+
+    y, sr = librosa.load(path, sr=args.sr, mono=True)
+    duration = float(librosa.get_duration(y=y, sr=sr))
+    hop = 512
+
+    # --- Tempo + beat grid ---
+    onset_env = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop)
+    tempo, beat_frames = librosa.beat.beat_track(onset_envelope=onset_env, sr=sr, hop_length=hop)
+    tempo = float(np.atleast_1d(tempo)[0])
+    beat_times = librosa.frames_to_time(beat_frames, sr=sr, hop_length=hop).tolist()
+
+    # --- Onset events (rhythmic density) ---
+    onset_frames = librosa.onset.onset_detect(onset_envelope=onset_env, sr=sr, hop_length=hop)
+    onset_times = librosa.frames_to_time(onset_frames, sr=sr, hop_length=hop)
+    onset_density = float(len(onset_times) / duration) if duration > 0 else 0.0
+
+    # --- RMS + onset-strength envelopes over time (bucketed) ---
+    rms = librosa.feature.rms(y=y, hop_length=hop)[0]
+    rms_db = librosa.amplitude_to_db(rms + 1e-10, ref=np.max(rms) + 1e-10)
+    # onset events per env bucket (rhythmic-intensity, not just amplitude)
+    n_frames = onset_env.shape[0]
+    onset_hist = np.zeros(n_frames)
+    for f in onset_frames:
+        if 0 <= f < n_frames:
+            onset_hist[f] = 1.0
+
+    # --- Chroma / tonal summary ---
+    chroma = librosa.feature.chroma_cqt(y=y, sr=sr, hop_length=hop)
+    chroma_mean = chroma.mean(axis=1)
+    chroma_norm = (
+        (chroma_mean / chroma_mean.sum()).tolist()
+        if chroma_mean.sum() > 0
+        else chroma_mean.tolist()
+    )
+    top_idx = list(np.argsort(chroma_mean)[::-1][:3])
+    top_pitches = [_PITCH_CLASSES[int(i)] for i in top_idx]
+    key = _estimate_key(chroma_mean)
+
+    # --- Spectral brightness (centroid), for the "unsettling tilt" budget ---
+    centroid = librosa.feature.spectral_centroid(y=y, sr=sr, hop_length=hop)[0]
+
+    # --- Section boundaries (structural segmentation) ---
+    # Agglomerative clustering over stacked chroma + MFCC gives robust,
+    # tempo-agnostic section edges (novelty-style) without hand-tuning.
+    try:
+        mfcc = librosa.feature.mfcc(y=y, sr=sr, hop_length=hop, n_mfcc=13)
+        stack = np.vstack(
+            [librosa.util.normalize(chroma, axis=1), librosa.util.normalize(mfcc, axis=1)]
+        )
+        k = max(2, min(int(args.segments), stack.shape[1] - 1))
+        bound_frames = librosa.segment.agglomerative(stack, k)
+        bound_times = librosa.frames_to_time(bound_frames, sr=sr, hop_length=hop).tolist()
+        # ensure the final boundary reaches the end of the track
+        if not bound_times or bound_times[-1] < duration - 1.0:
+            bound_times.append(round(duration, 3))
+        bound_times = [round(float(t), 3) for t in bound_times]
+    except Exception as exc:  # segmentation is best-effort, never fatal
+        bound_times = [0.0, round(duration, 3)]
+        sys.stderr.write(
+            "[analyze_refs] segmentation fell back for %s: %s\n" % (os.path.basename(path), exc)
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_basename": os.path.basename(path),
+        "analyzed_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "analysis_sr": sr,
+        "duration_sec": round(duration, 3),
+        "tempo": {
+            "bpm": round(tempo, 2),
+            "bpm_half": round(tempo / 2.0, 2),
+            "bpm_double": round(tempo * 2.0, 2),
+            "beat_count": len(beat_times),
+            "beat_times_sec": [round(float(t), 3) for t in beat_times],
+            "note": (
+                "BPM is a dominant-periodicity estimate; it can alias to "
+                "2x/4x of the felt tempo. bpm_half/bpm_double given for the "
+                "'ritual heartbeat' vs 'pattern' lanes (see REFERENCE_TRACKS.md)."
+            ),
+        },
+        "key": key,
+        "tonal": {
+            "chroma_mean_normalized": [round(float(c), 5) for c in chroma_norm],
+            "pitch_class_order": _PITCH_CLASSES,
+            "top_pitch_classes": top_pitches,
+            "note": (
+                "Tonal CENTER, not a functional key. Modal/drone material "
+                "(C/D center, fifth + flat-7) is the target home per "
+                "REFERENCE_TRACKS.md."
+            ),
+        },
+        "rhythm": {
+            "onset_count": int(len(onset_times)),
+            "onset_density_per_sec": round(onset_density, 3),
+            "onset_times_sec": [round(float(t), 3) for t in onset_times.tolist()],
+        },
+        "intensity_envelope": {
+            "buckets": int(args.env_buckets),
+            "rms": _bucket(rms, args.env_buckets),
+            "rms_db_rel_peak": _bucket(rms_db, args.env_buckets),
+            "onset_strength": _bucket(onset_env, args.env_buckets),
+            "onset_density": _bucket(onset_hist, args.env_buckets),
+            "spectral_centroid_hz": _bucket(centroid, args.env_buckets),
+            "note": (
+                "Arrays are time-ordered, evenly spaced across the whole "
+                "track (bucket count above). rms_db_rel_peak is the loudness "
+                "ARC (dB relative to peak) used to spot ritual build-release."
+            ),
+        },
+        "sections": {
+            "boundary_times_sec": bound_times,
+            "count": max(0, len(bound_times) - 1),
+            "note": "Agglomerative segmentation over chroma+MFCC (novelty-style).",
+        },
+        "spectral": {
+            "centroid_hz_mean": round(float(np.mean(centroid)), 1),
+            "low_energy_lt150hz_note": "not computed; use centroid as brightness proxy",
+        },
+    }
+
+
+def main(argv=None):
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    _require_librosa()  # after arg parse so --help never needs librosa
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    failures = 0
+    written = []
+
+    for path in args.tracks:
+        if not os.path.isfile(path):
+            sys.stderr.write("[analyze_refs] SKIP (not a file): %s\n" % path)
+            failures += 1
+            continue
+        stem = os.path.splitext(os.path.basename(path))[0]
+        out_path = os.path.join(args.out_dir, stem + ".json")
+        try:
+            print("[analyze_refs] analyzing: %s" % path)
+            profile = _analyze(path, args)
+            with open(out_path, "w", encoding="ascii") as fh:
+                json.dump(profile, fh, indent=2, ensure_ascii=True)
+                fh.write("\n")
+            written.append(out_path)
+            print(
+                "[analyze_refs]   -> %s  (bpm=%.1f key=%s %s, %d sections)"
+                % (
+                    out_path,
+                    profile["tempo"]["bpm"],
+                    profile["key"]["tonic"],
+                    profile["key"]["mode"],
+                    profile["sections"]["count"],
+                )
+            )
+        except Exception as exc:  # one bad file must not abort the batch
+            sys.stderr.write("[analyze_refs] FAILED on %s: %s\n" % (path, exc))
+            failures += 1
+
+    print("[analyze_refs] done: %d profile(s) written, %d failure(s)." % (len(written), failures))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Foundation for the game's adaptive-music work. **No game-logic changes** -- docs + one offline tool.

## What this adds

### `docs/audio/MUSIC_DROPIN_KIT.md` -- the drop-in kit
Documents the ACTUAL audio interface implemented by **#682 (`feat/adaptive-music`)** so a professional audio dev new to this repo can patch in real audio. Cited to `godot/autoload/music_manager.gd:line`. Covers:
1. **Stem/slot inventory** -- 5 tier slots (`cosy/uneasy/spooky/eldritch/terminal`), which doom band selects each, and current placeholder paths. Honest count: **0 of 5 slots have real composed stems** (all placeholders; only 4 distinct files; terminal layers two).
2. **Doom-band -> cue mapping** -- table + signal path (`GameManager.game_state_updated` -> `set_doom_level` -> `ThemeManager` band -> `MUSIC_TIER_BY_BAND` -> `switch_to_clip`); single any-to-any 4 s `FADE_CROSS`.
3. **Format/loop conventions** -- Godot 4.5 `.ogg`/`.mp3`/`.wav`, the runtime loop/BPM stamping (MP3/Ogg force-looped, WAV via import loop points), directory `godot/assets/audio/music/`.
4. **Step-by-step** to swap a placeholder for a real stem (drop file -> import -> register in `MUSIC_TIER_STEMS` -> test with `debug_force_tier` -> run unit tests).
5. **Gaps/TODO** -- what's ready (plumbing) vs what the dev must build (real stems, loop points, victory music, transition polish).

> Note: #682 is not yet merged to `main`; the doc flags this and cites the branch.

### `tools/music/analyze_refs.py` + `README.md` -- the reference analyzer
A Python 3.11 + librosa tool that turns the dev's beloved reference tracks into NUMBERS the Strudel/SuperCollider composition loop can match: tempo + beat grid, KS key/mode, section boundaries, RMS/onset intensity envelope, chroma/tonal summary. Emits one JSON profile per track to `tools/music/profiles/`.
- Graceful degradation: if librosa is absent it prints the `pip install librosa` line and exits non-zero (no traceback).
- Personal/copyrighted audio stays in gitignored `tools/music/ref_local/` -- never committed; only the numeric profiles are kept.
- README lists the recommended 5 reference tracks and how the JSON feeds the compose loop.

`.gitignore` excludes `tools/music/ref_local/` (+ `refs_local/`) and any flac/mp3/wav under `tools/music/`; `profiles/` kept via `.gitkeep`.

## Verification
- `python -m py_compile tools/music/analyze_refs.py` passes.
- `python tools/music/analyze_refs.py --help` prints usage, exits 0. librosa is NOT installed in this environment; the graceful-degradation path was confirmed (prints install line, exits 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)