### PR TITLE
docs(design): DQ-34 -- leaderboard disclosure tiers

### DIFF
--- a/docs/game-design/DQ_INDEX.md
+++ b/docs/game-design/DQ_INDEX.md
@@ -35,11 +35,12 @@
 | DQ-25 | Desperation-lever revisit | open | 298 |
 | DQ-26 | VC/equity depth revisit | open | 320 |
 | DQ-27 | Mortality guarantee -- where is it ratified? | open | 328 |
-| DQ-28 | Game "phases" as vocabulary + scenario-jump testing | RESOLVED | 617 |
+| DQ-28 | Game "phases" as vocabulary + scenario-jump testing | RESOLVED | 632 |
 | DQ-29 | Cover-up debt | open | 350 |
 | DQ-30 | Economic cycles | open | 359 |
 | DQ-31 | Org/actor taxonomy -- tags, not enums | open | 367 |
 | DQ-32 | News feedline + SA-priced information flow | open | 380 |
 | DQ-33 | Content-pool ladder (artefact promotion/relegation) | open | 399 |
+| DQ-34 | Leaderboard disclosure tiers: score vs reconstructable play | open | 418 |
 
-Total: 34 DQs -- 28 open, 6 with a terminal or advanced status.
+Total: 35 DQs -- 29 open, 6 with a terminal or advanced status.

--- a/docs/game-design/WORKSHOP_2_BACKLOG.md
+++ b/docs/game-design/WORKSHOP_2_BACKLOG.md
@@ -415,6 +415,21 @@ more interesting."*
   pattern), but provenance is recorded everywhere; (d) prove the mechanism at ~200 events before
   scaling. The monthly pool-shift report is itself content: league world-diff, News
   fodder (DQ-32), and dev-blog artifact from one pipeline. Feeds v0.14 pin.
+- **DQ-34 · Leaderboard disclosure tiers: score vs reconstructable play** *(Pip
+  2026-07-21, reviewing #712)* — submitting a score must not automatically make a
+  player's ACTIONS reconstructable by others. Design distinctions: hall-of-fame entry
+  (name, score, seed) vs detailed play data (replay / build guide); full-run sharing
+  likely **opt-in** (Pip leaning away from mandatory, pending how that interacts with
+  provenance). Deliberately sharing your build guide should be something players are
+  PROUD of — the poe.ninja lesson: assume the community WILL build mining/aggregation
+  tools on whatever is public by default, so design the default disclosure surface
+  deliberately rather than discovering it. Naming/attribution of strategies and forks
+  is better left an emergent cultural phenomenon — do not over-prescribe. Technical
+  note: save files and replay strings are effectively the same artifact (ADR-0006
+  replay-as-canonical), so tiering is about which artifacts the server accepts and
+  publishes, not about new formats. Interacts: DQ-3 (cross-version boards), DQ-11
+  (forks), DQ-32 (SA-priced info), DQ-33 (provenance), and the #712 vision doc
+  (held open for Pip's dedicated pass).
 - **L5 finance construction AUTHORIZED (Pip):** loans over months+, player optionality
   among offered instruments (interest-rate intuitions from ADR-0013), "orchestrate the
   construction… in parallel with the other finance ideas" — build lane L5 (#616)


### PR DESCRIPTION
Captures Pip's 2026-07-21 thoughts from reviewing #712: score submission must not auto-expose reconstructable play; hall-of-fame vs detailed-play tiers; opt-in full-run sharing (leaning away from mandatory); the poe.ninja default-disclosure lesson; naming/attribution left emergent; save files == replay strings (ADR-0006). Cross-refs DQ-3/11/32/33. #712 itself stays open for Pip's dedicated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)