### PR TITLE
fix(ui): restore action icon mapping + log opacity (closes #762)

### DIFF
--- a/godot/data/icon_mapping.json
+++ b/godot/data/icon_mapping.json
@@ -85,6 +85,46 @@
       "icon": "res://assets/icons/actions_facilities/action_facility_emergency_shutdown_64.png",
       "status": "mapped",
       "note": "Submenu for strategic/high-stakes actions - uses emergency icon"
+    },
+    "operations": {
+      "icon": "res://assets/icons/actions_facilities/action_facility_expand_office_64.png",
+      "status": "mapped",
+      "note": "#762 interim: reused existing office icon until a dedicated one lands"
+    },
+    "travel": {
+      "icon": "res://assets/icons/actions_policies/action_policy_international_cooperation_64.png",
+      "status": "mapped",
+      "note": "#762 interim: reused international-cooperation icon for travel/conferences"
+    },
+    "financing": {
+      "icon": "res://assets/icons/main_navigation/ui_budget_finance_64.png",
+      "status": "mapped",
+      "note": "#762 interim: reused finance icon until a dedicated one lands"
+    },
+    "advertise": {
+      "icon": "res://assets/icons/main_navigation/ui_staff_management_64.png",
+      "status": "mapped",
+      "note": "#762 interim: reused staff-management icon until a dedicated one lands"
+    },
+    "use_connections": {
+      "icon": "res://assets/icons/actions/action_publicity_network_64.png",
+      "status": "mapped",
+      "note": "#762 interim: reused network icon for work-your-connections"
+    },
+    "interview_next": {
+      "icon": "res://assets/icons/employee_status/employee_status_investigating_64.png",
+      "status": "mapped",
+      "note": "#762 interim: reused investigating icon for interviewing a candidate"
+    },
+    "hire_best": {
+      "icon": "res://assets/icons/buttons_normal/button_hire_normal_64.png",
+      "status": "mapped",
+      "note": "#762 interim: reused hire button for make-an-offer"
+    },
+    "onboard_next": {
+      "icon": "res://assets/icons/employee_status/employee_status_training_64.png",
+      "status": "mapped",
+      "note": "#762 interim: reused training icon for onboarding new hires"
     }
   },
   "hiring": {

--- a/godot/scripts/ui/terminal_theme.gd
+++ b/godot/scripts/ui/terminal_theme.gd
@@ -13,6 +13,11 @@ const BG_DARK := Color(0.035, 0.05, 0.043)
 const PANEL_BG := Color(0.07, 0.093, 0.082)
 const PANEL_BG_DEEP := Color(0.05, 0.066, 0.058)
 
+# Feed background: the main-UI off-black register (#170A1C, matching the turn-counter
+# box and the backdrop scrim) at high alpha so the live feed stays legible over the
+# office backdrop (#762). Deliberately the purple-black register, not the green panels.
+const FEED_BG := Color(0.09, 0.04, 0.11, 0.88)
+
 # Amber = PLAN register (strategy, calm). Green = WATCH register (tactics, live).
 const AMBER := Color(1.0, 0.72, 0.20)
 const AMBER_DIM := Color(0.66, 0.48, 0.16)
@@ -55,8 +60,19 @@ static func style_panel(node: Control, border: Color = RULE, bg: Color = PANEL_B
 
 
 static func style_feed(label: RichTextLabel) -> void:
-	"""The WATCH feed / message log: monospace, dim green-tinted text."""
+	"""The WATCH feed / message log: monospace, dim green-tinted text on an off-black
+	panel so it reads over the office backdrop (#762)."""
 	if label == null:
 		return
 	label.add_theme_font_override("normal_font", mono_font())
 	label.add_theme_color_override("default_color", TEXT)
+	# Opaque-ish panel behind the feed text -- RichTextLabel paints its "normal" stylebox
+	# as the background. #170A1C @ 0.88 alpha matches the main-UI register (turn-counter box).
+	var bg := StyleBoxFlat.new()
+	bg.bg_color = FEED_BG
+	bg.set_corner_radius_all(0)
+	bg.content_margin_left = 8
+	bg.content_margin_right = 8
+	bg.content_margin_top = 6
+	bg.content_margin_bottom = 6
+	label.add_theme_stylebox_override("normal", bg)

--- a/godot/tests/unit/test_action_icon_resolution.gd
+++ b/godot/tests/unit/test_action_icon_resolution.gd
@@ -1,0 +1,55 @@
+extends GutTest
+## Regression guard (#762): every unlocked top-level action must resolve to a REAL
+## icon, not the magenta-checkerboard placeholder.
+##
+## The July 2026 regression: most action-icon buttons rendered the placeholder
+## because several top-level action ids in data/actions/core.json (operations,
+## travel, financing, and the hiring pipeline advertise/use_connections/
+## interview_next/hire_best/onboard_next) had no entry in data/icon_mapping.json.
+## IconLoader.get_action_icon() falls back to the placeholder for unmapped ids.
+##
+## This test drives the SAME path the UI does: it takes the action set the main
+## panel renders (GameActions.get_all_actions(), filtered by is_action_unlocked at
+## a fresh state) and asserts each id resolves to a texture with a real res:// path.
+## A placeholder is a runtime-built ImageTexture whose resource_path is empty.
+
+
+func _fresh_state() -> Dictionary:
+	# All top-level core actions have no unlock_conditions, so a minimal empty-ish
+	# state unlocks the full set the player sees on turn 1.
+	return {
+		"turn": 0,
+		"total_staff": 0,
+		"reputation": 0,
+		"papers": 0,
+		"research": 0,
+		"purchased_upgrades": [],
+	}
+
+
+func test_every_unlocked_action_resolves_to_real_icon() -> void:
+	var state := _fresh_state()
+	var actions := GameActions.get_all_actions()
+	assert_gt(actions.size(), 0, "core action set must be non-empty")
+
+	var placeholder_ids: Array[String] = []
+	var checked := 0
+	for action in actions:
+		if not GameActions.is_action_unlocked(action, state):
+			continue
+		var id: String = action.get("id", "")
+		if id == "" or id == GameActions.PASS_ACTION_ID:
+			continue
+		checked += 1
+		var tex: Texture2D = IconLoader.get_action_icon(id)
+		# Placeholder is a code-built ImageTexture with no resource path; a real
+		# mapped icon loads from res://assets/... with a non-empty resource_path.
+		var is_real := tex != null and tex.resource_path.begins_with("res://")
+		if not is_real or IconLoader.is_placeholder(id):
+			placeholder_ids.append(id)
+
+	if placeholder_ids.size() > 0:
+		gut.p("[icon-regression] unmapped/placeholder action ids: " + str(placeholder_ids))
+	assert_eq(placeholder_ids.size(), 0,
+		"every unlocked action must have a real (non-placeholder) icon; missing: " + str(placeholder_ids))
+	assert_gt(checked, 0, "expected at least one unlocked action to check")


### PR DESCRIPTION
## Summary
HIGH-priority regression fix for #762: most action-icon buttons rendered the magenta-checkerboard placeholder.

### Root cause (diagnosed, not guessed)
IconLoader lookup is **id-keyed** (correct -- not the fragility). The gap was pure **data**: 8 top-level actions the main action panel renders had **no entry** in `data/icon_mapping.json`, so `get_action_icon()` fell back to the placeholder. A headless probe confirmed exactly which ids: `operations, travel, financing, advertise, use_connections, interview_next, hire_best, onboard_next`.

These ids entered `data/actions/core.json` in **#627 (2026-07-13)** (operations/travel/financing) and **#664 (2026-07-17)** (the hiring pipeline) **without** matching icon mappings -- so they have shown placeholders since then. What changed *today* and surfaced it: the new office backdrop (**#760**) sits behind the action panel, making the placeholders newly conspicuous in Pip's playtest. `icon_mapping.json`, `icon_loader.gd`, and the mapped icons themselves were **not** altered by #715 or #751 (verified: those merges did not touch the mapping keys, the ids, or delete any assets). The other 10 core actions resolve to real icons.

### Fix
- **Mapped the 8 missing action ids** to existing repo icons (reuse is an established pattern -- e.g. `media_campaign`/`publicity` already share one). Entries appended to the `actions` block and marked `#762 interim` so the **art-batch lane (`fable/art-batch-649`)** can promote dedicated icons later without confusion. Did **not** add the batch's 8 new icons; edit is minimal/append-safe.
- **New fast-tier test** `tests/unit/test_action_icon_resolution.gd`: drives the same path the UI does (unlocked actions from `GameActions.get_all_actions()`) and asserts every id resolves to a real (non-placeholder) `res://` icon. This would have caught the regression.

### Log opacity (also in #762 scope)
The WATCH feed had **no background stylebox**, so its text floated over the office backdrop. `TerminalTheme.style_feed` now paints an off-black panel: `#170A1C @ 0.88 alpha`, matching the turn-counter box (`StyleBoxFlat_TurnCounter`) and backdrop scrim register.

### First-load grey (investigated)
Most consistent with a **one-time cold-import decode**: #760's WebP backdrops import on first launch after pull; the first frame can render before the `.ctex` upload completes -> grey, then cached fine after. A `preload()` would not help -- the scene's `ExtResource` already effectively preloads the texture; the timing is import-cache generation, not runtime lazy load. Resolved by the normal `--import` pass. Documented rather than adding churn.

### Tests
Fast gate: **539 tests, 0 failures, 60/60 files** (includes the new icon-resolution test).

Do not merge -- for Pip's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)