### PR TITLE
fix(leaderboard): bounded lazy rendering -- stop loading the whole population into memory (data preserved)

### DIFF
--- a/godot/scripts/ui/leaderboard_screen.gd
+++ b/godot/scripts/ui/leaderboard_screen.gd
@@ -32,6 +32,16 @@ func _ready():
 	_setup_global_toggle()
 	_filter_and_display()
 
+func _exit_tree():
+	# Cleanup guard: drop the working-set references the instant the screen leaves
+	# the tree so the whole population of ScoreEntry objects is released now rather
+	# than lingering until the node is GC'd. Combined with freeing the transient
+	# Leaderboard Nodes in _load_all_leaderboards, re-opening the screen does not
+	# accumulate memory across opens.
+	all_leaderboards.clear()
+	all_entries.clear()
+	filtered_entries.clear()
+
 func _setup_global_toggle():
 	"""Add a Local/Global view toggle next to the seed filter, but only when remote
 	sync is enabled+configured. When off/unconfigured the screen stays local-only."""
@@ -104,22 +114,22 @@ func _load_all_leaderboards():
 
 	while file_name != "":
 		if file_name.ends_with(".json") and file_name.begins_with("leaderboard_"):
-			# Parse "leaderboard_SEED.json" or the version-keyed
-			# "leaderboard_SEED__VERSION.json" (ADR-0002 #5). '__' delimiter survives
-			# hyphens/underscores in seeds.
-			var base_name = file_name.trim_prefix("leaderboard_").trim_suffix(".json")
-			var lb_seed = base_name
-			var lb_version = ""
-			if base_name.contains("__"):
-				var parts = base_name.rsplit("__", true, 1)
-				lb_seed = parts[0]
-				lb_version = parts[1]
+			var identity = _parse_board_identity(file_name)
+			var lb_seed = identity["seed"]
+			var lb_version = identity["version"]
 
 			# Reconstruct with the same (seed, version) so file_path matches on load.
+			# MEMORY NOTE (bounded-view fix): Leaderboard `extends Node`, so an
+			# instance is NOT refcounted -- retaining it (as this used to) leaks one
+			# Node plus its whole entries array on EVERY (re)open of this screen,
+			# which is the unbounded growth behind the release-build segfault. We use
+			# the board only transiently to parse the file, copy its entries out
+			# (ScoreEntry is RefCounted and survives the free), then free() the Node.
 			var leaderboard = LeaderboardClass.new(lb_seed, lb_version)
 			# Key by full identity so same-seed/different-version boards don't collide.
 			var board_key = lb_seed if lb_version == "" else "%s (%s)" % [lb_seed, lb_version]
-			all_leaderboards[board_key] = leaderboard
+			# Store the plain entries array (NOT the Node) so nothing leaks.
+			all_leaderboards[board_key] = leaderboard.entries.duplicate()
 
 			# Add entries to combined list
 			for entry in leaderboard.entries:
@@ -130,6 +140,10 @@ func _load_all_leaderboards():
 				"Loaded leaderboard",
 				{"seed": lb_seed, "version": lb_version, "entries": leaderboard.entries.size()}
 			)
+
+			# Free the transient board Node now -- its entries are already copied
+			# above and stay alive via all_leaderboards / all_entries.
+			leaderboard.free()
 
 		file_name = dir.get_next()
 
@@ -147,6 +161,22 @@ func _load_all_leaderboards():
 		}
 	)
 
+func _parse_board_identity(file_name: String) -> Dictionary:
+	"""Parse a leaderboard filename into its (seed, version) identity.
+
+	Handles "leaderboard_SEED.json" and the version-keyed
+	"leaderboard_SEED__VERSION.json" (ADR-0002 #5). The '__' delimiter survives
+	hyphens/underscores in seeds. Shared by _load_all_leaderboards and
+	_perform_clear_all so the two never drift."""
+	var base_name = file_name.trim_prefix("leaderboard_").trim_suffix(".json")
+	var lb_seed = base_name
+	var lb_version = ""
+	if base_name.contains("__"):
+		var parts = base_name.rsplit("__", true, 1)
+		lb_seed = parts[0]
+		lb_version = parts[1]
+	return {"seed": lb_seed, "version": lb_version}
+
 func _populate_seed_dropdown():
 	"""Populate seed filter dropdown"""
 	seed_dropdown.clear()
