### PR TITLE
fix(hotpatch): remove game-over desktop-quit + cap event-feed buffer

### DIFF
--- a/godot/scenes/ui/game_over_screen.tscn
+++ b/godot/scenes/ui/game_over_screen.tscn
@@ -86,11 +86,5 @@ custom_minimum_size = Vector2(150, 50)
 layout_mode = 2
 text = "Main Menu"
 
-[node name="QuitButton" type="Button" parent="CenterContainer/PanelContainer/MarginContainer/VBox/ButtonsHBox"]
-custom_minimum_size = Vector2(150, 50)
-layout_mode = 2
-text = "Quit"
-
 [connection signal="pressed" from="CenterContainer/PanelContainer/MarginContainer/VBox/ButtonsHBox/PlayAgainButton" to="." method="_on_play_again_pressed"]
 [connection signal="pressed" from="CenterContainer/PanelContainer/MarginContainer/VBox/ButtonsHBox/MainMenuButton" to="." method="_on_main_menu_pressed"]
-[connection signal="pressed" from="CenterContainer/PanelContainer/MarginContainer/VBox/ButtonsHBox/QuitButton" to="." method="_on_quit_pressed"]

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -286,11 +286,6 @@ func _on_main_menu_pressed():
 	print("[GameOverScreen] Main Menu pressed")
 	get_tree().change_scene_to_file("res://scenes/welcome.tscn")
 
-func _on_quit_pressed():
-	"""Quit to desktop"""
-	print("[GameOverScreen] Quit pressed")
-	get_tree().quit()
-
 func _on_meta_clicked(meta):
 	"""Handle URL clicks in the stats label"""
 	print("[GameOverScreen] Opening URL: %s" % meta)

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -79,6 +79,7 @@ var current_turn_phase: String = "NOT_STARTED"
 # by default so real, actionable events aren't crowded out. The toggle flips this.
 var _feed_lines: Array = []              # [{text: String, channel: String}, ...]
 var _feed_important_only: bool = true    # default view hides the flavour spam
+const FEED_MAX_LINES: int = 500          # cap the backing model so a long run stays bounded (trim oldest)
 
 # Active dialog state for keyboard shortcuts
 var active_dialog: Control = null
@@ -1053,6 +1054,11 @@ func log_message(text: String, channel: String = "normal"):
 		date_stamp = game_manager.state.get_formatted_date()
 	var line := "[color=gray][%s][/color] %s" % [date_stamp, text]
 	_feed_lines.append({"text": line, "channel": channel})
+	# Cap the backing model: trim oldest lines so a long run's feed stays bounded (same
+	# latent unbounded-growth issue the old message_log had). The arxiv-flood filter still
+	# applies within whatever lines remain stored.
+	if _feed_lines.size() > FEED_MAX_LINES:
+		_feed_lines = _feed_lines.slice(_feed_lines.size() - FEED_MAX_LINES)
 	if not _feed_passes_filter(channel):
 		return  # recorded but hidden under the current filter
 	message_log.text += "\n" + line


### PR DESCRIPTION
Small post-alpha hotpatch, two fixes.

## Fix 1: remove direct-to-desktop button from the game-over screen
The game-over/leaderboard screen had a one-click "Quit to Desktop" button (`_on_quit_pressed` -> `get_tree().quit()`) -- rage-quit friction with no confirmation.

**Approach taken: scene-node removal** (the preferred option).
- Removed the `QuitButton` node and its `pressed` signal connection from `godot/scenes/ui/game_over_screen.tscn`.
- Removed the now-unused `_on_quit_pressed()` handler from `godot/scripts/ui/game_over_screen.gd`.
- Left the "Main Menu" button and the ENTER-to-leaderboard path intact. The pause menu keeps its deliberate Quit-to-Desktop, and alt-F4 still works for anyone who wants it.

## Fix 2: cap the event-feed line buffer
`_feed_lines` in `godot/scripts/ui/main_ui.gd` (the P0 feed model) grew unbounded over a long run -- the same latent issue the old `message_log` had.
- Added `const FEED_MAX_LINES: int = 500` and trim oldest on append (`_feed_lines = _feed_lines.slice(size - FEED_MAX_LINES)`), so the stored model + feed rebuild stay bounded.
- Cap value: **500** (no nearby existing constant suggested another value).
- The arxiv-flood filter behaviour is unchanged -- the cap applies to the stored model; the filter still hides/shows within the retained lines.

## Verify
- Fast gate: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **459 tests, 0 failures**.
- GDScript syntax check passed; no non-ASCII introduced.

Files touched: `godot/scenes/ui/game_over_screen.tscn`, `godot/scripts/ui/game_over_screen.gd`, `godot/scripts/ui/main_ui.gd`.

Do not merge -- left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)