### PR TITLE
fix(endgame): isolate score-post so it can't crash/quit the defeat screen

### DIFF
--- a/godot/autoload/leaderboard_sync.gd
+++ b/godot/autoload/leaderboard_sync.gd
@@ -29,13 +29,27 @@ const ENDPOINT_FILE := "score_api.php"
 const REQUEST_TIMEOUT_SEC := 8.0
 const PLACEHOLDER_TOKEN := "CHANGE_ME_set_a_long_random_token"
 
+# Durable outbox: every score we attempt to submit is written here FIRST, and removed only
+# once the server acks it. If the app quits / crashes / loses network before the POST lands
+# (the live release-blocker: a force-quit at the defeat freeze killed the in-flight POST and
+# the score reached the server on ZERO occasions), the entry survives and is retried at the
+# next launch. The server dedups by entry_uuid, so a resend of a landed score is a harmless
+# no-op. This is what makes "the score actually lands even if the endpoint is slow/down".
+const OUTBOX_PATH := "user://pending_scores.json"
+
 # Loaded from CONFIG_PATH at _ready. Public so tests can set them directly.
 var enabled: bool = false
 var base_url: String = ""
 var token: String = ""
 
 func _ready() -> void:
+	# ALWAYS process: an in-flight HTTPRequest must keep polling even if the SceneTree is
+	# paused (pause menu, window resolver) -- otherwise a POST started at the defeat screen
+	# could stall forever and never leave the machine.
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	_load_config()
+	# Retry anything left in the outbox from a previous session (prior crash / offline run).
+	_flush_outbox()
 
 func _load_config() -> void:
 	if not FileAccess.file_exists(CONFIG_PATH):
@@ -148,6 +162,8 @@ static func parse_board_entries(body: String) -> Dictionary:
 # --------------------------------------------------------------------------
 
 ## Fire-and-forget upload. No-op (emits an "off" status) when not submitting.
+## Durability: the POST body is written to the outbox BEFORE dispatch and removed only on a
+## server ack, so an app-exit / crash / offline window can't lose the score.
 func submit_score(entry, seed: String, version: String) -> void:
 	if not should_submit():
 		# Disabled / unconfigured / opted-out -> pure no-op, no HTTP.
@@ -157,17 +173,38 @@ func submit_score(entry, seed: String, version: String) -> void:
 		submit_completed.emit(false, false, 0, "")
 		return
 
+	var body := build_post_body(entry.to_dict(), seed, version)
+	_outbox_add(body)  # persist FIRST -- survives a crash between here and the server ack
+
+	_dispatch_post(body, func(ok: bool, added: bool, rank: int):
+		if ok:
+			_outbox_remove(str(body.get("entry_uuid", "")))  # landed -> drop from retry queue
+		var msg := ""
+		if ok:
+			msg = "submitted (rank %d)" % rank if rank > 0 else "submitted"
+		else:
+			msg = "offline -- saved locally"
+		submit_completed.emit(ok, added, rank, msg)
+	)
+
+## Shared POST dispatcher. on_done is called EXACTLY once with (ok, added, rank) whether the
+## request succeeds, errors, or times out -- so callers never hang and never crash. Reused by
+## submit_score and by the outbox flush.
+func _dispatch_post(body: Dictionary, on_done: Callable) -> void:
+	if base_url.strip_edges() == "":
+		if on_done.is_valid():
+			on_done.call(false, false, 0)
+		return
 	var url := build_endpoint(base_url)
 	var headers := [
 		"Content-Type: application/json",
 		"X-PDoom-Token: %s" % token,
 	]
-	var payload := JSON.stringify(build_post_body(entry.to_dict(), seed, version))
+	var payload := JSON.stringify(body)
 
 	var http := _new_request()
 	http.request_completed.connect(
 		func(result: int, code: int, _headers: PackedStringArray, resp_body: PackedByteArray):
-			var msg := ""
 			var ok := false
 			var added := false
 			var rank := 0
@@ -176,22 +213,83 @@ func submit_score(entry, seed: String, version: String) -> void:
 				ok = parsed["ok"]
 				added = parsed["added"]
 				rank = parsed["rank"]
-				if ok:
-					if rank > 0:
-						msg = "submitted (rank %d)" % rank
-					else:
-						msg = "submitted"
-				else:
-					msg = "offline -- saved locally"
-			else:
-				msg = "offline -- saved locally"
-			submit_completed.emit(ok, added, rank, msg)
+			if on_done.is_valid():
+				on_done.call(ok, added, rank)
 			http.queue_free()
 	)
 	var err := http.request(url, headers, HTTPClient.METHOD_POST, payload)
 	if err != OK:
 		http.queue_free()
