### PR TITLE
docs(art): masters policy -- 512-canonical, own-hosting archive, no LFS

### DIFF
--- a/docs/art/ART_MASTERS_POLICY.md
+++ b/docs/art/ART_MASTERS_POLICY.md
@@ -1,0 +1,19 @@
+# Art masters policy (RULED 2026-07-22)
+
+Git is 512px/WebP-CANONICAL: the committed assets are what the game ships.
+Full-resolution masters (1024+ PNGs, over the 1MB hook cap) are a
+convenience cache, NOT the source of truth -- the true source is the
+committed YAML prompt manifests (art_prompts/*.yaml), from which any master
+is regenerable for cents. Git LFS was considered and REJECTED (quota cost +
+per-clone friction to version a cache; two lanes independently declined
+raising the 1MB cap -- permanent history bloat).
+
+Masters archive: Pip's own hosting (pdoom infrastructure, a few GB, cheap;
+NOT a public web path -- keep outside the docroot or auth-protected).
+Interim staging on the dev machine: G:/tmp/pdoom1-art-masters/ -- agents
+producing oversized masters copy them there (or note their worktree
+location) until Pip syncs the folder to hosting. Migration later is trivial
+by design: it is a plain folder of regenerable files.
+
+Agent rule: never commit files over the hook cap, never use --no-verify for
+size, never delete masters without them being staged in the archive first.


### PR DESCRIPTION
Ratifies Pip's 2026-07-22 call: git stays 512/WebP-canonical, YAML manifests are the true source, masters archive on his own hosting (non-public path), LFS rejected. Records the agent rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)