### PR TITLE
art(ui): directional menu-consistency pass (palette/texture alignment)

### DIFF
--- a/docs/game-design/UI_MENU_CONSISTENCY_2026-07-20.md
+++ b/docs/game-design/UI_MENU_CONSISTENCY_2026-07-20.md
@@ -1,0 +1,208 @@
+# UI Menu Consistency Pass -- 2026-07-20
+
+Directional coherence audit of every menu/screen against the established visual
+direction: warm-grime base + heavy-outline heft + deeper shadow
+(`docs/art/reviews/2026-07-17-overnight-sweep.md`), palette = dark
+indigo/doom-purple grounds + hand-sourced warm amber accent
+(`docs/art/palette.json`, `docs/art/PALETTE_AND_DOOM_INTENSITY.md`).
+This was a COHERENCE pass, not a redesign: colors and one texture swap only;
+no layout or node changes anywhere.
+
+## The shared retone vocabulary (applied consistently)
+
+The single biggest off-style pattern was a slate-blue button stylebox set
+(bg `Color(0.2,0.3,0.5)`, border `Color(0.4,0.5,0.7)`, bright-blue focus fill)
+copy-pasted across five menu scenes plus ice-blue (`0.6,0.8,1`) section-header
+labels. Blue is semantically reserved in the palette doc for "computers acting
+up" (Axis B), not menu chrome. Replaced everywhere with palette values:
+
+| role | old | new | palette source |
+|---|---|---|---|
+| button normal bg | 0.2,0.3,0.5 slate blue | 0.18,0.145,0.278 (#2E2547) | doom-indigo (palette.json) |
+| button normal border | 0.4,0.5,0.7 light blue | 0.09,0.04,0.11 (#170A1C) | deep aubergine = heavy dark outline (the sweep's "heavy-outline heft") |
+| button hover bg | 0.3,0.5,0.8 | 0.231,0.192,0.349 (lightened indigo) | -- |
+| button hover border | 0.7,0.8,1 | 0.91,0.64,0.24 (#E8A33D) | cozy amber -- accent appears on interaction |
+| button pressed bg | 0.15,0.25,0.4 | 0.106,0.078,0.165 (#1B142A) | darker indigo |
+| pressed/focus border | 0.9..1 white-blue | 0.965,0.659,0 (#F6A800) | amber UI token (glow_cat "the ONLY saturated accent") |
+| focus bg | 0.4,0.6,1 bright blue FILL | same as normal bg + 3px amber border | keeps keyboard-nav visible without a loud fill |
+| section-header labels | 0.6,0.8,1 / 0.4,0.8,1 ice blue | 0.91,0.64,0.24 cozy amber | amber CRT header register |
+| screen titles | 0.86,0.94,1 ice white | 0.914,0.949,0.949 (#E9F2F2) | off-white text neutral |
+| modal panel bg | bluish/neutral grays | #170A1C / #1B142A | dread grounds |
+| modal panel border | 0.3-0.4,0.5-0.6,0.7-0.8 blue | 0.91,0.64,0.24 @ 0.8 alpha | amber frame on the active modal |
+
+Rationale for border direction: the sweep ruling is heavy-OUTLINE heft, so
+resting buttons get a near-black aubergine outline (dark outline around a
+raised indigo fill) and amber only appears on hover/press/focus and on modal
+frames. This keeps the "one saturated accent" lighting discipline.
+
+## Menu-by-menu audit (ranked by visual impact)
+
+### 1. Welcome / main menu (`godot/scenes/welcome.tscn`) -- WAS most off-style, RETONED
+- Background: `tex_grid_circuit_trace_512` -- verified warm brown grime +
+  verdigris traces; ON-style, kept.
+- Overlay: WAS `tex_green_scanlines_512` at 0.15 alpha -- green reads
+  Matrix-terminal and green is reserved for "computers OK" semantics.
+  SWAPPED to `tex_amber_scanlines_512` (existing asset, same folder) -- the
+  amber CRT glow is the brand accent. APPLIED.
+- Buttons: full slate-blue set -> shared retone vocabulary. APPLIED.
+- WhatsNewButton light-blue font trio -> amber trio. AISafetyButton blue trio
+  -> teal `#1EC3B3` trio (palette "UI action" token; keeps the external-link
+  differentiation without blue). APPLIED.
+- Title/Subtitle plain white/gray: fine. Emoji glyphs in two button labels
+  ("trophy", "link") render from system font -- style question, flagged below.
+
+### 2. Pregame setup (`godot/scenes/pregame_setup.tscn`) -- RETONED
+- Background `tex_bakelite_cracked_512` -- verified dark warm brown, very
+  close to Warm panel #2B221A; the MOST on-style menu background. Kept.
+- Amber scanline overlay already on-style. Kept.
+- Slate-blue styleboxes + 4 ice-blue field labels -> shared retone. APPLIED.
+- Note: LaunchButton deliberately uses the hover box as its normal state --
+  after retone this gives the primary CTA a lighter fill + amber border at
+  rest. Reads as intended emphasis; kept the pattern.
+
+### 3. Settings (`godot/scenes/settings_menu.tscn`) -- RETONED
+- Background `tex_painted_metal_panel_512` -- verified sage-green peeling
+  paint; institutional-grime, green-leaning but within the grime family.
+  Kept (borderline -- see flags).
+- Gray dither overlay: neutral, kept.
+- Slate-blue styleboxes + 6 ice-blue section headers + ice title -> shared
+  retone. APPLIED.
+- Sliders/OptionButtons/CheckButtons are default Godot theme (gray) -- see
+  cross-cutting flag on a shared Theme resource.
+
+### 4. Pause menu (`godot/scenes/pause_menu.tscn`) -- RETONED
+- Panel was bluish-dark bg + 3px blue border -> deep aubergine bg (0.96 a) +
+  dimmed amber border. Title + "Audio Settings" header retoned. APPLIED.
+- Buttons are default-theme gray: flagged (shared Theme), not changed.
+
+### 5. Player guide (`godot/scenes/player_guide.tscn`) -- RETONED
+- Flat bluish-gray ColorRect background -> deep aubergine #170A1C; panel
+  bluish-navy -> #1B142A + dimmed amber border; 4 blue section titles ->
+  amber; back-button styleboxes -> shared retone. APPLIED.
+- The RichTextLabel bodies use raw bbcode color names (green/red/cyan/
+  purple/yellow/blue) as resource-name coding. Semantically load-bearing
+  (matches researcher dot colors), so NOT touched -- flagged for a later
+  pass to swap named colors for palette hexes.
+
+### 6. What's New modal (`godot/scenes/ui/whats_new_modal.tscn`) -- RETONED
+- Navy panel + steel-blue border + blue button + blue version label -> aubergine
+  panel, amber frame, indigo/amber button, amber version line. APPLIED.
+
+### 7. Bug report panel (`godot/scenes/ui/bug_report_panel.tscn`) -- RETONED
+- Neutral-gray panel + blue border -> aubergine + dimmed amber frame. APPLIED.
+- Form controls (LineEdit/TextEdit/OptionButton/CheckBox) default-theme; flagged.
+
+### 8. Main in-game HUD (`godot/scenes/main.tscn` + runtime styling) -- LIGHT TOUCH
+- Much of the in-game look is applied at runtime and is ALREADY on-doctrine:
+  `scripts/ui/terminal_theme.gd` defines the amber-PLAN/green-WATCH CRT
+  register (AMBER 1,0.72,0.2), `main_ui.gd` sets the TopBar title to
+  TerminalTheme.AMBER. Scene-level stragglers unified to that register:
+  - TurnLabel yellow (0.9,0.9,0.3) + yellow-bordered TurnCounter box ->
+    TerminalTheme amber (1,0.72,0.2) + aubergine box bg. APPLIED.
+  - Instrument "P(DOOM)" title (1,0.6,0) -> (1,0.72,0.2). APPLIED.
+  - EndTurnButton cyan (0.2,0.9,0.9) -> teal token #1EC3B3. APPLIED.
+- Left alone: doom number red, roster/queue hint grays (neutral), category
+  colors from theme_manager (gameplay-legibility coding, not chrome).
+
+### 9. Plan screen (`godot/scenes/ui/plan_screen.tscn`) -- LIGHT TOUCH
+- CommandLabel violet (0.6,0.5,0.8) and PassButton lavender text (0.8,0.7,1):
+  purple is doctrine-reserved for band 3+ eldritch; a resting menu label
+  should not spend it. Retoned to TerminalTheme AMBER_DIM (0.66,0.48,0.16)
+  and TEXT (0.82,0.86,0.78). APPLIED. (If the lavender was an intentional
+  "weird command" joke, revert is one line -- noted for Pip.)
+- Green tip hint kept (green = OK register).
+
+### 10. Leaderboard (`godot/scenes/leaderboard_screen.tscn`) -- FLAGGED ONLY
+- Background `tex_oxidized_copper_512` -- verified green verdigris circuit
+  motif + cyan ISPF overlay: the most green/cyan-leaning menu ground. It IS
+  grimy, but a warmer ground (bakelite/plywood) would match the register
+  better. Subjective texture call -> needs Pip's eye.
+- ALL buttons/panel are default Godot theme (no styleboxes at all) -- the
+  screen looks unthemed next to the retoned menus. Fix belongs in a shared
+  Theme resource (below), not another copy-paste set. No changes applied.
+- Emoji trophies in the title label: style call, flagged.
+
+### 11. Keybind screen (`godot/scenes/keybind_screen.tscn`) -- FLAGGED ONLY
+- Zero styling: no background, default-theme buttons/dropdowns on the clear
+  color. Reads as a debug screen. Needs the menu background+overlay pattern
+  (suggest bakelite or concrete + amber scanlines) and the shared button set
+  -- structural additions, so flagged rather than done.
+
+### 12. Game over (`godot/scenes/ui/game_over_screen.tscn` + `.gd`) -- OK / minor
+- Styled at runtime: dark panel (0.10,0.12,0.15,0.98) with a sage border,
+  green title for wins / red for losses. Semantically sound (win/lose coding);
+  panel tone is bluish-neutral rather than aubergine -- one-line candidate in
+  `game_over_screen.gd:33-35` but it is script code, so left for Pip/next lane.
+
+### 13. Staff perks panel + compact (`godot/scenes/ui/staff_perks_*.tscn`) -- DELIBERATE REGISTER, kept
+- Coherent internal green-phosphor terminal identity (dark-green panels,
+  green/blue/gold/purple tier coding). Green = "computers OK" fits doctrine;
+  tier colors are information coding. Left untouched; if Pip wants these
+  pulled toward aubergine-ground later it should be one deliberate re-skin.
+
+### 14. Employee screen / watch screen / office cat / doom meter / fanfare / debug overlay -- OK
+- Mostly default containers styled at runtime (employee_screen.gd,
+  watch_screen.gd via TerminalTheme, doom_meter.gd draws via
+  ThemeManager.DOOM_STOPS ramp -- the single doom source of truth). Debug
+  overlay is developer chrome; intentionally unthemed. No changes.
+
+### 15. Ledger + submenus (script-driven, no .tscn) -- OK / minor
+- `submenu_chrome.gd` styles submenu panels (0.12,0.13,0.16,0.97 + gray-green
+  border) -- near-neutral, mildly bluish; acceptable. The ledger has its own
+  leather look (explicitly protected from chrome clobbering in
+  `submenu_chrome.gd:37`). Script-side retones left for a code lane.
+
+## Applied changes (complete list)
+
+- `godot/scenes/welcome.tscn` -- overlay green->amber scanlines (line 5);
+  4 styleboxes retoned (lines 7-53); WhatsNew font trio -> amber (214-216);
+  AISafety font trio -> teal (227-229).
+- `godot/scenes/settings_menu.tscn` -- 4 styleboxes (7-53); title (102);
+  6 section headers (blue->amber, replace-all).
+- `godot/scenes/pregame_setup.tscn` -- 4 styleboxes (7-53); title (114);
+  4 field labels (blue->amber, replace-all).
+- `godot/scenes/config_confirmation.tscn` -- 4 styleboxes (5-51); background
+  ColorRect -> #170A1C (69); title (108); 5 row labels (blue->amber).
+- `godot/scenes/player_guide.tscn` -- 3 button styleboxes + panel stylebox
+  (5-51); background ColorRect -> #170A1C (69); title (101); 4 section
+  titles (blue->amber).
+- `godot/scenes/pause_menu.tscn` -- panel stylebox -> aubergine+amber (5-11);
+  title (57); Audio header (75).
+- `godot/scenes/ui/whats_new_modal.tscn` -- panel + button styleboxes (5-27);
+  title (76); version label (83).
+- `godot/scenes/ui/bug_report_panel.tscn` -- panel stylebox (5-11).
+- `godot/scenes/main.tscn` -- TurnCounter stylebox (17-23); TurnLabel font
+  (74); instrument P(DOOM) title (192); EndTurnButton font -> teal (365).
+- `godot/scenes/ui/plan_screen.tscn` -- CommandLabel violet -> AMBER_DIM (51);
+  PassButton lavender -> terminal text (58).
+
+## Needs Pip's eye (NOT changed)
+
+1. `godot/theme/welcome_theme.tres` -- unused (only referenced from
+   `godot/docs/README.md`) AND malformed: Theme styles are written as inline
+   dictionaries, which Godot does not parse into StyleBoxes. Recommend delete
+   or rebuild as the real shared Theme (next item).
+2. A real shared `Theme` resource. The same stylebox set now exists as five
+   per-scene copies (was already true pre-pass); sliders, dropdowns,
+   checkboxes, and the leaderboard/keybind/pause/game-over buttons all fall
+   back to default gray. One `menu_theme.tres` applied at the root of each
+   menu scene would kill the duplication and theme the stock controls.
+   Structural, so not done in this pass.
+3. Leaderboard background/overlay (verdigris+cyan) -- swap toward a warm
+   ground, or embrace it as the "institutional records" room? Taste call.
+4. Keybind screen -- needs the full menu treatment (background, overlay,
+   buttons); additive work.
+5. Emoji in labels (welcome "Leaderboard"/"AI Safety Info", leaderboard
+   title, submenu close glyph) vs the ASCII-flavoured look elsewhere
+   ("[M]", ">>", "[ESC] close").
+6. Script-side stragglers for a code lane: `game_over_screen.gd:33-35` panel
+   tone; `submenu_chrome.gd:26-28` submenu panel tone; player-guide bbcode
+   named colors; `theme_manager.gd` `apply_button_style()` "Style Guide"
+   STEEL_DARK/ELECTRIC_BLUE/NEON_MAGENTA block (predates the palette doc --
+   any runtime-created button still gets electric blue + neon magenta; high
+   leverage but touches game code, so left).
+7. Settings background (sage peeling paint) -- kept, but it is the
+   greenest-leaning of the kept grounds.
+8. plan_screen "Do Nothing" lavender -- retoned to the amber register per the
+   purple-is-expensive rule; revert `godot/scenes/ui/plan_screen.tscn:51,58`
+   if the lavender was a deliberate gag.

--- a/godot/UI_STYLE_GUIDE.md
+++ b/godot/UI_STYLE_GUIDE.md
@@ -1,7 +1,7 @@
 # P(Doom) UI Style Guide
 ## Visual Design System for Godot Implementation
 
-_Last updated: 2025-11-20_
+_Last updated: 2026-07-20_
 _Status: Living document - evolving as brand identity develops_
 
 ---
@@ -536,6 +536,42 @@ var icon = load(ThemeManager.theme.assets["cat_icon"])
 - SUCCESS Info bar at bottom for persistent context (vs tooltips)
 - SUCCESS Cat panel moved to top-right (better space usage)
 - SUCCESS Notifications slide from right, auto-stack (NotificationManager)
+
+---
+
+## 17. Menu Chrome Tokens (2026-07-20 consistency pass)
+
+Menus/modals were retoned from legacy slate-blue chrome to the palette in
+`docs/art/palette.json` + `docs/art/PALETTE_AND_DOOM_INTENSITY.md` (warm-grime
++ heavy-outline heft; amber as the one saturated accent at rest). Full audit:
+`docs/game-design/UI_MENU_CONSISTENCY_2026-07-20.md`.
+
+```gdscript
+# Menu button styleboxes (welcome, settings, pregame, config-confirm, guide)
+menu_btn_bg = Color(0.18, 0.145, 0.278)        # #2E2547 doom-indigo fill
+menu_btn_outline = Color(0.09, 0.04, 0.11)     # #170A1C heavy dark outline (rest)
+menu_btn_hover_bg = Color(0.231, 0.192, 0.349) # lightened indigo
+menu_btn_hover_border = Color(0.91, 0.64, 0.24)  # #E8A33D cozy amber
+menu_btn_pressed_bg = Color(0.106, 0.078, 0.165) # #1B142A
+menu_btn_active_border = Color(0.965, 0.659, 0)  # #F6A800 amber (pressed/focus)
+
+# Modal panels (pause, whats-new, bug-report, player-guide)
+modal_bg = Color(0.09, 0.04, 0.11)             # #170A1C deep aubergine
+modal_border = Color(0.91, 0.64, 0.24, 0.8)    # dimmed amber frame
+
+# Text accents
+menu_header = Color(0.91, 0.64, 0.24)          # section headers (was ice blue)
+menu_title = Color(0.914, 0.949, 0.949)        # #E9F2F2 off-white titles
+external_link = Color(0.118, 0.765, 0.702)     # #1EC3B3 teal (AI Safety link)
+```
+
+Rules of thumb:
+- Resting buttons get the dark heavy outline; amber appears only on
+  hover/press/focus and on the active modal frame.
+- Blue is reserved for the weirdness axis (computers acting up), purple for
+  band 3+ eldritch -- neither is menu chrome.
+- In-game HUD amber uses the TerminalTheme register (`Color(1, 0.72, 0.2)`),
+  not #F6A800; keep each register internally consistent.
 
 ---
 

--- a/godot/scenes/config_confirmation.tscn
+++ b/godot/scenes/config_confirmation.tscn
@@ -3,48 +3,48 @@
 [ext_resource type="Script" path="res://scripts/ui/config_confirmation.gd" id="1_config"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_normal"]
-bg_color = Color(0.2, 0.3, 0.5, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.4, 0.5, 0.7, 1)
+border_color = Color(0.09, 0.04, 0.11, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hover"]
-bg_color = Color(0.3, 0.5, 0.8, 1)
+bg_color = Color(0.231, 0.192, 0.349, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.7, 0.8, 1, 1)
+border_color = Color(0.91, 0.64, 0.24, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pressed"]
-bg_color = Color(0.15, 0.25, 0.4, 1)
+bg_color = Color(0.106, 0.078, 0.165, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.9, 0.9, 1, 1)
+border_color = Color(0.965, 0.659, 0, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_focus"]
-bg_color = Color(0.4, 0.6, 1, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-border_color = Color(1, 1, 1, 1)
+border_color = Color(0.965, 0.659, 0, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
@@ -66,7 +66,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0.16, 0.18, 0.22, 1)
+color = Color(0.09, 0.04, 0.11, 1)
 
 [node name="PatternOverlay" type="Control" parent="."]
 layout_mode = 1
@@ -105,7 +105,7 @@ theme_override_constants/separation = 20
 
 [node name="Title" type="Label" parent="Panel/VBox"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.86, 0.94, 1, 1)
+theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
 theme_override_font_sizes/font_size = 38
 text = "LABORATORY CONFIGURATION"
 horizontal_alignment = 1
@@ -131,7 +131,7 @@ layout_mode = 2
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/PlayerNameRow"]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Player Name:"
 
@@ -148,7 +148,7 @@ layout_mode = 2
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/LabNameRow"]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Lab Name:"
 
@@ -165,7 +165,7 @@ layout_mode = 2
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/SeedRow"]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Experimental Seed:"
 
@@ -182,7 +182,7 @@ layout_mode = 2
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/DifficultyRow"]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Research Intensity:"
 
@@ -199,7 +199,7 @@ layout_mode = 2
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/FundingRow"]
 custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Starting Funding:"
 

--- a/godot/scenes/main.tscn
+++ b/godot/scenes/main.tscn
@@ -15,12 +15,12 @@
 [ext_resource type="PackedScene" uid="uid://dqc4gxtx62j3s" path="res://scenes/debug_overlay.tscn" id="11_debugoverlay"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_TurnCounter"]
-bg_color = Color(0.15, 0.15, 0.2, 0.8)
+bg_color = Color(0.09, 0.04, 0.11, 0.85)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.9, 0.9, 0.3, 0.5)
+border_color = Color(1, 0.72, 0.2, 0.5)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
@@ -71,7 +71,7 @@ modulate = Color(0.4, 0.4, 0.5, 1)
 layout_mode = 2
 text = "Week 1 | Mon Jul 3, 2017 | Day 1/5"
 theme_override_font_sizes/font_size = 18
-theme_override_colors/font_color = Color(0.9, 0.9, 0.3, 1)
+theme_override_colors/font_color = Color(1, 0.72, 0.2, 1)
 theme_override_styles/normal = SubResource("StyleBoxFlat_TurnCounter")
 
 [node name="TurnCountLabel" type="Label" parent="TabManager/MainUI/TopBar"]
@@ -189,7 +189,7 @@ layout_mode = 2
 text = "P(DOOM)"
 horizontal_alignment = 1
 theme_override_font_sizes/font_size = 24
-theme_override_colors/font_color = Color(1.0, 0.6, 0.0, 1)
+theme_override_colors/font_color = Color(1, 0.72, 0.2, 1)
 
 [node name="CoreZone" type="HBoxContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn"]
 layout_mode = 2
@@ -362,7 +362,7 @@ text = "END TURN (Space)"
 tooltip_text = "Execute queued actions and advance to next turn. Shows warning if you have unused AP."
 disabled = true
 theme_override_font_sizes/font_size = 16
-theme_override_colors/font_color = Color(0.2, 0.9, 0.9, 1)
+theme_override_colors/font_color = Color(0.118, 0.765, 0.702, 1)
 theme_override_colors/font_disabled_color = Color(0.4, 0.4, 0.4, 1)
 
 [node name="CommitPlanButton" type="Button" parent="TabManager/MainUI/BottomBar/ControlButtons"]

--- a/godot/scenes/pause_menu.tscn
+++ b/godot/scenes/pause_menu.tscn
@@ -3,12 +3,12 @@
 [ext_resource type="Script" path="res://scripts/ui/pause_menu.gd" id="1_pause"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
-bg_color = Color(0.1, 0.1, 0.15, 0.95)
+bg_color = Color(0.09, 0.04, 0.11, 0.96)
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-border_color = Color(0.4, 0.5, 0.7, 1)
+border_color = Color(0.91, 0.64, 0.24, 0.8)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -54,7 +54,7 @@ theme_override_constants/separation = 15
 
 [node name="Title" type="Label" parent="Panel/VBox"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.86, 0.94, 1, 1)
+theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
 theme_override_font_sizes/font_size = 36
 text = "GAME PAUSED"
 horizontal_alignment = 1
@@ -72,7 +72,7 @@ theme_override_constants/separation = 8
 
 [node name="AudioLabel" type="Label" parent="Panel/VBox/SettingsContainer/AudioSettings"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Audio Settings"
 

--- a/godot/scenes/player_guide.tscn
+++ b/godot/scenes/player_guide.tscn
@@ -3,48 +3,48 @@
 [ext_resource type="Script" path="res://scripts/ui/player_guide.gd" id="1_guide"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_normal"]
-bg_color = Color(0.2, 0.3, 0.5, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.4, 0.5, 0.7, 1)
+border_color = Color(0.09, 0.04, 0.11, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hover"]
-bg_color = Color(0.3, 0.5, 0.8, 1)
+bg_color = Color(0.231, 0.192, 0.349, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.7, 0.8, 1, 1)
+border_color = Color(0.91, 0.64, 0.24, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pressed"]
-bg_color = Color(0.15, 0.25, 0.4, 1)
+bg_color = Color(0.106, 0.078, 0.165, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.9, 0.9, 1, 1)
+border_color = Color(0.965, 0.659, 0, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
-bg_color = Color(0.12, 0.14, 0.18, 1)
+bg_color = Color(0.106, 0.078, 0.165, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.3, 0.4, 0.6, 1)
+border_color = Color(0.91, 0.64, 0.24, 0.8)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8
@@ -66,7 +66,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0.16, 0.18, 0.22, 1)
+color = Color(0.09, 0.04, 0.11, 1)
 
 [node name="Panel" type="Panel" parent="."]
 layout_mode = 1
@@ -98,7 +98,7 @@ theme_override_constants/separation = 20
 
 [node name="Title" type="Label" parent="Panel/VBox"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.86, 0.94, 1, 1)
+theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
 theme_override_font_sizes/font_size = 42
 text = "PLAYER GUIDE"
 horizontal_alignment = 1
@@ -129,7 +129,7 @@ theme_override_constants/separation = 10
 
 [node name="Title" type="Label" parent="Panel/VBox/ContentScroll/ContentVBox/ObjectiveSection"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.4, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 24
 text = "GAME OBJECTIVE"
 
@@ -152,7 +152,7 @@ theme_override_constants/separation = 10
 
 [node name="Title" type="Label" parent="Panel/VBox/ContentScroll/ContentVBox/ControlsSection"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.4, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 24
 text = "CONTROLS"
 
@@ -182,7 +182,7 @@ theme_override_constants/separation = 10
 
 [node name="Title" type="Label" parent="Panel/VBox/ContentScroll/ContentVBox/ResourcesSection"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.4, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 24
 text = "KEY RESOURCES"
 
@@ -213,7 +213,7 @@ theme_override_constants/separation = 10
 
 [node name="Title" type="Label" parent="Panel/VBox/ContentScroll/ContentVBox/StrategySection"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.4, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 24
 text = "STRATEGY TIPS"
 

--- a/godot/scenes/pregame_setup.tscn
+++ b/godot/scenes/pregame_setup.tscn
@@ -5,48 +5,48 @@
 [ext_resource type="Texture2D" path="res://assets/textures/terminal/tex_amber_scanlines_512.png" id="3_overlay"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_normal"]
-bg_color = Color(0.2, 0.3, 0.5, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.4, 0.5, 0.7, 1)
+border_color = Color(0.09, 0.04, 0.11, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hover"]
-bg_color = Color(0.3, 0.5, 0.8, 1)
+bg_color = Color(0.231, 0.192, 0.349, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.7, 0.8, 1, 1)
+border_color = Color(0.91, 0.64, 0.24, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pressed"]
-bg_color = Color(0.15, 0.25, 0.4, 1)
+bg_color = Color(0.106, 0.078, 0.165, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.9, 0.9, 1, 1)
+border_color = Color(0.965, 0.659, 0, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_focus"]
-bg_color = Color(0.4, 0.6, 1, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-border_color = Color(1, 1, 1, 1)
+border_color = Color(0.965, 0.659, 0, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
@@ -111,7 +111,7 @@ theme_override_constants/separation = 25
 
 [node name="Title" type="Label" parent="Panel/VBox"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.86, 0.94, 1, 1)
+theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
 theme_override_font_sizes/font_size = 42
 text = "LABORATORY CONFIGURATION"
 horizontal_alignment = 1
@@ -137,7 +137,7 @@ theme_override_constants/separation = 8
 
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/PlayerNameRow"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Player Name:"
 
@@ -158,7 +158,7 @@ layout_mode = 2
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/LabNameRow/LabelRow"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Lab Name:"
 
@@ -182,7 +182,7 @@ theme_override_constants/separation = 8
 
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/SeedRow"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Experimental Seed (Optional):"
 
@@ -222,7 +222,7 @@ theme_override_constants/separation = 10
 
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/DifficultyRow/LabelRow"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Research Intensity:"
 
@@ -248,7 +248,7 @@ theme_override_constants/separation = 10
 
 [node name="Label" type="Label" parent="Panel/VBox/FieldsContainer/ScenarioRow/LabelRow"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Scenario:"
 

--- a/godot/scenes/settings_menu.tscn
+++ b/godot/scenes/settings_menu.tscn
@@ -5,48 +5,48 @@
 [ext_resource type="Texture2D" path="res://assets/textures/terminal/tex_gray_dither_512.png" id="3_overlay"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_normal"]
-bg_color = Color(0.2, 0.3, 0.5, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.4, 0.5, 0.7, 1)
+border_color = Color(0.09, 0.04, 0.11, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hover"]
-bg_color = Color(0.3, 0.5, 0.8, 1)
+bg_color = Color(0.231, 0.192, 0.349, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.7, 0.8, 1, 1)
+border_color = Color(0.91, 0.64, 0.24, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pressed"]
-bg_color = Color(0.15, 0.25, 0.4, 1)
+bg_color = Color(0.106, 0.078, 0.165, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.9, 0.9, 1, 1)
+border_color = Color(0.965, 0.659, 0, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_focus"]
-bg_color = Color(0.4, 0.6, 1, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-border_color = Color(1, 1, 1, 1)
+border_color = Color(0.965, 0.659, 0, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
@@ -99,7 +99,7 @@ theme_override_constants/separation = 20
 
 [node name="Title" type="Label" parent="VBox"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.86, 0.94, 1, 1)
+theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
 theme_override_font_sizes/font_size = 48
 text = "LABORATORY SETTINGS"
 horizontal_alignment = 1
@@ -125,7 +125,7 @@ theme_override_constants/separation = 8
 
 [node name="AudioLabel" type="Label" parent="VBox/SettingsContainer/AudioSettings"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
 text = "Audio Settings"
 
@@ -207,7 +207,7 @@ theme_override_constants/separation = 8
 
 [node name="GraphicsLabel" type="Label" parent="VBox/SettingsContainer/GraphicsSettings"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
 text = "Graphics Settings"
 
@@ -256,7 +256,7 @@ theme_override_constants/separation = 8
 
 [node name="GameplayLabel" type="Label" parent="VBox/SettingsContainer/GameplaySettings"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
 text = "Gameplay Settings"
 
@@ -288,7 +288,7 @@ theme_override_constants/separation = 8
 
 [node name="UILabel" type="Label" parent="VBox/SettingsContainer/UISettings"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
 text = "UI Settings"
 
@@ -322,7 +322,7 @@ theme_override_constants/separation = 8
 
 [node name="AccessibilityLabel" type="Label" parent="VBox/SettingsContainer/AccessibilitySettings"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
 text = "Accessibility"
 
@@ -350,7 +350,7 @@ theme_override_constants/separation = 8
 
 [node name="KeyboardLabel" type="Label" parent="VBox/SettingsContainer/KeyboardShortcuts"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
 text = "Keyboard Shortcuts"
 

--- a/godot/scenes/ui/bug_report_panel.tscn
+++ b/godot/scenes/ui/bug_report_panel.tscn
@@ -3,12 +3,12 @@
 [ext_resource type="Script" path="res://scripts/ui/bug_report_panel.gd" id="1_bugreport"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_border"]
-bg_color = Color(0.15, 0.15, 0.15, 1)
+bg_color = Color(0.09, 0.04, 0.11, 1)
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-border_color = Color(0.4, 0.6, 0.8, 1)
+border_color = Color(0.91, 0.64, 0.24, 0.8)
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8

--- a/godot/scenes/ui/plan_screen.tscn
+++ b/godot/scenes/ui/plan_screen.tscn
@@ -48,11 +48,11 @@ layout_mode = 2
 text = "Command"
 horizontal_alignment = 1
 theme_override_font_sizes/font_size = 11
-theme_override_colors/font_color = Color(0.6, 0.5, 0.8, 1)
+theme_override_colors/font_color = Color(0.66, 0.48, 0.16, 1)
 
 [node name="PassButton" type="Button" parent="CommandZone"]
 layout_mode = 2
 custom_minimum_size = Vector2(120, 36)
 text = "Do Nothing"
 theme_override_font_sizes/font_size = 12
-theme_override_colors/font_color = Color(0.8, 0.7, 1.0, 1)
+theme_override_colors/font_color = Color(0.82, 0.86, 0.78, 1)

--- a/godot/scenes/ui/whats_new_modal.tscn
+++ b/godot/scenes/ui/whats_new_modal.tscn
@@ -3,24 +3,24 @@
 [ext_resource type="Script" path="res://scripts/ui/whats_new_modal.gd" id="1_whatsnew"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
-bg_color = Color(0.1, 0.12, 0.15, 1)
+bg_color = Color(0.09, 0.04, 0.11, 1)
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-border_color = Color(0.3, 0.5, 0.7, 1)
+border_color = Color(0.91, 0.64, 0.24, 0.8)
 corner_radius_top_left = 12
 corner_radius_top_right = 12
 corner_radius_bottom_right = 12
 corner_radius_bottom_left = 12
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_button"]
-bg_color = Color(0.2, 0.35, 0.5, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.4, 0.6, 0.8, 1)
+border_color = Color(0.91, 0.64, 0.24, 1)
 corner_radius_top_left = 6
 corner_radius_top_right = 6
 corner_radius_bottom_right = 6
@@ -73,14 +73,14 @@ theme_override_constants/separation = 15
 
 [node name="TitleLabel" type="Label" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
+theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
 theme_override_font_sizes/font_size = 36
 text = "What's New"
 horizontal_alignment = 1
 
 [node name="VersionLabel" type="Label" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.75, 0.9, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 18
 text = "Version 0.11.0 - Travel & Conferences"
 horizontal_alignment = 1

--- a/godot/scenes/welcome.tscn
+++ b/godot/scenes/welcome.tscn
@@ -2,51 +2,51 @@
 
 [ext_resource type="Script" path="res://scripts/ui/welcome_screen.gd" id="1_welcome"]
 [ext_resource type="Texture2D" path="res://assets/textures/surfaces/tex_grid_circuit_trace_512.png" id="2_background"]
-[ext_resource type="Texture2D" path="res://assets/textures/terminal/tex_green_scanlines_512.png" id="3_overlay"]
+[ext_resource type="Texture2D" path="res://assets/textures/terminal/tex_amber_scanlines_512.png" id="3_overlay"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_normal"]
-bg_color = Color(0.2, 0.3, 0.5, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.4, 0.5, 0.7, 1)
+border_color = Color(0.09, 0.04, 0.11, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hover"]
-bg_color = Color(0.3, 0.5, 0.8, 1)
+bg_color = Color(0.231, 0.192, 0.349, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.7, 0.8, 1, 1)
+border_color = Color(0.91, 0.64, 0.24, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pressed"]
-bg_color = Color(0.15, 0.25, 0.4, 1)
+bg_color = Color(0.106, 0.078, 0.165, 1)
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.9, 0.9, 1, 1)
+border_color = Color(0.965, 0.659, 0, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
 corner_radius_bottom_left = 4
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_focus"]
-bg_color = Color(0.4, 0.6, 1, 1)
+bg_color = Color(0.18, 0.145, 0.278, 1)
 border_width_left = 3
 border_width_top = 3
 border_width_right = 3
 border_width_bottom = 3
-border_color = Color(1, 1, 1, 1)
+border_color = Color(0.965, 0.659, 0, 1)
 corner_radius_top_left = 4
 corner_radius_top_right = 4
 corner_radius_bottom_right = 4
@@ -211,9 +211,9 @@ text = "🏆 Leaderboard"
 [node name="WhatsNewButton" type="Button" parent="VBox/MenuContainer"]
 custom_minimum_size = Vector2(400, 50)
 layout_mode = 2
-theme_override_colors/font_color = Color(0.6, 0.85, 1, 1)
-theme_override_colors/font_hover_color = Color(0.8, 0.95, 1, 1)
-theme_override_colors/font_pressed_color = Color(0.5, 0.75, 1, 1)
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
+theme_override_colors/font_hover_color = Color(0.97, 0.76, 0.4, 1)
+theme_override_colors/font_pressed_color = Color(0.8, 0.55, 0.2, 1)
 theme_override_font_sizes/font_size = 24
 theme_override_styles/normal = SubResource("StyleBoxFlat_normal")
 theme_override_styles/hover = SubResource("StyleBoxFlat_hover")
@@ -224,9 +224,9 @@ text = "What's New"
 [node name="AISafetyButton" type="Button" parent="VBox/MenuContainer"]
 custom_minimum_size = Vector2(400, 50)
 layout_mode = 2
-theme_override_colors/font_color = Color(0.4, 0.8, 1, 1)
-theme_override_colors/font_hover_color = Color(0.6, 0.9, 1, 1)
-theme_override_colors/font_pressed_color = Color(0.3, 0.7, 1, 1)
+theme_override_colors/font_color = Color(0.118, 0.765, 0.702, 1)
+theme_override_colors/font_hover_color = Color(0.3, 0.85, 0.79, 1)
+theme_override_colors/font_pressed_color = Color(0.059, 0.647, 0.627, 1)
 theme_override_font_sizes/font_size = 24
 theme_override_styles/normal = SubResource("StyleBoxFlat_normal")
 theme_override_styles/hover = SubResource("StyleBoxFlat_hover")


### PR DESCRIPTION
## What

A COHERENCE pass over every menu/screen -- not a redesign. Aligns menu chrome
to the established direction (warm-grime base + heavy-outline heft, dark
indigo/aubergine grounds + cozy-amber accent) per `docs/art/palette.json`,
`docs/art/PALETTE_AND_DOOM_INTENSITY.md`, and the overnight sweep rulings.

Full menu-by-menu audit + ranked findings + needs-Pips-eye list:
`docs/game-design/UI_MENU_CONSISTENCY_2026-07-20.md`.

## Applied (low-risk, directional: colors + one texture swap only)

- Retired the copy-pasted **slate-blue button stylebox** set across welcome,
  settings, pregame, config-confirmation, player-guide -> doom-indigo fill +
  heavy aubergine outline, amber on hover/press/focus.
- **Ice-blue section headers/titles** -> cozy amber / off-white.
- **Modal panels** (pause, whats-new, bug-report, player-guide) -> deep
  aubergine grounds + dimmed amber frames.
- **Welcome overlay**: green scanlines -> amber scanlines (existing asset;
  green is reserved for the "computers OK" semantic); AI-Safety link button
  -> teal UI-action token.
- **In-game HUD** stragglers unified to the TerminalTheme amber register;
  plan-screen resting purple retired (purple is doctrine-reserved for
  band 3+ eldritch).
- Recorded the new menu chrome tokens in `godot/UI_STYLE_GUIDE.md`.

No layout, node, or @onready-path changes anywhere; every screen stays
functional.

## Flagged for Pip (NOT changed)

Leaderboard + keybind screens are unthemed (default Godot controls); the real
fix is a shared `menu_theme.tres` rather than more copy-paste. Also: emoji in
labels, leaderboard verdigris background, and several script-side stragglers
(theme_manager `apply_button_style` still emits electric-blue/neon-magenta).
See the report's "Needs Pip's eye" section.

## Verify

Fast gate: **510 tests, 0 failures, 57/57 files** (`--quick --ci-mode
--min-tests 300`). A stray first run showed 5 failures from stale `user://`
leaderboard JSON in this worktree; confirmed by stashing the edits (same 5
failed with a clean tree) and they cleared on re-run -- unrelated to the retone.

Do NOT merge -- Pip eyeballs UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
