### PR TITLE
ci: bump deprecated GitHub Actions to current majors (closes #531)

### DIFF
--- a/.github/workflows/data-validation.yml
+++ b/.github/workflows/data-validation.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload validation report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: validation-report
           path: validation-report.txt
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Verify schema files exist
         run: |
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Validate schema syntax
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 
@@ -154,10 +154,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -169,7 +169,7 @@ jobs:
           echo '{"status": "placeholder"}' > public/feeds/events.json
 
       - name: Upload feed artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: data-feeds
           path: public/feeds/

--- a/.github/workflows/dev-blog-automation.yml
+++ b/.github/workflows/dev-blog-automation.yml
@@ -45,12 +45,12 @@ jobs:
       tags: ${{ steps.analysis.outputs.tags }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 100  # Get enough history to analyze changes
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: '3.11'
 
@@ -162,12 +162,12 @@ jobs:
     if: needs.analyze-changes.outputs.should_create_entry == 'true'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 100
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: '3.11'
 
@@ -289,12 +289,12 @@ jobs:
     if: always() && needs.create-dev-blog-entry.result == 'success'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: main  # Make sure we get the latest changes
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: '3.11'
 

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -80,7 +80,7 @@ jobs:
           git push
 
       - name: Upload website export artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: website-docs-export
           path: _website_export/
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Download website export
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: website-docs-export
 

--- a/.github/workflows/enhanced-cicd-pipeline.yml
+++ b/.github/workflows/enhanced-cicd-pipeline.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -131,10 +131,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -224,7 +224,7 @@ jobs:
           echo "Health gate assessment: COMPLETED"
 
       - name: Upload Health Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: health-report-${{ github.sha }}
           path: health_report.json
@@ -243,10 +243,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -294,7 +294,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Update Quality Metrics
         run: |

--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -33,10 +33,10 @@ jobs:
       validation_status: ${{ steps.validate.outputs.status }}
       validation_hash: ${{ steps.validate.outputs.hash }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload validation report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: validation-report
           path: |
@@ -127,7 +127,7 @@ jobs:
     needs: validate-data
     if: needs.validate-data.outputs.validation_status == 'success' || inputs.skip_validation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Godot
         uses: chickensoft-games/setup-godot@v1
@@ -137,7 +137,7 @@ jobs:
           include-templates: true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -159,19 +159,19 @@ jobs:
           python scripts/build_all_platforms.py --version "$VERSION" --godot-path "$(which godot)"
 
       - name: Upload Windows build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-windows
           path: builds/windows/${{ github.event.inputs.version || github.ref_name }}/
 
       - name: Upload Linux build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-linux
           path: builds/linux/${{ github.event.inputs.version || github.ref_name }}/
 
       - name: Upload macOS build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-mac
           path: builds/mac/${{ github.event.inputs.version || github.ref_name }}/
@@ -181,12 +181,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-data, build-godot]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Need full history for git tags
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -202,7 +202,7 @@ jobs:
           python scripts/generate_release_metadata.py --version "$VERSION"
 
       - name: Upload metadata artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-feeds
           path: public/releases/
@@ -214,7 +214,7 @@ jobs:
     outputs:
       manifest_hash: ${{ steps.manifest.outputs.hash }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Generate release manifest
         id: manifest
@@ -261,7 +261,7 @@ jobs:
           cat release_manifest.json | jq .
 
       - name: Upload manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-manifest
           path: release_manifest.json
@@ -271,12 +271,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-data, build-godot, generate-feeds, create-release-manifest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Extract changelog
         id: changelog
@@ -325,10 +325,10 @@ jobs:
     needs: create-github-release
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download feed artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-feeds
           path: public/releases/

--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Godot
         uses: chickensoft-games/setup-godot@v1
@@ -58,7 +58,7 @@ jobs:
     needs: syntax-check
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Godot
         uses: chickensoft-games/setup-godot@v1
@@ -67,7 +67,7 @@ jobs:
           use-dotnet: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unit-test-results
           path: godot/test-results-quick.xml
@@ -92,7 +92,7 @@ jobs:
     needs: syntax-check
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Godot
         uses: chickensoft-games/setup-godot@v1
@@ -101,7 +101,7 @@ jobs:
           use-dotnet: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-test-results
           path: godot/test-results-integration.xml
@@ -128,7 +128,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Godot
         uses: chickensoft-games/setup-godot@v1
@@ -137,7 +137,7 @@ jobs:
           use-dotnet: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: simulation-test-results
           path: godot/test-results-simulation.xml

--- a/.github/workflows/pre-release-checks.yml
+++ b/.github/workflows/pre-release-checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Note: unit tests run on PRs via godot-tests.yml (GUT). Pre-release focuses
       # on release-readiness (changelog, version, clean tree). The former pygame-era

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: '3.11'
 

--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Post Release Checklist Comment
         uses: actions/github-script@v7

--- a/.github/workflows/sync-dev-blog.yml
+++ b/.github/workflows/sync-dev-blog.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout pdoom1 repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2  # Need previous commit for diff
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -42,7 +42,7 @@ jobs:
           echo "SUCCESS Blog entries validated successfully"
 
       - name: Checkout website repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: PipFoweraker/pdoom1-website
           token: ${{ secrets.WEBSITE_SYNC_TOKEN }}

--- a/.github/workflows/sync-documentation.yml
+++ b/.github/workflows/sync-documentation.yml
@@ -44,12 +44,12 @@ jobs:
 
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2  # Need for diff detection
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 
@@ -64,7 +64,7 @@ jobs:
           exit 0
 
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: PipFoweraker/${{ matrix.target.repo }}
           token: ${{ secrets.CROSS_REPO_TOKEN }}

--- a/.github/workflows/sync-game-version.yml
+++ b/.github/workflows/sync-game-version.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
     - name: Checkout Game Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Need full history for changelog
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: '3.11'
 


### PR DESCRIPTION
## Summary
- Sweeps all `.github/workflows/*.yml` and bumps `actions/checkout`, `actions/setup-python`, `actions/setup-node`, `actions/upload-artifact`, and `actions/download-artifact` off the deprecated Node-20 majors.
- Verified current stable majors **live via the GitHub releases API** on 2026-07-21 rather than trusting memory or the issue's suggested versions (which were already stale by the time of this PR): `checkout` -> `v7`, `setup-python` -> `v7`, `setup-node` -> `v7`, `upload-artifact` -> `v7`, `download-artifact` -> `v8`. All confirmed non-prerelease, non-draft releases.
- Normalizes the previously inconsistent `setup-python@v4`/`@v5` mix in `data-validation.yml` to `v7` across the board (issue flagged this inconsistency explicitly).
- `actions/cache@v3` in `enhanced-cicd-pipeline.yml` is left untouched -- not in this issue's explicit action list, kept out of scope deliberately.
- No workflow logic, triggers, inputs, or job structure changed -- version pins only.

## Behavior-change check (per-action changelog review)
- **setup-python v7** dropped the `pip-install` input -- grepped the repo's workflows, none use it, no impact.
- **upload-artifact v4->v7** requires unique artifact names per job (a v3->v4 era change) -- all `name:` values in this repo are already unique, no impact.
- **download-artifact v8** defaults `digest-mismatch` handling to `error` instead of warning -- only bites if a download hash actually mismatches; nothing in these workflows relies on the old warn-and-continue behavior. Worth watching on the first real run.
- **checkout v7** blocks checking out fork PRs for `pull_request_target`/`workflow_run` triggers -- none of these workflows use those triggers against forks, no impact expected.

## Validation
- `python -c "import yaml; ...safe_load_all..."` parses every workflow file cleanly (script run, all 12 files OK).
- pre-commit's `check-yaml` hook passed on the commit.
- **This is syntax-level validation only.** The workflows cannot be executed locally -- the real test is the first CI run on this PR. Please watch for any startup failures or unexpected annotations on that run before merging.

## Test plan
- [ ] First CI run on this PR completes without startup failures
- [ ] No `Node.js 20 is deprecated` annotations remain on any workflow run
- [ ] Artifact upload/download jobs (data-validation, docs-sync, enhanced-release) succeed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)