### PR TITLE
fix(ui): ledger dead-end + auto-discovering no-UI-dead-end escape-contract test

### DIFF
--- a/docs/game-design/UI_ESCAPE_CONTRACT.md
+++ b/docs/game-design/UI_ESCAPE_CONTRACT.md
@@ -1,0 +1,65 @@
+# UI escape contract -- no dead-ends
+
+- **Status:** ACCEPTED
+- **Date:** 2026-07-19
+- **Branch:** fix/ui-no-dead-ends
+- **Enforced by:** `godot/tests/unit/test_ui_no_dead_ends.gd`
+
+## The failure class
+
+A *UI dead-end* is a panel that opens with no working way out: no visible close /
+back control, and `ui_cancel` (Esc) does nothing. The player is trapped and can only
+force-quit. The reported instance was the Liability Ledger (`ledger_screen.gd`):
+`build_screen()` returned a bare `Panel` whose exit was ENTIRELY host-provided
+(`MainUI._decorate_active_submenu` for the `[X]`, `MainUI._input` for Esc). A panel
+whose only exit lives in a caller is one wiring-regression away from trapping the
+player -- and it is invisible to isolation tests.
+
+## The contract
+
+**Every openable overlay panel MUST provide its OWN working exit.** Concretely, once
+the panel is instanced and shown, at least one of these must close it (free it, hide
+it, or emit a zero-arg close/closed/cancel signal for its parent):
+
+1. **`ui_cancel` (Esc).** An `_input` / `_unhandled_input` / `_shortcut_input` handler
+   that closes the panel when `event.is_action_pressed("ui_cancel")`. This is the
+   preferred, primary path -- Esc closes the topmost panel, everywhere.
+2. **A visible close / back affordance.** A discoverable `Button` (a `[X]`, "Close",
+   "Back", "Continue", ...) whose `pressed` handler hides / frees the panel.
+
+Both SHOULD be present. "Intrinsic" is the key word: the exit must not depend on a
+host input router being wired, because that wiring can be absent (isolation, reuse) or
+regress.
+
+### How the shared frame delivers it
+
+`SubmenuChrome.add_close_affordance(dialog, on_close)` (the shared submenu frame) now
+attaches BOTH: the clickable `[X]` + "[ESC] close" hint AND an `EscToClose` helper
+node (`scripts/ui/esc_to_close.gd`) that calls `on_close` on `ui_cancel`. Any panel
+routed through the chrome inherits the full contract for free. Procedural panels
+(e.g. the ledger) call it from their own `build_screen()`; in the running game
+`MainUI._input` still consumes Esc first, so the helper never double-fires -- it is
+the intrinsic fallback.
+
+## Naming / discovery conventions (so the test finds future panels automatically)
+
+`test_ui_no_dead_ends.gd` auto-discovers panels -- there is no hand-maintained list.
+For it to cover a NEW panel, follow one of these conventions:
+
+- **Scene overlays:** name the `.tscn` under `res://scenes/ui/` with a `_panel` or
+  `_modal` suffix (e.g. `foo_panel.tscn`).
+- **Procedural overlays:** expose a `build_screen(data, viewport_size) -> Control`
+  builder on the script (as `ledger_screen.gd` does). The test instances it with
+  `build_screen(null, <size>)` and checks the returned node.
+
+Transient toasts (`_popup`, e.g. `fanfare_popup`) auto-dismiss (backdrop click /
+Continue / Esc) and are a separate class; they are not in the test's scope but still
+honor `ui_cancel`.
+
+## Why a functional (not structural) test
+
+Per ADR-0017 (anti-hollow tests), the guard must exercise the thing it protects. The
+test does not grep for an Esc handler; it INSTANCES each panel in the live tree, shows
+it, dispatches a real `ui_cancel` `InputEvent` (then, failing that, presses the close
+button), and asserts the panel ends up freed / hidden / signalled-closed. It was
+watched fail red-first against the unfixed ledger before this contract was accepted.