-		submit_completed.emit(false, false, 0, "offline -- saved locally")
+		if on_done.is_valid():
+			on_done.call(false, false, 0)
+
+# --------------------------------------------------------------------------
+# Durable outbox (user://pending_scores.json). All IO is fully guarded: a missing /
+# malformed / unwritable file degrades to an empty queue and never throws.
+# --------------------------------------------------------------------------
+
+func _read_outbox() -> Array:
+	if not FileAccess.file_exists(OUTBOX_PATH):
+		return []
+	var f := FileAccess.open(OUTBOX_PATH, FileAccess.READ)
+	if f == null:
+		return []
+	var text := f.get_as_text()
+	f.close()
+	var json := JSON.new()
+	if json.parse(text) != OK or typeof(json.data) != TYPE_ARRAY:
+		return []
+	return json.data
+
+func _write_outbox(entries: Array) -> void:
+	var f := FileAccess.open(OUTBOX_PATH, FileAccess.WRITE)
+	if f == null:
+		push_warning("[LeaderboardSync] Could not write outbox at %s" % OUTBOX_PATH)
+		return
+	f.store_string(JSON.stringify(entries))
+	f.close()
+
+func _outbox_add(body: Dictionary) -> void:
+	var uuid := str(body.get("entry_uuid", ""))
+	var entries := _read_outbox()
+	# De-dupe by entry_uuid so retries don't pile up copies of the same score.
+	for e in entries:
+		if typeof(e) == TYPE_DICTIONARY and str(e.get("entry_uuid", "")) == uuid and uuid != "":
+			return
+	entries.append(body)
+	_write_outbox(entries)
+
+func _outbox_remove(uuid: String) -> void:
+	if uuid == "":
+		return
+	var entries := _read_outbox()
+	var kept: Array = []
+	for e in entries:
+		if typeof(e) == TYPE_DICTIONARY and str(e.get("entry_uuid", "")) == uuid:
+			continue
+		kept.append(e)
+	if kept.size() != entries.size():
+		_write_outbox(kept)
+
+## Retry every queued score once. Called at launch. Each landed score drops itself from the
+## queue on ack; failures stay for the next launch. Silent (no status blip): this is
+## background catch-up, not a live submit.
+func _flush_outbox() -> void:
+	if not (enabled and is_configured()):
+		return  # can't reach the server right now; keep the queue for later
+	var entries := _read_outbox()
+	if entries.is_empty():
+		return
+	print("[LeaderboardSync] Flushing %d queued score(s) from a previous session." % entries.size())
+	for e in entries:
+		if typeof(e) != TYPE_DICTIONARY:
+			continue
+		var body: Dictionary = e
+		var uuid := str(body.get("entry_uuid", ""))
+		_dispatch_post(body, func(ok: bool, _added: bool, _rank: int):
+			if ok:
+				_outbox_remove(uuid)
+		)
 
 ## Async board fetch. Invokes callback(ok: bool, entries: Array[ScoreEntry]).
 ## On any failure -> callback(false, []) so callers fall back to local silently.

--- a/godot/scripts/core/baseline_simulator.gd
+++ b/godot/scripts/core/baseline_simulator.gd
@@ -145,6 +145,32 @@ static func get_baseline_score(game_seed: String) -> Dictionary:
 	_baseline_cache[game_seed] = result
 	return result
 