@@ -157,7 +187,7 @@ func _populate_seed_dropdown():
 	seeds.sort()
 
 	for seed in seeds:
-		var entry_count = all_leaderboards[seed].entries.size()
+		var entry_count = all_leaderboards[seed].size()
 		seed_dropdown.add_item("%s (%d)" % [seed, entry_count], idx)
 		seed_dropdown.set_item_metadata(idx, seed)
 		idx += 1
@@ -180,7 +210,7 @@ func _filter_and_display():
 	else:
 		filtered_entries.clear()
 		if all_leaderboards.has(current_seed):
-			filtered_entries = all_leaderboards[current_seed].entries.duplicate()
+			filtered_entries = all_leaderboards[current_seed].duplicate()
 		subtitle.text = "Top scores for seed: %s" % current_seed
 
 	# Reset to page 1 when filter changes
@@ -191,11 +221,28 @@ func _filter_and_display():
 	_update_pagination_ui()
 	_update_stats()
 
-func _display_current_page():
-	"""Display entries for current page"""
-	# Clear existing entries
+func _free_row_nodes():
+	"""Free every instantiated row widget in the entries container, immediately.
+
+	Bounded-render guarantee: at most `entries_per_page` row nodes (plus the
+	empty-state label) are ever alive at once, no matter how many thousands of
+	entries the population holds. We free() rather than queue_free() so the bound
+	holds SYNCHRONOUSLY -- queue_free defers to end-of-frame, which would let two
+	pages' worth of rows briefly coexist when paging. get_children() returns a
+	copy, so freeing while iterating is safe."""
 	for child in entries_container.get_children():
-		child.queue_free()
+		entries_container.remove_child(child)
+		child.free()
+
+func _display_current_page():
+	"""Display entries for current page.
+
+	Only the current page's slice is ever instantiated as row widgets; the full
+	(sorted) population lives in filtered_entries as lightweight data and is never
+	turned into nodes wholesale. Paging frees the prior page first (_free_row_nodes),
+	so node memory stays bounded regardless of population size."""
+	# Clear existing entries (bounded: previous page's rows are freed first).
+	_free_row_nodes()
 
 	if filtered_entries.size() == 0:
 		var no_entries = Label.new()
@@ -435,15 +482,30 @@ func _on_clear_button_pressed():
 	dialog.popup_centered()
 
 func _perform_clear_all():
-	"""Actually clear all scores"""
+	"""Actually clear all scores.
+
+	all_leaderboards now holds plain entry arrays (not Leaderboard Nodes -- see the
+	memory note in _load_all_leaderboards), so we reconstruct each board transiently
+	from disk to call clear(), then free() the Node. Same file set, same clear()
+	semantics as before -- only the in-memory representation changed."""
 	ErrorHandler.warning(
 		ErrorHandler.Category.SAVE_LOAD,
 		"Clearing all leaderboard scores",
 		{"count": all_entries.size()}
 	)
 
-	for leaderboard in all_leaderboards.values():
-		leaderboard.clear()
+	var dir = DirAccess.open("user://leaderboards")
+	if dir:
+		dir.list_dir_begin()
+		var file_name = dir.get_next()
+		while file_name != "":
+			if file_name.ends_with(".json") and file_name.begins_with("leaderboard_"):
+				var identity = _parse_board_identity(file_name)
+				var leaderboard = LeaderboardClass.new(identity["seed"], identity["version"])
+				leaderboard.clear()
+				leaderboard.free()  # transient Node -- free to avoid a leak.
+			file_name = dir.get_next()
+		dir.list_dir_end()
 
 	# Reload
 	_load_all_leaderboards()