--- a/godot/scripts/ui/esc_to_close.gd
+++ b/godot/scripts/ui/esc_to_close.gd
@@ -1,0 +1,32 @@
+extends Node
+class_name EscToClose
+## Universal escape-contract helper (fix/ui-no-dead-ends).
+##
+## Attaches ui_cancel (Esc) handling to any panel/dialog -- INCLUDING scriptless
+## Panels built procedurally (e.g. the Liability Ledger) -- so the panel honors the
+## "every panel is escapable" contract on its OWN, without depending on a host input
+## router (MainUI._input) being wired. That intrinsic exit is what stops a panel
+## becoming a dead-end if the host wiring is ever absent or regresses. See
+## docs/game-design/UI_ESCAPE_CONTRACT.md.
+##
+## Uses _unhandled_input on purpose: an in-game host that consumes Esc FIRST
+## (MainUI._input calls set_input_as_handled) still wins, so this never double-fires
+## in the running game; it is the fallback that guarantees the panel is never trapped.
+
+var on_close: Callable
+
+static func attach(target: Node, close_cb: Callable) -> EscToClose:
+	var helper := EscToClose.new()
+	helper.name = "EscToClose"
+	helper.on_close = close_cb
+	target.add_child(helper)
+	return helper
+
+func _unhandled_input(event: InputEvent) -> void:
+	if not on_close.is_valid():
+		return
+	if event.is_action_pressed("ui_cancel"):
+		on_close.call()
+		var vp := get_viewport()
+		if vp:
+			vp.set_input_as_handled()

--- a/godot/scripts/ui/esc_to_close.gd.uid
+++ b/godot/scripts/ui/esc_to_close.gd.uid
@@ -1,0 +1,1 @@
+uid://dx3xkk3afi4ni

--- a/godot/scripts/ui/fanfare_popup.gd
+++ b/godot/scripts/ui/fanfare_popup.gd
@@ -156,6 +156,14 @@ func _on_backdrop_input(event: InputEvent) -> void:
 		_dismiss()
 
 
+func _unhandled_input(event: InputEvent) -> void:
+	# Escape contract (fix/ui-no-dead-ends): Esc dismisses the fanfare, like the backdrop
+	# click and the Continue button -- so it is never a dead-end on the keyboard path.
+	if event.is_action_pressed("ui_cancel"):
+		_dismiss()
+		get_viewport().set_input_as_handled()
+
+
 func _dismiss() -> void:
 	if _dismissing:
 		return

--- a/godot/scripts/ui/ledger_screen.gd
+++ b/godot/scripts/ui/ledger_screen.gd
@@ -102,7 +102,7 @@ func update_summary(ledger_data: Dictionary) -> void:
 		# Warm parchment when only owed; warm amber as secret liabilities mount (exposure pressure).
 		_summary_button.add_theme_color_override("font_color", _LEDGER_INK_CLEAN if secrets == 0 else _LEDGER_INK_SECRET)
 
