### PR TITLE
docs(design): DQ-35 ext -- scene unlocks + conditional event art

### DIFF
--- a/docs/game-design/DQ_INDEX.md
+++ b/docs/game-design/DQ_INDEX.md
@@ -35,13 +35,14 @@
 | DQ-25 | Desperation-lever revisit | open | 298 |
 | DQ-26 | VC/equity depth revisit | open | 320 |
 | DQ-27 | Mortality guarantee -- where is it ratified? | open | 328 |
-| DQ-28 | Game "phases" as vocabulary + scenario-jump testing | RESOLVED | 650 |
+| DQ-28 | Game "phases" as vocabulary + scenario-jump testing | RESOLVED | 659 |
 | DQ-29 | Cover-up debt | open | 350 |
 | DQ-30 | Economic cycles | open | 359 |
 | DQ-31 | Org/actor taxonomy -- tags, not enums | open | 367 |
 | DQ-32 | News feedline + SA-priced information flow | open | 380 |
 | DQ-33 | Content-pool ladder (artefact promotion/relegation) | open | 399 |
 | DQ-34 | Leaderboard disclosure tiers: score vs reconstructable play | open | 418 |
-| DQ-35 | Cosmetic progression + community insignia | open | 433 |
+| DQ-35 | Cosmetic progression + community insignia | open | 442 |
+| DQ-35 ext | Scene/art unlocks + conditional event art | open | 433 |
 
-Total: 36 DQs -- 30 open, 6 with a terminal or advanced status.
+Total: 37 DQs -- 31 open, 6 with a terminal or advanced status.

--- a/docs/game-design/WORKSHOP_2_BACKLOG.md
+++ b/docs/game-design/WORKSHOP_2_BACKLOG.md
@@ -430,6 +430,15 @@ more interesting."*
   publishes, not about new formats. Interacts: DQ-3 (cross-version boards), DQ-11
   (forks), DQ-32 (SA-priced info), DQ-33 (provenance), and the #712 vision doc
   (held open for Pip's dedicated pass).
+- **DQ-35 ext · Scene/art unlocks + conditional event art** *(Pip 2026-07-21, scene-wave
+  verdicts -- "directionally very strong")* -- concrete mechanisms for DQ-35: (a) event
+  hero-art VARIANTS as unlockables (crisis V3 as achievement unlock; records_vault as
+  unlocked leaderboard ground; records_trophy_terminal as a post-game achievements
+  surface); (b) CONDITIONAL art selection -- e.g. opportunity events show V2 vs V4
+  depending on likelihood of success -- art as legible world-state signal; (c) backdrop
+  rotation across keepers. Also RULED: board/council art must be menacing but VARIED
+  (representation rule extends to authority figures); board members/overseers get
+  characterised over time (ties DQ-31 actor tags).
 - **DQ-35 · Cosmetic progression + community insignia** *(Pip 2026-07-21, pinned for
   next workshop)* — background theory of rewarding progress: one of the few things Pip
   likes in CoD is its appeasement of hardcore grinders via **lots of little cosmetic


### PR DESCRIPTION
Captures Pip's scene-wave verdict design signals: art variants as achievement unlocks, condition-driven event art (opportunity V2/V4 by success likelihood), backdrop rotation, and the varied-authority-figures representation ruling for board art. Index regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)