### PR TITLE
diag+harden: leaderboard crash diagnostic builds + build-verify/scene-smoke/asset-validation defenses

### DIFF
--- a/docs/LEADERBOARD_CRASH_DIAGNOSIS.md
+++ b/docs/LEADERBOARD_CRASH_DIAGNOSIS.md
@@ -26,18 +26,27 @@ so each pack below is confirmed built from the current source (NOT a stale cache
 | 2 | THEME-STRIPPED | `--export-release` | `tex_cyan_ispf_512` + `tex_oxidized_copper_512` **removed from theme_manager AND absent from the pack** (source files stashed so no `.ctex` is generated -- verified 0 occurrences in the pack) | `G:\Documents\Organising_Life\Code\pdoom1\builds\leaderboard-diag\strip01\PDoom.exe` |
 | 3 | MINIMAL SCENE | `--export-release` | `leaderboard_screen.tscn` at its real path reduced to Control + ColorRect + Label + EntriesContainer stub + Back button, with a dependency-free stub script (`leaderboard_screen_min_stub.gd`) | `G:\Documents\Organising_Life\Code\pdoom1\builds\leaderboard-diag\min01\PDoom.exe` |
 
-Run the **`PDoom.console.exe`** next to each `PDoom.exe` (the console wrapper) so stdout/
-stderr are visible; the plain `PDoom.exe` is windowed and swallows the log.
+Capturing the log (IMPORTANT -- differs by build):
+- **Build 1 (DEBUG)** ships a **`PDoom.console.exe`** wrapper next to `PDoom.exe`. Run the
+  console one so stdout/stderr are visible.
+- **Builds 2 and 3 (RELEASE)** do NOT ship a console wrapper (Godot only emits it for
+  debug exports). Two reliable ways to get the log:
+  1. From a terminal, redirect the GUI exe -- inherited handles are captured even though
+     the window is GUI-subsystem: `PDoom.exe --verbose > run_buildNN.log 2>&1`.
+  2. Or read Godot's own user log afterwards:
+     `%APPDATA%\Godot\app_userdata\P(Doom)\logs\godot.log` (newest entry).
 
 ---
 
 ## Ordered protocol -- run in this order, stop when a step is conclusive
 
-For every run: launch the console exe with `--verbose`, redirect to a log, then play ->
-lose -> press ENTER for leaderboard, and inspect the tail of the log:
+For every run: launch with `--verbose` capturing the log (see "Capturing the log" above --
+console wrapper for the debug build, redirection or the user log for the release builds),
+then play -> lose -> press ENTER for leaderboard, and inspect the tail of the log:
 
 ```
-"C:\path\to\buildNN\PDoom.console.exe" --verbose > run_buildNN.log 2>&1
+# Build 1 (debug):    "C:\...\debug01\PDoom.console.exe" --verbose > run_build1.log 2>&1
+# Builds 2/3 (release): "C:\...\strip01\PDoom.exe"       --verbose > run_build2.log 2>&1
 ```
 
 ### STEP 1 -- Build 1 (DEBUG): get the deepest trace

--- a/docs/LEADERBOARD_CRASH_DIAGNOSIS.md
+++ b/docs/LEADERBOARD_CRASH_DIAGNOSIS.md
@@ -1,0 +1,133 @@
+# Leaderboard crash -- diagnostic builds + ordered kill protocol
+
+Release-blocking bug: the game **segfaults while LOADING the leaderboard scene** on the
+game-over -> leaderboard transition. RELEASE-ONLY. The crash happens **before**
+`leaderboard_screen.gd::_ready` runs (trace prints never fired). Main-menu-from-game-over
+works, so it is leaderboard-scene-specific, not a teardown fault. #728 already swapped the
+leaderboard bg textures for ColorRects and the crash persisted in a verified-fresh build.
+
+This doc is COMMITTED on purpose (must survive compaction). It lists three verified-fresh
+diagnostic builds and the exact ordered protocol to run them. The builds were each
+produced with `tools/build_release.py`, which nukes `godot/.godot`, injects a unique
+marker file, exports, and PROVES the marker is in the `.pck` before emitting the build --
+so each pack below is confirmed built from the current source (NOT a stale cache).
+
+---
+
+## The three diagnostic builds (each verified-fresh at build time)
+
+> Paths are the STABLE copies under the main repo `builds/` tree (gitignored). They are
+> also present in the agent worktree under `builds_diag/` but that worktree may be cleaned
+> up; prefer the stable paths.
+
+| # | Build | Mode | What it changes | Absolute path (PDoom.exe / .console.exe next to PDoom.pck) |
+|---|---|---|---|---|
+| 1 | DEBUG | `--export-debug` | current source + `[LBTRACE-n]` probes in `_ready` | `G:\Documents\Organising_Life\Code\pdoom1\builds\leaderboard-diag\debug01\PDoom.exe` |
+| 2 | THEME-STRIPPED | `--export-release` | `tex_cyan_ispf_512` + `tex_oxidized_copper_512` **removed from theme_manager AND absent from the pack** (source files stashed so no `.ctex` is generated -- verified 0 occurrences in the pack) | `G:\Documents\Organising_Life\Code\pdoom1\builds\leaderboard-diag\strip01\PDoom.exe` |
+| 3 | MINIMAL SCENE | `--export-release` | `leaderboard_screen.tscn` at its real path reduced to Control + ColorRect + Label + EntriesContainer stub + Back button, with a dependency-free stub script (`leaderboard_screen_min_stub.gd`) | `G:\Documents\Organising_Life\Code\pdoom1\builds\leaderboard-diag\min01\PDoom.exe` |
+
+Run the **`PDoom.console.exe`** next to each `PDoom.exe` (the console wrapper) so stdout/
+stderr are visible; the plain `PDoom.exe` is windowed and swallows the log.
+
+---
+
+## Ordered protocol -- run in this order, stop when a step is conclusive
+
+For every run: launch the console exe with `--verbose`, redirect to a log, then play ->
+lose -> press ENTER for leaderboard, and inspect the tail of the log:
+
+```
+"C:\path\to\buildNN\PDoom.console.exe" --verbose > run_buildNN.log 2>&1
+```
+
+### STEP 1 -- Build 1 (DEBUG): get the deepest trace
+The earlier "debug didn't crash" was very likely itself a STALE build. Build 1 is a
+verified-fresh debug export; a debug build installs a crash handler that prints a
+**symbolized backtrace** on segfault -- the single most valuable signal.
+
+Look for, in `run_build1.log`:
+- `[LBDIAG-TRACE-DEBUG-01] ... _ready ENTERED` and the `[LBTRACE-1..6]` lines.
+- A crash dump ("Dumping the backtrace" + stack frames).
+
+Interpretation:
+- **No `[LBTRACE]` lines + a backtrace** -> crash is genuinely pre-`_ready`. The backtrace
+  names the native call (scene/resource loader, text server, or renderer). This is the
+  deepest lever -- read the top non-Godot-internal frame. GO no further until you've read
+  this trace; it may name the cause outright.
+- **Some `[LBTRACE-n]` lines then crash** -> the crash is actually INSIDE `_ready` at step
+  `n+1` (the pre-`_ready` claim was a stale-build artifact). Jump to the named call.
+- **Build 1 does NOT crash at all** -> confirmed release-only (optimizer/renderer). Go to
+  STEP 2/3 (release builds) to isolate.
+
+### STEP 2 -- Build 2 (RELEASE, textures ABSENT): exonerate or convict the textures
+The two suspect textures are **not in this pack at all** (verified: 0 occurrences).
+
+- **Still crashes** -> textures are **fully EXONERATED**. This is the expected outcome
+  given the code reading (nothing ever `load()`s them; they were dead string paths). Go to
+  STEP 3.
+- **No crash** -> textures WERE implicated despite never being loaded by game code (would
+  implicate the `all_resources` packing / a pack-time decode path). Fix = keep them
+  excluded/deleted; done.
+
+### STEP 3 -- Build 3 (RELEASE, MINIMAL scene): structure vs content
+Build 3 puts a bare scene at the real `res://scenes/leaderboard_screen.tscn` path.
+
+- **Minimal LOADS fine (reaches the minimal board, `[LBMIN-TRACE]` prints)** -> the crash
+  is in the REAL scene's structure/content, not the transition. Binary-search it back:
+  copy the real scene, delete ~half its nodes, rebuild with `tools/build_release.py`,
+  retest; halve until the offending node/sub-resource is isolated. Prime suspects, in
+  order: the `OptionButton` (SeedDropdown -- instantiates an internal PopupMenu; unique to
+  this scene, absent from welcome/game-over), then the `Panel` + `ScrollContainer` nesting,
+  then the emoji Labels (though welcome.tscn also has an emoji Label and loads fine).
+- **Minimal ALSO crashes** -> the fault is more fundamental than scene content: the
+  game-over -> leaderboard scene-CHANGE path itself, or a renderer/text-server interaction
+  triggered by ANY scene at this path in a release build. Diff against the welcome.tscn
+  transition (which works) for the differentiator.
+
+---
+
+## Rebuilding any variant (for the STEP 3 binary search)
+
+Always rebuild through the verify-the-pack tool -- never a raw `--export`:
+
+```
+python tools/build_release.py --mode release --output builds/leaderboard-diag/probeNN
+```
+
+It refuses to emit a build whose pack does not contain its injected marker, so you can
+never again waste a cycle testing a stale pack.
+
+## Reproducing the minimal build (Build 3) from scratch
+1. `cp godot/scenes/leaderboard_screen_minimal.tscn godot/scenes/leaderboard_screen.tscn`
+   then fix the uid line back to `uid://c8jkm2s8cdp4t` (keeps other refs stable).
+2. `python tools/build_release.py --mode release --output builds/leaderboard-diag/min01`
+3. `git checkout -- godot/scenes/leaderboard_screen.tscn` to restore the real scene.
+
+---
+
+## Best current hypothesis (from reading the scene + theme code)
+
+Reading the code (not yet confirmed by a live trace -- headless cannot reproduce this):
+
+1. **Textures are almost certainly NOT the cause.** `tex_cyan_ispf` / `tex_oxidized_copper`
+   are referenced ONLY as dead string paths in `theme_manager.gd`; nothing ever
+   `preload`/`load`s them. Meanwhile `welcome.tscn` loads REAL textures (as `TextureRect`
+   ext_resources) and is the boot scene -- it loads fine. So "textured scene" is not the
+   discriminator; the leaderboard scene is now textureless yet crashes. Build 2 is the
+   falsification test.
+2. **The script preload chain is clean.** `leaderboard_screen.gd` member-preloads
+   `scripts/leaderboard.gd`, which has no resource dependencies, and `game_over_screen.gd`
+   already uses the `Leaderboard` class successfully -- so that dependency is resolved
+   before the transition and is not the fault.
+3. **Leading suspect: the `OptionButton` (SeedDropdown).** It is the one node type unique
+   to this scene (absent from welcome and game-over). `OptionButton` builds an internal
+   `PopupMenu`/`Window` sub-resource at instantiation; a Window/Popup created during a
+   scene-change, in a release renderer, is a plausible pre-`_ready` native-crash site.
+   Build 3 (which has NO OptionButton) is the direct test: if Build 3 loads and the real
+   scene does not, the OptionButton is the prime candidate to bisect to first.
+
+Ranked: (a) OptionButton/PopupMenu instantiation in the release renderer ~45%; (b) some
+other scene sub-resource/structure interaction ~30%; (c) the scene-change machinery itself
+on this specific transition ~15%; (d) textures ~5%; (e) something else ~5%. Build 3's
+result splits (a)+(b) from (c), and Build 1's backtrace should name the native frame
+directly.

--- a/docs/POSTMORTEM_v0.11.0_ALPHA.md
+++ b/docs/POSTMORTEM_v0.11.0_ALPHA.md
@@ -1,0 +1,110 @@
+# Postmortem -- v0.11.0 friends-and-family alpha
+
+Status: living document. This file is created on branch
+`fix/leaderboard-crash-deep-diagnosis`; if PR #730 (the earlier postmortem/lessons
+doc) lands first, fold these sections in rather than duplicating.
+
+The release was blocked for an extended period by a single release-only segfault
+(game-over -> leaderboard). The engineering cost was dominated NOT by the bug itself
+but by a diagnostic-tooling trap that made every test cycle lie. The lessons below are
+ordered by how much time they cost.
+
+---
+
+## Lesson 1 (most expensive): Godot's `.godot/exported/` cache silently ships STALE scenes
+
+### What happened
+Every export run from the release-build worktree packed an OLD, converted copy of the
+leaderboard scene. Fixes (the #728 texture->ColorRect swap) and diagnostic `printerr`
+traces were written, committed, and exported -- and were simply NOT in the build that
+was tested. ~12 test cycles were burned "reproducing" a bug that the current source may
+already have changed, because nobody could prove which source a given `.pck` was built
+from. `--import` did NOT clear the stale artifact; deleting `.godot/exported/` alone did
+not reliably clear it either.
+
+### Root cause
+Godot caches converted/imported artifacts under `godot/.godot/` (including
+`.godot/exported/`). Under some worktree/cache states the exporter reuses a stale
+converted scene instead of reconverting from the `.tscn` source.
+
+### The discipline (now enforced in code)
+1. **Before ANY export: `rm -rf godot/.godot`** to force a genuine from-scratch build.
+2. **Prove the pack is fresh** before trusting it (next lesson).
+`tools/build_release.py` does both and refuses to emit an unverified build.
+
+---
+
+## Lesson 2: "grep the pack for a string you added" does NOT work here -- anchor on a FILENAME
+
+The natural freshness check -- add a unique `printerr("TAG")` to a script, then grep the
+`.pck` for `TAG` -- is UNRELIABLE in this project's export config, and quietly so.
+
+### Why (verified 2026-07-21)
+This project exports GDScript as **binary-tokenized `.gdc`** (the pack lists
+`res://scripts/ui/leaderboard_screen.gdc` + a `.gd.remap`). String LITERALS inside
+scripts do **not** survive as grep-able UTF-8 (nor UTF-16, nor UTF-32) in the pack.
+Grepping the pack for an existing script string such as `"Leaderboard screen opened"`
+returns **nothing**.
+
+What DOES survive, reliably, is **resource PATHS / filenames** in the pack's file table:
+grepping for `res://scripts/leaderboard.gd` or the substring `leaderboard_screen` hits.
+
+### The reliable anchor
+Drop a **uniquely-named marker file** into the project immediately before export (e.g.
+`buildstamp<uuidhex>.gd`), then grep the pack for that unique token. Its `res://` path
+lands in the file table, so a hit proves the pack was built from the current working
+tree. This is what `tools/build_release.py` injects and verifies; a miss aborts the
+build non-zero.
+
+Corollary correction to earlier notes (SESSION_STATUS_2026-07-21): the advice to "grep
+the pack for a SCRIPT string you added (e.g. an added printerr tag)" should be replaced
+with "grep the pack for a unique marker FILENAME you added."
+
+---
+
+## Lesson 3: `export_filter="all_resources"` packs textures regardless of code references
+
+The leaderboard segfault was suspected to involve two background textures
+(`tex_cyan_ispf_512`, `tex_oxidized_copper_512`) that were referenced only as **dead
+string paths** in `theme_manager.gd` (stored, never `preload`/`load`-ed). A natural fix
+-- "remove the strings so the textures are not packed" -- does NOT unpack them: the
+Windows preset uses `export_filter="all_resources"`, which packs every resource in the
+project irrespective of references.
+
+Consequences for diagnosis:
+- Removing the `theme_manager.gd` strings is still worth doing (kills a dead reference)
+  but changes nothing about what is packed.
+- To PROVE a texture is not the cause, the source asset (and its import sidecar) must be
+  **absent** so no imported `.ctex` artifact is generated. Excluding only the source
+  `*.png` via `exclude_filter` leaves the imported `.ctex` (hashed name still contains
+  the source stem) in the pack -- partial, not conclusive.
+
+---
+
+## Lesson 4: the render-gate limitation -- what headless CANNOT catch
+
+Headless Godot (tests, `--import`, `--script` probes, even a verified-fresh pack) uses a
+dummy rendering/audio driver. It does **not** GPU-decode textures, allocate real VRAM,
+or run the platform's release-mode renderer. Therefore:
+- A crash that only manifests in a **release export on a real GPU** will not reproduce in
+  any headless check. The v0.11.0 leaderboard segfault is exactly this class (it did not
+  reproduce headless; the existing smoke test already instantiate()s the scene cleanly).
+- Headless gates (`test_smoke_load_all.gd`, the new `test_ui_scene_ready_smoke.gd`,
+  `validate_assets.py`) are **necessary but not sufficient**. The final ship gate is a
+  **human playing a release build** through the exact transition (play -> lose ->
+  leaderboard) on real hardware.
+
+---
+
+## Defenses added on `fix/leaderboard-crash-deep-diagnosis`
+
+| Defense | File | Catches |
+|---|---|---|
+| From-clean export + pack-freshness verify (marker filename) | `tools/build_release.py` | stale-cache builds (Lessons 1-2) |
+| UI-scene add-to-tree + `_ready` smoke | `godot/tests/unit/test_ui_scene_ready_smoke.gd` | `_ready`-time faults the instantiate-only smoke missed |
+| Asset-import validation gate | `tools/validate_assets.py` + `godot/tools/validate_assets_probe.gd` | a corrupt/undecodable asset before it ships |
+| Ordered crash-diagnosis protocol + diagnostic builds | `docs/LEADERBOARD_CRASH_DIAGNOSIS.md` | reproducing + isolating THIS crash |
+
+All three defenses are honest about the render-gate limit (Lesson 4): they harden the
+whole class of load-time faults, but the human release-build playtest remains the gate
+that would have caught this specific segfault fastest.

--- a/godot/autoload/theme_manager.gd
+++ b/godot/autoload/theme_manager.gd
@@ -126,7 +126,12 @@ class ThemeData:
 		"tex_blue_bsod_pattern": "res://assets/textures/terminal/tex_blue_bsod_pattern_512.png",
 		"tex_gray_lowcontrast": "res://assets/textures/terminal/tex_gray_lowcontrast_512.png",
 		"tex_gray_dither": "res://assets/textures/terminal/tex_gray_dither_512.png",
-		"tex_cyan_ispf": "res://assets/textures/terminal/tex_cyan_ispf_512.png",
+		# tex_cyan_ispf removed (v0.11.0 leaderboard-crash diagnosis): it was referenced
+		# ONLY here as a dead string path (nothing preloads/loads it) and was a suspect in
+		# the release-only leaderboard segfault. Removed to eliminate the code-level
+		# reference. NOTE: export_presets uses export_filter="all_resources", so the PNG is
+		# still PACKED regardless of this string -- true exclusion needs exclude_filter or
+		# deleting the file. See docs/LEADERBOARD_CRASH_DIAGNOSIS.md.
 		"tex_cyan_border": "res://assets/textures/terminal/tex_cyan_border_512.png",
 
 		# Surface textures (backgrounds/materials)
@@ -138,7 +143,9 @@ class ThemeData:
 		"tex_painted_metal_panel": "res://assets/textures/surfaces/tex_painted_metal_panel_512.png",
 		"tex_plywood_stained": "res://assets/textures/surfaces/tex_plywood_stained_512.png",
 		"tex_crt_burnin": "res://assets/textures/surfaces/tex_crt_burnin_512.png",
-		"tex_oxidized_copper": "res://assets/textures/surfaces/tex_oxidized_copper_512.png",
+		# tex_oxidized_copper removed (v0.11.0 leaderboard-crash diagnosis): dead string
+		# reference only; a leaderboard-segfault suspect. See the note on tex_cyan_ispf above
+		# and docs/LEADERBOARD_CRASH_DIAGNOSIS.md (all_resources still packs the PNG).
 		"tex_bakelite_cracked": "res://assets/textures/surfaces/tex_bakelite_cracked_512.png",
 	}
 