-func build_screen(ledger, viewport_size: Vector2) -> Panel:
+func build_screen(ledger, viewport_size: Vector2, on_close: Callable = Callable()) -> Panel:
 	"""BL-1: the full Liability Ledger screen — lists every live entry (source, currency,
 	principal, fuse, secrecy) plus death attribution.
 
@@ -216,5 +216,18 @@ func build_screen(ledger, viewport_size: Vector2) -> Panel:
 			att.text = "Attributed damage: %d billed shortfalls" % ledger.death_attribution.size()
 			att.add_theme_color_override("font_color", _LEDGER_WARN_RED)
 			vbox.add_child(att)
+
+	# fix/ui-no-dead-ends: give the ledger its OWN exit so it is never a dead-end.
+	# The reported bug -- opened the ledger, no working close/back, Esc did nothing --
+	# came from build_screen returning a bare Panel whose exit was ENTIRELY host-provided
+	# (MainUI._decorate_active_submenu for the [X], MainUI._input for Esc). If that host
+	# wiring is absent or regresses, the player is trapped. Routing through the shared
+	# submenu chrome attaches a visible [X] close control AND intrinsic ui_cancel (Esc)
+	# handling to the panel itself. on_close defaults to a self-free so the panel is
+	# escapable in isolation; the host passes its own close routine to keep bookkeeping.
+	var close_cb: Callable = on_close
+	if not close_cb.is_valid():
+		close_cb = func(): dialog.queue_free()
+	SubmenuChrome.add_close_affordance(dialog, close_cb)
 
 	return dialog

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -2266,7 +2266,11 @@ func _show_ledger_screen():
 		active_dialog_buttons = []
 
 	var ledger = game_manager.state.ledger if (game_manager and game_manager.state) else null
-	var dialog: Panel = ledger_screen.build_screen(ledger, get_viewport().get_visible_rect().size)
+	# fix/ui-no-dead-ends: build_screen now attaches the close [X] + intrinsic Esc
+	# (ui_cancel) affordance itself, wired to our _close_active_submenu so the dialog
+	# bookkeeping stays with the host. No separate _decorate_active_submenu() needed --
+	# doing both would stack two [X] buttons.
+	var dialog: Panel = ledger_screen.build_screen(ledger, get_viewport().get_visible_rect().size, _close_active_submenu)
 
 	active_dialog = dialog
 	active_dialog_buttons = []
@@ -2274,7 +2278,6 @@ func _show_ledger_screen():
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
-	_decorate_active_submenu()
 
 func _show_publicity_submenu():
 	"""Show popup dialog with publicity/influence options with keyboard support - icon grid layout"""

--- a/godot/scripts/ui/staff_perks_panel.gd
+++ b/godot/scripts/ui/staff_perks_panel.gd
@@ -459,3 +459,11 @@ func _on_close_pressed():
 	"""Handle close button"""
 	close_requested.emit()
 	hide()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	# Escape contract (fix/ui-no-dead-ends): Esc closes the panel, matching the [X]
+	# button, so the keyboard path is never a dead-end.
+	if visible and event.is_action_pressed("ui_cancel"):
+		_on_close_pressed()
+		get_viewport().set_input_as_handled()

--- a/godot/scripts/ui/submenu_chrome.gd
+++ b/godot/scripts/ui/submenu_chrome.gd
@@ -66,6 +66,12 @@ static func add_close_affordance(dialog: Control, on_close: Callable) -> void:
 	hint.position = Vector2(dialog.size.x - 122, dialog.size.y - 20)
 	dialog.add_child(hint)
 
+	# Universal escape contract (fix/ui-no-dead-ends): make the panel honor ui_cancel
+	# (Esc) on its OWN via a helper node, so it is escapable even without a host input
+	# router. In-game MainUI._input still consumes Esc first (this never double-fires);
+	# this is the intrinsic fallback that stops the panel ever becoming a dead-end.
+	EscToClose.attach(dialog, on_close)
+
 static func align_to_button(dialog: Control, button: Button) -> void:
 	"""Position a submenu just to the RIGHT of the action button that opened it and
 	top-aligned to it, so it clearly expands from that row rather than over it