+static func get_baseline_score_if_ready(game_seed: String) -> Dictionary:
+	"""NON-BLOCKING baseline read for the defeat transition.
+
+	Returns the baseline dict ONLY if it is already available (precomputed, cached, or a
+	finished background thread we can harvest without waiting). If the baseline is not ready
+	-- not started, or a background thread is still running -- returns {} and NEVER blocks.
+
+	Why this exists: get_baseline_score() blocks the main thread (wait_to_finish, or a full
+	synchronous BLIND simulation ~4s) which, called from show_game_over(), froze the game at
+	the exact defeat moment ("Not Responding") and starved/delayed the score POST. The score
+	is the product; the baseline is a cosmetic comparison -- it must never block the end-game.
+	"""
+	if _precomputed_baselines.has(game_seed):
+		return _precomputed_baselines[game_seed]
+	if _baseline_cache.has(game_seed):
+		return _baseline_cache[game_seed]
+	# A background thread that has already FINISHED can be harvested without blocking
+	# (wait_to_finish returns immediately and disposes the thread properly).
+	if _background_seed == game_seed and not _is_computing:
+		_wait_for_background()
+		if _background_result.size() > 0:
+			_baseline_cache[game_seed] = _background_result
+			return _background_result
+	# Not ready and we refuse to block. Caller degrades to "no baseline comparison".
+	return {}
+
 static func clear_cache():
 	"""Clear the baseline cache (useful for testing)"""
 	_baseline_cache.clear()

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -16,6 +16,11 @@ var baseline_result: Dictionary = {}
 var leaderboard_entry_uuid: String = ""
 var game_start_time: float = 0.0
 var sync_status_label: Label = null  # Tiny non-blocking remote-sync status blip
+# Re-entrancy guard: the game-over signal fires on EVERY state update (incl. leftover
+# day-ticks in a month playback), so show_game_over() can be called many times. The
+# scoring side-effects (local save + remote POST + music) must run EXACTLY ONCE; later
+# calls only keep the overlay visible.
+var _game_over_shown: bool = false
 
 func _ready():
 	# Initially hidden
@@ -50,16 +55,35 @@ func _input(event: InputEvent):
 			get_viewport().set_input_as_handled()
 
 func show_game_over(is_victory: bool, final_state: Dictionary):
-	"""Display game over screen with final statistics"""
+	"""Display game over screen with final statistics.
+
+	ISOLATION CONTRACT (fix/endgame-quit-score-post -- release blocker). This is the view
+	layer at the defeat transition; the live remote leaderboard turned it into a place where
+	a bug loses scores. The rules this method now enforces:
+	  1. RE-ENTRANCY: the game-over signal fires on every state update (incl. leftover
+	     day-ticks in a month playback), so run the scoring side-effects EXACTLY ONCE.
+	  2. SCORE FIRST: persist + submit the score BEFORE any heavy/optional work, so a hang,
+	     force-quit, or later error can't lose it. The submit was previously the LAST step,
+	     after a multi-second synchronous baseline sim -- a force-quit during that freeze
+	     meant the POST was never even dispatched (root cause of the live score loss).
+	  3. NEVER BLOCK: read the baseline NON-BLOCKING (get_baseline_score() ran a ~4s
+	     synchronous simulation on the main thread -> "Not Responding" at the defeat moment).
+	  4. NEVER CRASH: music / save / submit are all failure-tolerant side-effects.
+	"""
+	# Rule 1 -- re-entrancy guard. Later calls only keep the overlay visible.
+	if _game_over_shown:
+		visible = true
+		return
+	_game_over_shown = true
+
 	visible = true
 
-	# Play appropriate end-game music
+	# Play appropriate end-game music (MusicManager already no-ops a missing/failed track).
 	if is_victory:
 		# Victory music not yet implemented, keep gameplay music
 		pass
 	else:
 		MusicManager.play_context(MusicManager.MusicContext.DEFEAT)
-
 
 	# ADR-0002: the engine is the scoring authority — read the (turns, doom_integral)
 	# tuple straight off final_state; no formula here.
@@ -68,54 +92,31 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 	final_doom_integral = st[1]
 	print("[GameOverScreen] Final score: %s" % GameState.format_score(final_turns, final_doom_integral))
 
-	# Get baseline (no-action) score for comparison (Issue #372)
 	var game_seed = GameConfig.get_display_seed()
