### PR TITLE
art: asset-gen pipeline audit + hero palette + icon manifest (no-spend foundation)

### DIFF
--- a/docs/art/ASSET_PIPELINE.md
+++ b/docs/art/ASSET_PIPELINE.md
@@ -1,0 +1,180 @@
+# Asset generation pipeline (gpt-image-1.5)
+
+Audit of the existing `tools/assets/` pipeline plus the no-spend foundation added
+alongside it (palette extractor + first icon manifest). Nothing in this doc calls
+an image API; the generation step is described, not run.
+
+Read order: this file for the loop, `docs/art/palette.json` for the brand colours,
+`tools/assets/manifests/icons_v1.json` for the first icon set.
+
+## TL;DR loop
+
+```
+manifest (YAML native; JSON also parses)
+    |
+    v
+tools/assets/generate_images.py  --file <manifest> [--dry-run] [--variants N] [--yes]
+    |  (OpenAI Images API, model gpt-image-1.5; needs OPENAI_API_KEY)
+    v
+art_generated/<asset_type>/v1/<id>[_vN]_<size>.png     <-- master + downscaled widths
+    |
+    v
+REVIEW  --  tools/assets/select_assets.py --gallery generated   (writes asset_gallery.html)
+    |         [click variants -> copy "id:vN ..." commands]
+    v
+tools/assets/select_assets.py --select id:vN ...   (writes selected_variant into the manifest)
+    |
+    v
+tools/assets/promote_assets.py --file <manifest> [--mark-promoted]
+    |  (copies selected variant, strips the _vN suffix)
+    v
+godot/assets/icons/<category>/<id>_<size>.png
+    |
+    v
+tools/assets/audit_icons.py   (checks godot/assets/icons vs godot/data/icon_mapping.json)
+```
+
+The nicer keyboard-driven `tools/art_review/build.py` viewer is a **separate track**
+(pixellab sweep, not gpt-image output) -- see "Glue gaps" #1.
+
+## What each script does
+
+### `tools/assets/generate_images.py` -- the generator
+- **Input format:** a **YAML** prompt file passed as `--file <path>`
+  (`load_prompts` uses `yaml.safe_load`, lines 204-207; arg at line 380, load at
+  line 438). Because JSON is a subset of YAML, `yaml.safe_load` also parses a JSON
+  manifest, so `--file tools/assets/manifests/icons_v1.json` works unchanged
+  (verified by a dry-run). Top-level keys the script reads: `asset_type`,
+  `default_size`, `output_sizes`, `styles`, `themes`, `assets` (lines 441-445).
+  Unknown keys (e.g. our `_meta`, `schema_version`) are ignored.
+- **Per-asset fields:** `id`, `category`, `status`, `theme`, `prompt_tail`
+  (plus optional `display_name`, `reference_images`, `generation_history`).
+  The full prompt is assembled in `build_full_prompt` (lines 216-243) as
+  `styles[theme.style_overrides...] + theme.color_bias + prompt_tail`.
+- **Backend / model:** default backend `openai`, default model **gpt-image-1.5**
+  (`DEFAULT_OPENAI_MODEL`, line 42; gpt-image-1 retires 2026-10-23). A dormant
+  `--backend gemini` (Nano Banana Pro) path exists (lines 158-201) and is the
+  only path that consumes `--reference-images` for style consistency.
+- **API key:** `get_client()` (lines 122-129) constructs `OpenAI()`, which reads
+  **`OPENAI_API_KEY` from the environment implicitly** -- there is no key CLI arg.
+  `--dry-run` never constructs the client, so it needs no key (confirmed).
+- **Size / quality:** the request passes only `model, prompt, size`
+  (`_openai_generate_bytes`, line 154). `size` comes from the manifest's
+  `default_size` (line 443). There is **no quality param and no
+  `background="transparent"`** in the call -- see Glue gaps #2.
+- **Where it writes:** `art_generated/<asset_type>/v1/` (line 451). It saves a
+  master `<id>[_vN]_<masterwidth>.png` then downscales to each width in
+  `output_sizes` (lines 286-318). Logs go to `art_generated/logs/` (lines 73-104).
+- **Cost:** dry-run/confirm estimate only (`estimate_cost_per_image`, lines 56-62;
+  ~$0.06 at 1024, ~$0.09 for landscape). Real spend is whatever the API charges.
+- **Key CLI:** `--file` (required), `--dry-run`, `--status`, `--category`,
+  `--ids`, `--limit`, `--variants N`, `--add-variant`, `--force`, `--yes/-y`,
+  `--update-yaml`, `--backend`, `--model`, `--reference-images`.
+
+### `tools/assets/select_assets.py` -- the reviewer/selector
+- **Input:** same `--file <manifest>`; `--gallery <status>`, `--select id:vN ...`,
+  `--list <status>`, or interactive (default).
+- **Gallery:** `generate_gallery_html` (lines 69-324) scans
+  `art_generated/<asset_type>/v1/` (with a `game_icons` fallback, lines 77-82),
+  embeds each variant via a `file://` URL, and writes **`asset_gallery.html`** to
+  the project root (line 507). You click variants; it emits `id:vN` commands.
+- **Select:** `--select id:vN` sets `selected_variant` + `status: selected` on the
+  asset and **saves the manifest via `yaml.dump`** (lines 603-607, save at 27-30).
+- **Output:** an updated manifest (selection state) + `asset_gallery.html`.
+
+### `tools/assets/promote_assets.py` -- the promoter
+- **Input:** `--file <manifest>`, `--status` (default `selected`), `--category`,
+  `--ids`, `--dest` (default **`godot/assets/icons`**, lines 133-136), `--dry-run`,
+  `--mark-promoted`.
+- **What it does:** for each matching asset, copies
+  `art_generated/<asset_type>/v1/<id>_<selected>_<size>.png` (falling back to the
+  no-variant name) into `<dest>/<category>/<id>_<size>.png` -- the `_vN` suffix is
+  stripped for clean game paths (`promote_asset`, lines 33-96). `--mark-promoted`
+  flips `status: promoted` and re-saves the manifest via `yaml.dump`.
+- **Output:** PNGs under `godot/assets/icons/<category>/`.
+
+### `tools/assets/audit_icons.py` -- the usage auditor
+- **Input:** none but the tree. Scans `godot/assets/icons/**/*_64.png` (64px treated
+  as canonical, line 30) and compares against
+  `godot/data/icon_mapping.json` (line 23).
+- **Output:** used / unused / missing / placeholder report;
+  `--format json|markdown|summary` (line 251). This closes the loop -- it tells you
+  which promoted icons are actually wired into the game and which mapping entries
+  are still `PLACEHOLDER` (with a `suggested_prompt`).
+
+### `tools/assets/extract_palette.py` -- brand palette extractor (added here)
+- **Input:** `<image>` (positional) `--n <count>` (default 24),
+  `--out-json`, `--out-html`. Pillow import is guarded -- if PIL is missing it
+  prints `pip install pillow` and exits non-zero rather than crashing.
+- **Method:** downscales the longest edge to 400px, runs PIL adaptive median-cut
+  `quantize`, sorts the resulting palette by pixel frequency, and labels each
+  colour with a best-guess role from its HSV coordinates (`role_guess`).
+- **Output:** `docs/art/palette.json` (`[{hex, rgb, role_guess, weight_pct}]`) and
+  `tools/art_review/palette_swatches.html` (standalone, inline styles, no external
+  assets). Re-runnable: `python tools/assets/extract_palette.py <image> --n 24`.
+- The hero (`godot/assets/dump_october_31_2025/hero-bg-2400w.webp`) is
+  **dark-dominant** -- the palette skews to ink / deep-indigo / doom-purple,
+  matching the "purple doom-end" art direction. No warm amber accent exists in the
+  hero, so an accent colour (e.g. the review tool's `--amber #e8a33d`) has to be
+  brought in by hand if a set needs one.
+
+## The first manifest
+
+`tools/assets/manifests/icons_v1.json` -- 6 icons grounded in `docs/art/palette.json`,
+one coherent set (shared `global_icon_base` + `brand_palette` styles, one
+`brand_doom` theme). IDs and intent:
+
+| id | resource | direction |
+|----|----------|-----------|
+| `icon_doom` | doom | ROBOT-flavoured skull -- machined cranium, glowing sensor eyes, slotted grille instead of teeth (per `docs/art/reviews/2026-07-17-overnight-sweep.md`: old ones "too teethy / Heavy-Metal / too human") |
+| `icon_compute` | compute | GPU / stacked rack-blades with cooling fins + power node -- explicitly off the literal microchip square |
+| `icon_money` | money | banked credit-chip stack + upward funding arrow |
+| `icon_reputation` | reputation | heraldic seal / shield with a centred star |
+| `icon_papers` | papers | fanned research sheets in a bracket clip |
+| `icon_governance` | governance | balance scale on a pillared plinth (oversight) |
+
+Resource names (`money`, `compute`, `reputation`, `papers`, `governance`) verified
+against `godot/scripts/core/game_state.gd` (lines 9-48). Prompts pin the specific
+palette hexes (indigo `#181b3b`/`#2e2547`, doom-purple `#300e1c`/`#351b33`, ink
+`#0e020c`, bone keyline `#ece0cf`) so the set reads as one system.
+
+## Glue gaps (flagged, not yet fixed)
+
+1. **Two review tools; only one sees generator output.**
+   `select_assets.py --gallery` scans `art_generated/<asset_type>/v1/` and is the
+   reviewer for gpt-image output. The newer keyboard-driven viewer
+   `tools/art_review/build.py` does **not** read `art_generated/` -- it renders
+   committed PNGs under `art_source/<image_root>/<batch.dir>/` per
+   `tools/art_review/manifest.json` (build.py lines 277-288) plus the pixellab
+   `sweep`/`reroll` dirs (lines 171-273). So the nice viewer is a pixellab track.
+   **Bridge needed** to review gpt-image icons there: after generation, copy/rename
+   `art_generated/game_icons/v1/*.png` into an `art_source/<batch>/` dir and add a
+   `gallery` batch to `manifest.json`, or extend `build.py` to scan `art_generated/`.
+
+2. **Transparent background is prompted but never requested.**
+   The manifest prompts (and the older ui_icons prompts) ask for a transparent
+   background, but `_openai_generate_bytes` (line 154) passes only
+   `model/prompt/size` -- no `background="transparent"`. The `img.convert("RGBA")`
+   at line 309 only adds an all-opaque alpha channel. Icons will come back with a
+   baked background until `background="transparent"` is added to the
+   `images.generate(...)` call.
+
+3. **JSON manifest is a one-way convenience.**
+   `generate_images.py` *reads* JSON fine (via `yaml.safe_load`). But
+   `select_assets.py` and `promote_assets.py` *write* the manifest back with
+   `yaml.dump` (select lines 27-30, promote lines 27-30) whenever you `--select`,
+   `--update-yaml`, or `--mark-promoted`. Running those on `icons_v1.json` rewrites
+   it in YAML syntax (still a valid file, wrong extension). Options: keep the JSON
+   read-only and pass `--dry-run` style flows only, or `cp icons_v1.json
+   icons_v1.yaml` before the select/promote stages and drive those off the YAML.
+
+4. **API key is implicit.** `OpenAI()` (line 128) reads `OPENAI_API_KEY` from the
+   environment; there is no CLI flag. `--dry-run` needs no key.
+
+## No-spend verification done here
+- `python -m py_compile tools/assets/extract_palette.py` -- passes.
+- `extract_palette.py <hero> --n 24` -- wrote `palette.json` (24 colours) +
+  `palette_swatches.html`.
+- `icons_v1.json` parses as JSON **and** via `yaml.safe_load`.
+- `generate_images.py --file icons_v1.json --dry-run` -- lists all 6 icons and
+  builds their full prompts (no API call, no spend).

--- a/docs/art/palette.json
+++ b/docs/art/palette.json
@@ -1,0 +1,242 @@
+[
+  {
+    "hex": "#17132d",
+    "rgb": [
+      23,
+      19,
+      45
+    ],
+    "role_guess": "screen-blue",
+    "weight_pct": 8.63
+  },
+  {
+    "hex": "#150e26",
+    "rgb": [
+      21,
+      14,
+      38
+    ],
+    "role_guess": "ink",
+    "weight_pct": 5.33
+  },
+  {
+    "hex": "#1b0d22",
+    "rgb": [
+      27,
+      13,
+      34
+    ],
+    "role_guess": "ink",
+    "weight_pct": 5.03
+  },
+  {
+    "hex": "#181b3b",
+    "rgb": [
+      24,
+      27,
+      59
+    ],
+    "role_guess": "screen-blue",
+    "weight_pct": 5.02
+  },
+  {
+    "hex": "#0e020c",
+    "rgb": [
+      14,
+      2,
+      12
+    ],
+    "role_guess": "ink",
+    "weight_pct": 4.87
+  },
+  {
+    "hex": "#13091d",
+    "rgb": [
+      19,
+      9,
+      29
+    ],
+    "role_guess": "ink",
+    "weight_pct": 4.8
+  },
+  {
+    "hex": "#0a020e",
+    "rgb": [
+      10,
+      2,
+      14
+    ],
+    "role_guess": "ink",
+    "weight_pct": 4.72
+  },
+  {
+    "hex": "#0d0413",
+    "rgb": [
+      13,
+      4,
+      19
+    ],
+    "role_guess": "ink",
+    "weight_pct": 4.67
+  },
+  {
+    "hex": "#0e081a",
+    "rgb": [
+      14,
+      8,
+      26
+    ],
+    "role_guess": "ink",
+    "weight_pct": 4.66
+  },
+  {
+    "hex": "#300e1c",
+    "rgb": [
+      48,
+      14,
+      28
+    ],
+    "role_guess": "doom-purple",
+    "weight_pct": 4.51
+  },
+  {
+    "hex": "#130716",
+    "rgb": [
+      19,
+      7,
+      22
+    ],
+    "role_guess": "ink",
+    "weight_pct": 4.51
+  },
+  {
+    "hex": "#180919",
+    "rgb": [
+      24,
+      9,
+      25
+    ],
+    "role_guess": "ink",
+    "weight_pct": 4.3
+  },
+  {
+    "hex": "#150c20",
+    "rgb": [
+      21,
+      12,
+      32
+    ],
+    "role_guess": "ink",
+    "weight_pct": 4.22
+  },
+  {
+    "hex": "#110d25",
+    "rgb": [
+      17,
+      13,
+      37
+    ],
+    "role_guess": "ink",
+    "weight_pct": 4.16
+  },
+  {
+    "hex": "#120412",
+    "rgb": [
+      18,
+      4,
+      18
+    ],
+    "role_guess": "ink",
+    "weight_pct": 3.89
+  },
+  {
+    "hex": "#220d1f",
+    "rgb": [
+      34,
+      13,
+      31
+    ],
+    "role_guess": "ink",
+    "weight_pct": 3.71
+  },
+  {
+    "hex": "#180512",
+    "rgb": [
+      24,
+      5,
+      18
+    ],
+    "role_guess": "ink",
+    "weight_pct": 3.49
+  },
+  {
+    "hex": "#0e0311",
+    "rgb": [
+      14,
+      3,
+      17
+    ],
+    "role_guess": "ink",
+    "weight_pct": 3.18
+  },
+  {
+    "hex": "#2e2547",
+    "rgb": [
+      46,
+      37,
+      71
+    ],
+    "role_guess": "doom-indigo",
+    "weight_pct": 3.09
+  },
+  {
+    "hex": "#250813",
+    "rgb": [
+      37,
+      8,
+      19
+    ],
+    "role_guess": "ink",
+    "weight_pct": 2.87
+  },
+  {
+    "hex": "#351b33",
+    "rgb": [
+      53,
+      27,
+      51
+    ],
+    "role_guess": "doom-purple",
+    "weight_pct": 2.66
+  },
+  {
+    "hex": "#1d0715",
+    "rgb": [
+      29,
+      7,
+      21
+    ],
+    "role_guess": "ink",
+    "weight_pct": 2.65
+  },
+  {
+    "hex": "#383761",
+    "rgb": [
+      56,
+      55,
+      97
+    ],
+    "role_guess": "screen-blue",
+    "weight_pct": 2.6
+  },
+  {
+    "hex": "#2c1327",
+    "rgb": [
+      44,
+      19,
+      39
+    ],
+    "role_guess": "doom-purple",
+    "weight_pct": 2.42
+  }
+]

--- a/tools/art_review/palette_swatches.html
+++ b/tools/art_review/palette_swatches.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>P(Doom)1 brand palette -- 24 swatches</title>
+<style>
+  body{margin:0;font-family:ui-monospace,Consolas,monospace;background:#181410;color:#ece0cf;padding:2rem}
+  h1{font-size:1.1rem;letter-spacing:.04em;margin:0 0 .3rem}
+  p.sub{color:#a9977f;font-size:.8rem;margin:0 0 1.6rem}
+  .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:.7rem}
+  .sw{margin:0;border-radius:10px;min-height:120px;display:flex;align-items:flex-end;
+       padding:.6rem;border:1px solid rgba(255,255,255,.08)}
+  figcaption{display:flex;flex-direction:column;gap:.1rem;font-size:.72rem;line-height:1.35}
+  .hex{font-weight:700;letter-spacing:.06em}
+  .role{opacity:.92}
+  .meta{opacity:.75;font-size:.66rem}
+</style>
+</head>
+<body>
+  <h1>P(Doom)1 brand palette</h1>
+  <p class="sub">24 swatches extracted from <code>hero-bg-2400w.webp</code> (adaptive median-cut quantise, sorted by pixel frequency). Roles are guesses -- rename freely.</p>
+  <div class="grid">
+    <figure class="sw" style="background:#17132d;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#17132d</span>
+        <span class="role">screen-blue</span>
+        <span class="meta">rgb(23,19,45) &middot; 8.63%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#150e26;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#150e26</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(21,14,38) &middot; 5.33%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#1b0d22;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#1b0d22</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(27,13,34) &middot; 5.03%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#181b3b;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#181b3b</span>
+        <span class="role">screen-blue</span>
+        <span class="meta">rgb(24,27,59) &middot; 5.02%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#0e020c;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#0e020c</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(14,2,12) &middot; 4.87%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#13091d;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#13091d</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(19,9,29) &middot; 4.8%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#0a020e;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#0a020e</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(10,2,14) &middot; 4.72%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#0d0413;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#0d0413</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(13,4,19) &middot; 4.67%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#0e081a;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#0e081a</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(14,8,26) &middot; 4.66%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#300e1c;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#300e1c</span>
+        <span class="role">doom-purple</span>
+        <span class="meta">rgb(48,14,28) &middot; 4.51%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#130716;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#130716</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(19,7,22) &middot; 4.51%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#180919;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#180919</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(24,9,25) &middot; 4.3%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#150c20;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#150c20</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(21,12,32) &middot; 4.22%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#110d25;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#110d25</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(17,13,37) &middot; 4.16%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#120412;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#120412</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(18,4,18) &middot; 3.89%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#220d1f;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#220d1f</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(34,13,31) &middot; 3.71%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#180512;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#180512</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(24,5,18) &middot; 3.49%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#0e0311;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#0e0311</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(14,3,17) &middot; 3.18%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#2e2547;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#2e2547</span>
+        <span class="role">doom-indigo</span>
+        <span class="meta">rgb(46,37,71) &middot; 3.09%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#250813;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#250813</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(37,8,19) &middot; 2.87%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#351b33;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#351b33</span>
+        <span class="role">doom-purple</span>
+        <span class="meta">rgb(53,27,51) &middot; 2.66%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#1d0715;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#1d0715</span>
+        <span class="role">ink</span>
+        <span class="meta">rgb(29,7,21) &middot; 2.65%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#383761;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#383761</span>
+        <span class="role">screen-blue</span>
+        <span class="meta">rgb(56,55,97) &middot; 2.6%</span>
+      </figcaption>
+    </figure>
+    <figure class="sw" style="background:#2c1327;color:#f4f4f4">
+      <figcaption>
+        <span class="hex">#2c1327</span>
+        <span class="role">doom-purple</span>
+        <span class="meta">rgb(44,19,39) &middot; 2.42%</span>
+      </figcaption>
+    </figure>
+  </div>
+</body>
+</html>

--- a/tools/assets/extract_palette.py
+++ b/tools/assets/extract_palette.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+Extract a brand palette from an image (default: the P(Doom)1 hero background).
+
+Part of the no-spend asset-generation pipeline: the palette it emits grounds the
+generation manifests (icons/textures) so a whole set reads as one colour system,
+and the swatch page lets Pip eyeball + rename the roles.
+
+Method: PIL adaptive quantise (median-cut) over the actual pixels of a downscaled
+copy of the image, then sort the resulting palette by pixel frequency and label
+each colour with a best-guess role from its HSV coordinates. Nothing here calls a
+network or an image API -- it only reads local pixels.
+
+Usage:
+    python tools/assets/extract_palette.py <image> [--n 24]
+    python tools/assets/extract_palette.py godot/assets/dump_october_31_2025/hero-bg-2400w.webp --n 24
+
+Outputs (relative to repo root, override with flags):
+    docs/art/palette.json                  -- [{hex, rgb, role_guess, weight_pct}, ...]
+    tools/art_review/palette_swatches.html -- standalone swatch page (no external assets)
+"""
+
+import argparse
+import colorsys
+import json
+import sys
+from pathlib import Path
+
+# Repo root is two levels up from tools/assets/extract_palette.py
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_JSON = REPO_ROOT / "docs" / "art" / "palette.json"
+DEFAULT_HTML = REPO_ROOT / "tools" / "art_review" / "palette_swatches.html"
+
+# Downscale the longest edge to this before quantising -- keeps it fast while
+# preserving the colour distribution (quantise samples pixels, not detail).
+SAMPLE_MAX_EDGE = 400
+
+
+def guarded_pillow():
+    """Import Pillow, or print the install line and exit non-zero (no crash)."""
+    try:
+        from PIL import Image  # noqa: F401
+
+        return Image
+    except ImportError:
+        print("Pillow (PIL) is required for palette extraction.", file=sys.stderr)
+        print("Install it with:  pip install pillow", file=sys.stderr)
+        sys.exit(1)
+
+
+def rgb_to_hex(r, g, b):
+    return "#{:02x}{:02x}{:02x}".format(r, g, b)
+
+
+def role_guess(r, g, b):
+    """Best-effort semantic role from HSV. These are hints for Pip to rename, not
+    ground truth -- value/saturation gate first, then hue buckets."""
+    h, s, v = colorsys.rgb_to_hsv(r / 255.0, g / 255.0, b / 255.0)
+    hue = h * 360.0
+
+    # Achromatic / value extremes first.
+    if v < 0.16:
+        return "ink"
+    if s < 0.12:
+        if v > 0.82:
+            return "paper-bone"
+        if v > 0.5:
+            return "ash-grey"
+        return "shadow-grey"
+
+    # Chromatic buckets (hue in degrees).
+    if hue < 20 or hue >= 345:
+        return "alert-red"
+    if hue < 45:
+        return "ground-warm" if v < 0.6 else "accent-amber"
+    if hue < 70:
+        return "brass-yellow"
+    if hue < 160:
+        return "signal-green"
+    if hue < 200:
+        return "screen-cyan"
+    if hue < 255:
+        return "screen-blue"
+    if hue < 290:
+        return "doom-indigo"
+    return "doom-purple"
+
+
+def extract_palette(image_path, n, Image):
+    """Return a list of {hex, rgb, role_guess, weight_pct} sorted by frequency."""
+    img = Image.open(image_path).convert("RGB")
+
+    # Downscale for speed; the colour histogram is preserved well enough.
+    img.thumbnail((SAMPLE_MAX_EDGE, SAMPLE_MAX_EDGE), Image.LANCZOS)
+
+    # Adaptive (median-cut) quantise over the actual pixels.
+    quant = img.quantize(colors=n, method=Image.Quantize.MEDIANCUT)
+
+    palette = quant.getpalette()  # flat [r,g,b, r,g,b, ...]
+    counts = quant.getcolors(maxcolors=n * n) or []  # [(count, index), ...]
+    total = sum(c for c, _ in counts) or 1
+
+    entries = []
+    for count, index in counts:
+        base = index * 3
+        r, g, b = palette[base], palette[base + 1], palette[base + 2]
+        entries.append(
+            {
+                "hex": rgb_to_hex(r, g, b),
+                "rgb": [r, g, b],
+                "role_guess": role_guess(r, g, b),
+                "weight_pct": round(100.0 * count / total, 2),
+            }
+        )
+
+    entries.sort(key=lambda e: e["weight_pct"], reverse=True)
+    return entries
+
+
+def write_swatches_html(entries, out_path, source_name):
+    """Standalone swatch page -- inline styles only, no external assets."""
+    cells = []
+    for e in entries:
+        r, g, b = e["rgb"]
+        # Pick a legible text colour against the swatch (perceived luminance).
+        lum = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        text = "#111" if lum > 140 else "#f4f4f4"
+        cells.append(
+            """    <figure class="sw" style="background:{hexv};color:{text}">
+      <figcaption>
+        <span class="hex">{hexv}</span>
+        <span class="role">{role}</span>
+        <span class="meta">rgb({r},{g},{b}) &middot; {wt}%</span>
+      </figcaption>
+    </figure>""".format(
+                hexv=e["hex"],
+                text=text,
+                role=e["role_guess"],
+                r=r,
+                g=g,
+                b=b,
+                wt=e["weight_pct"],
+            )
+        )
+
+    html = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>P(Doom)1 brand palette -- {n} swatches</title>
+<style>
+  body{{margin:0;font-family:ui-monospace,Consolas,monospace;background:#181410;color:#ece0cf;padding:2rem}}
+  h1{{font-size:1.1rem;letter-spacing:.04em;margin:0 0 .3rem}}
+  p.sub{{color:#a9977f;font-size:.8rem;margin:0 0 1.6rem}}
+  .grid{{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:.7rem}}
+  .sw{{margin:0;border-radius:10px;min-height:120px;display:flex;align-items:flex-end;
+       padding:.6rem;border:1px solid rgba(255,255,255,.08)}}
+  figcaption{{display:flex;flex-direction:column;gap:.1rem;font-size:.72rem;line-height:1.35}}
+  .hex{{font-weight:700;letter-spacing:.06em}}
+  .role{{opacity:.92}}
+  .meta{{opacity:.75;font-size:.66rem}}
+</style>
+</head>
+<body>
+  <h1>P(Doom)1 brand palette</h1>
+  <p class="sub">{n} swatches extracted from <code>{src}</code> (adaptive median-cut quantise, sorted by pixel frequency). Roles are guesses -- rename freely.</p>
+  <div class="grid">
+{cells}
+  </div>
+</body>
+</html>
+""".format(
+        n=len(entries), src=source_name, cells="\n".join(cells)
+    )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(html, encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract a brand palette from an image.")
+    parser.add_argument("image", help="Path to the source image (webp/png/jpg).")
+    parser.add_argument("--n", type=int, default=24, help="Number of swatches (default: 24).")
+    parser.add_argument("--out-json", default=str(DEFAULT_JSON), help="Palette JSON output path.")
+    parser.add_argument("--out-html", default=str(DEFAULT_HTML), help="Swatch HTML output path.")
+    args = parser.parse_args()
+
+    Image = guarded_pillow()
+
+    image_path = Path(args.image)
+    if not image_path.exists():
+        print("Image not found: {}".format(image_path), file=sys.stderr)
+        sys.exit(2)
+
+    entries = extract_palette(image_path, args.n, Image)
+
+    out_json = Path(args.out_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+
+    out_html = Path(args.out_html)
+    write_swatches_html(entries, out_html, image_path.name)
+
+    print("Extracted {} colours from {}".format(len(entries), image_path.name))
+    print("  palette JSON -> {}".format(out_json))
+    print("  swatch HTML  -> {}".format(out_html))
+    roles = ", ".join("{} {}".format(e["hex"], e["role_guess"]) for e in entries[:4])
+    print("  top roles: {}".format(roles))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/assets/manifests/icons_v1.json
+++ b/tools/assets/manifests/icons_v1.json
@@ -1,0 +1,81 @@
+{
+  "_meta": {
+    "note": "Generation manifest for generate_images.py. Native format is YAML, but yaml.safe_load (used by --file) parses this JSON as-is: python tools/assets/generate_images.py --file tools/assets/manifests/icons_v1.json --dry-run. See docs/art/ASSET_PIPELINE.md for the full loop and glue caveats (transparent-bg param, JSON-vs-YAML round-trip, art_review bridge).",
+    "palette_source": "docs/art/palette.json (extracted from godot/assets/dump_october_31_2025/hero-bg-2400w.webp)",
+    "palette_anchors": {
+      "ink_black": "#0e020c",
+      "indigo_deep": "#181b3b",
+      "indigo_mid": "#2e2547",
+      "indigo_lit": "#383761",
+      "doom_purple": "#300e1c",
+      "doom_purple_lit": "#351b33",
+      "doom_magenta": "#2c1327",
+      "bone_keyline": "#ece0cf"
+    },
+    "quality_note": "gpt-image-1.5 quality/background are NOT per-asset fields the current generate_images.py reads; it passes only model/prompt/size. default_size below drives size. To actually get alpha, generate_images.py must add background='transparent' to the images.generate call (glue gap flagged in ASSET_PIPELINE.md)."
+  },
+  "schema_version": "1.0",
+  "asset_type": "game_icons",
+  "default_size": "1024x1024",
+  "output_sizes": [1024, 512, 256, 128, 64],
+  "styles": {
+    "global_icon_base": "bold flat vector game icon, single centred symbol, one heavy and consistent stroke weight throughout, strong chunky silhouette that reads clearly at 64x64, flat-ish shading with a single light source (no gradients or painterly rendering), transparent background, no text, no scene, no background props, view-locked straight-on and symmetrical, centered composition",
+    "brand_palette": "limited palette drawn from the P(Doom)1 hero image only: deep indigo #181b3b and #2e2547, lit indigo #383761, doom-purple #300e1c and #351b33, doom-magenta #2c1327, near-black ink #0e020c for shadow, plus a single thin warm bone keyline #ece0cf for edge legibility; no other hues, no white fills except the keyline"
+  },
+  "themes": {
+    "brand_doom": {
+      "style_overrides": ["global_icon_base", "brand_palette"],
+      "color_bias": "cohesive doom-end brand set: indigo and doom-purple bodies, ink shadow, one glowing accent per icon, bone keyline for the outline so every icon reads as one system"
+    }
+  },
+  "assets": [
+    {
+      "id": "icon_doom",
+      "category": "resource_icons",
+      "display_name": "Doom",
+      "status": "pending",
+      "theme": "brand_doom",
+      "prompt_tail": "a ROBOT-flavoured skull, not a human or organic skull: a machined metal cranium with a smooth angular faceplate, two glowing rectangular optical-sensor eye sockets, a slotted intake grille or vent bars where a jaw would be instead of organic teeth, subtle panel seams and rivets, one small antenna node on top; cold and industrial and menacing, front-on and symmetrical; faceplate in doom-purple #300e1c, deep ink #0e020c shadow, eye-sensors glowing lit-indigo #383761, thin bone #ece0cf keyline. Deliberately NOT teethy, NOT a Heavy-Metal-magazine skull, NOT human anatomy"
+    },
+    {
+      "id": "icon_compute",
+      "category": "resource_icons",
+      "display_name": "Compute",
+      "status": "pending",
+      "theme": "brand_doom",
+      "prompt_tail": "a stack of GPU / compute cards seen straight-on: three chunky rack blades layered front-to-back with visible parallel cooling fins and one glowing power node, reading as a mini server rack, hard industrial rectangular silhouette; explicitly NOT a flat square microchip and NOT a single CPU die; blades in indigo #181b3b and #2e2547, fins in ink #0e020c, power node glowing lit-indigo #383761, thin bone #ece0cf keyline"
+    },
+    {
+      "id": "icon_money",
+      "category": "resource_icons",
+      "display_name": "Money",
+      "status": "pending",
+      "theme": "brand_doom",
+      "prompt_tail": "a compact stack of banked credit chips or coins with a single subtle upward arrow behind them signalling funding, bold rounded silhouette, no dollar-sign text; stack in doom-purple #351b33 with ink #0e020c edges, arrow glowing lit-indigo #383761, thin bone #ece0cf keyline"
+    },
+    {
+      "id": "icon_reputation",
+      "category": "resource_icons",
+      "display_name": "Reputation",
+      "status": "pending",
+      "theme": "brand_doom",
+      "prompt_tail": "a bold heraldic seal or shield with a single centred star reading as trust and standing, symmetrical and centred, no ribbons or laurels; shield in indigo #2e2547, star glowing lit-indigo #383761, ink #0e020c inner shadow, thin bone #ece0cf keyline"
+    },
+    {
+      "id": "icon_papers",
+      "category": "resource_icons",
+      "display_name": "Papers",
+      "status": "pending",
+      "theme": "brand_doom",
+      "prompt_tail": "a small fan of two or three overlapping research-paper sheets with one folded corner and a couple of abstract horizontal text-lines, held by a bold bracket clip, reading as published research; sheets faced in bone #ece0cf over an indigo #181b3b backing sheet, ink #0e020c outline, thin bone keyline; flat and iconic"
+    },
+    {
+      "id": "icon_governance",
+      "category": "resource_icons",
+      "display_name": "Governance",
+      "status": "pending",
+      "theme": "brand_doom",
+      "prompt_tail": "a bold balance scale on a short pillared plinth reading as oversight, rules and control, perfectly symmetrical and centred; scale and pillar in doom-indigo #2e2547 with a #383761 rim-light along the top edges, ink #0e020c base shadow, thin bone #ece0cf keyline"
+    }
+  ]
+}


### PR DESCRIPTION
No-spend foundation for the asset-generation CI/CD loop. **No image API is called anywhere in this PR** -- generation is documented and dry-run-verified, not run.

## What's here
- **`docs/art/ASSET_PIPELINE.md`** -- audit of the existing `tools/assets/` scripts (`generate_images.py`, `select_assets.py`, `promote_assets.py`, `audit_icons.py`) with `file:line` cites, the end-to-end loop diagram, and 4 flagged glue gaps.
- **`tools/assets/extract_palette.py`** -- repeatable Pillow adaptive median-cut palette extractor; guarded PIL import (prints `pip install pillow` and exits non-zero if missing).
- **`docs/art/palette.json`** -- 24 colours extracted from `hero-bg-2400w.webp` (hex/rgb/role_guess/weight). Hero is dark-dominant, so the palette skews ink / deep-indigo / doom-purple, matching the "purple doom-end" direction.
- **`tools/art_review/palette_swatches.html`** -- standalone swatch page (no external assets) to eyeball + rename roles.
- **`tools/assets/manifests/icons_v1.json`** -- first icon set grounded in the palette: `icon_doom` (robot-flavoured skull, per the sweep-review "too teethy/human" note), `icon_compute` (GPU/rack, off the literal chip), plus `money`/`reputation`/`papers`/`governance` (resource names verified against `game_state.gd`).

## Key findings
- `generate_images.py` consumes a **YAML** manifest via `--file`; `yaml.safe_load` also parses JSON, so `icons_v1.json` is consumed as-is (verified via `--dry-run`, all 6 prompts build).
- `OPENAI_API_KEY` is read implicitly by `OpenAI()`; `--dry-run` needs no key.
- **Glue gaps flagged:** (1) the nice `tools/art_review/build.py` viewer scans committed `art_source/` PNGs, not `art_generated/` output -- gpt-image review goes through `select_assets.py`'s gallery instead; (2) prompts ask for transparent bg but `_openai_generate_bytes` never passes `background="transparent"`; (3) `select`/`promote` re-save the manifest via `yaml.dump`, so a `.json` manifest becomes YAML-syntax after the first write.

## Verified (no spend)
- `py_compile extract_palette.py` passes.
- `extract_palette.py <hero> --n 24` -> 24 colours + swatch HTML.
- `icons_v1.json` parses as JSON and via `yaml.safe_load`.
- `generate_images.py --file icons_v1.json --dry-run` lists all 6 icons.

Do NOT merge -- for Pip's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)