--- a/godot/tests/unit/test_ui_no_dead_ends.gd
+++ b/godot/tests/unit/test_ui_no_dead_ends.gd
@@ -1,0 +1,277 @@
+extends GutTest
+## No-UI-dead-ends escape-contract test (fix/ui-no-dead-ends, ADR-0017 red-first).
+##
+## THE failure class this guards: a panel opens with NO working way out -- no close/
+## back control, and Esc does nothing -- trapping the player (the reported Liability
+## Ledger bug). A per-button hand-written list would rot; instead this test
+## AUTO-DISCOVERS openable overlay panels and asserts each has a WORKING EXIT.
+##
+## Discovery (no hardcoded per-panel list -- future panels are covered automatically):
+##   1. Scene panels: every res://scenes/ui/**/*.tscn whose basename ends in the
+##      overlay-convention suffixes "_panel" or "_modal".
+##   2. Procedural panels: every res://scripts/ui/*.gd that exposes a build_screen()
+##      builder (the Liability Ledger is built this way, not from a .tscn).
+## Both sources grow automatically as the UI grows, provided the naming/build
+## conventions in docs/game-design/UI_ESCAPE_CONTRACT.md are followed.
+##
+## Working exit (the contract, EITHER is sufficient):
+##   - an _input/_unhandled_input/_shortcut_input handler that closes the panel on
+##     ui_cancel (Esc), OR
+##   - a discoverable close/back Button whose press hides/frees the panel (or emits a
+##     zero-arg close/closed/cancel/dismiss signal for a parent to act on).
+## Verified FUNCTIONALLY: the panel is instanced in the live tree, shown, then a real
+## ui_cancel InputEvent is dispatched (and, failing that, its close button pressed);
+## the panel must end up freed / hidden / signalled-closed. A panel that survives both
+## with no exit is a dead-end and fails the test, naming itself.
+##
+## Red-first proof (ADR-0017): run against the UNFIXED Liability Ledger, this file goes
+## RED naming ledger_screen.gd -- build_screen() returned a bare Panel with no intrinsic
+## exit. See the PR body for the captured red output.
+
+const SCENE_UI_ROOT := "res://scenes/ui"
+const SCRIPT_UI_ROOT := "res://scripts/ui"
+const OVERLAY_SUFFIXES := ["_panel", "_modal"]  # summonable-overlay naming convention
+
+# Floor so the discovery walk cannot silently go hollow (ADR-0017 "silence is failure").
+const MIN_PANELS := 3
+
+const CLOSE_TEXT_KEYWORDS := [
+	"close", "back", "cancel", "dismiss", "done", "return", "exit", "ok",
+	"continue", "✕", "✖", "x",
+]
+const CLOSE_SIGNAL_KEYWORDS := ["close", "cancel", "dismiss", "back", "done", "exit"]
+
+var _bg: Control  # a stand-in "game" background the panels open on top of
+
+
+func before_each() -> void:
+	_bg = Control.new()
+	_bg.name = "DeadEndTestBackground"
+	_bg.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	get_tree().root.add_child(_bg)
+
+
+func after_each() -> void:
+	if is_instance_valid(_bg):
+		_bg.queue_free()
+	_bg = null
+
+
+# --- Discovery -----------------------------------------------------------------
+
+func _collect(root: String, ext: String) -> Array:
+	## Recursive list of res:// paths under `root` ending in `ext`.
+	var out: Array = []
+	var dir := DirAccess.open(root)
+	if dir == null:
+		return out
+	dir.list_dir_begin()
+	var name := dir.get_next()
+	while name != "":
+		if name == "." or name == "..":
+			name = dir.get_next()
+			continue
+		var path := root + "/" + name
+		if dir.current_is_dir():
+			out.append_array(_collect(path, ext))
+		elif name.ends_with(ext):
+			out.append(path)
+		name = dir.get_next()
+	dir.list_dir_end()
+	return out
+
+
+func _discover_scene_panels() -> Array:
+	var panels: Array = []
+	for path in _collect(SCENE_UI_ROOT, ".tscn"):
+		var base := String(path).get_file().get_basename()  # e.g. "bug_report_panel"
+		for suffix in OVERLAY_SUFFIXES:
+			if base.ends_with(suffix):
+				panels.append({"name": base, "path": path, "kind": "scene"})
+				break
+	return panels
+
+
+func _discover_procedural_panels() -> Array:
+	var panels: Array = []
+	for path in _collect(SCRIPT_UI_ROOT, ".gd"):
+		var script = load(path)
+		if script == null or not (script is GDScript):
+			continue
+		for m in script.get_script_method_list():
+			if String(m.get("name", "")) == "build_screen":
+				panels.append({"name": path.get_file().get_basename(), "path": path, "kind": "proc"})
+				break
+	return panels
+
+
+func _discover_all_panels() -> Array:
+	var all: Array = _discover_scene_panels()
+	all.append_array(_discover_procedural_panels())
+	all.sort_custom(func(a, b): return String(a.name) < String(b.name))
+	return all
+
+
+# --- Building an instance we can drive -----------------------------------------
+
+func _build_panel_node(spec: Dictionary):
+	## Returns [node, cleanup_extra] or null. cleanup_extra is a builder object that
+	## must be freed after the node (procedural builders are Nodes we instanced).
+	if spec.kind == "scene":
+		var packed = load(spec.path)
+		if packed == null or not (packed is PackedScene) or not packed.can_instantiate():
+			return null
+		return [packed.instantiate(), null]
+	# procedural: instance the builder, call build_screen(null, size) -> Control panel.
+	var script = load(spec.path)
+	if script == null:
+		return null
+	var builder = script.new()
+	if builder == null or not builder.has_method("build_screen"):
+		if builder is Node:
+			builder.free()
+		return null
+	var panel = builder.build_screen(null, Vector2(1152, 648))
+	return [panel, builder]
+
+
+func _activate(node) -> void:
+	## Show the panel the way it is actually opened, so lazily-built content exists.
+	if node.has_method("show_panel"):
+		node.show_panel()
+	elif node.has_method("present"):
+		node.present("Escape-contract self-test", "This panel must be escapable.")
+	if node is CanvasItem and not node.visible:
+		node.visible = true
+
+
+# --- Exit detection ------------------------------------------------------------
+
+func _gather_buttons(node: Node, out: Array) -> void:
+	for child in node.get_children():
+		if child is Button:
+			out.append(child)
+		_gather_buttons(child, out)
+
+
+func _find_close_button(node: Node) -> Button:
+	var buttons: Array = []
+	_gather_buttons(node, buttons)
+	# Prefer a semantically-named close/back/cancel button.
+	for b in buttons:
+		var t := String(b.text).strip_edges().to_lower()
+		for kw in CLOSE_TEXT_KEYWORDS:
+			if t == kw or (kw.length() > 1 and t.contains(kw)):
+				return b
+	# Otherwise the first button that is actually wired to something.
+	for b in buttons:
+		if b.pressed.get_connections().size() > 0:
+			return b
+	return null
+
+
+func _watch_close_signals(node: Node, flag: Array) -> void:
+	for s in node.get_signal_list():
+		if int(s.get("args", []).size()) != 0:
+			continue  # only zero-arg signals can take our zero-arg sink safely
+		var n := String(s.name).to_lower()
+		for kw in CLOSE_SIGNAL_KEYWORDS:
+			if n.contains(kw):
+				node.connect(s.name, func(): flag[0] = true)
+				break
+
+
+func _send_ui_cancel() -> void:
+	var ev := InputEventKey.new()
+	ev.keycode = KEY_ESCAPE
+	ev.physical_keycode = KEY_ESCAPE
+	ev.pressed = true
+	get_viewport().push_input(ev)
+
+
+func _settle() -> void:
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+
+func _is_gone_or_hidden(node) -> bool:
+	if not is_instance_valid(node):
+		return true
+	if node is CanvasItem:
+		return not node.visible
+	if node is CanvasLayer:
+		return not node.visible
+	return false
+
+
+func _has_working_exit(node) -> bool:
+	var closed := [false]
+	_watch_close_signals(node, closed)
+
+	# 1) The contract's preferred path: ui_cancel (Esc) closes it.
+	_send_ui_cancel()
+	await _settle()
+	if _is_gone_or_hidden(node) or closed[0]:
+		return true
+
+	# 2) Fallback: a discoverable close/back button that hides/frees/signals.
+	if is_instance_valid(node):
+		var btn := _find_close_button(node)
+		if btn != null and is_instance_valid(btn):
+			btn.pressed.emit()
+			await _settle()
+			if _is_gone_or_hidden(node) or closed[0]:
+				return true
+	return false
+
+
+# --- Tests ---------------------------------------------------------------------
+
+func test_discovery_is_not_hollow():
+	# If the walk finds (almost) nothing, a refactor moved the tree and this whole
+	# file would pass vacuously -- fail LOUDLY instead (ADR-0017 MIN floor).
+	var panels := _discover_all_panels()
+	var names := panels.map(func(p): return p.name)
+	gut.p("discovered %d openable panels: %s" % [panels.size(), str(names)])
+	assert_gte(panels.size(), MIN_PANELS,
+		"discovery found only %d panels (< floor %d) -- the walk may be hollow" % [panels.size(), MIN_PANELS])
+
+
+func test_no_ui_dead_ends():
+	var panels := _discover_all_panels()
+	assert_gte(panels.size(), MIN_PANELS, "no panels discovered -- discovery is hollow")
+
+	var dead_ends: Array = []
+	for spec in panels:
+		var built = _build_panel_node(spec)
+		if built == null:
+			dead_ends.append("%s (could not instance/build -- %s)" % [spec.name, spec.path])
+			continue
+		var node = built[0]
+		var builder = built[1]
+		if node == null or not (node is Node):
+			dead_ends.append("%s (build_screen/instantiate returned non-Node)" % spec.name)
+			if builder is Node and is_instance_valid(builder):
+				builder.free()
+			continue
+
+		_bg.add_child(node)
+		await _settle()  # let _ready() run
+		_activate(node)
+		await _settle()
+
+		var ok: bool = await _has_working_exit(node)
+		if not ok:
+			dead_ends.append("%s [%s] -- opens with NO working exit (no ui_cancel handler, no close/back button that hides/frees it)" % [spec.name, spec.kind])
+			gut.p("  DEAD-END: %s (%s)" % [spec.name, spec.path])
+		else:
+			gut.p("  ok: %s (%s)" % [spec.name, spec.kind])
+
+		if is_instance_valid(node):
+			node.queue_free()
+		if builder is Node and is_instance_valid(builder):
+			builder.free()
+		await _settle()
+
+	assert_eq(dead_ends.size(), 0,
+		"%d UI panel(s) are dead-ends (no working exit): %s" % [dead_ends.size(), str(dead_ends)])