-	baseline_result = BaselineSimulator.get_baseline_score(game_seed)
+
+	# Rule 3 -- baseline comparison (Issue #372), NON-BLOCKING. If the background sim isn't
+	# ready yet we skip the comparison rather than freeze the defeat screen computing it.
+	# baseline_turns == 0 is exactly what the stats block already treats as "no baseline".
+	baseline_result = BaselineSimulator.get_baseline_score_if_ready(game_seed)
 	baseline_turns = int(baseline_result.get("turns", 0))
 	baseline_doom_integral = int(round(baseline_result.get("doom_integral", 0.0)))
-	print("[GameOverScreen] Baseline: %s" % GameState.format_score(baseline_turns, baseline_doom_integral))
+	if baseline_turns > 0:
+		print("[GameOverScreen] Baseline: %s" % GameState.format_score(baseline_turns, baseline_doom_integral))
+	else:
+		print("[GameOverScreen] Baseline not ready -- skipping comparison (defeat screen must not block).")
 
-	# Stop verification tracking and get final hash
+	# Rule 2 -- SCORE FIRST. Persist locally + fire the async remote POST immediately, before
+	# the verification export and stats rendering below.
+	_persist_and_submit_score(final_state, game_seed)
+
+	# Verification export (decorative here -- a future dispute artifact). Cheap; kept AFTER
+	# the durable save so nothing scoring-critical depends on it.
 	VerificationTracker.stop_tracking()
 	var final_hash = VerificationTracker.get_final_hash()
-
-	# Export verification data for submission (future leaderboard integration)
 	var verification_data = VerificationTracker.export_for_submission(final_state)
 	verification_data["turns_survived"] = final_turns  # ADR-0002 score tuple
 	verification_data["doom_integral"] = final_doom_integral
 	print("[GameOverScreen] Game ended - Verification hash: %s..." % final_hash.substr(0, 16))
-	print("[GameOverScreen] Score: %s" % GameState.format_score(final_turns, final_doom_integral))
-	print("[GameOverScreen] Full verification data ready for submission")
-
-
-	# Save score to leaderboard (game_seed already obtained for baseline)
-	var leaderboard = Leaderboard.new(game_seed, "v" + GameConfig.CURRENT_VERSION)
-	var duration = Time.get_ticks_msec() / 1000.0 - game_start_time
-
-	var entry = Leaderboard.ScoreEntry.new(
-		final_turns,
-		GameConfig.lab_name,
-		final_state.get("turn", 0),
-		"v" + GameConfig.CURRENT_VERSION,  # Game version from GameConfig
-		duration,
-		baseline_turns,  # Baseline turns for comparison (Issue #372)
-		final_doom_integral,  # ADR-0002 tiebreak
-		baseline_doom_integral
-	)
-
-	var result = leaderboard.add_score(entry)
-	leaderboard_entry_uuid = entry.entry_uuid
-	var rank = result.get("rank", -1)
-
-	print("[GameOverScreen] Score saved to leaderboard - Rank: %d" % rank)
-
-	# Store entry UUID globally for leaderboard highlighting
-	GameConfig.latest_leaderboard_entry = leaderboard_entry_uuid
-
-	# Remote leaderboard sync (ADR-0006: pure view side-effect, off the deterministic
-	# path). Fire-and-forget; the local save above already succeeded, so a network
-	# failure just leaves the score local. Only runs when enabled+configured+opted-in.
-	_maybe_submit_remote(entry, game_seed)
 
 	# Set title and colors based on outcome
 	if is_victory:
@@ -220,6 +221,35 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 	stats_text += "[center][color=gold][b]⏎ Press ENTER for Leaderboard[/b][/color][/center]"
 
 	stats_label.text = stats_text
