### PR TITLE
feat(doom): rival-attributed overhang breakdown + death attribution on game over

### DIFF
--- a/godot/scripts/debug/debug_overlay.gd
+++ b/godot/scripts/debug/debug_overlay.gd
@@ -190,10 +190,12 @@ func update_game_state():
 	if state.rival_labs.size() > 0:
 		lines.append("[b]Rival Labs (%d)[/b]" % state.rival_labs.size())
 		for rival in state.rival_labs:
+			# RivalLab fields are capability_progress / funding (ADR-0015 renamed them; the old
+			# get("capabilities")/get("money") read null and printed garbage). Direct access.
 			lines.append("- %s (Cap: %.0f, Money: $%.0fk)" % [
-				rival.get("name", "Unknown"),
-				rival.get("capabilities", 0),
-				rival.get("money", 0) / 1000
+				rival.name,
+				rival.capability_progress,
+				rival.funding / 1000
 			])
 
 	# Historical Events (Issue #442)

--- a/godot/scripts/ui/doom_breakdown.gd
+++ b/godot/scripts/ui/doom_breakdown.gd
@@ -15,19 +15,35 @@ const EPSILON := 0.05
 
 ## Human-readable labels for known source keys. Unknown keys fall back to Capitalized words,
 ## so a new DoomSystem source still renders sanely without touching this map.
+##
+## ADR-0015 stream vocabulary (baseline/overhang/diffusion/compute/panic/alarm/ledger) is the
+## live key set that DoomSystem populates; the older keys (base/safety/momentum/technical_debt)
+## are retained for save-compat and the tech-debt coupling. The dead "rivals" key was REMOVED:
+## post-ADR-0015 no rival writes doom, so no "rivals" source is ever populated (pinned by
+## test_doom_system.gd). Rival attribution now rides the "overhang" stream -- see set_sources().
 const SOURCE_LABELS := {
-	"base": "Base",
-	"rivals": "Rivals",
-	"safety": "Safety",
+	"baseline": "Baseline",
+	"overhang": "Overhang",
+	"diffusion": "Diffusion",
+	"compute": "Compute",
+	"panic": "Panic",
+	"alarm": "Alarm",
+	"ledger": "Ledger",
 	"momentum": "Momentum",
+	"technical_debt": "Technical Debt",
+	"base": "Base",
+	"safety": "Safety",
 	"specializations": "Specializations",
 	"capabilities": "Capabilities",
 	"events": "Events",
-	"technical_debt": "Technical Debt",
 	"cascades": "Cascades",
 	"market_pressure": "Market Pressure",
 	"unproductive": "Unproductive Staff",
 }
+
+## Frontier slices below this magnitude round to "no meaningful frontier" and are left out of
+## the overhang attribution list (a rival that has not moved the frontier is not driving doom).
+const FRONTIER_EPSILON := 0.5
 
 static func label_for(source_key: String) -> String:
 	if SOURCE_LABELS.has(source_key):
@@ -71,12 +87,70 @@ static func build_entries(doom_sources: Dictionary) -> Array:
 	entries.sort_custom(func(a, b): return abs(a["value"]) > abs(b["value"]))
 	return entries
 
