### PR TITLE
feat(rivals): surface rival actions in feed, month review, and discovery reveal

### DIFF
--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -27,6 +27,12 @@ var fullscreen: bool = false
 # Accessibility Settings
 var colorblind_mode: bool = false  # Adds patterns/symbols alongside colors
 
+# Interface Settings
+# Rival-lab intel lines in the WATCH feed (the "rivals" channel, v0 of the future
+# News feedline / DQ-32). Default ON; players who find rival chatter noisy can hide
+# it. Display-only -- the underlying log content and simulation are unchanged.
+var show_rivals_feed: bool = true
+
 # Leaderboard Settings
 # Opt-out for uploading scores to the global leaderboard (LeaderboardSync).
 # Default ON for alpha; players who flip it off keep local scores only.
@@ -102,6 +108,9 @@ func save_config() -> void:
 	# Accessibility section
 	config.set_value("accessibility", "colorblind_mode", colorblind_mode)
 
+	# Interface section
+	config.set_value("interface", "show_rivals_feed", show_rivals_feed)
+
 	# Leaderboard section
 	config.set_value("leaderboard", "submit_scores_global", submit_scores_global)
 
@@ -147,6 +156,9 @@ func load_config() -> void:
 
 	# Load accessibility settings
 	colorblind_mode = config.get_value("accessibility", "colorblind_mode", colorblind_mode)
+
+	# Load interface settings
+	show_rivals_feed = config.get_value("interface", "show_rivals_feed", show_rivals_feed)
 
 	# Load leaderboard settings
 	submit_scores_global = config.get_value("leaderboard", "submit_scores_global", submit_scores_global)

--- a/godot/scripts/core/rivals.gd
+++ b/godot/scripts/core/rivals.gd
@@ -92,6 +92,64 @@ class RivalLab:
 		lab.estimated_reputation = float(d.get("estimated_reputation", 0.0))
 		return lab
 
+# ---------------------------------------------------------------------------
+# Player-facing narration (issue: rivals become narratively visible)
+#
+# Voice: the deadpan bureaucratic register of achievements.gd ("Reviewer 2 had
+# concerns. Humanity gains a PDF."). No exclamation marks, no tycoon enthusiasm.
+# These are FEED-tier lines only -- they never open a window/popup. The turn
+# manager appends them for VISIBLE rivals only; hidden/undiscovered labs act
+# without ever narrating. Kept as a const map (one place) rather than JSON:
+# there is no existing narrative-flavour JSON channel to slot into, and the
+# strings are tightly coupled to the six action ids in _choose_rival_action.
+# "%s" is filled with the rival's visible name.
+const ACTION_FEED_TEMPLATES: Dictionary = {
+	"hire_researcher": "%s hires aggressively. Their blog post calls it 'consolidating talent.'",
+	"buy_compute": "%s expands its compute footprint. The purchase order says 'modest.'",
+	"publish_paper": "%s publishes. Reviewer 2 was not consulted.",
+	"fundraise": "%s closes a round. The press release says 'responsibly.'",
+	"capability_research": "%s pushes the frontier. The word 'safety' appears once, in the footer.",
+	"safety_research": "%s files an alignment result. It is thorough, and unread.",
+}
+
+# When a rival takes several actions in one turn, narrate ONE headline so the
+# feed does not flood. Chosen by fixed salience (most player-relevant first) --
+# deterministic, no RNG. Reckless capability moves lead; quiet compute buys trail.
+const ACTION_SALIENCE: Array = [
+	"capability_research", "publish_paper", "fundraise",
+	"hire_researcher", "buy_compute", "safety_research",
+]
+
+static func pick_headline_action(actions: Array) -> String:
+	## The single most feed-worthy action from a rival's turn (fixed priority, no RNG).
+	for candidate in ACTION_SALIENCE:
+		if candidate in actions:
+			return candidate
+	return String(actions[0]) if not actions.is_empty() else ""
+
+static func get_action_feed_line(rival: RivalLab, action: String) -> String:
+	## Deadpan feed line for a VISIBLE rival's action, or "" if the rival is not
+	## visible or the action has no template. Callers must still gate on visibility;
+	## this double-checks so a hidden rival can never leak a line.
+	if rival == null or not rival.is_visible_to_player():
+		return ""
+	var template: String = ACTION_FEED_TEMPLATES.get(action, "")
+	if template == "":
+		return ""
+	return template % rival.get_visible_name()
+
+static func capability_drift_label(delta: float) -> String:
+	## Qualitative month-over-month capability-progress drift for the month review.
+	## Thresholds sized to process_rival_turn's increments (capability_research +10,
+	## hire +5): a fast month is one where a rival stacked a reckless move on a hire.
+	if delta > 8.0:
+		return "capabilities climbing fast"
+	if delta > 0.5:
+		return "capabilities rising"
+	if delta < -0.5:
+		return "capabilities slipping"
+	return "capabilities flat"
+
 static func get_rival_labs() -> Array[RivalLab]:
 	var rivals: Array[RivalLab] = []
 
