### PR TITLE
docs(design): DQ-31 -- org/actor taxonomy as tags

### DIFF
--- a/docs/game-design/DQ_INDEX.md
+++ b/docs/game-design/DQ_INDEX.md
@@ -35,9 +35,10 @@
 | DQ-25 | Desperation-lever revisit | open | 298 |
 | DQ-26 | VC/equity depth revisit | open | 320 |
 | DQ-27 | Mortality guarantee -- where is it ratified? | open | 328 |
-| DQ-28 | Game "phases" as vocabulary + scenario-jump testing | RESOLVED | 579 |
+| DQ-28 | Game "phases" as vocabulary + scenario-jump testing | RESOLVED | 594 |
 | DQ-29 | Cover-up debt | open | 350 |
 | DQ-30 | Economic cycles | open | 359 |
 | DQ-31 | Org/actor taxonomy -- tags, not enums | open | 367 |
+| DQ-32 | News feedline + SA-priced information flow | open | 380 |
 
-Total: 32 DQs -- 26 open, 6 with a terminal or advanced status.
+Total: 33 DQs -- 27 open, 6 with a terminal or advanced status.

--- a/docs/game-design/DQ_INDEX.md
+++ b/docs/game-design/DQ_INDEX.md
@@ -35,8 +35,9 @@
 | DQ-25 | Desperation-lever revisit | open | 298 |
 | DQ-26 | VC/equity depth revisit | open | 320 |
 | DQ-27 | Mortality guarantee -- where is it ratified? | open | 328 |
-| DQ-28 | Game "phases" as vocabulary + scenario-jump testing | RESOLVED | 566 |
+| DQ-28 | Game "phases" as vocabulary + scenario-jump testing | RESOLVED | 579 |
 | DQ-29 | Cover-up debt | open | 350 |
 | DQ-30 | Economic cycles | open | 359 |
+| DQ-31 | Org/actor taxonomy -- tags, not enums | open | 367 |
 
-Total: 31 DQs -- 25 open, 6 with a terminal or advanced status.
+Total: 32 DQs -- 26 open, 6 with a terminal or advanced status.

--- a/docs/game-design/WORKSHOP_2_BACKLOG.md
+++ b/docs/game-design/WORKSHOP_2_BACKLOG.md
@@ -377,6 +377,21 @@ more interesting."*
   RIVALS_SURFACING_OPTIONS_2026-07-20.md) should ship with a `tags: []` field, and new
   code should say "actor" where it means any lab. Full design deferred to the DQ-22
   workshop (aggro/midgame is where actor classes start mattering).
+- **DQ-32 · News feedline + SA-priced information flow** *(Pip 2026-07-20, reviewing
+  #726)* — rival/world information should arrive on a **News** feedline: v0 is just a
+  distinct colour on the Events tab (the #726 `rivals` channel, made filter-outable, is
+  the seed), later possibly its own submenu on the action feed that **lights up with
+  unread items**. The Civ analogy: you learn by *seeing opponents' movements*; as
+  **situational awareness** rises, the player earns more detail on shifting patterns in
+  their display — possibly, eventually, interaction with the moving components
+  themselves. The design line underneath: "in and out of god mode" — which information
+  is *bought* in-run (SA-priced; the outward twin of DQ-10's inward ledger visibility)
+  vs hard-baked into the player's standing ability to learn. Anti-exploit motivation:
+  designing against brute-force-mining a league cycle's seed — SA-gating what the
+  display reveals makes mining **combinatorially safer** while staying close to the
+  design ideals. Interacts: DQ-10 (inward SA), DQ-12 (v0 surface built in #725/#726),
+  DQ-14 (world-state progression display), DQ-31 (actor tags likely determine what News
+  can say about whom). Higher-level workshop consideration, not a build lane.
 - **L5 finance construction AUTHORIZED (Pip):** loans over months+, player optionality
   among offered instruments (interest-rate intuitions from ADR-0013), "orchestrate the
   construction… in parallel with the other finance ideas" — build lane L5 (#616)

--- a/docs/game-design/WORKSHOP_2_BACKLOG.md
+++ b/docs/game-design/WORKSHOP_2_BACKLOG.md
@@ -364,6 +364,19 @@ more interesting."*
   emergent-from-mechanism (Pip's R2-Q5 preference) rather than a hardcoded clock. Sits on
   ADR-0013 finance + the ADR-0016 league/world-update surface (real macro conditions
   injected monthly).
+- **DQ-31 · Org/actor taxonomy — tags, not enums** *(Pip 2026-07-20, on reviewing the
+  rivals-surfacing PRs)* — the sim currently knows exactly two actor kinds: "the player"
+  and `RivalLab`. Pip wants labs (and future actors) carrying a **tags-based category
+  set** rather than a rigid type: e.g. `frontier`, `player-run`, `rival`,
+  `antagonist-founded`, later `agent-run` (autonomous-AI actor) — so a frontier lab
+  started by the game's antagonist(s) is mechanically distinguishable from a garden
+  rival, and multiplayer/PvE ("players vs rivals vs agents") needs no retrofit. Latent
+  hooks already exist: overhang prices off **max-actor** frontier (player included,
+  #725), and WORLD_AND_LORE.md's Antagonist_Lab fiction has no mechanical home — tags
+  give it one. Cheap headroom NOW: the data-driven roster (rivals.json, option #13 in
+  RIVALS_SURFACING_OPTIONS_2026-07-20.md) should ship with a `tags: []` field, and new
+  code should say "actor" where it means any lab. Full design deferred to the DQ-22
+  workshop (aggro/midgame is where actor classes start mattering).
 - **L5 finance construction AUTHORIZED (Pip):** loans over months+, player optionality
   among offered instruments (interest-rate intuitions from ADR-0013), "orchestrate the
   construction… in parallel with the other finance ideas" — build lane L5 (#616)


### PR DESCRIPTION
Logs Pip's 2026-07-20 review note as DQ-31 in the backlog: labs (and future actors) should carry a tags-based category set (frontier / player-run / rival / antagonist-founded / agent-run) rather than a rigid player-vs-rival enum, so an antagonist-founded frontier lab is mechanically distinguishable and multiplayer/PvE needs no retrofit.

Notes latent hooks (max-actor overhang pricing from #725; WORLD_AND_LORE's Antagonist_Lab with no mechanical home) and the cheap headroom to take now: rivals.json (option 13) ships with a tags field; new code says actor where it means any lab. Full design deferred to the DQ-22 workshop.

DQ_INDEX.md regenerated -- first real exercise of the pre-commit staleness gate, which passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)