--- a/godot/scenes/leaderboard_screen_minimal.tscn
+++ b/godot/scenes/leaderboard_screen_minimal.tscn
@@ -1,0 +1,47 @@
+[gd_scene load_steps=2 format=3 uid="uid://b7lbminimaldiag01"]
+
+; Diagnostic MINIMAL leaderboard scene (v0.11.0 leaderboard-crash isolation).
+; Bare Control + Background ColorRect + one Label + a Back Button + an empty
+; EntriesContainer stub, attached to a dependency-free stub script. Used to test
+; whether the release-only game-over -> leaderboard segfault is the scene STRUCTURE /
+; sub-resources / scene-change machinery (pre-_ready) vs the real scene's content.
+; See docs/LEADERBOARD_CRASH_DIAGNOSIS.md. NOT shipped: copied over
+; leaderboard_screen.tscn only to build the diagnostic "min" pack.
+
+[ext_resource type="Script" path="res://scripts/ui/leaderboard_screen_min_stub.gd" id="1_stub"]
+
+[node name="LeaderboardScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_stub")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(0.090196, 0.039216, 0.109804, 1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Title" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Leaderboard (minimal diagnostic)"
+horizontal_alignment = 1
+
+[node name="EntriesContainer" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Back"
+
+[connection signal="pressed" from="VBoxContainer/BackButton" to="." method="_on_back_button_pressed"]

--- a/godot/scripts/ui/leaderboard_screen.gd
+++ b/godot/scripts/ui/leaderboard_screen.gd
@@ -35,15 +35,32 @@ var global_toggle_button: Button = null
 @onready var best_score_label = $MarginContainer/VBoxContainer/Stats/BestScore
 @onready var subtitle = $MarginContainer/VBoxContainer/Header/Subtitle
 
+# Diagnostic RUNTIME trace stamp (issue: release-only leaderboard segfault). This is a
+# STDERR signal, NOT a pack-freshness anchor: in this export config GDScript is packed
+# as binary-tokenized .gdc, so string literals do NOT survive as grep-able text (verified
+# -- see docs/LEADERBOARD_CRASH_DIAGNOSIS.md). Pack freshness is proven separately via a
+# unique marker FILENAME (tools/build_release.py). What this printerr buys us: if a
+# --verbose run of the diagnostic build shows this line, _ready began (crash is later);
+# if it NEVER appears, the crash is pre-_ready (scene load / node instantiation) -- the
+# observed case.
+const LB_DIAG_BUILDSTAMP := "[LBDIAG-TRACE-DEBUG-01]"
+
 func _ready():
+	printerr("%s leaderboard_screen _ready ENTERED" % LB_DIAG_BUILDSTAMP)
+	printerr("[LBTRACE-1] before ErrorHandler.info")
 	ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Leaderboard screen opened", {})
+	printerr("[LBTRACE-2] before _discover_boards")
 	# Cheap open: list board files (no parse), populate the dropdown, then show ONLY
 	# the current/most-relevant board. The full all-seeds aggregate is parsed lazily
 	# in _ensure_aggregate_loaded when the user selects "All Seeds".
 	_discover_boards()
+	printerr("[LBTRACE-3] before _populate_seed_dropdown")
 	_populate_seed_dropdown()
+	printerr("[LBTRACE-4] before _setup_global_toggle")
 	_setup_global_toggle()
+	printerr("[LBTRACE-5] before _select_default_view")
 	_select_default_view()
+	printerr("[LBTRACE-6] _ready COMPLETE")
 
 func _exit_tree():
 	# Cleanup guard: drop the working-set references the instant the screen leaves

--- a/godot/scripts/ui/leaderboard_screen_min_stub.gd
+++ b/godot/scripts/ui/leaderboard_screen_min_stub.gd
@@ -1,0 +1,14 @@
+extends Control
+## Diagnostic STUB for the minimal-leaderboard build (v0.11.0 leaderboard-crash
+## isolation). Attached to leaderboard_screen_minimal.tscn. Deliberately dependency-free:
+## no preloads, no autoload calls, no @onready node derefs -- so a crash while LOADING
+## the minimal scene can only be the scene STRUCTURE / sub-resources / the scene-change
+## machinery itself, NOT the real leaderboard_screen.gd content. See
+## docs/LEADERBOARD_CRASH_DIAGNOSIS.md for how this is used.
+
+func _ready() -> void:
+	printerr("[LBMIN-TRACE] minimal leaderboard stub _ready ENTERED")
+
+func _on_back_button_pressed() -> void:
+	printerr("[LBMIN-TRACE] back pressed")
+	get_tree().change_scene_to_file("res://scenes/welcome.tscn")

--- a/godot/scripts/ui/leaderboard_screen_min_stub.gd.uid
+++ b/godot/scripts/ui/leaderboard_screen_min_stub.gd.uid
@@ -1,0 +1,1 @@
+uid://b2kyjphmq0ry5

--- a/godot/tests/unit/test_ui_scene_ready_smoke.gd
+++ b/godot/tests/unit/test_ui_scene_ready_smoke.gd
@@ -1,0 +1,131 @@
+extends GutTest
+## UI-scene _ready smoke test (anti-hollow uplift, ADR-0017).
+##
+## WHY THIS EXISTS: the v0.11.0-alpha release-blocker was a segfault while LOADING
+## the leaderboard scene on the game-over -> leaderboard transition. The existing
+## test_smoke_load_all.gd instantiate()s every scene but NEVER enters the SceneTree,
+## so _ready() never runs -- it cannot see a fault that happens at add-to-tree time.
+## This test closes that specific gap: it INSTANTIATES + ADDS-TO-TREE + runs _ready()
+## on every standalone UI screen and every scene under scenes/ui/**, asserting the
+## process survives (no crash) and the node is still valid after a frame.
+##
+## WHAT IT CATCHES: a null-deref / bad @onready path / autoload-contract break / any
+## GDScript fault that fires in _ready() and takes the process down. A hard native
+## crash kills the whole run -> the runner reports missing results -> RED (exactly the
+## signal we want for the leaderboard fault, IF it reproduces headlessly).
+##
+## RENDER-GATE LIMITATION (read before trusting a green here): headless Godot uses a
+## dummy rendering/audio driver. It does NOT GPU-decode textures, allocate real VRAM,
+## or run the platform's release-mode renderer. A crash that only manifests in a
+## release EXPORT with a real GPU (the class the v0.11.0 leaderboard segfault is
+## suspected to be) will NOT reproduce here. This test is a necessary gate, not a
+## sufficient one: the human release-build playtest (play -> lose -> leaderboard on a
+## real machine) remains the final ship gate. See docs/LEADERBOARD_CRASH_DIAGNOSIS.md.
+
+# Every scene under these roots is swept recursively.
+const SCENE_DIR_ROOTS := ["res://scenes/ui"]
+
+# Standalone top-level screens (navigation targets) added explicitly. main.tscn is
+# deliberately EXCLUDED: adding it to the tree boots the entire game (timers, audio,
+# turn manager) with side effects unsuitable for a smoke test; the existing
+# test_smoke_load_all.gd::test_main_scene_chain_instantiates covers its load path.
+const EXPLICIT_SCENES := [
+	"res://scenes/welcome.tscn",
+	"res://scenes/leaderboard_screen.tscn",
+	"res://scenes/pregame_setup.tscn",
+	"res://scenes/settings_menu.tscn",
+	"res://scenes/pause_menu.tscn",
+	"res://scenes/keybind_screen.tscn",
+	"res://scenes/player_guide.tscn",
+	"res://scenes/config_confirmation.tscn",
+]
+
+# Scenes whose _ready() self-navigates or hard-requires an in-progress game such that
+# adding them cold would disrupt the run. Each entry MUST carry a justification -- an
+# empty/undocumented skip is how a test goes hollow. (Empty today; kept as the
+# documented escape hatch so a future problem scene is skipped visibly, not silently.)
+const SKIP := {}
+
+# Floor so the sweep cannot pass vacuously if the tree is moved/renamed.
+const MIN_SCENES := 12
+
+
+func _collect(root: String, ext: String) -> Array:
+	var out: Array = []
+	var dir := DirAccess.open(root)
+	if dir == null:
+		return out
+	dir.list_dir_begin()
+	var name := dir.get_next()
+	while name != "":
+		if name == "." or name == "..":
+			name = dir.get_next()
+			continue
+		var path := root + "/" + name
+		if dir.current_is_dir():
+			out.append_array(_collect(path, ext))
+		elif name.ends_with(ext):
+			out.append(path)
+		name = dir.get_next()
+	dir.list_dir_end()
+	return out
+
+
+func _all_scenes() -> Array:
+	var scenes: Array = []
+	for root in SCENE_DIR_ROOTS:
+		scenes.append_array(_collect(root, ".tscn"))
+	for s in EXPLICIT_SCENES:
+		if not scenes.has(s):
+			scenes.append(s)
+	scenes.sort()
+	return scenes
+
+
+func test_ui_scenes_ready_without_crash():
+	var scenes := _all_scenes()
+	assert_gte(scenes.size(), MIN_SCENES,
+		"sweep found only %d UI scenes (< floor %d) -- the walk may be hollow" % [scenes.size(), MIN_SCENES])
+
+	var processed := 0
+	var failed: Array = []
+	for path in scenes:
+		if SKIP.has(path):
+			gut.p("  SKIP (%s): %s" % [SKIP[path], path])
+			continue
+
+		var packed = load(path)
+		if packed == null or not (packed is PackedScene) or not packed.can_instantiate():
+			failed.append("%s (load/can_instantiate failed)" % path)
+			continue
+
+		var inst = packed.instantiate()
+		if inst == null:
+			failed.append("%s (instantiate returned null)" % path)
+			continue
+
+		# add_child fires _ready(). If _ready() hard-crashes the engine, the whole
+		# process dies here and the runner reports missing results (RED) -- which is
+		# the intended detection for the leaderboard-class fault.
+		add_child(inst)
+		# Two frames: let _ready() run and one idle tick settle (deferred calls, first
+		# layout pass) before we tear the node down.
+		await get_tree().process_frame
+		await get_tree().process_frame
+
+		# Reaching here proves no hard crash. is_instance_valid guards the rare scene
+		# that legitimately frees itself in _ready (would be a false-negative to assert
+		# against); we only require that we survived and can clean up.
+		if is_instance_valid(inst):
+			remove_child(inst)
+			inst.free()
+		processed += 1
+
+	if not failed.is_empty():
+		for f in failed:
+			gut.p("  FAILED: %s" % f)
+	assert_eq(failed.size(), 0,
+		"%d UI scene(s) failed to instantiate/enter-tree (see list above)" % failed.size())
+	assert_gte(processed, MIN_SCENES,
+		"only %d UI scenes ran _ready (< floor %d)" % [processed, MIN_SCENES])
+	gut.p("ui-ready smoke: %d UI scenes entered the tree and ran _ready cleanly" % processed)

--- a/godot/tests/unit/test_ui_scene_ready_smoke.gd.uid
+++ b/godot/tests/unit/test_ui_scene_ready_smoke.gd.uid
@@ -1,0 +1,1 @@
+uid://cbpp7k52cno6g

--- a/godot/tools/validate_assets_probe.gd
+++ b/godot/tools/validate_assets_probe.gd
@@ -1,0 +1,86 @@
+extends SceneTree
+## Asset-import validation probe (run headless via tools/validate_assets.py).
+##
+## PURPOSE: catch a bad-asset landmine BEFORE it ships -- a corrupt/undecodable texture
+## or resource that imports "successfully" but fails to load, which is exactly the kind
+## of silent time-bomb that could crash a release build. It walks res://assets, LOADS
+## every importable resource, and asserts each one resolves to a non-null resource of a
+## sane type. A failure names the file and sets a non-zero exit code.
+##
+## HEADLESS-SAFE CHECKS ONLY: textures are validated by metadata (get_width/get_height
+## > 0), NOT by get_image() -- VRAM-compressed textures legitimately discard their CPU
+## image under the headless dummy renderer, so a get_image() check would false-fail. So
+## this proves the resource is STRUCTURALLY loadable; it does NOT GPU-decode. That last
+## mile is the human release-build playtest (see docs/LEADERBOARD_CRASH_DIAGNOSIS.md).
+
+const ASSET_ROOT := "res://assets"
+
+# Extensions we treat as loadable Godot resources. (.import sidecars and .uid are meta.)
+const LOADABLE_EXT := [
+	"png", "jpg", "jpeg", "webp", "svg", "bmp", "tga",   # textures
+	"ogg", "wav", "mp3",                                  # audio
+	"ttf", "otf", "woff", "woff2",                        # fonts
+	"tres", "res",                                        # packed resources
+]
+
+# Floor so a moved/emptied asset tree fails LOUDLY instead of passing vacuously.
+const MIN_ASSETS := 200
+
+
+func _collect(root: String) -> Array:
+	var out: Array = []
+	var dir := DirAccess.open(root)
+	if dir == null:
+		return out
+	dir.list_dir_begin()
+	var name := dir.get_next()
+	while name != "":
+		if name == "." or name == "..":
+			name = dir.get_next()
+			continue
+		var path := root + "/" + name
+		if dir.current_is_dir():
+			out.append_array(_collect(path))
+		else:
+			var ext := name.get_extension().to_lower()
+			if LOADABLE_EXT.has(ext):
+				out.append(path)
+		name = dir.get_next()
+	dir.list_dir_end()
+	return out
+
+
+func _init():
+	print("[validate_assets] walking %s ..." % ASSET_ROOT)
+	var assets := _collect(ASSET_ROOT)
+	assets.sort()
+	print("[validate_assets] found %d loadable asset files" % assets.size())
+
+	var failures: Array = []
+	var checked := 0
+	for path in assets:
+		var res = ResourceLoader.load(path)
+		if res == null:
+			failures.append("%s (ResourceLoader.load returned null -- corrupt or failed import)" % path)
+			continue
+		if res is Texture2D:
+			var tex := res as Texture2D
+			if tex.get_width() <= 0 or tex.get_height() <= 0:
+				failures.append("%s (Texture2D has non-positive size %dx%d)" % [path, tex.get_width(), tex.get_height()])
+				continue
+		checked += 1
+
+	print("[validate_assets] checked=%d  failed=%d" % [checked, failures.size()])
+	for f in failures:
+		printerr("[validate_assets][FAIL] %s" % f)
+
+	if assets.size() < MIN_ASSETS:
+		printerr("[validate_assets][FATAL] found only %d assets (< floor %d) -- the walk itself may be hollow" % [assets.size(), MIN_ASSETS])
+		quit(2)
+		return
+	if not failures.is_empty():
+		printerr("[validate_assets][FATAL] %d asset(s) failed to load -- DO NOT SHIP" % failures.size())
+		quit(1)
+		return
+	print("[validate_assets][PASS] all %d assets loaded structurally cleanly" % checked)
+	quit(0)

--- a/godot/tools/validate_assets_probe.gd.uid
+++ b/godot/tools/validate_assets_probe.gd.uid
@@ -1,0 +1,1 @@
+uid://dn1ccjxw0ogji

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -1,0 +1,224 @@
+# !/usr/bin/env python3
+"""
+build_release.py -- export a P(Doom) build FROM A VERIFIED-CLEAN STATE.
+
+WHY THIS EXISTS (the hard-won lesson behind v0.11.0-alpha):
+    Godot's `godot/.godot/exported/` cache can silently pack a STALE converted scene.
+    Running `--import` does NOT clear it. The result: an export command reports SUCCESS
+    while packing OLD scenes/scripts -- so a fix (or a diagnostic trace) you KNOW you
+    wrote is simply not in the build you test. ~12 test cycles were burned re-running an
+    already-fixed bug because nobody could prove which source a given .pck was built from.
+
+THE DISCIPLINE THIS TOOL ENFORCES (no build ships unverified):
+    1. `rm -rf godot/.godot` BEFORE the export -- forces a genuine from-scratch build.
+    2. Drop a UNIQUELY-NAMED marker script into the project so its res:// path lands in
+       the exported pack's file table.
+    3. Export, then VERIFY the marker's unique token is present in the .pck (or the exe,
+       if the pack is embedded). If it is missing, the export was served stale -> this
+       tool exits NON-ZERO and LOUD. A green build here means the pack provably reflects
+       the current working tree.
+
+FRESHNESS-ANCHOR NOTE (why a marker FILE, not a grepped string):
+    In this project's export config, GDScript is packed as binary-tokenized `.gdc`, so
+    string LITERALS inside scripts do NOT survive as grep-able text -- the old
+    "grep the pack for a printerr tag" advice is UNRELIABLE here. Resource PATHS/filenames
+    DO survive in the pack file table. So we anchor on a unique FILENAME, which is a
+    reliable, encoding-independent freshness proof.
+
+RENDER-GATE LIMITATION:
+    A clean, verified pack proves the RIGHT BITS shipped. It does NOT prove the game runs
+    on a real GPU -- headless tooling never GPU-decodes textures or runs the release
+    renderer. The human release-build playtest remains the final ship gate.
+
+Usage:
+    python tools/build_release.py                       # release, Windows, default paths
+    python tools/build_release.py --mode debug          # debug build (symbolized crash backtrace)
+    python tools/build_release.py --preset "Windows Desktop" --output builds/win
+    python tools/build_release.py --godot-path "C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe"
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_GODOT_CANDIDATES = [
+    Path("C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe"),
+    Path("C:/Program Files/Godot/Godot.exe"),
+    Path.home() / "Godot" / "Godot_v4.5.1-stable_win64.exe",
+    Path("/usr/bin/godot"),
+    Path("/usr/local/bin/godot"),
+    Path("/Applications/Godot.app/Contents/MacOS/Godot"),
+]
+
+
+def find_godot(explicit: Optional[str]) -> Path:
+    if explicit:
+        p = Path(explicit)
+        if not p.exists():
+            fail(f"--godot-path does not exist: {p}")
+        return p
+    for cand in DEFAULT_GODOT_CANDIDATES:
+        if cand.exists():
+            return cand
+    which = shutil.which("godot")
+    if which:
+        return Path(which)
+    fail("Godot executable not found; pass --godot-path")
+    raise SystemExit(2)  # unreachable; keeps type-checkers happy
+
+
+def fail(msg: str) -> None:
+    print(f"\n[BUILD-VERIFY][FATAL] {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def info(msg: str) -> None:
+    print(f"[build_release] {msg}")
+
+
+def run(cmd: list[str], cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
+    info("run: " + " ".join(str(c) for c in cmd))
+    return subprocess.run(cmd, cwd=str(cwd) if cwd else None, text=True, check=False)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--godot-path", default=None, help="Path to the Godot 4.5.1 executable.")
+    ap.add_argument("--preset", default="Windows Desktop", help="export_presets.cfg preset name.")
+    ap.add_argument("--mode", choices=["release", "debug"], default="release", help="Export mode.")
+    ap.add_argument(
+        "--output", default=None, help="Output directory (default: builds/<preset-slug>)."
+    )
+    ap.add_argument("--project", default=None, help="Godot project dir (default: <repo>/godot).")
+    ap.add_argument(
+        "--no-clean",
+        action="store_true",
+        help="Skip the rm -rf .godot from-scratch step (NOT recommended).",
+    )
+    ap.add_argument(
+        "--keep-marker",
+        action="store_true",
+        help="Leave the freshness marker file in the project tree.",
+    )
+    args = ap.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    project = Path(args.project).resolve() if args.project else (repo_root / "godot")
+    if not (project / "project.godot").exists():
+        fail(f"no project.godot under {project}")
+
+    godot = find_godot(args.godot_path)
+    info(f"Godot: {godot}")
+    info(f"Project: {project}")
+    info(f"Mode: {args.mode}   Preset: {args.preset}")
+
+    out_dir = (
+        Path(args.output).resolve()
+        if args.output
+        else (repo_root / "builds" / args.preset.replace(" ", "_").lower())
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    exe_path = out_dir / "PDoom.exe"
+
+    dot_godot = project / ".godot"
+
+    # ---- STEP 1: from-scratch state (the anti-stale-cache core) -----------------
+    if not args.no_clean:
+        if dot_godot.exists():
+            info(
+                f"rm -rf {dot_godot}  (forcing a from-scratch build; clears .godot/exported cache)"
+            )
+            shutil.rmtree(dot_godot, ignore_errors=True)
+        else:
+            info(".godot absent already (clean).")
+    else:
+        info("--no-clean set: NOT clearing .godot (stale-cache risk accepted by caller).")
+
+    # ---- STEP 2: unique freshness marker ----------------------------------------
+    token = "buildstamp" + uuid.uuid4().hex  # e.g. buildstamp3f9a...  (alnum, grep-safe)
+    marker_path = project / f"{token}.gd"
+    marker_path.write_text(
+        "extends Node\n"
+        "# Auto-generated build-freshness marker (tools/build_release.py). Safe to delete.\n"
+        f'const MARKER := "{token}"\n',
+        encoding="utf-8",
+    )
+    info(f"wrote freshness marker: {marker_path.name}")
+
+    try:
+        # ---- STEP 3: import (populates a fresh .godot incl. the marker) ----------
+        r = run([str(godot), "--headless", "--path", str(project), "--import"])
+        # Import can exit non-zero on benign class-cache noise in a cold tree; do not
+        # gate on it. The export below is the real gate.
+        if r.returncode != 0:
+            info(f"import returned {r.returncode} (tolerated; cold-cache noise is expected).")
+
+        # ---- STEP 4: export -----------------------------------------------------
+        export_flag = "--export-release" if args.mode == "release" else "--export-debug"
+        r = run(
+            [
+                str(godot),
+                "--headless",
+                "--path",
+                str(project),
+                export_flag,
+                args.preset,
+                str(exe_path),
+            ]
+        )
+        if r.returncode != 0:
+            fail(f"godot {export_flag} exited {r.returncode} (see output above).")
+        if not exe_path.exists():
+            fail(f"export reported success but {exe_path} does not exist.")
+
+        # ---- STEP 5: VERIFY the pack is fresh -----------------------------------
+        pck_path = exe_path.with_suffix(".pck")
+        search_targets = [p for p in (pck_path, exe_path) if p.exists()]
+        needle = token.encode("ascii")
+        found_in = None
+        for tgt in search_targets:
+            data = tgt.read_bytes()
+            if needle in data:
+                found_in = tgt
+                break
+        if found_in is None:
+            fail(
+                "FRESHNESS CHECK FAILED: marker '%s' NOT found in %s.\n"
+                "  The exported pack does NOT reflect the current working tree -- it was\n"
+                "  almost certainly served from a STALE .godot/exported cache. DO NOT SHIP.\n"
+                "  Re-run WITHOUT --no-clean." % (token, [str(t) for t in search_targets])
+            )
+
+        # ---- success ------------------------------------------------------------
+        size_mb = (pck_path.stat().st_size if pck_path.exists() else exe_path.stat().st_size) / (
+            1024 * 1024
+        )
+        print("\n" + "=" * 68)
+        print("[BUILD-VERIFY][PASS] pack is provably fresh.")
+        print(f"  marker token : {token}")
+        print(f"  found in     : {found_in}")
+        print(f"  exe          : {exe_path}")
+        if pck_path.exists():
+            print(f"  pck          : {pck_path}  ({size_mb:.1f} MB)")
+        print(f"  mode         : {args.mode}")
+        print("=" * 68)
+        print("REMINDER: a fresh, verified pack proves the RIGHT BITS shipped. It does NOT")
+        print("prove the game runs on a real GPU. The human release-build playtest")
+        print("(play -> lose -> leaderboard on a real machine) is the final ship gate.")
+        return 0
+    finally:
+        if not args.keep_marker and marker_path.exists():
+            marker_path.unlink()
+            info(f"removed freshness marker: {marker_path.name}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_assets.py
+++ b/tools/validate_assets.py
@@ -1,0 +1,115 @@
+# !/usr/bin/env python3
+"""
+validate_assets.py -- pre-release asset-import validation gate.
+
+WHY THIS EXISTS: a corrupt or undecodable texture/resource can import "successfully"
+in the editor yet fail to load at runtime -- a silent landmine that could crash a
+release build the first time a scene references it. This gate reimports the project
+from a clean asset cache and then LOADS every resource under godot/assets, failing
+loudly (non-zero exit) if any asset does not resolve. Run it before cutting a build.
+
+WHAT IT DOES:
+    1. (default) `godot --import` so the asset cache reflects the current tree.
+    2. Runs godot/tools/validate_assets_probe.gd headless, which walks res://assets,
+       ResourceLoader.load()s each importable file, and checks textures have a sane
+       size. The probe exits non-zero on any failure or if the walk finds too few
+       assets (anti-hollow floor).
+
+LIMITATION (honest): headless validation proves each asset is STRUCTURALLY loadable;
+it does NOT GPU-decode textures (the dummy renderer discards VRAM-compressed CPU
+images). The human release-build playtest remains the final gate.
+
+Usage:
+    python tools/validate_assets.py
+    python tools/validate_assets.py --no-import        # skip the reimport pass (faster)
+    python tools/validate_assets.py --godot-path "C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe"
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_GODOT_CANDIDATES = [
+    Path("C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe"),
+    Path("C:/Program Files/Godot/Godot.exe"),
+    Path.home() / "Godot" / "Godot_v4.5.1-stable_win64.exe",
+    Path("/usr/bin/godot"),
+    Path("/usr/local/bin/godot"),
+    Path("/Applications/Godot.app/Contents/MacOS/Godot"),
+]
+
+PROBE = "res://tools/validate_assets_probe.gd"
+
+
+def find_godot(explicit: Optional[str]) -> Path:
+    if explicit:
+        p = Path(explicit)
+        if not p.exists():
+            print(f"[validate_assets][FATAL] --godot-path does not exist: {p}", file=sys.stderr)
+            sys.exit(2)
+        return p
+    for cand in DEFAULT_GODOT_CANDIDATES:
+        if cand.exists():
+            return cand
+    which = shutil.which("godot")
+    if which:
+        return Path(which)
+    print("[validate_assets][FATAL] Godot executable not found; pass --godot-path", file=sys.stderr)
+    sys.exit(2)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--godot-path", default=None)
+    ap.add_argument("--project", default=None, help="Godot project dir (default: <repo>/godot).")
+    ap.add_argument(
+        "--no-import", action="store_true", help="Skip the reimport pass before validating."
+    )
+    args = ap.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    project = Path(args.project).resolve() if args.project else (repo_root / "godot")
+    if not (project / "project.godot").exists():
+        print(f"[validate_assets][FATAL] no project.godot under {project}", file=sys.stderr)
+        return 2
+
+    godot = find_godot(args.godot_path)
+    print(f"[validate_assets] Godot:   {godot}")
+    print(f"[validate_assets] Project: {project}")
+
+    if not args.no_import:
+        print("[validate_assets] reimport pass ...")
+        r = subprocess.run(
+            [str(godot), "--headless", "--path", str(project), "--import"],
+            text=True,
+            check=False,
+        )
+        # Import may exit non-zero on cold class-cache noise; the probe is the real gate.
+        if r.returncode != 0:
+            print(f"[validate_assets] import returned {r.returncode} (tolerated; running probe).")
+
+    print("[validate_assets] running probe ...")
+    r = subprocess.run(
+        [str(godot), "--headless", "--path", str(project), "--script", PROBE],
+        text=True,
+        check=False,
+    )
+    if r.returncode == 0:
+        print("[validate_assets][PASS] all assets loaded structurally cleanly.")
+    else:
+        print(
+            f"[validate_assets][FAIL] probe exited {r.returncode} -- see [FAIL] lines above. DO NOT SHIP.",
+            file=sys.stderr,
+        )
+    return r.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Two jobs: (A) prepare to NAIL the release-only leaderboard segfault, (B) bulletproof against the class.

**The bug:** RELEASE-ONLY segfault while LOADING the leaderboard scene (game-over -> leaderboard), BEFORE `_ready` runs. Headless cannot reproduce it (verified: the new smoke test add-to-trees + runs `_ready` on the leaderboard scene cleanly). So this PR ships diagnostic builds + protocol + defenses, not a blind fix. **Do not merge** -- Pip runs the builds first.

### Part A -- the kill kit
- **3 verified-fresh diagnostic builds** produced by `tools/build_release.py` (each proven built-from-current-source; see below). Placed at stable paths under `builds/leaderboard-diag/{debug01,strip01,min01}/` (gitignored).
- `docs/LEADERBOARD_CRASH_DIAGNOSIS.md` -- **committed** ordered kill protocol (which build, exact `--verbose` command, what each result means).
- `leaderboard_screen.gd` -- `[LBTRACE-n]` stderr probes bracketing every `_ready` step.
- `leaderboard_screen_minimal.tscn` + `leaderboard_screen_min_stub.gd` -- reproducible minimal-scene fixture for the structure-vs-content bisection.
- `theme_manager.gd` -- drop the two dead `tex_cyan_ispf`/`tex_oxidized_copper` string refs (nothing `load()`s them).

### Part B -- bulletproofing (half the value)
- **`tools/build_release.py`** -- exports from a clean state (`rm -rf .godot`) then PROVES the pack is fresh via a unique **marker filename** (key finding: script string literals do NOT survive as grep-able text in this project's binary-tokenized `.gdc` export -- the old "grep for a printerr tag" advice is unreliable; filenames in the pack file table do survive). No build ships unverified.
- **`test_ui_scene_ready_smoke.gd`** -- add-to-tree + run `_ready` on every `scenes/ui` scene + standalone screen (the existing instantiate-only smoke never ran `_ready`). 21 scenes exercised.
- **`tools/validate_assets.py`** + `validate_assets_probe.gd` -- load every asset under `godot/assets`, fail loud on any that will not resolve.
- **`docs/POSTMORTEM_v0.11.0_ALPHA.md`** -- stale-export-cache trap, verify-the-pack discipline, the `all_resources` packing gotcha, and the headless render-gate limitation.

### Gate
Fast gate green: **534 tests, 0 failures (60/60 files)**. `build_release.py` dogfooded 3x (all PASS); `validate_assets.py` PASS.

### Best current hypothesis
Textures are almost certainly NOT the cause (dead string refs; welcome.tscn loads REAL textures fine as the boot scene). Leading suspect: the **`OptionButton` (SeedDropdown)** -- the one node type unique to this scene, which builds an internal PopupMenu/Window at instantiation, a plausible pre-`_ready` native-crash site in the release renderer. Build 3 (no OptionButton) is the direct test.

Headless cannot reproduce this class of crash; the human release-build playtest remains the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)