--- a/godot/tests/unit/test_leaderboard_view_bounded.gd
+++ b/godot/tests/unit/test_leaderboard_view_bounded.gd
@@ -1,0 +1,128 @@
+extends GutTest
+## Bounded-view / memory regression tests for the leaderboard screen
+## (godot/scripts/ui/leaderboard_screen.gd).
+##
+## Context: opening the leaderboard on a huge accumulated population spiked memory
+## and segfaulted the RELEASE build. The DATA is a deliberate substrate and must NOT
+## be reduced; only the VIEW is bounded. These tests pin the two invariants that
+## keep runtime memory bounded while every stored byte is preserved:
+##
+##  1. RENDER is page-bounded: no matter how large the population (5000 here), only
+##     ~entries_per_page ROW NODES are ever instantiated -- never one node per entry.
+##  2. LOAD does not leak: Leaderboard `extends Node` (NOT RefCounted), so the screen
+##     must not RETAIN those Node instances. It now stores plain entry arrays and
+##     frees the transient board Nodes, so loading leaves no orphan Nodes behind and
+##     re-opening does not accumulate memory.
+
+const SCREEN := preload("res://scenes/leaderboard_screen.tscn")
+
+# ScoreEntry.new(score, player_name, level, mode, duration, baseline, doom_integral, baseline_integral)
+func _make_entry(score: int) -> Leaderboard.ScoreEntry:
+	return Leaderboard.ScoreEntry.new(score, "Lab %d" % score, score, "test", 1.0, 0, score % 7, 0)
+
+func _make_screen():
+	var screen = SCREEN.instantiate()
+	add_child_autofree(screen)  # triggers _ready -> loads real user:// boards (may be empty in CI)
+	return screen
+
+func _huge_population(n: int) -> Array:
+	# Already sorted descending (matches the screen's sort order) so page bounds are obvious.
+	var entries: Array = []
+	for i in range(n):
+		entries.append(_make_entry(n - i))
+	return entries
+
+# --- Invariant 1: render is page-bounded even for a 5000-entry population ------
+
+func test_render_is_page_bounded_for_huge_population():
+	var screen = _make_screen()
+	screen.filtered_entries = _huge_population(5000)
+	screen.current_seed = "all"
+	screen.current_page = 1
+	screen._display_current_page()
+
+	var count: int = screen.entries_container.get_child_count()
+	assert_eq(count, screen.entries_per_page,
+		"page 1 must instantiate exactly entries_per_page rows, got %d for a 5000-entry board" % count)
+	# The whole point: memory is bounded -- we did NOT build a node per entry.
+	assert_lt(count, 5000,
+		"render must NOT instantiate a node per entry (that is the unbounded-memory bug)")
+
+func test_paging_frees_prior_rows_and_stays_bounded():
+	var screen = _make_screen()
+	screen.filtered_entries = _huge_population(5000)
+	screen.current_seed = "all"
+	screen.current_page = 1
+	screen._display_current_page()
+	var after_page1: int = screen.entries_container.get_child_count()
+
+	# Page forward several times: 5000/20 = 250 pages, so these are all full pages.
+	for _p in range(5):
+		screen._on_next_button_pressed()
+	var after_paging: int = screen.entries_container.get_child_count()
+
+	assert_eq(after_page1, screen.entries_per_page, "page 1 bounded to entries_per_page")
+	assert_eq(after_paging, screen.entries_per_page,
+		"paging must FREE the previous page's rows (bounded, not accumulating): got %d" % after_paging)
+
+func test_last_partial_page_is_bounded():
+	var screen = _make_screen()
+	# 45 entries, 20/page -> page 3 holds the remaining 5 (still <= entries_per_page).
+	screen.filtered_entries = _huge_population(45)
+	screen.current_seed = "all"
+	screen.current_page = 3
+	screen._display_current_page()
+	var count: int = screen.entries_container.get_child_count()
+	assert_lte(count, screen.entries_per_page,
+		"a partial last page never exceeds entries_per_page rows, got %d" % count)
+	assert_eq(count, 5, "page 3 of a 45-entry board shows the trailing 5 entries")
+
+# --- Invariant 2: loading does not retain / leak Leaderboard Nodes ------------
+
+func test_load_stores_arrays_not_nodes_and_leaves_no_orphans():
+	var screen = _make_screen()
+
+	# Seed a few synthetic boards on disk with unique test-only seeds (no '__' in the
+	# seed itself so filename parsing is unambiguous).
+	var seeds: Array = []
+	for i in range(3):
+		var s := "zzzViewBounded%dx%d" % [i, Time.get_ticks_usec()]
+		seeds.append(s)
+		var lb := Leaderboard.new(s, "test")
+		lb.clear()
+		for j in range(5):
+			lb.add_score(_make_entry(j))  # writes the file
+		lb.free()
+
+	var orphans_before: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
+	screen._load_all_leaderboards()
+	var orphans_after: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
+
+	# Boards must be stored as PLAIN ARRAYS -- never retained Leaderboard Nodes.
+	for s in seeds:
+		var key := "%s (test)" % s
+		assert_true(screen.all_leaderboards.has(key), "seeded board %s should be loaded" % key)
+		var val = screen.all_leaderboards[key]
+		assert_true(val is Array, "board must be stored as a plain Array (not a Node)")
+		assert_false(val is Node, "board must NOT be a retained Leaderboard Node (that is the leak)")
+
+	# Parsing every board must leave NO orphan Nodes -- each transient board is freed.
+	assert_true(orphans_after <= orphans_before,
+		"_load_all_leaderboards leaked %d orphan Node(s)" % (orphans_after - orphans_before))
+
+	# Cleanup: remove the synthetic files so we don't pollute user://leaderboards.
+	var dir := DirAccess.open("user://leaderboards")
+	if dir:
+		for s in seeds:
+			dir.remove("leaderboard_%s__test.json" % s)
+
+func test_reload_does_not_accumulate_orphans():
+	var screen = _make_screen()
+	# Repeated loads (as happens on Refresh / re-open) must not grow orphan Nodes.
+	screen._load_all_leaderboards()
+	var baseline: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
+	for _i in range(3):
+		screen._load_all_leaderboards()
+	var after: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
+	assert_true(after <= baseline,
+		"repeated loads leaked %d orphan Node(s) (re-open would accumulate memory)" % (after - baseline))


