### PR TITLE
deploy: nginx snippet for score API

### DIFF
--- a/server/leaderboard/nginx-score.conf
+++ b/server/leaderboard/nginx-score.conf
@@ -1,0 +1,18 @@
+# nginx location snippet for the P(Doom)1 score API (served by PHP-FPM).
+# Include this INSIDE the api.pdoom1.com server block. Exact-match (=) so it
+# only ever catches /score_api.php and leaves everything else proxying to the
+# app on :8080 untouched.
+#
+# Deploy:
+#   sudo curl -fsSL <raw-url-of-this-file> -o /etc/nginx/snippets/pdoom-score.conf
+#   sudo sed -i '/access_log.*pdoom1.*access/i include snippets/pdoom-score.conf;' \
+#        /etc/nginx/sites-available/api.pdoom1.com
+#   sudo nginx -t && sudo systemctl reload nginx
+#
+# The php-fpm socket below assumes PHP 8.3 (Ubuntu 24.04 default). Adjust if
+# your `ls /run/php/*.sock` shows a different version.
+location = /score_api.php {
+    fastcgi_pass unix:/run/php/php8.3-fpm.sock;
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME /var/www/pdoom-scores/score_api.php;
+}


### PR DESCRIPTION
nginx location snippet for serving score_api.php via PHP-FPM on api.pdoom1.com. Curled onto the server during deploy.