+# ============================================================================
+# OVERHANG ATTRIBUTION -- name the rival labs behind the acute-hazard stream.
+#
+# The "overhang" stream (doom_system.gd _compute_streams (b)) is priced off the MAX actor
+# frontier: W_frontier * max(0, max_actor(frontier_capability) - safety_absorption). So the
+# actor holding the highest frontier IS the one setting the acute hazard. We rank the
+# non-negligible frontier holders (player + rivals) and mask each rival's name through its
+# real visibility, so an undiscovered lab reads "an unknown actor" -- never a pre-discovery
+# leak of its real name (e.g. StealthAI while still HIDDEN). READ-ONLY over sim state.
+# ============================================================================
+
+## Resolve a frontier actor id to a player-facing name. "player" is the local lab; a rival id
+## is matched against the serialized rival dicts (state.rival_labs_full) and masked by its own
+## visibility (RivalLab.is_visible_to_player()/get_visible_name()). Unknown/hidden -> masked.
+static func mask_actor_name(actor_id: String, rival_labs) -> String:
+	if actor_id == "player":
+		return "your own frontier"
+	if rival_labs is Array:
+		for rd in rival_labs:
+			if rd is Dictionary and str(rd.get("id", "")) == actor_id:
+				var lab := RivalLabs.RivalLab.from_dict(rd)
+				if lab.is_visible_to_player():
+					return lab.get_visible_name()
+				return "an unknown actor"
+	return "an unknown actor"
+
+## Ordered (descending frontier) list of {id, name, value} for actors holding a non-negligible
+## frontier slice. Names are already visibility-masked. Pure -- unit-tested.
+static func frontier_leaders(frontier_capability, rival_labs) -> Array:
+	var out: Array = []
+	if not (frontier_capability is Dictionary):
+		return out
+	for actor_id in frontier_capability.keys():
+		var v: float = float(frontier_capability[actor_id])
+		if v < FRONTIER_EPSILON:
+			continue
+		out.append({
+			"id": str(actor_id),
+			"name": mask_actor_name(str(actor_id), rival_labs),
+			"value": v,
+		})
+	out.sort_custom(func(a, b): return a["value"] > b["value"])
+	return out
+
+## One-line attribution for the overhang stream, e.g. "frontier held by CapabiliCorp, DeepSafety".
+## Empty string when no actor holds a meaningful frontier. Lists up to three top holders.
+static func overhang_attribution_text(frontier_capability, rival_labs) -> String:
+	var leaders := frontier_leaders(frontier_capability, rival_labs)
+	if leaders.is_empty():
+		return ""
+	var names: Array = []
+	for leader in leaders.slice(0, 3):
+		names.append(str(leader["name"]))
+	return "frontier held by %s" % ", ".join(names)
+
 func _ready() -> void:
 	add_theme_constant_override("separation", 1)
 	visible = false  # nothing to show until the first doom_sources arrives
 
 ## Rebuild the breakdown from a doom_sources dict (state["doom_system"]["doom_sources"]).
-func set_sources(doom_sources) -> void:
+## frontier_capability (state["frontier_capability"]) and rival_labs (state["rival_labs_full"])
+## are optional -- when supplied, a dim per-lab attribution sub-line is rendered under the
+## overhang line naming which actors' frontier is driving the acute hazard.
+func set_sources(doom_sources, frontier_capability = {}, rival_labs = []) -> void:
 	# Clear previous lines immediately (avoid a one-frame duplicate that queue_free would leave).
 	while get_child_count() > 0:
 		var old := get_child(0)
@@ -100,3 +174,14 @@ func set_sources(doom_sources) -> void:
 		line.add_theme_font_size_override("font_size", 22)
 		line.add_theme_color_override("font_color", color_for_sign(entry["sign"]))
 		add_child(line)
+
+		# Under a doom-increasing overhang line, name the rival labs whose frontier is
+		# driving it (visibility-masked). Only when we were handed the frontier data.
+		if entry["key"] == "overhang" and entry["sign"] > 0:
+			var attribution := overhang_attribution_text(frontier_capability, rival_labs)
+			if attribution != "":
+				var sub := Label.new()
+				sub.text = "  " + attribution
+				sub.add_theme_font_size_override("font_size", 16)
+				sub.add_theme_color_override("font_color", ThemeManager.get_color("text_dim"))
+				add_child(sub)

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -16,6 +16,7 @@ var baseline_result: Dictionary = {}
 var leaderboard_entry_uuid: String = ""
 var game_start_time: float = 0.0
 var sync_status_label: Label = null  # Tiny non-blocking remote-sync status blip
+var attribution_label: RichTextLabel = null  # EE-8 cause-of-death chain, above the stats scroll
 # Re-entrancy guard: the game-over signal fires on EVERY state update (incl. leftover
 # day-ticks in a month playback), so show_game_over() can be called many times. The
 # scoring side-effects (local save + remote POST + music) must run EXACTLY ONCE; later