### PR DESCRIPTION
## Problem
Opening the leaderboard on a large accumulated population (thousands of entries -- the dev saw ~400 pages) spikes memory and **segfaults the RELEASE build** right after "Transitioning to leaderboard"; the debug build strains but survives.

## Hard constraint (honored)
The full dataset -- on disk (`user://leaderboards/...`), the score contract, submission richness, and the per-file cap -- is a deliberate substrate for future visualizations. **No data was reduced, trimmed, or capped.** This PR fixes only the runtime VIEW.

## Root causes (VIEW layer only)
1. **Node leak -- the unbounded growth.** `leaderboard.gd` is `extends Node`, so a `Leaderboard` instance is **not** refcounted. `_load_all_leaderboards()` created one board Node per file and RETAINED it in `all_leaderboards` forever, never freeing it. Every (re)open leaked one Node plus its entire `entries` array -> memory grew each time the screen was opened, ending in the segfault.
2. **Deferred row-clear.** `_display_current_page()` cleared rows with `queue_free()` (end-of-frame), so two pages' worth of row widgets could briefly coexist.

## Fix
- `_load_all_leaderboards`: parse each board **transiently**, copy its entries out (`ScoreEntry` is RefCounted and survives), then `free()` the Node. `all_leaderboards` now holds **plain entry arrays, never Nodes**.
- `_free_row_nodes()`: frees the current page's rows **immediately**, so at most `~entries_per_page` row nodes ever exist regardless of population.
- `_exit_tree()`: drops the working-set references the moment the screen closes; `_load_all_leaderboards` stays idempotent (clears first) so Refresh / re-open never accumulate.
- `_parse_board_identity()`: shared filename->(seed,version) parse used by load + clear (`_perform_clear_all` reconstructs boards transiently to clear, since values are arrays now).

Sorting/filtering/stats still run across the **full** population; only instantiation is page-bounded.

## Test
`godot/tests/unit/test_leaderboard_view_bounded.gd`:
- With a synthetic **5000-entry** board, `_display_current_page()` instantiates **exactly `entries_per_page` rows** (asserts `== entries_per_page` and `< 5000`).
- Paging forward frees the prior page (row count stays at `entries_per_page`, does not accumulate).
- `_load_all_leaderboards` stores **Arrays not Nodes** and leaves **no orphan Nodes** behind (`OBJECT_ORPHAN_NODE_COUNT` delta <= 0); repeated loads do not accumulate orphans.

Fast gate: `508 tests, 0 failures, 56/56 files collected`.

## Not verified
The actual GUI segfault cannot be verified here (needs a display). Dev should re-test the RELEASE build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)