### PR TITLE
fix(leaderboard): replace crashing background textures with palette solids (fixes segfault on open)

### DIFF
--- a/godot/scenes/leaderboard_screen.tscn
+++ b/godot/scenes/leaderboard_screen.tscn
@@ -1,8 +1,6 @@
-[gd_scene load_steps=4 format=3 uid="uid://c8jkm2s8cdp4t"]
+[gd_scene load_steps=2 format=3 uid="uid://c8jkm2s8cdp4t"]
 
 [ext_resource type="Script" path="res://scripts/ui/leaderboard_screen.gd" id="1_leaderboard"]
-[ext_resource type="Texture2D" path="res://assets/textures/surfaces/tex_oxidized_copper_512.png" id="2_background"]
-[ext_resource type="Texture2D" path="res://assets/textures/terminal/tex_cyan_ispf_512.png" id="3_overlay"]
 
 [node name="LeaderboardScreen" type="Control"]
 layout_mode = 3
@@ -13,26 +11,23 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_leaderboard")
 
-[node name="Background" type="TextureRect" parent="."]
+[node name="Background" type="ColorRect" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-texture = ExtResource("2_background")
-stretch_mode = 1
+color = Color(0.090196, 0.039216, 0.109804, 1)
 
-[node name="ScanlineOverlay" type="TextureRect" parent="."]
-modulate = Color(1, 1, 1, 0.08)
+[node name="ScanlineOverlay" type="ColorRect" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-texture = ExtResource("3_overlay")
-stretch_mode = 1
+color = Color(0.090196, 0.039216, 0.109804, 0.08)
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1


### PR DESCRIPTION
## Problem (release-blocking)
The release build **segfaults when opening the leaderboard**, on both Vulkan and OpenGL (renderer-independent). `--verbose` traces the crash to the CPU-side decode of the imported `.ctex` for the two background textures that are used *only* by `leaderboard_screen.tscn`:
- `res://assets/textures/surfaces/tex_oxidized_copper_512.png`
- `res://assets/textures/terminal/tex_cyan_ispf_512.png`

Headless instancing missed it because headless does not fully decode textures.

## Fix (ship fix)
In `godot/scenes/leaderboard_screen.tscn`:
- Swapped the two background `TextureRect` nodes (`Background`, `ScanlineOverlay`) to `ColorRect` solids using the menu-chrome off-black indigo `#170A1C` = `Color(0.090196, 0.039216, 0.109804, ...)`, matching the Fable menu-consistency direction (PR #717).
- Removed the two `ext_resource` texture entries (the crash source); `load_steps` 4 -> 2.
- Kept node **names/anchors/tree** unchanged so the `@onready` paths in `leaderboard_screen.gd` still resolve (none reference these two nodes anyway).
- No changes to `leaderboard_screen.gd` logic or the leaderboard data.

## Investigation: why did the texture decode crash? (report, not fixed here)
Static analysis does **not** support a "malformed source PNG":
- All 20 textures in `assets/textures/{surfaces,terminal}/` are structurally **identical**: 512x512, 8-bit, RGBA, non-interlaced, **no ICC profile**, valid `IEND`, not truncated. The two crashers are indistinguishable from their 18 siblings.
- `.import` params are byte-identical across all 20 (`compress/mode=0` lossless).
- All 20 (incl. both crashers) **decode cleanly through libpng/PIL** to full 1 MB RGBA buffers.
- Chunk layout is the same shape (`IHDR` + N*`IDAT` + `IEND`); IDAT count only scales with file size. No anomalous/ancillary chunks.

So if the release build truly segfaults on decode, it is a Godot-internal codec edge-case on the specific pixel payload of these two files (not a detectable malformation), **or** the `.ctex` log line is the last flushed event before an unrelated crash. Either way the ColorRect swap removes the trigger.

**Batch risk:** the same background-texture pattern (a `surfaces` bg + a `terminal` overlay, node ids `2_background`/`3_overlay`) with structurally-identical sibling textures is also used by `welcome.tscn`, `settings_menu.tscn`, and `pregame_setup.tscn`. If this is a genuine Godot decode edge-case, those three menus carry the same latent risk -- but they reportedly do not crash, which argues the two leaderboard files are specific in payload rather than a systematic landmine. Worth a targeted re-test of those three screens on the release build.

## Verification
- Fast gate: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **511 tests, 0 failures** (57/57 files).
- The GUI decode-crash **cannot be reproduced headlessly** (headless does not fully decode textures) -- the dev must re-test the exported release build.

Do NOT merge -- coordinator merges + re-exports for the dev's re-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)