### PR TITLE
fix(ui): doom label collision, icon packing, modal barriers, 3 icon mappings, office-floor scale (closes #767 #768 #770 #771)

### DIFF
--- a/godot/data/icon_mapping.json
+++ b/godot/data/icon_mapping.json
@@ -125,6 +125,31 @@
       "icon": "res://assets/icons/employee_status/employee_status_training_64.png",
       "status": "mapped",
       "note": "#762 interim: reused training icon for onboarding new hires"
+    },
+    "submit_paper": {
+      "icon": "res://assets/icons/actions_research/action_research_formal_verification_64.png",
+      "status": "mapped",
+      "note": "#768 interim: reused formal-verification/paper icon for submit-paper-to-conference"
+    },
+    "attend_conference": {
+      "icon": "res://assets/icons/actions_policies/action_policy_international_cooperation_64.png",
+      "status": "mapped",
+      "note": "#768 interim: reused international-cooperation icon (travel/conference theme)"
+    },
+    "send_delegation": {
+      "icon": "res://assets/icons/actions/action_publicity_network_64.png",
+      "status": "mapped",
+      "note": "#768 interim: reused network icon for sending a delegation"
+    },
+    "order_supplies": {
+      "icon": "res://assets/icons/actions_facilities/action_facility_expand_office_64.png",
+      "status": "mapped",
+      "note": "#768 interim: reused office/facility icon for operations order-supplies"
+    },
+    "office_maintenance": {
+      "icon": "res://assets/icons/actions_facilities/action_facility_expand_office_64.png",
+      "status": "mapped",
+      "note": "#768 interim: reused office/facility icon for operations maintenance"
     }
   },
   "hiring": {

--- a/godot/scenes/main.tscn
+++ b/godot/scenes/main.tscn
@@ -260,6 +260,7 @@ theme_override_constants/margin_bottom = 2
 
 [node name="DoomMeter" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones/DoomMeterZone/DoomMeterPanel/MarginContainer" instance=ExtResource("4_doom_meter")]
 layout_mode = 2
+show_percentage = false
 
 [node name="DoomExplanation" type="CenterContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones"]
 layout_mode = 2

--- a/godot/scripts/ui/doom_meter.gd
+++ b/godot/scripts/ui/doom_meter.gd
@@ -14,6 +14,10 @@ class_name DoomMeter
 
 @export var gauge_thickness: float = 12.0
 @export var show_momentum_indicator: bool = true
+## #771: draw the gauge's own centre "%d%%" readout. Turn OFF wherever a separate
+## numeric label already shows the value (main.tscn's NumericDoomLabel) so the two
+## don't collide ("27.2%" over "27%"). Defaults ON for standalone/other uses.
+@export var show_percentage: bool = true
 
 # Doom tier colors + status labels now live in ThemeManager (shared ramp, #512).
 const COLOR_BACKGROUND = Color(0.110, 0.153, 0.188, 0.3)  # Steel translucent (ring background)
@@ -61,18 +65,22 @@ func _draw():
 	# Draw doom arc (starts at top, clockwise)
 	draw_arc(center, radius, -PI/2, -PI/2 + doom_angle, 64, doom_color, current_thickness, true)
 
-	# Doom percentage text
-	var doom_text = "%d%%" % doom_value
 	var font = get_theme_default_font()
-	var font_size = 24
-	var text_size = font.get_string_size(doom_text, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size)
-	var text_pos = center - text_size / 2
 
-	# In colorblind mode, shift percentage up to make room for status label
-	if GameConfig.colorblind_mode:
-		text_pos.y -= 8
+	# Doom percentage text -- guarded (#771): suppressed where a separate numeric
+	# label already renders the value (main.tscn NumericDoomLabel), preventing the
+	# "27.2%" over "27%" collision. Still drawn by default for standalone uses.
+	if show_percentage:
+		var doom_text = "%d%%" % doom_value
+		var font_size = 24
+		var text_size = font.get_string_size(doom_text, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size)
+		var text_pos = center - text_size / 2
 
-	draw_string(font, text_pos, doom_text, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size, doom_color)
+		# In colorblind mode, shift percentage up to make room for status label
+		if GameConfig.colorblind_mode:
+			text_pos.y -= 8
+
+		draw_string(font, text_pos, doom_text, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size, doom_color)
 
 	# Colorblind mode: Draw status label and pattern indicator
 	if GameConfig.colorblind_mode:

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -1200,6 +1200,7 @@ func _on_actions_available(actions: Array):
 	# Create a single-column vertical stack for icons on left edge
 	var icon_stack = VBoxContainer.new()
 	icon_stack.add_theme_constant_override("separation", 1)  # #594: tighter vertical packing for 11+ icons
+	icon_stack.alignment = BoxContainer.ALIGNMENT_BEGIN  # P2/#768: pack to the top, no vertical float
 	actions_list.add_child(icon_stack)
 
 	# Create icon buttons - single column layout
@@ -1224,7 +1225,9 @@ func _on_actions_available(actions: Array):
 			icon_button.custom_minimum_size = Vector2(70, 70)  # square icon tiles
 			# #594: hug the 70px icon instead of ballooning across the wide left panel -- this
 			# reclaims the empty padding around each icon (and stops expand_icon distorting them).
-			icon_button.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+			# P2/#768: bind to the LEFT (was SHRINK_CENTER) so icons pack against the column edge
+			# instead of floating centred with wide side margins (Pip's "white gaps" complaint).
+			icon_button.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
 			icon_button.focus_mode = Control.FOCUS_NONE
 
 			# Get icon texture
@@ -1459,6 +1462,27 @@ func _close_active_submenu() -> void:
 	active_dialog = null
 	active_dialog_buttons = []
 
+func _present_modal_dialog(dialog: Control) -> void:
+	"""Mount a modal Panel over the board WITH a full-rect input barrier beneath it
+	(#767). Before this, submenu/pipeline/ledger panels were added over the board with
+	no blocker, so clicks landing outside the panel still reached the action icons
+	behind (e.g. buy compute while the hiring pipeline was open). This mirrors the
+	event-dialog blocker pattern (event_dialog.gd): a MOUSE_FILTER_STOP ColorRect that
+	swallows every click to the board. The barrier is a sibling added just BEFORE the
+	dialog (so the dialog, a later sibling, still receives its own clicks) and is freed
+	automatically when the dialog leaves the tree -- via ANY close path (X, ESC, cancel,
+	or a replacing dialog's queue_free) -- so no call site needs to manage it."""
+	var barrier := ColorRect.new()
+	barrier.name = "ModalInputBarrier"
+	barrier.color = Color(0.0, 0.0, 0.0, 0.35)   # faint dim so the board reads as "behind"
+	barrier.mouse_filter = Control.MOUSE_FILTER_STOP
+	tab_manager.add_child(barrier)
+	barrier.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	tab_manager.add_child(dialog)   # later sibling -> drawn above the barrier, stays interactive
+	# Free the barrier whenever the dialog leaves the tree -- via ANY close path (X, ESC,
+	# cancel button, or a replacing dialog's queue_free). No call site manages it.
+	dialog.tree_exited.connect(barrier.queue_free)
+
 
 func _debug_nudge_doom(delta: float) -> void:
 	"""DEBUG-only QA helper: bump doom by delta, record a history point so the trend graph
@@ -1533,7 +1557,7 @@ func _show_doom_trend_expanded() -> void:
 
 	_add_submenu_close_affordance(dialog)
 	active_dialog = dialog
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -1668,7 +1692,7 @@ func _show_hiring_submenu():
 	_add_submenu_close_affordance(dialog)
 	active_dialog = dialog
 	active_dialog_buttons = []
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -1991,7 +2015,7 @@ func _show_offer_dialog(candidate_id: String) -> void:
 	_add_submenu_close_affordance(dialog)
 	active_dialog = dialog
 	active_dialog_buttons = []
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -2160,7 +2184,7 @@ func _show_fundraising_submenu():
 
 	# Add dialog to TabManager (parent) so it overlays everything without shifting layout
 	print("[MainUI] Adding dialog to TabManager as overlay...")
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000  # Very high z-index to ensure it's on top
 	dialog.z_as_relative = false  # Absolute z-index, not relative to parent
@@ -2279,7 +2303,7 @@ func _show_financing_submenu():
 
 	active_dialog = dialog
 	active_dialog_buttons = buttons
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -2322,7 +2346,7 @@ func _show_ledger_screen():
 
 	active_dialog = dialog
 	active_dialog_buttons = []
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -2469,7 +2493,7 @@ func _show_publicity_submenu():
 
 	# Add dialog to TabManager as overlay
 	print("[MainUI] Adding dialog to TabManager as overlay...")
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -2661,7 +2685,7 @@ func _show_strategic_submenu():
 	print("[MainUI] Strategic submenu opened, tracked %d buttons" % buttons.size())
 
 	# Add dialog to TabManager as overlay
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -2944,7 +2968,7 @@ func _show_travel_submenu():
 	print("[MainUI] Travel submenu opened, tracked %d buttons" % buttons.size())
 
 	# Add dialog to TabManager as overlay
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -3086,7 +3110,7 @@ func _show_paper_submission_dialog():
 
 	_add_submenu_close_affordance(dialog)  # X + ESC hint, consistent with action submenus (#510)
 	active_dialog = dialog
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -3202,7 +3226,7 @@ func _show_conference_attendance_dialog():
 
 	_add_submenu_close_affordance(dialog)  # X + ESC hint, consistent with action submenus (#510)
 	active_dialog = dialog
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
@@ -3679,7 +3703,7 @@ func _show_operations_submenu():
 	print("[MainUI] Operations submenu opened, tracked %d buttons" % buttons.size())
 
 	# Add dialog to TabManager as overlay
-	tab_manager.add_child(dialog)
+	_present_modal_dialog(dialog)
 	dialog.visible = true
 	dialog.z_index = 1000
 	dialog.z_as_relative = false

--- a/godot/scripts/ui/office_floor/employee_sprite.gd
+++ b/godot/scripts/ui/office_floor/employee_sprite.gd
@@ -21,6 +21,10 @@ class_name OfficeEmployeeSprite
 
 const BODY_RADIUS := 11.0
 const ARRIVE_EPS := 4.0
+# #770: integer nearest-neighbor upscale of the tier-1 character art so employees
+# read at a sensible size in the WATCH office strip (the pixellab frames are ~24x32,
+# which drew tiny). Movement/bounds are unchanged -- this only scales the drawn art.
+const SPRITE_SCALE := Vector2(2.0, 2.0)
 
 # Micro-behavior tuning (seconds / per-second chances; all cosmetic).
 const BREAK_CHANCE_PER_SEC := 0.14      # once off cooldown, chance/sec to start a break
@@ -113,10 +117,12 @@ func _ready() -> void:
 	_anim.visible = false
 	# Crisp pixel art, no blur, regardless of per-file .import filter settings.
 	_anim.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_anim.scale = SPRITE_SCALE   # #770: draw the character art larger in the WATCH strip
 	add_child(_anim)
 	_facing_sprite = Sprite2D.new()
 	_facing_sprite.visible = false
 	_facing_sprite.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_facing_sprite.scale = SPRITE_SCALE   # #770: match the animated-clip scale
 	add_child(_facing_sprite)
 	_label = Label.new()
 	_label.add_theme_font_size_override("font_size", 10)

--- a/godot/scripts/ui/office_floor/office_floor.gd
+++ b/godot/scripts/ui/office_floor/office_floor.gd
@@ -40,7 +40,10 @@ const PROP_SERVER := preload("res://assets/office_floor/props/server_cluster.png
 # per the source tileset metadata in art_source/pixellab_2026-07-21-rerolls/tilesets/).
 # Cropped once into a standalone tileable texture.
 const FLOOR_BASE_REGION := Rect2i(64, 32, 32, 32)
-const PROP_TARGET_H := 30.0                    # draw props scaled to this pixel height (art varies)
+# #770: integer nearest-neighbor upscale of the base floor tile so the concrete reads
+# at a sensible scale in the WATCH strip (the atlas tiles are 32px, which tiled tiny).
+const FLOOR_TILE_SCALE := 2
+const PROP_TARGET_H := 46.0                    # #770: props drawn larger (was 30) to match the bigger floor
 const FLOOR_DIM := Color(0.62, 0.63, 0.66)     # tint floor/props muted so sprites + UI read over them
 
 @export var tier: int = 0: set = set_tier
@@ -71,6 +74,9 @@ var _floor_tile: Texture2D = null   # base concrete tile cropped from the Wang a
 
 func _ready() -> void:
 	custom_minimum_size = Vector2(360, 260)
+	# #770: nearest-neighbor so the upscaled floor tile + props stay crisp pixel art
+	# (sprites already force NEAREST per-node; this covers the floor/prop draws here).
+	texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_floor_tile = _build_floor_tile()
 	_rng.randomize()
 	_collab_timer = _rng.randf_range(COLLAB_CHECK_RANGE.x, COLLAB_CHECK_RANGE.y)
@@ -228,7 +234,11 @@ func _build_floor_tile() -> Texture2D:
 	var r := FLOOR_BASE_REGION
 	if r.position.x + r.size.x > atlas_img.get_width() or r.position.y + r.size.y > atlas_img.get_height():
 		return null
-	return ImageTexture.create_from_image(atlas_img.get_region(r))
+	var tile_img := atlas_img.get_region(r)
+	# #770: integer nearest-neighbor upscale so the tiled concrete reads larger/crisper
+	# in the WATCH strip instead of as a fine 32px grid.
+	tile_img.resize(r.size.x * FLOOR_TILE_SCALE, r.size.y * FLOOR_TILE_SCALE, Image.INTERPOLATE_NEAREST)
+	return ImageTexture.create_from_image(tile_img)
 
 # Draw a promoted prop texture centred horizontally on `at`, feet-anchored (bottom edge at
 # `at`) so it sits on the floor, scaled to PROP_TARGET_H (aspect kept) and dimmed to match.

--- a/godot/scripts/ui/watch_screen.gd
+++ b/godot/scripts/ui/watch_screen.gd
@@ -70,11 +70,13 @@ func _ready() -> void:
 
 	office_floor = OfficeFloorScene.instantiate()
 	add_child(office_floor)
-	# Override the standalone-demo sizing (360x260) for the narrow WATCH column and dim it.
-	office_floor.custom_minimum_size = Vector2(0, 180)
+	# #770: give the floor more of the right column -- taller strip (was 180) and a touch
+	# brighter (was 0.82) so the scaled-up sprites/props read, while EXPAND_FILL keeps it
+	# spanning the full column width. Pip will eyeball final height.
+	office_floor.custom_minimum_size = Vector2(0, 260)
 	office_floor.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	office_floor.size_flags_vertical = Control.SIZE_SHRINK_CENTER
-	office_floor.modulate = Color(1, 1, 1, 0.82)   # dim so it never fights the feed
+	office_floor.modulate = Color(1, 1, 1, 0.9)   # dim so it never fights the feed
 	office_floor.set_sprite_frames(OfficeWorkerFrames)
 	office_floor.set_tier(1)
 

--- a/godot/tests/unit/test_action_icon_resolution.gd
+++ b/godot/tests/unit/test_action_icon_resolution.gd
@@ -1,6 +1,6 @@
 extends GutTest
-## Regression guard (#762): every unlocked top-level action must resolve to a REAL
-## icon, not the magenta-checkerboard placeholder.
+## Regression guard (#762, widened #768): every action id the UI renders an icon
+## for must resolve to a REAL icon, not the magenta-checkerboard placeholder.
 ##
 ## The July 2026 regression: most action-icon buttons rendered the placeholder
 ## because several top-level action ids in data/actions/core.json (operations,
@@ -8,9 +8,21 @@ extends GutTest
 ## interview_next/hire_best/onboard_next) had no entry in data/icon_mapping.json.
 ## IconLoader.get_action_icon() falls back to the placeholder for unmapped ids.
 ##
-## This test drives the SAME path the UI does: it takes the action set the main
-## panel renders (GameActions.get_all_actions(), filtered by is_action_unlocked at
-## a fresh state) and asserts each id resolves to a texture with a real res:// path.
+## #768 follow-up: the original test only drove GameActions.get_all_actions()
+## (the top-level left-column icons). submit_paper / attend_conference /
+## send_delegation slipped through because they render inside the TRAVEL SUBMENU
+## (main_ui.gd:_show_travel_submenu -> IconLoader.get_action_icon(travel_id)),
+## NOT the top-level set. So this test now drives EVERY surface in main_ui.gd that
+## calls IconLoader.get_action_icon():
+##   * get_all_actions()          -> left-column icon stack (main_ui.gd ~1231)
+##   * get_fundraising_options()  -> fundraising submenu   (main_ui.gd ~2079)
+##   * get_publicity_options()    -> publicity submenu     (main_ui.gd ~2392)
+##   * get_strategic_options()    -> strategic submenu     (main_ui.gd ~2590)
+##   * get_travel_options()       -> travel submenu        (main_ui.gd ~2785)
+##   * get_operations_options()   -> operations submenu    (main_ui.gd ~3621)
+## (get_financing_options() is deliberately excluded: its submenu renders text-only
+## buttons with no icon, so it is not an icon-rendering surface.)
+##
 ## A placeholder is a runtime-built ImageTexture whose resource_path is empty.
 
 
@@ -27,6 +39,14 @@ func _fresh_state() -> Dictionary:
 	}
 
 
+func _icon_is_real(id: String) -> bool:
+	# A real mapped icon loads from res://assets/... with a non-empty resource_path;
+	# the placeholder is a code-built ImageTexture with no resource path.
+	var tex: Texture2D = IconLoader.get_action_icon(id)
+	var has_res_path := tex != null and tex.resource_path.begins_with("res://")
+	return has_res_path and not IconLoader.is_placeholder(id)
+
+
 func test_every_unlocked_action_resolves_to_real_icon() -> void:
 	var state := _fresh_state()
 	var actions := GameActions.get_all_actions()
@@ -41,11 +61,7 @@ func test_every_unlocked_action_resolves_to_real_icon() -> void:
 		if id == "" or id == GameActions.PASS_ACTION_ID:
 			continue
 		checked += 1
-		var tex: Texture2D = IconLoader.get_action_icon(id)
-		# Placeholder is a code-built ImageTexture with no resource path; a real
-		# mapped icon loads from res://assets/... with a non-empty resource_path.
-		var is_real := tex != null and tex.resource_path.begins_with("res://")
-		if not is_real or IconLoader.is_placeholder(id):
+		if not _icon_is_real(id):
 			placeholder_ids.append(id)
 
 	if placeholder_ids.size() > 0:
@@ -53,3 +69,36 @@ func test_every_unlocked_action_resolves_to_real_icon() -> void:
 	assert_eq(placeholder_ids.size(), 0,
 		"every unlocked action must have a real (non-placeholder) icon; missing: " + str(placeholder_ids))
 	assert_gt(checked, 0, "expected at least one unlocked action to check")
+
+
+func test_every_submenu_option_resolves_to_real_icon() -> void:
+	# Each of these submenus renders an icon per option via IconLoader.get_action_icon()
+	# (see main_ui.gd render sites in the header). Every option id -- regardless of
+	# affordability or stub state, since the icon is drawn either way -- must resolve
+	# to a real icon. This is the surface #768's three ids (submit_paper /
+	# attend_conference / send_delegation) actually render through.
+	var surfaces := {
+		"fundraising": GameActions.get_fundraising_options(),
+		"publicity": GameActions.get_publicity_options(),
+		"strategic": GameActions.get_strategic_options(),
+		"travel": GameActions.get_travel_options(),
+		"operations": GameActions.get_operations_options(),
+	}
+
+	var placeholder_ids: Array[String] = []
+	var checked := 0
+	for surface_name in surfaces.keys():
+		var options: Array = surfaces[surface_name]
+		for option in options:
+			var id: String = option.get("id", "")
+			if id == "":
+				continue
+			checked += 1
+			if not _icon_is_real(id):
+				placeholder_ids.append("%s/%s" % [surface_name, id])
+
+	if placeholder_ids.size() > 0:
+		gut.p("[icon-regression] unmapped/placeholder submenu ids: " + str(placeholder_ids))
+	assert_eq(placeholder_ids.size(), 0,
+		"every submenu option must have a real (non-placeholder) icon; missing: " + str(placeholder_ids))
+	assert_gt(checked, 0, "expected at least one submenu option to check")


### PR DESCRIPTION
Five filed UX quickfixes from Pip's 2026-07-22 playtest. **Do not merge -- Pip eyeballs the visual items first.**

## Items

- **#771 doom double-label [T]** -- `DoomMeter` guards its internal `%d%%` readout behind a new exported `show_percentage` flag, set `false` on `main.tscn`'s meter (where `NumericDoomLabel` already renders the value). Kills the "27.2%" over "27%" overlap.
- **P2/#768 icon packing [T]** -- action icon buttons switch `SIZE_SHRINK_CENTER` -> `SIZE_SHRINK_BEGIN` and the `icon_stack` VBox aligns to BEGIN, so icons bind top-left instead of floating centred (Pip's "white gaps"). Partial fix pending the submenu redesign.
- **#767 modal discipline [S]** -- new `_present_modal_dialog()` mounts every board-overlay modal with a full-rect `MOUSE_FILTER_STOP` `ColorRect` barrier beneath it, following the event-dialog pattern. The barrier is a sibling added just before the dialog (dialog stays interactive) and is freed via `dialog.tree_exited` -- so **any** close path (X, ESC, cancel, replacing dialog) cleans it up; no call site manages it. Covers all 12 overlay modals: hiring pipeline, offer, fundraising/publicity/strategic/travel/operations submenus, ledger, paper-submission, conference-attendance, doom-trend.
  - **Audit finding:** the full-screen **Employee** and **Settings** views are TabManager screen-swaps (the board is hidden, not overlaid), so they never leaked input. Only the `Panel` overlays added to `tab_manager` lacked a barrier. Event dialogs already blocked correctly (their own `click_blocker`).
- **#768 icon mappings + wider test [S]** -- `submit_paper`, `attend_conference`, `send_delegation` render through the **travel submenu** (`_show_travel_submenu` -> `get_action_icon(travel_id)`), outside `get_all_actions()`, which is why #766's test missed them. Widened `test_action_icon_resolution.gd` to drive **every** `get_action_icon()` surface in `main_ui` (top-level + fundraising/publicity/strategic/travel/operations submenus). The wider net also caught `order_supplies` + `office_maintenance` (operations submenu, same bug). All five get interim reuse mappings tagged `#768 interim`; `icon_mapping.json` edits are append-only (append-safe for `fable/art-batch-649`).
- **#770 office-floor scale [S]** -- floor tile integer-upscaled 2x (nearest-neighbor), props `30->46`, tier-1 sprites drawn at 2x, floor Control set to `TEXTURE_FILTER_NEAREST`; WATCH strip raised `180->260px` with `modulate 0.82->0.9` and full-width fill. Values chosen to be eyeballed/tuned.

## Tests
Fast gate green: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **547 tests, 0 failures**, including both methods of the widened icon-resolution test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)