--- a/godot/tests/unit/test_ui_no_dead_ends.gd.uid
+++ b/godot/tests/unit/test_ui_no_dead_ends.gd.uid
@@ -1,0 +1,1 @@
+uid://7okxgn4enf7n


### PR DESCRIPTION
## The bug

Opening the **Liability Ledger** trapped the player: no working close/back, Esc did nothing. Root cause: `ledger_screen.build_screen()` returned a **bare `Panel`** whose exit was **entirely host-provided** -- the `[X]` came from `MainUI._decorate_active_submenu` and Esc from `MainUI._input`. A panel whose only exit lives in a caller is one wiring-regression away from trapping the player, and it is invisible to any isolation test.

## The robust test (built first, proven RED)

`godot/tests/unit/test_ui_no_dead_ends.gd` -- **auto-discovers** openable panels (no hardcoded per-button list):
- scene overlays: `scenes/ui/**/*.tscn` named `*_panel` / `*_modal`
- procedural overlays: any `scripts/ui/*.gd` exposing `build_screen()` (the ledger)

For each: instance in the live tree, show, dispatch a real `ui_cancel` `InputEvent` (else press the discovered close button), then assert the panel is **freed / hidden / signalled-closed**. A discovery floor guards against a hollow walk (ADR-0017).

**Red-first (unfixed ledger)** -- 4 panels discovered, ledger the sole dead-end:
```
discovered 4 openable panels: ["bug_report_panel", "ledger_screen", "staff_perks_panel", "whats_new_modal"]
  ok: bug_report_panel (scene)
  DEAD-END: ledger_screen (res://scripts/ui/ledger_screen.gd)
  ok: staff_perks_panel (scene)
  ok: whats_new_modal (scene)
[Failed]: 1 UI panel(s) are dead-ends (no working exit): ["ledger_screen [proc] -- opens with NO working exit (no ui_cancel handler, no close/back button that hides/frees it)"]
```
Official runner red-first: `505 tests, 1 failures` (the ledger).

## The fix (intrinsic exit + universal contract)

- `SubmenuChrome.add_close_affordance` now also attaches an `EscToClose` helper node (`scripts/ui/esc_to_close.gd`) that honors `ui_cancel` -- so every panel routed through the shared frame is escapable **on its own**, not just when the host router is wired. In-game `MainUI._input` still consumes Esc first, so it never double-fires.
- `ledger_screen.build_screen()` routes through the chrome (visible `[X]` + intrinsic Esc); `MainUI._show_ledger_screen` passes `_close_active_submenu` as the callback and drops the now-redundant decorate call (no double `[X]`).
- Added `ui_cancel` to `staff_perks_panel` and `fanfare_popup` for the universal contract.
- Contract documented in `docs/game-design/UI_ESCAPE_CONTRACT.md`.

## Green

- New test: 4/4 panels pass, 0 dead-ends.
- Fast gate: `505 tests, 0 failures, 56/56 files collected`.

Do **not** merge -- game code, dev reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)