@@ -132,6 +133,9 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 		# by its ACTUAL death cause so the headline never lies about what killed you.
 		subtitle_label.text = _get_defeat_title(final_state)
 		subtitle_label.add_theme_color_override("font_color", Color(1.0, 0.6, 0.6))
+		# EE-8: the turn-stamped causal chain (DeathAttribution), named + prominent, above
+		# the stats scroll. Names the killer lab when the doom death was overhang-driven.
+		_render_death_attribution()
 
 	# Build statistics display
 	var stats_text = "[center][b]FINAL STATISTICS[/b][/center]\n\n"
@@ -324,6 +328,82 @@ func _fmt_money(amount: float) -> String:
 	"""Money display — routes through the ONE formatter (L0 #620: was a duplicate
 	compact implementation; GameConfig.format_money is the canonical one)."""
 	return GameConfig.format_money(amount)
+
+## EE-8 (ADR-0012): render DeathAttribution's turn-stamped causal chain prominently above the
+## stats scroll, so the defeat screen tells the player HOW they lost in concrete named causes.
+## READ-ONLY: reads the finished GameManager.state, never mutates. No-op (hidden) when there is
+## no live state or no attribution data (e.g. a bare test harness / empty cause_log).
+func _render_death_attribution() -> void:
+	var bbcode := _build_death_attribution_bbcode()
+	if bbcode == "":
+		return
+	if not is_instance_valid(attribution_label):
+		attribution_label = RichTextLabel.new()
+		attribution_label.bbcode_enabled = true
+		attribution_label.fit_content = true
+		attribution_label.scroll_active = false
+		var parent: Node = stats_label.get_parent() if stats_label else self
+		parent.add_child(attribution_label)
+		# Sit directly above the stats scroll (StatsLabel), below the subtitle.
+		if stats_label:
+			parent.move_child(attribution_label, stats_label.get_index())
+	attribution_label.text = bbcode
+	attribution_label.visible = true
+
+## Build the cause-of-death BBCode from the live finished state. Empty when unavailable.
+func _build_death_attribution_bbcode() -> String:
+	if not (GameManager.is_initialized and GameManager.state):
+		return ""
+	var st = GameManager.state
+	var result: Dictionary = DeathAttribution.classify(st)
+	var chain: Array = result.get("chain", [])
+	var surface := str(result.get("surface", ""))
+	var dominant := ""
+	if st.doom_system:
+		dominant = st.doom_system.get_dominant_stream()
+	var killer := overhang_killer_line(surface, dominant, st.frontier_capability, _rival_dicts(st))
+	return build_attribution_bbcode(chain, killer)
+
+## Serialize the live rival labs to dicts so the shared DoomBreakdown name-masking (which reads
+## the save-shaped rival dicts) can resolve visibility identically on the defeat screen.
+func _rival_dicts(st) -> Array:
+	var out: Array = []
+	if st and st.rival_labs is Array:
+		for rival in st.rival_labs:
+			out.append(rival.to_dict())
+	return out
+
+## When the run died of doom AND the overhang stream was the dominant contributor, name the top
+## visible frontier holder as the killer. Deadpan bureaucratic register (achievements.gd tone).
+## Empty string when the death was not overhang-driven or no frontier holder is identifiable.
+static func overhang_killer_line(surface: String, dominant_stream: String, frontier_capability, rival_labs) -> String:
+	if surface != "doom":
+		return ""
+	if dominant_stream != "overhang":
+		return ""
+	var leaders := DoomBreakdown.frontier_leaders(frontier_capability, rival_labs)
+	if leaders.is_empty():
+		return ""
+	var top: Dictionary = leaders[0]
+	if str(top.get("id", "")) == "player":
+		return "Your own frontier outran your absorption. The paperwork was filed on time."
+	return "%s's frontier outran your absorption. The paperwork was filed on time." % str(top.get("name", "an unknown actor"))
+
+## Compose the cause-of-death panel BBCode from a causal chain + optional named-killer line.
+## Empty string when there is nothing to show. Pure -- unit-tested.
+static func build_attribution_bbcode(chain: Array, killer_line: String) -> String:
+	var has_chain: bool = chain != null and not chain.is_empty()
+	if not has_chain and killer_line == "":
+		return ""
+	var out := "[center][b]CAUSE OF DEATH[/b][/center]\n"
+	if killer_line != "":
+		out += "[center][color=orange]%s[/color][/center]\n" % killer_line
+	if has_chain:
+		out += "[color=gray]"
+		for line in chain:
+			out += "  " + str(line) + "\n"
+		out += "[/color]"
+	return out
 
 func _get_ledger_attribution_text(final_state: Dictionary) -> String:
 	"""Surface the ledger death_attribution already in state, so the player learns what

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -816,7 +816,10 @@ func _on_game_state_updated(state: Dictionary):
 
 	# Feed the per-source doom breakdown (#578)
 	if doom_breakdown:
-		doom_breakdown.set_sources(state.get("doom_system", {}).get("doom_sources", {}))
+		doom_breakdown.set_sources(
+			state.get("doom_system", {}).get("doom_sources", {}),
+			state.get("frontier_capability", {}),
+			state.get("rival_labs_full", []))
 
 	# BL-1: refresh the compact Liability Ledger summary (#622 L10: lives in LedgerScreen)
 	if ledger_screen:

--- a/godot/tests/test_phase5_features.gd
+++ b/godot/tests/test_phase5_features.gd
@@ -123,5 +123,7 @@ func test_full_turn_with_all_phase5_features():
 	# Check manager was hired
 	assert_eq(state.managers, 1, "Should have hired 1 manager")
 
-	# Check doom changed (rivals + base + capabilities)
+	# Check doom changed. Post-ADR-0015 no rival/action writes doom directly: a turn advances
+	# the world-state intermediaries (frontier_capability, safety_absorption, global_alarm/panic)
+	# and DoomSystem re-derives the level from the named streams (baseline + overhang + ...).
 	assert_true(state.doom != 50.0, "Doom should change from starting value")

--- a/godot/tests/unit/test_doom_breakdown.gd
+++ b/godot/tests/unit/test_doom_breakdown.gd
@@ -27,12 +27,14 @@ func test_zero_and_negligible_classified_as_omit():
 	assert_eq(DoomBreakdown.classify(-0.03), 0, "Below-epsilon negative should be omitted")
 
 func test_build_entries_omits_zero_sources():
+	# Keys are the ADR-0015 stream vocabulary (overhang/alarm/...); the dead "rivals" key
+	# is gone -- rival hazard now rides the "overhang" stream, no direct rival doom write.
 	var sources := {
-		"base": 1.0,
-		"rivals": 12.3,
-		"safety": -14.4,
-		"momentum": 0.0,       # exactly zero — omitted
-		"specializations": 0.01,  # negligible — omitted
+		"baseline": 1.0,
+		"overhang": 12.3,
+		"alarm": -14.4,
+		"momentum": 0.0,       # exactly zero -- omitted
+		"diffusion": 0.01,     # negligible -- omitted
 	}
 	var entries := DoomBreakdown.build_entries(sources)
 	assert_eq(entries.size(), 3, "Only non-zero sources should be shown")
@@ -40,32 +42,127 @@ func test_build_entries_omits_zero_sources():
 	for e in entries:
 		keys.append(e["key"])
 	assert_does_not_have(keys, "momentum", "Zero source omitted")
-	assert_does_not_have(keys, "specializations", "Negligible source omitted")
+	assert_does_not_have(keys, "diffusion", "Negligible source omitted")
 
 func test_build_entries_signed_text_and_labels():
-	var entries := DoomBreakdown.build_entries({"rivals": 12.3, "safety": -14.4})
-	# Sorted by descending magnitude: safety (14.4) before rivals (12.3).
-	assert_eq(entries[0]["text"], "Safety -14.4", "Negative source shows human label + signed value")
-	assert_eq(entries[0]["sign"], -1, "Safety pulls doom down")
-	assert_eq(entries[1]["text"], "Rivals +12.3", "Positive source shows explicit + sign")
-	assert_eq(entries[1]["sign"], 1, "Rivals push doom up")
+	var entries := DoomBreakdown.build_entries({"overhang": 12.3, "alarm": -14.4})
+	# Sorted by descending magnitude: alarm (14.4) before overhang (12.3).
+	assert_eq(entries[0]["text"], "Alarm -14.4", "Negative source shows human label + signed value")
+	assert_eq(entries[0]["sign"], -1, "Alarm pulls doom down")
+	assert_eq(entries[1]["text"], "Overhang +12.3", "Positive source shows explicit + sign")
+	assert_eq(entries[1]["sign"], 1, "Overhang pushes doom up")
 
 func test_build_entries_sorted_by_magnitude():
 	var entries := DoomBreakdown.build_entries({
-		"base": 1.0,
-		"rivals": 12.3,
-		"safety": -14.4,
+		"baseline": 1.0,
+		"overhang": 12.3,
+		"alarm": -14.4,
 	})
-	assert_eq(entries[0]["key"], "safety", "Biggest mover (|14.4|) first")
-	assert_eq(entries[1]["key"], "rivals", "Then |12.3|")
-	assert_eq(entries[2]["key"], "base", "Then |1.0|")
+	assert_eq(entries[0]["key"], "alarm", "Biggest mover (|14.4|) first")
+	assert_eq(entries[1]["key"], "overhang", "Then |12.3|")
+	assert_eq(entries[2]["key"], "baseline", "Then |1.0|")
 
 func test_label_for_known_and_unknown_keys():
+	assert_eq(DoomBreakdown.label_for("overhang"), "Overhang", "ADR-0015 stream key uses friendly label")
 	assert_eq(DoomBreakdown.label_for("technical_debt"), "Technical Debt", "Known key uses friendly label")
-	assert_eq(DoomBreakdown.label_for("market_pressure"), "Market Pressure", "Known key uses friendly label")
+	# The dead "rivals" key no longer has a bespoke label -- it just capitalizes now.
+	assert_eq(DoomBreakdown.label_for("rivals"), "Rivals", "Removed key falls back to capitalize")
 	# Unknown key falls back to a capitalized rendering rather than crashing.
 	assert_eq(DoomBreakdown.label_for("some_new_source"), "Some New Source", "Unknown key capitalizes")
 
+func test_no_rivals_label_in_map():
+	# ADR-0015 pin: no "rivals" doom-source key is ever populated, so the bespoke label was
+	# removed. Guard against a future re-introduction masking the dead key.
+	assert_false(DoomBreakdown.SOURCE_LABELS.has("rivals"), "Dead 'rivals' label must not be re-added")
+
 func test_build_entries_empty_when_all_zero():
-	var entries := DoomBreakdown.build_entries({"base": 0.0, "rivals": 0.0})
+	var entries := DoomBreakdown.build_entries({"baseline": 0.0, "overhang": 0.0})
 	assert_eq(entries.size(), 0, "All-zero sources produce an empty (hidden) breakdown")
+
+# ---------------------------------------------------------------------------
+# Overhang attribution -- names the rival labs behind the acute-hazard stream,
+# masked by each lab's real visibility (never leaks an undiscovered lab's name).
+# ---------------------------------------------------------------------------
+
+func _rival_dict(lab_name: String, visibility: int, aggression: float = 0.9) -> Dictionary:
+	var lab := RivalLabs.RivalLab.new(lab_name, aggression)
+	lab.visibility = visibility
+	return lab.to_dict()
+
+func test_overhang_attribution_lists_visible_labs():
+	# CapabiliCorp holds the highest frontier and is KNOWN -> named in the attribution line.
+	var rivals := [
+		_rival_dict("CapabiliCorp", RivalLabs.VisibilityState.KNOWN),
+		_rival_dict("DeepSafety", RivalLabs.VisibilityState.KNOWN, 0.3),
+	]
+	var frontier := {"player": 100.0, "capabilicorp": 800.0, "deepsafety": 200.0}
+	var text := DoomBreakdown.overhang_attribution_text(frontier, rivals)
+	assert_true(text.find("CapabiliCorp") != -1, "Visible frontier leader is named")
+	# Leader (max frontier) comes first in the list.
+	assert_true(text.begins_with("frontier held by CapabiliCorp"), "Max-frontier actor leads: %s" % text)
+
+func test_overhang_attribution_hides_undiscovered_labs():
+	# A HIDDEN lab holding the frontier must read as an unknown actor -- never its real name.
+	var rivals := [_rival_dict("StealthAI", RivalLabs.VisibilityState.HIDDEN)]
+	var frontier := {"player": 50.0, "stealthai": 900.0}
+	var text := DoomBreakdown.overhang_attribution_text(frontier, rivals)
+	assert_eq(text.find("StealthAI"), -1, "Undiscovered lab name must NOT leak: %s" % text)
+	assert_true(text.find("an unknown actor") != -1, "Hidden lab masked as unknown actor: %s" % text)
+
+func test_frontier_leaders_skip_negligible_and_rank():
+	var rivals := [_rival_dict("CapabiliCorp", RivalLabs.VisibilityState.KNOWN)]
+	var frontier := {"player": 300.0, "capabilicorp": 800.0, "idle": 0.1}
+	var leaders := DoomBreakdown.frontier_leaders(frontier, rivals)
+	assert_eq(leaders.size(), 2, "Negligible (<epsilon) frontier slices are dropped")
+	assert_eq(str(leaders[0]["id"]), "capabilicorp", "Highest frontier ranks first")
+	assert_eq(str(leaders[1]["id"]), "player", "Player second")
+	assert_eq(str(leaders[1]["name"]), "your own frontier", "Player slice reads as own frontier")
+
+func test_overhang_attribution_empty_without_frontier():
+	assert_eq(DoomBreakdown.overhang_attribution_text({}, []), "", "No frontier data -> no attribution")
+	assert_eq(DoomBreakdown.overhang_attribution_text({"player": 0.0}, []), "", "All-negligible -> no attribution")
+
+# ---------------------------------------------------------------------------
+# Death attribution on the game-over screen -- the causal chain renders, and the
+# overhang killer line names the top visible lab for an overhang-driven doom death.
+# ---------------------------------------------------------------------------
+
+func test_game_over_renders_attribution_chain_when_data_present():
+	# DeathAttribution.classify over a state with a logged cause yields a non-empty chain,
+	# which the game-over BBCode builder must render as a non-empty cause-of-death panel.
+	var state := GameState.new("test_death_chain")
+	state.cause_log.append({
+		"turn": 3,
+		"kind": "ledger_default",
+		"source": "payroll",
+		"effects": {"doom": 2.0, "reputation": -8.0},
+	})
+	var result := DeathAttribution.classify(state)
+	var chain: Array = result.get("chain", [])
+	assert_gt(chain.size(), 0, "DeathAttribution should produce a non-empty chain")
+	var bbcode := GameOverScreen.build_attribution_bbcode(chain, "")
+	assert_ne(bbcode, "", "Non-empty chain must render a non-empty attribution panel")
+	assert_true(bbcode.find("CAUSE OF DEATH") != -1, "Panel carries the cause-of-death header")
+
+func test_game_over_attribution_empty_without_data():
+	assert_eq(GameOverScreen.build_attribution_bbcode([], ""), "", "No chain + no killer line -> empty")
+
+func test_overhang_killer_line_names_visible_lab():
+	var rivals := [_rival_dict("CapabiliCorp", RivalLabs.VisibilityState.KNOWN)]
+	var frontier := {"player": 100.0, "capabilicorp": 900.0}
+	var line := GameOverScreen.overhang_killer_line("doom", "overhang", frontier, rivals)
+	assert_true(line.find("CapabiliCorp") != -1, "Overhang doom death names the visible frontier leader")
+	assert_eq(line.find("!"), -1, "Deadpan register: no exclamation marks")
+
+func test_overhang_killer_line_masks_hidden_lab():
+	var rivals := [_rival_dict("StealthAI", RivalLabs.VisibilityState.HIDDEN)]
+	var frontier := {"player": 50.0, "stealthai": 900.0}
+	var line := GameOverScreen.overhang_killer_line("doom", "overhang", frontier, rivals)
+	assert_eq(line.find("StealthAI"), -1, "Hidden lab name must not leak on the death screen")
+	assert_true(line.find("an unknown actor") != -1, "Hidden killer masked as unknown actor")
+
+func test_overhang_killer_line_only_for_overhang_doom_death():
+	var rivals := [_rival_dict("CapabiliCorp", RivalLabs.VisibilityState.KNOWN)]
+	var frontier := {"capabilicorp": 900.0}
+	assert_eq(GameOverScreen.overhang_killer_line("rep", "overhang", frontier, rivals), "", "Rep death -> no overhang lab line")
+	assert_eq(GameOverScreen.overhang_killer_line("doom", "ledger", frontier, rivals), "", "Ledger-dominant doom death -> no lab line")


### PR DESCRIPTION
## What

Lane B of the "doom attribution names the rivals" bundle -- makes the game
concretely name the rival labs behind your doom, both live and at death.

- **Overhang attribution in the doom breakdown.** Under a doom-increasing
  `overhang` line, a dim sub-line now names which actors' frontier is driving the
  acute hazard (e.g. "frontier held by CapabiliCorp, DeepSafety"). The overhang
  stream is priced off the MAX actor frontier, so the frontier leader IS the
  actor setting the hazard. Each rival name is masked by its real visibility
  (`RivalLab.is_visible_to_player()` / `get_visible_name()`), so an undiscovered
  lab reads "an unknown actor" -- StealthAI never leaks pre-discovery.
- **Removed the dead `rivals` label.** Post-ADR-0015 no rival writes doom, so no
  `rivals` doom-source key is ever populated. Replaced with the ADR-0015 stream
  vocabulary labels (overhang / baseline / diffusion / panic / alarm / ledger).
- **DeathAttribution wired into the game-over screen.** The turn-stamped causal
  chain now renders in a "CAUSE OF DEATH" panel above the stats scroll, and an
  overhang-driven doom death names the killer lab: "CapabiliCorp's frontier
  outran your absorption. The paperwork was filed on time." Deadpan bureaucratic
  register (achievements.gd), no exclamation marks. The existing ledger
  attribution line is kept.
- **Bug fix (debug_overlay.gd):** stale field access `rival.get("capabilities")`
  / `rival.get("money")` read null; RivalLab's fields are `capability_progress`
  / `funding`. Switched to direct field access.
- **Doc fix (test_phase5_features.gd):** corrected the stale ADR-0015 comment
  ("doom changed (rivals + base + capabilities)") to describe the overhang-stream
  path.

## Why

The fresh-eyes UX teardown flagged that doom is opaque: the player never learns
which rival is killing them. This surfaces named, visibility-respecting causes
live and at the defeat moment, making "how did I lose" legible and interesting.

## Constraints honored

READ-ONLY over simulation state -- pure rendering/attribution. Zero writes to
`state.doom`, no changes to DoomSystem computation, `_step_*` order, or the
deterministic RNG/replay stream. Untouched: rivals.gd, turn_manager.gd,
game_manager.gd month-review, defaults.json (owned by the parallel lane).

## Tests

Fast gate: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`
-> **521 tests, 0 failures, 57/57 files collected.**

New coverage in test_doom_breakdown.gd: overhang attribution lists visible labs,
hides undiscovered labs, ranks by frontier, the removed `rivals` label, the
game-over attribution chain renders when DeathAttribution has data, and the
overhang killer line (names visible lab, masks hidden lab, doom-only gate). No
simulation-tier run needed (no sim changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)