+
+func _persist_and_submit_score(final_state: Dictionary, game_seed: String) -> void:
+	"""SCORE FIRST (isolation contract, rule 2): save the run's score to the LOCAL board and
+	fire the async remote POST. Runs before the verification export + stats rendering so the
+	score is durable the instant the defeat screen appears -- a later hang / force-quit /
+	error cannot lose it. The remote POST is fire-and-forget on the LeaderboardSync autoload
+	(lifecycle-independent from this screen) and internally bulletproof against network
+	failure, so nothing here can crash or freeze the end-game."""
+	var duration = Time.get_ticks_msec() / 1000.0 - game_start_time
+	var entry = Leaderboard.ScoreEntry.new(
+		final_turns,
+		GameConfig.lab_name,
+		final_state.get("turn", 0),
+		"v" + GameConfig.CURRENT_VERSION,  # Game version from GameConfig
+		duration,
+		baseline_turns,  # Baseline turns for comparison (Issue #372); 0 when not ready
+		final_doom_integral,  # ADR-0002 tiebreak
+		baseline_doom_integral
+	)
+
+	# ---- local save (authoritative: the score must exist locally regardless of network) --
+	var leaderboard = Leaderboard.new(game_seed, "v" + GameConfig.CURRENT_VERSION)
+	var result: Dictionary = leaderboard.add_score(entry)
+	leaderboard_entry_uuid = entry.entry_uuid
+	GameConfig.latest_leaderboard_entry = leaderboard_entry_uuid  # for leaderboard highlight
+	print("[GameOverScreen] Score saved locally - Rank: %d" % int(result.get("rank", -1)))
+
+	# ---- remote submit (async; failure just leaves the score local + queued for retry) ----
+	_maybe_submit_remote(entry, game_seed)
 
 func _maybe_submit_remote(entry, game_seed: String) -> void:
 	"""Upload the just-saved score to the global board, if sync is on. Never blocks;

--- a/godot/tests/unit/test_endgame_score_isolation.gd
+++ b/godot/tests/unit/test_endgame_score_isolation.gd
@@ -1,0 +1,122 @@
+extends GutTest
+## Release-blocker regression (fix/endgame-quit-score-post).
+##
+## The live v0.11.0 build "quit weirdly" at the defeat screen and NO score ever reached the
+## remote board. Root cause: show_game_over() ran a multi-second SYNCHRONOUS baseline
+## simulation on the main thread (freeze -> force-quit) and fired the score POST only AFTER
+## it, so a force-quit during the freeze meant the POST was never dispatched. Plus there was
+## no re-entrancy guard, so the game-over signal (fires on every state update) could submit
+## repeatedly.
+##
+## These tests pin the fixed contract:
+##   1. show_game_over() NEVER blocks the main thread (no synchronous baseline at defeat).
+##   2. The defeat screen renders even when the remote endpoint is unreachable (no crash).
+##   3. Scoring side-effects run EXACTLY ONCE across repeated game-over signals.
+##   4. The durable outbox persists a pending score and drops it only on a server ack, and
+##      survives a missing / malformed queue file.
+
+const UNREACHABLE := "https://10.255.255.1"  # unroutable: connect never completes -> timeout
+
+func before_each():
+	# Isolate the outbox file per test.
+	if FileAccess.file_exists(LeaderboardSync.OUTBOX_PATH):
+		DirAccess.remove_absolute(LeaderboardSync.OUTBOX_PATH)
+
+func after_each():
+	if FileAccess.file_exists(LeaderboardSync.OUTBOX_PATH):
+		DirAccess.remove_absolute(LeaderboardSync.OUTBOX_PATH)
+
+func _final_state() -> Dictionary:
+	return {
+		"turn": 12, "doom": 100.0, "doom_integral": 640.0, "reputation": 30.0,
+		"money": 15000, "compute": 4.0, "research": 22.0, "papers": 2,
+		"safety_researchers": 1, "capability_researchers": 2, "compute_engineers": 0,
+		"purchased_upgrades": [], "doom_momentum": 0.0, "ledger": {},
+	}
+
+func _make_screen() -> Node:
+	var scene = load("res://scenes/ui/game_over_screen.tscn").instantiate()
+	add_child_autofree(scene)
+	return scene
+
+# ---- 1 + 2: defeat screen is non-blocking AND survives an unreachable endpoint ----------
+
+func test_show_game_over_does_not_block_and_survives_unreachable_endpoint():
+	LeaderboardSync.enabled = true
+	LeaderboardSync.base_url = UNREACHABLE
+	LeaderboardSync.token = "regression-token"
+	assert_true(LeaderboardSync.should_submit(), "precondition: remote submit is on")
+
+	var scene = _make_screen()
+	await get_tree().process_frame
+
+	var t0 := Time.get_ticks_msec()
+	scene.show_game_over(false, _final_state())
+	var elapsed := Time.get_ticks_msec() - t0
+
+	# The old blocking baseline sim was ~4000ms. Non-blocking must be well under that; the
+	# only work here is cheap. Generous ceiling so the gate isn't flaky on a slow CI box.
+	assert_lt(elapsed, 1500, "show_game_over must not block the main thread (was ~4s baseline freeze); took %dms" % elapsed)
+	assert_true(scene.visible, "defeat screen must be shown even with the endpoint unreachable")
+	assert_eq(scene.title_label.text, "DEFEAT", "defeat title rendered")
+	# Score persisted locally the instant the screen appeared (before any async network work).
+	assert_ne(scene.leaderboard_entry_uuid, "", "score must be saved locally at defeat")
+
+# ---- 3: re-entrancy -- repeated game-over signals submit/save exactly once ---------------
+
+func test_show_game_over_is_idempotent_across_repeat_calls():
+	LeaderboardSync.enabled = false  # keep this test purely local + synchronous
+	var scene = _make_screen()
+	await get_tree().process_frame
+
+	scene.show_game_over(false, _final_state())
+	var uuid1: String = scene.leaderboard_entry_uuid
+	assert_ne(uuid1, "", "first game-over saved a score")
+
+	# Second signal (e.g. a leftover day-tick in a month playback) with DIFFERENT state.
+	var s2 := _final_state()
+	s2["turn"] = 99
+	scene.show_game_over(false, s2)
+	var uuid2: String = scene.leaderboard_entry_uuid
+
+	assert_eq(uuid1, uuid2, "repeat game-over must NOT create a second score entry (re-entrancy guard)")
+
+# ---- 4: durable outbox -------------------------------------------------------------------
+
+func test_outbox_add_read_remove_roundtrip():
+	assert_eq(LeaderboardSync._read_outbox().size(), 0, "outbox starts empty")
+	LeaderboardSync._outbox_add({"entry_uuid": "abc", "score": 5})
+	LeaderboardSync._outbox_add({"entry_uuid": "def", "score": 7})
+	assert_eq(LeaderboardSync._read_outbox().size(), 2, "two distinct scores queued")
+
+	# De-dup by entry_uuid: re-adding the same uuid must not grow the queue.
+	LeaderboardSync._outbox_add({"entry_uuid": "abc", "score": 5})
+	assert_eq(LeaderboardSync._read_outbox().size(), 2, "re-adding same uuid does not duplicate")
+
+	LeaderboardSync._outbox_remove("abc")
+	var remaining := LeaderboardSync._read_outbox()
+	assert_eq(remaining.size(), 1, "ack removes exactly the acked score")
+	assert_eq(str(remaining[0].get("entry_uuid", "")), "def", "the other score is retained for retry")
+
+func test_outbox_read_degrades_on_missing_and_malformed_file():
+	# Missing file -> empty queue, no throw.
+	assert_eq(LeaderboardSync._read_outbox().size(), 0, "missing outbox reads as empty")
+	# Malformed file -> empty queue, no throw.
+	var f := FileAccess.open(LeaderboardSync.OUTBOX_PATH, FileAccess.WRITE)
+	f.store_string("{ this is not valid json [[[")
+	f.close()
+	assert_eq(LeaderboardSync._read_outbox().size(), 0, "malformed outbox degrades to empty (never crashes)")
+
+func test_submit_enqueues_to_outbox_before_dispatch():
+	LeaderboardSync.enabled = true
+	LeaderboardSync.base_url = UNREACHABLE
+	LeaderboardSync.token = "regression-token"
+	var entry := Leaderboard.ScoreEntry.new(42, "Contoso Safety Lab", 42, "v0.11.0", 1.0, 0, 100, 0)
+
+	LeaderboardSync.submit_score(entry, "seed-x", "v0.11.0")
+	# The body is persisted synchronously at dispatch time, before the async result -- so an
+	# app-exit right now would still leave the score queued for retry next launch.
+	var queued := LeaderboardSync._read_outbox()
+	assert_eq(queued.size(), 1, "submit persists the score to the outbox before the POST resolves")
+	assert_eq(str(queued[0].get("entry_uuid", "")), entry.entry_uuid, "queued body carries the entry uuid")
+	assert_eq(str(queued[0].get("seed", "")), "seed-x", "queued body carries the seed (POST contract)")

--- a/godot/tests/unit/test_game_over_remote_isolation.gd
+++ b/godot/tests/unit/test_game_over_remote_isolation.gd
@@ -1,0 +1,101 @@
+extends GutTest
+## Regression: the remote score POST at game-over must never crash, block, or quit
+## the defeat screen. Drives the real GameOverScreen scene with LeaderboardSync ENABLED
+## but pointed at an UNREACHABLE endpoint (the live-build condition that first exposed the
+## "weird quit" -- leaderboard_config.json enabled=true), and asserts the screen still
+## renders and the game-over flow completes without throwing.
+##
+## See fix/endgame-quit-score-post. The sync client is async/defensive on its own; this
+## guards the CALL SITE (game_over_screen.show_game_over) and the fire-and-forget contract.
+
+const SCENE_PATH := "res://scenes/ui/game_over_screen.tscn"
+
+var _prev_enabled: bool
+var _prev_base: String
+var _prev_token: String
+var _prev_optin: bool
+
+func before_each():
+	_prev_enabled = LeaderboardSync.enabled
+	_prev_base = LeaderboardSync.base_url
+	_prev_token = LeaderboardSync.token
+	_prev_optin = GameConfig.submit_scores_global
+	if FileAccess.file_exists(LeaderboardSync.OUTBOX_PATH):
+		DirAccess.remove_absolute(LeaderboardSync.OUTBOX_PATH)
+
+func after_each():
+	LeaderboardSync.enabled = _prev_enabled
+	LeaderboardSync.base_url = _prev_base
+	LeaderboardSync.token = _prev_token
+	GameConfig.submit_scores_global = _prev_optin
+	if FileAccess.file_exists(LeaderboardSync.OUTBOX_PATH):
+		DirAccess.remove_absolute(LeaderboardSync.OUTBOX_PATH)
+
+func _defeat_state() -> Dictionary:
+	# Minimal game-over defeat state: doom>=100 death. Every consumer uses .get() with a
+	# default, so a sparse dict is a valid worst-case.
+	return {
+		"game_over": true,
+		"victory": false,
+		"turn": 12,
+		"doom": 100.0,
+		"reputation": 20,
+		"money": 5000,
+		"compute": 3.0,
+		"research": 4.0,
+		"papers": 1,
+	}
+
+func _instance_screen() -> Control:
+	var scene: PackedScene = load(SCENE_PATH)
+	var screen: Control = scene.instantiate()
+	add_child_autofree(screen)
+	return screen
+
+func test_show_game_over_survives_unreachable_remote():
+	# Live-build condition: sync ENABLED + opted in, but the endpoint refuses fast.
+	# Port 9 (discard) on loopback -> RESULT_CANT_CONNECT without waiting on DNS/timeout.
+	LeaderboardSync.enabled = true
+	LeaderboardSync.base_url = "http://127.0.0.1:9"
+	LeaderboardSync.token = "test-token"
+	GameConfig.submit_scores_global = true
+	assert_true(LeaderboardSync.should_submit(), "precondition: sync would submit")
+
+	var screen := _instance_screen()
+	# Must not throw. Defeat -> doom>=100 path.
+	screen.show_game_over(false, _defeat_state())
+
+	assert_true(screen.visible, "defeat screen renders despite remote sync being live")
+	assert_gt(screen.final_turns, 0, "score tuple computed")
+
+	# Let the async HTTPRequest resolve/fail; the failure must stay contained.
+	await get_tree().create_timer(0.3).timeout
+	assert_true(is_instance_valid(screen), "screen still valid after remote failure resolves")
+
+func test_show_game_over_is_idempotent():
+	# main_ui calls _on_game_state_updated (hence show_game_over) from multiple sites; a
+	# game-over state must be processed ONCE, not re-fire the remote POST every frame.
+	#
+	# We assert this DETERMINISTICALLY via the durable outbox (each submit_score writes its
+	# body there synchronously, de-duped by entry_uuid) instead of racing the async network
+	# completion: an unreachable endpoint can take up to the full request timeout to resolve,
+	# so counting submit_completed emissions inside a short window is inherently flaky. The
+	# re-entrancy guard means 4 refreshes create ONE score entry -> ONE queued body; a broken
+	# guard would create four distinct uuids -> four queued bodies.
+	LeaderboardSync.enabled = true
+	LeaderboardSync.base_url = "http://127.0.0.1:9"
+	LeaderboardSync.token = "test-token"
+	GameConfig.submit_scores_global = true
+
+	var screen := _instance_screen()
+	for i in range(4):
+		screen.show_game_over(false, _defeat_state())
+
+	assert_eq(LeaderboardSync._read_outbox().size(), 1,
+		"remote submit fires once, not once-per-refresh (re-entrancy guard)")
+
+func test_show_game_over_noop_when_sync_disabled():
+	LeaderboardSync.enabled = false
+	var screen := _instance_screen()
+	screen.show_game_over(false, _defeat_state())
+	assert_true(screen.visible, "defeat screen renders with sync disabled")


### PR DESCRIPTION
## Release-blocker

Live v0.11.0 (first build with the remote leaderboard enabled) "quit weirdly" at the defeat screen and **no score reached the server** (confirmed: server data dir held only the deploy-test board after a full playthrough).

## Root cause (`game_over_screen.gd` `show_game_over`)

The defeat transition ran a **multi-second synchronous baseline simulation on the main thread** and fired the score POST only **after** it.

Default `baseline_mode=0` ("Auto") with the normal empty/daily seed starts **no** background sim and never sets a precomputed baseline, so `BaselineSimulator.get_baseline_score()` falls to a full **synchronous BLIND simulation** right at game-over (**~4.0s measured**). Result: the window goes "Not Responding", the player force-quits during the freeze, and the async POST (the **last** scoring step, after the freeze) is **never dispatched** -> nothing reaches the server.

Secondary: **no re-entrancy guard** -- `game_state_updated` fires from ~10 sites (incl. leftover month-playback day-ticks), so `show_game_over` could re-run scoring and re-POST.

The remote client itself was already async/defensive (verified empirically: unreachable endpoint -> graceful `offline -- saved locally`, no crash). The bug was the blocking baseline in front of it plus the late, unguarded, non-durable POST.

**Were scores lost?** Yes -- the POST fired only *after* the freeze, so a force-quit during the freeze meant it was never sent. Now the score is persisted + dispatched *first*, and an outbox guarantees eventual delivery.

## Fix

- **Non-blocking baseline at defeat** -- `BaselineSimulator.get_baseline_score_if_ready()` returns `{}` instead of blocking/simulating; the comparison is skipped when not ready. Removes the freeze = fixes the "weird quit".
- **Score first** -- persist locally + fire the async POST before the verification export / stats rendering, so a hang/force-quit can't lose it.
- **Re-entrancy guard** -- scoring side-effects (local save + remote POST + music) run exactly once per game-over.
- **Durable outbox** (`LeaderboardSync`) -- every submit is written to `user://pending_scores.json` before dispatch and removed only on a server ack; retried at next launch. Score now lands even if the endpoint is slow/down or the app exits mid-post. `PROCESS_MODE_ALWAYS` so a paused tree can't stall an in-flight POST.

## Tests

- `test_endgame_score_isolation.gd` (new): non-blocking (<1.5s vs old ~4s), renders + saves once with the endpoint unreachable, outbox add/read/remove/dedup, malformed-file degrade, enqueue-before-dispatch.
- `test_game_over_remote_isolation.gd`: idempotency assertion made deterministic via the synchronous outbox (was racing an 8s network timeout).

Fast gate: **496 tests, 0 failures, 54/54 files collected**.

Do NOT merge -- release-blocking, dev reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)