@@ -136,11 +194,14 @@ static func check_discovery(rival: RivalLab, player_state: GameState, rng: Rando
 			rival.discovery_turn = player_state.turn
 		match result["new_visibility"]:
 			VisibilityState.DISCOVERED:
-				result["message"] = "Intel on %s: %s-focused org." % [rival.name, rival.focus]
+				# The reveal moment (item 3): felt, deadpan. A rumor resolves into a
+				# named competitor. String only -- the two randf_range draws below are
+				# the discovery RNG stream and MUST stay in place/order (no new RNG).
+				result["message"] = "Intel: there is another lab. There was always another lab. It has a name -- %s, and a %s habit." % [rival.name, rival.focus]
 				rival.estimated_funding = rival.funding * rng.randf_range(0.7, 1.3)
 				rival.estimated_reputation = rival.reputation * rng.randf_range(0.8, 1.2)
 			VisibilityState.KNOWN:
-				result["message"] = "Full intel on %s acquired." % rival.name
+				result["message"] = "Full dossier on %s. The unknowns are now merely known unknowns." % rival.name
 	return result
 
 static func process_rival_turn(rival: RivalLab, player_state: GameState, rng: RandomNumberGenerator) -> Dictionary:

--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -502,10 +502,21 @@ func _step_process_rival_turns(results: Array) -> float:
 	comes out of the intermediaries on the next DoomSystem tick. Returns 0.0 (compat)."""
 	for rival in state.rival_labs:
 		var rival_result = RivalLabs.process_rival_turn(rival, state, state.rng)
-		results.append({
-			"success": true,
-			"message": "%s: %s" % [rival_result["name"], ", ".join(rival_result["actions"])]
-		})
+		# Rivals-visibility (item 1): only rivals the player can see surface to the
+		# feed, and as a single deadpan headline line (feed tier -- never a window).
+		# Hidden/undiscovered labs still act (RNG stream unchanged) but narrate
+		# nothing. The old raw "<name>: <action, action>" dump leaked every rival,
+		# visible or not; this replaces it. No RNG added, step order unchanged.
+		if not rival_result.get("visible", false):
+			continue
+		var headline: String = RivalLabs.pick_headline_action(rival_result["actions"])
+		var line: String = RivalLabs.get_action_feed_line(rival, headline)
+		if line != "":
+			results.append({
+				"success": true,
+				"channel": "rivals",
+				"message": "[color=#9aa7b8]" + line + "[/color]"
+			})
 	return 0.0
 
 func _step_check_rival_discovery(results: Array) -> void:
@@ -513,9 +524,13 @@ func _step_check_rival_discovery(results: Array) -> void:
 	for rival in state.rival_labs:
 		var discovery_result = RivalLabs.check_discovery(rival, state, state.rng)
 		if discovery_result["discovered"]:
+			# The reveal is felt (item 3): a deadpan feed event on the "rivals"
+			# channel, distinct from routine rival narration. check_discovery emits
+			# exactly one message per rival per turn, so one reveal line per reveal.
 			results.append({
 				"success": true,
-				"message": "[INTEL] " + discovery_result["message"]
+				"channel": "rivals",
+				"message": "[color=#c8b98a][INTEL] " + discovery_result["message"] + "[/color]"
 			})
 
 func _step_process_paper_decisions(results: Array) -> void:

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -21,6 +21,11 @@ var month_playback_active: bool = false
 # Seconds between visible day ticks during month playback. var (not const) so headless
 # smokes/tests can run a month fast; a player-facing speed control is future UI work.
 var day_tick_seconds: float = 0.2
+# Rivals-in-review (item 2): last capability_progress seen per visible rival, keyed by id,
+# so the month review can show a qualitative month-over-month drift. Display-only cache --
+# deliberately NOT serialized (a loaded game just shows "flat" on its first review). Never
+# read by the simulation, so it cannot touch determinism.
+var _rival_cap_snapshot: Dictionary = {}
 # Synthetic month-review dialog id — intercepted by resolve_event before any engine path.
 const MONTH_REVIEW_EVENT_ID := "__month_review__"
 
@@ -46,6 +51,7 @@ func start_new_game(game_seed: String = ""):
 	# state we are about to drop.
 	month_playback_active = false
 	_release_game_objects()
+	_rival_cap_snapshot.clear()  # fresh drift baseline for the new run
 
 	state = GameState.new(game_seed)
 
@@ -615,14 +621,36 @@ func _finish_month_playback() -> void:
 	var review := {
 		"id": MONTH_REVIEW_EVENT_ID,
 		"name": "Month Review — %s" % label,
-		"description": "%s begins.\n\nAttention: %d fresh decisions this month (last month's unspent reserve evaporated — no banking).\nFunds: %s   ·   Doom: %.1f%%   ·   Staff: %d\n\nQueue this month's actions, then End Turn to play the month out." % [
-			label, attention_now, GameConfig.format_money(state.money), state.doom, state.get_total_staff()],
+		"description": "%s begins.\n\nAttention: %d fresh decisions this month (last month's unspent reserve evaporated — no banking).\nFunds: %s   ·   Doom: %.1f%%   ·   Staff: %d%s\n\nQueue this month's actions, then End Turn to play the month out." % [
+			label, attention_now, GameConfig.format_money(state.money), state.doom, state.get_total_staff(),
+			_build_rivals_review_section()],
 		"type": "popup",
 		"options": [
 			{"id": "begin_planning", "text": "Begin planning %s" % label, "costs": {}, "effects": {}}
 		],
 	}
 	event_triggered.emit(review)
+
+
+func _build_rivals_review_section() -> String:
+	"""Rivals this month (item 2): a short block in the month review naming each VISIBLE
+	rival, its focus, and a qualitative capability-drift read since last review. Returns ""
+	when nothing is visible so the review stays clean. Deadpan register, display-only (no
+	RNG, no sim reads that could move determinism)."""
+	if state == null:
+		return ""
+	var lines: Array[String] = []
+	for rival in state.rival_labs:
+		if not rival.is_visible_to_player():
+			continue
+		var rid: String = rival.id
+		var prev: float = float(_rival_cap_snapshot.get(rid, rival.capability_progress))
+		var drift: String = RivalLabs.capability_drift_label(rival.capability_progress - prev)
+		_rival_cap_snapshot[rid] = rival.capability_progress
+		lines.append("  %s (%s) -- %s" % [rival.get_visible_name(), rival.focus, drift])
+	if lines.is_empty():
+		return ""
+	return "\n\nRivals this month:\n" + "\n".join(lines)
 
 
 func get_game_state() -> Dictionary:
@@ -679,6 +707,7 @@ func load_saved_game(path: String = SaveLoad.QUICKSAVE_PATH) -> bool:
 	# code freed only `state`, leaking its orphaned doom_system/risk_system and the old
 	# turn_manager on every load.
 	_release_game_objects()
+	_rival_cap_snapshot.clear()  # drift baseline restarts from the loaded snapshot
 	state = loaded
 	# Scenario custom events live as node meta (Issue #483), not in state
 	# serialization — re-attach them from the pack recorded in the envelope.

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -79,6 +79,9 @@ var current_turn_phase: String = "NOT_STARTED"
 # by default so real, actionable events aren't crowded out. The toggle flips this.
 var _feed_lines: Array = []              # [{text: String, channel: String}, ...]
 var _feed_important_only: bool = true    # default view hides the flavour spam
+# Rival-intel filter (v0 News feedline / DQ-32): hide the "rivals" channel when the player
+# opts out. Mirrors the persisted GameConfig.show_rivals_feed; display-only, determinism-safe.
+var _feed_hide_rivals: bool = not GameConfig.show_rivals_feed
 const FEED_MAX_LINES: int = 500          # cap the backing model so a long run stays bounded (trim oldest)
 
 # Active dialog state for keyboard shortcuts
@@ -110,6 +113,11 @@ func _ready():
 	if watch_screen and watch_screen.has_signal("feed_filter_changed"):
 		watch_screen.feed_filter_changed.connect(_on_feed_filter_changed)
 		_feed_important_only = watch_screen.feed_filter_button.button_pressed
+
+	# Rival-intel filter: reflect the persisted preference and re-render on flip.
+	if watch_screen and watch_screen.has_signal("rivals_filter_changed"):
+		watch_screen.rivals_filter_changed.connect(_on_rivals_filter_changed)
+		_feed_hide_rivals = watch_screen.rivals_filter_button.button_pressed
 
 	# #622 L10: event dialog presenter (script-instantiated child, same mount pattern as
 	# the #500 selector). Choices route back through game_manager.resolve_event so the
@@ -1070,8 +1078,14 @@ func log_message(text: String, channel: String = "normal"):
 		scroll.scroll_vertical = scroll.get_v_scroll_bar().max_value
 
 func _feed_passes_filter(channel: String) -> bool:
-	"""A line is visible unless the 'important only' filter is on and it's flavour spam."""
-	return not (_feed_important_only and channel == "flavour")
+	"""A line is visible unless a filter suppresses its channel: the 'important only' filter
+	hides flavour spam; the rival-intel filter hides the 'rivals' channel. Display-only --
+	suppressed lines stay recorded in _feed_lines, so the underlying content is unchanged."""
+	if _feed_important_only and channel == "flavour":
+		return false
+	if _feed_hide_rivals and channel == "rivals":
+		return false
+	return true
 
 func _render_feed() -> void:
 	"""Rebuild the visible feed from the recorded lines under the current filter (called when
@@ -1088,6 +1102,14 @@ func _render_feed() -> void:
 
 func _on_feed_filter_changed(important_only: bool) -> void:
 	_feed_important_only = important_only
+	_render_feed()
+
+func _on_rivals_filter_changed(hide_rivals: bool) -> void:
+	"""Player toggled rival-intel visibility. Persist the preference (GameConfig ->
+	user://config.cfg) and re-render; the backing feed lines are untouched."""
+	_feed_hide_rivals = hide_rivals
+	GameConfig.show_rivals_feed = not hide_rivals
+	GameConfig.save_config()
 	_render_feed()
 
 func _on_actions_available(actions: Array):

--- a/godot/scripts/ui/watch_screen.gd
+++ b/godot/scripts/ui/watch_screen.gd
@@ -16,6 +16,11 @@ extends VBoxContainer
 signal feed_filter_changed(important_only: bool)
 var feed_filter_button: CheckButton
 
+## Rival-intel filter (v0 News feedline / DQ-32): toggled ON = hide the "rivals" channel
+## lines. Preference persists via GameConfig.show_rivals_feed; main_ui listens and re-renders.
+signal rivals_filter_changed(hide_rivals: bool)
+var rivals_filter_button: CheckButton
+
 
 func _ready() -> void:
 	# The feed reads in the terminal register: monospace, dim phosphor text.
@@ -33,3 +38,13 @@ func _ready() -> void:
 	feed_filter_button.toggled.connect(func(on: bool): feed_filter_changed.emit(on))
 	add_child(feed_filter_button)
 	move_child(feed_filter_button, message_log_label.get_index() + 1)
+
+	# Rival-intel filter: reflect the persisted preference (show_rivals_feed ON -> unpressed).
+	rivals_filter_button = CheckButton.new()
+	rivals_filter_button.text = "Hide rival intel"
+	rivals_filter_button.button_pressed = not GameConfig.show_rivals_feed
+	rivals_filter_button.tooltip_text = "Collapse rival-lab intel lines in the feed"
+	rivals_filter_button.add_theme_color_override("font_color", TerminalTheme.GREEN_DIM)
+	rivals_filter_button.toggled.connect(func(hide: bool): rivals_filter_changed.emit(hide))
+	add_child(rivals_filter_button)
+	move_child(rivals_filter_button, feed_filter_button.get_index() + 1)

--- a/godot/tests/unit/test_rivals_feed_filter.gd
+++ b/godot/tests/unit/test_rivals_feed_filter.gd
@@ -1,0 +1,66 @@
+extends GutTest
+## Rival-intel feed filter (PR #726 review request): the "rivals" feed channel must be
+## player-filterable, with the preference persisted (GameConfig / user://config.cfg pattern),
+## display-only (no effect on the underlying log content or simulation).
+##
+## Covers the WATCH-screen toggle wiring (reflects + emits) and the GameConfig round-trip.
+## The filter predicate itself (main_ui._feed_passes_filter) is exercised in-game; here we
+## pin the persisted preference and the toggle contract that drives it.
+
+const WATCH_SCENE := "res://scenes/ui/watch_screen.tscn"
+
+
+func _instance(path: String) -> Node:
+	var scene: PackedScene = load(path)
+	assert_not_null(scene, "scene %s should load" % path)
+	var node: Node = scene.instantiate()
+	add_child_autofree(node)
+	return node
+
+
+func test_watch_screen_exposes_rivals_filter_toggle():
+	var watch = _instance(WATCH_SCENE)
+	await get_tree().process_frame
+	assert_not_null(watch.rivals_filter_button, "WatchScreen exposes the rival-intel toggle")
+	assert_true(watch.has_signal("rivals_filter_changed"), "WatchScreen emits rivals_filter_changed")
+
+
+func test_rivals_toggle_reflects_persisted_preference():
+	var prev: bool = GameConfig.show_rivals_feed
+	# show ON -> the "Hide rival intel" toggle is unpressed.
+	GameConfig.show_rivals_feed = true
+	var w_on = _instance(WATCH_SCENE)
+	await get_tree().process_frame
+	assert_false(w_on.rivals_filter_button.button_pressed,
+		"show_rivals_feed ON -> Hide toggle starts unpressed")
+	# show OFF -> the toggle starts pressed (rivals hidden).
+	GameConfig.show_rivals_feed = false
+	var w_off = _instance(WATCH_SCENE)
+	await get_tree().process_frame
+	assert_true(w_off.rivals_filter_button.button_pressed,
+		"show_rivals_feed OFF -> Hide toggle starts pressed")
+	GameConfig.show_rivals_feed = prev
+
+
+func test_rivals_toggle_emits_on_flip():
+	var watch = _instance(WATCH_SCENE)
+	await get_tree().process_frame
+	watch_signals(watch)
+	var before: bool = watch.rivals_filter_button.button_pressed
+	watch.rivals_filter_button.button_pressed = not before  # user flips the toggle
+	assert_signal_emitted(watch, "rivals_filter_changed",
+		"Flipping the toggle emits rivals_filter_changed")
+
+
+func test_show_rivals_feed_persists_across_save_load():
+	var prev: bool = GameConfig.show_rivals_feed
+	# Persist OFF, clobber in memory, reload -> the persisted OFF wins.
+	GameConfig.show_rivals_feed = false
+	GameConfig.save_config()
+	GameConfig.show_rivals_feed = true
+	GameConfig.load_config()
+	assert_false(GameConfig.show_rivals_feed,
+		"show_rivals_feed survives save -> load (persisted preference)")
+	# Restore the original value on disk so the test is net-neutral.
+	GameConfig.show_rivals_feed = prev
+	GameConfig.save_config()

--- a/godot/tests/unit/test_rivals_feed_visibility.gd
+++ b/godot/tests/unit/test_rivals_feed_visibility.gd
@@ -1,0 +1,127 @@
+extends GutTest
+## Rivals become narratively visible (lane A, tier-S bundle).
+##
+## Pins the three player-facing guarantees:
+##   1. A VISIBLE rival's turn surfaces a deadpan feed line (feed tier, never a window).
+##   2. A HIDDEN rival's turn surfaces NOTHING.
+##   3. A discovery fires exactly one reveal event.
+## Plus the pure narration helpers (visibility gate, salience pick, drift label).
+##
+## Tests drive the real _step_* functions directly (same pattern as
+## test_turn_manager's risk-pool tests) so no RNG is added and step order is untouched.
+
+var state: GameState
+var turn_manager: TurnManager
+
+
+func before_each():
+	# Isolate from the live historical timeline (see test_turn_manager.before_each).
+	if EventService:
+		EventService.transformed_events.clear()
+	state = GameState.new("rivals_feed_seed")
+	turn_manager = TurnManager.new(state)
+
+
+func _make_rival(rname: String, aggression: float, visibility: int) -> RivalLabs.RivalLab:
+	var r := RivalLabs.RivalLab.new(rname, aggression)
+	r.visibility = visibility
+	r.funding = 500000.0  # enough to guarantee non-fundraise capability actions
+	return r
+
+
+func _join_messages(results: Array) -> String:
+	var joined := ""
+	for r in results:
+		joined += String(r.get("message", ""))
+	return joined
+
+
+# --- item 1: visible rivals surface, hidden rivals do not -------------------
+
+func test_visible_rival_action_produces_feed_entry():
+	var visible := _make_rival("CapabiliCorp", 0.9, RivalLabs.VisibilityState.KNOWN)
+	state.rival_labs = [visible]
+	var results: Array = []
+	turn_manager._step_process_rival_turns(results)
+	assert_gt(results.size(), 0, "A visible rival should surface at least one feed line")
+	assert_string_contains(_join_messages(results), "CapabiliCorp",
+		"Feed line names the visible rival")
+	# Feed tier: carries the rivals channel and never a window/options payload.
+	for r in results:
+		assert_eq(String(r.get("channel", "")), "rivals", "rival feed line rides the rivals channel")
+		assert_false(r.has("options"), "feed tier -- a rival line must never be a window/popup")
+
+
+func test_hidden_rival_action_produces_no_feed_entry():
+	var hidden := _make_rival("StealthLab", 0.9, RivalLabs.VisibilityState.HIDDEN)
+	state.rival_labs = [hidden]
+	var results: Array = []
+	turn_manager._step_process_rival_turns(results)
+	assert_eq(results.size(), 0, "A hidden rival must not surface any feed line")
+
+
+func test_only_visible_rival_surfaces_in_mixed_field():
+	var visible := _make_rival("DeepSafety", 0.3, RivalLabs.VisibilityState.KNOWN)
+	var hidden := _make_rival("StealthLab", 0.9, RivalLabs.VisibilityState.HIDDEN)
+	state.rival_labs = [visible, hidden]
+	var results: Array = []
+	turn_manager._step_process_rival_turns(results)
+	var joined := _join_messages(results)
+	assert_string_contains(joined, "DeepSafety", "Visible rival is narrated")
+	assert_false(joined.contains("StealthLab"), "Hidden rival must never leak into the feed")
+
+
+# --- item 3: discovery reveal is exactly one felt event ---------------------
+
+func test_discovery_produces_exactly_one_reveal_event():
+	var rumored := _make_rival("StealthAI", 0.5, RivalLabs.VisibilityState.RUMORED)
+	rumored.discovery_threshold = 0.0
+	state.rival_labs = [rumored]
+	# reputation huge -> discovery_chance > 1 -> rng.randf() (< 1) always fires. No seed
+	# dependence, no new RNG (check_discovery already owns this draw).
+	state.reputation = 1000.0
+	var results: Array = []
+	turn_manager._step_check_rival_discovery(results)
+	assert_eq(results.size(), 1, "Discovery fires exactly one reveal event")
+	var msg := String(results[0].get("message", ""))
+	assert_string_contains(msg, "INTEL", "Reveal is tagged intel")
+	assert_string_contains(msg, "another lab", "Reveal uses the deadpan reveal register")
+	assert_eq(String(results[0].get("channel", "")), "rivals", "Reveal rides the rivals channel")
+
+
+func test_no_discovery_when_reputation_below_threshold():
+	var rumored := _make_rival("StealthAI", 0.5, RivalLabs.VisibilityState.RUMORED)
+	rumored.discovery_threshold = 100.0
+	state.rival_labs = [rumored]
+	state.reputation = 0.0  # below threshold -> discovery_chance stays 0 -> never fires
+	var results: Array = []
+	turn_manager._step_check_rival_discovery(results)
+	assert_eq(results.size(), 0, "No reveal when reputation is below the discovery threshold")
+
+
+# --- pure narration helpers -------------------------------------------------
+
+func test_get_action_feed_line_gated_on_visibility():
+	var hidden := _make_rival("Ghost", 0.9, RivalLabs.VisibilityState.HIDDEN)
+	assert_eq(RivalLabs.get_action_feed_line(hidden, "capability_research"), "",
+		"Hidden rival yields no line even when asked directly")
+	var seen := _make_rival("Ghost", 0.9, RivalLabs.VisibilityState.KNOWN)
+	assert_ne(RivalLabs.get_action_feed_line(seen, "capability_research"), "",
+		"Visible rival yields a narrative line")
+	assert_eq(RivalLabs.get_action_feed_line(seen, "not_a_real_action"), "",
+		"Unknown action id yields no line")
+
+
+func test_pick_headline_action_prefers_salient():
+	assert_eq(RivalLabs.pick_headline_action(["buy_compute", "capability_research"]),
+		"capability_research", "Reckless capability move outranks a quiet compute buy")
+	assert_eq(RivalLabs.pick_headline_action(["safety_research"]), "safety_research",
+		"Single action is the headline")
+	assert_eq(RivalLabs.pick_headline_action([]), "", "Empty action list yields no headline")
+
+
+func test_capability_drift_label_thresholds():
+	assert_eq(RivalLabs.capability_drift_label(10.0), "capabilities climbing fast")
+	assert_eq(RivalLabs.capability_drift_label(2.0), "capabilities rising")
+	assert_eq(RivalLabs.capability_drift_label(0.0), "capabilities flat")
+	assert_eq(RivalLabs.capability_drift_label(-5.0), "capabilities slipping")


### PR DESCRIPTION
## What

Makes the (already-simulated) rival AI labs narratively visible to the player, in the deadpan bureaucratic register of `achievements.gd`. Four items, all lane A of the tier-S "rivals become narratively visible" bundle:

1. **Rival actions in the feed.** `turn_manager._step_process_rival_turns` now surfaces a feed line only for rivals where `is_visible_to_player()` is true, as a single deadpan headline per rival per turn (feed tier -- never a window/popup). The prior `"<name>: <action, action>"` raw dump leaked *every* rival regardless of visibility; it is replaced. Narration lives in a `const` template map keyed by action id in `rivals.gd`; the headline action is chosen by fixed salience order (deterministic, no RNG).
2. **"Rivals this month" in the month review.** `game_manager._finish_month_playback` appends a short block (name, focus, qualitative capability-drift) for visible rivals via a new `_build_rivals_review_section()`. Drift uses a display-only per-run cache (`_rival_cap_snapshot`) that is deliberately not serialized and never read by the sim.
3. **Discovery reveal moment.** The `RUMORED -> DISCOVERED` transition now fires a deadpan feed event ("Intel: there is another lab. There was always another lab.") on the `rivals` channel. String-only change; `check_discovery`'s RNG draws are untouched and in place.
4. **`panic_per_capability_action`.** The task premise ("currently 0.0") is stale -- `origin/main` already carries the conservative `0.05`. Left as-is and confirmed the simulation tier stays green with it (see below). No `defaults.json` edit was needed.

## Why

Rivals advanced their capability/safety stocks and even nudged `global_panic`, but the player never saw any of it -- the competitive world was invisible. This surfaces it as ambient narrative pressure without changing simulation behavior.

## Constraints honored

- No new RNG calls; no reordering of `_step_*` functions (the deterministic RNG stream is preserved).
- Rival lines are feed tier only -- they are appended to `action_results` (log lines), never routed as windows/popups.
- Simulation behavior unchanged except the (pre-existing) `0.05` panic value, which the slow tier verifies.

## panic value decision

`rivals.panic_per_capability_action = 0.05` (already on main). A reckless rival can take up to ~3 capability actions/month, so this contributes at most ~0.15 global_panic/month per aggressive lab -- a nudge, not a dominant driver. The determinism and replay-verification tests pass with it, so no revert was required.

## Tests

- New `godot/tests/unit/test_rivals_feed_visibility.gd`: visible-rival actions produce feed entries; hidden-rival actions produce none; mixed field surfaces only the visible; discovery produces exactly one reveal event; no discovery below threshold; plus the pure narration helpers (visibility gate, salience pick, drift label).
- Fast gate: `519 tests, 0 failures` (58/58 files).
- Simulation tier: `96 tests, 0 failures` (7/7 files) -- determinism + replay verification green with the 0.05 panic value.

## For Pip to review

- Rival feed lines use a new `"rivals"` feed channel (styled gray via BBCode) so they read as ambient intel rather than player-action successes, and are never hidden by the arxiv-flood filter. Reasonable? Alternative was leaving them on the default lime "player did a thing" styling.
- Density: one headline line per visible rival per month (not one per action) to avoid flooding the feed. Easy to dial up if you want more chatter.
- The capability-drift indicator is month-over-month delta from a non-serialized cache, so the first review after a save/load shows "capabilities flat" for everyone. Acceptable for a display-only signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
