### PR TITLE
feat(ui): A/B layout harness + proposed PLAN/WATCH (submenus, operations gantt, reflow)

### DIFF
--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -33,6 +33,14 @@ var colorblind_mode: bool = false  # Adds patterns/symbols alongside colors
 # it. Display-only -- the underlying log content and simulation are unchanged.
 var show_rivals_feed: bool = true
 
+# A/B UI layout switch (UI_PROPOSALS_2026-07-22 section 4). Scaffolding for Pip's
+# in-game iteration: "classic" = today's PLAN/WATCH arrangement (pixel-identical);
+# "proposed" = the P6/P9/P10/P11 assembly (constrained cat, grouped action submenus,
+# committed-queue gantt, space reclaim). Container-reflow only -- never touches the sim.
+# The loser is deleted once Pip picks; this flag is not a permanent feature.
+var ui_layout: String = "classic"
+const UI_LAYOUTS := ["classic", "proposed"]
+
 # Leaderboard Settings
 # Opt-out for uploading scores to the global leaderboard (LeaderboardSync).
 # Default ON for alpha; players who flip it off keep local scores only.
@@ -110,6 +118,7 @@ func save_config() -> void:
 
 	# Interface section
 	config.set_value("interface", "show_rivals_feed", show_rivals_feed)
+	config.set_value("interface", "ui_layout", ui_layout)
 
 	# Leaderboard section
 	config.set_value("leaderboard", "submit_scores_global", submit_scores_global)
@@ -159,6 +168,9 @@ func load_config() -> void:
 
 	# Load interface settings
 	show_rivals_feed = config.get_value("interface", "show_rivals_feed", show_rivals_feed)
+	ui_layout = config.get_value("interface", "ui_layout", ui_layout)
+	if not UI_LAYOUTS.has(ui_layout):
+		ui_layout = "classic"  # guard against a stale/garbage persisted value
 
 	# Load leaderboard settings
 	submit_scores_global = config.get_value("leaderboard", "submit_scores_global", submit_scores_global)
@@ -232,6 +244,12 @@ func set_setting(key: String, value, save_immediately: bool = false) -> void:
 			colorblind_mode = value
 		"submit_scores_global":
 			submit_scores_global = value
+		"ui_layout":
+			# Reject unknown layout names so the UI never applies a garbage flag.
+			if not UI_LAYOUTS.has(value):
+				print("[GameConfig] WARNING: Unknown ui_layout: ", value)
+				return
+			ui_layout = value
 		"baseline_mode":
 			baseline_mode = value
 		_:

--- a/godot/scripts/ui/layout_controller.gd
+++ b/godot/scripts/ui/layout_controller.gd
@@ -1,0 +1,178 @@
+class_name LayoutController
+extends Node
+## A/B layout controller (UI_PROPOSALS_2026-07-22 section 4). Sibling to ScreenModeController,
+## same proven move: it does NOT duplicate scenes and does NOT rebuild the widget tree -- it
+## REGISTERS the existing container nodes and flips a handful of their layout properties from a
+## persisted flag (GameConfig.ui_layout). "classic" restores the captured scene defaults so it
+## stays pixel-identical to today; "proposed" applies the P6/P9/P10/P11 container deltas.
+##
+## Every A/B difference this node owns lives in _apply_proposed / _restore_classic so the two
+## arrangements are legible side by side and easy to tune. apply_layout() is idempotent: it
+## always restores classic first, then layers proposed on top, so flip->flip->flip never drifts.
+##
+## VIEW-ONLY (ADR-0006): container properties only -- zero writes to game state, zero RNG, no
+## turn-logic. P9 (grouped action submenus) and P10 (the committed-queue gantt) need game-data
+## population hooks, so main_ui gates those on is_proposed(); this node owns the pure reflow:
+##   P6  -- clamp the OfficeCat so it can't dominate the PLAN centre.
+##   P11 -- rebalance the three column stretch ratios (reclaim the instrument dead-zone, give
+##          the WATCH office-floor more of the right side) + dock the orphaned upgrades list.
+
+signal layout_changed(name: String)
+
+var current: String = "classic"
+
+# Registered reflow targets (set by main_ui via register_targets()).
+var _plan_col: Control
+var _instrument_col: Control
+var _watch_col: Control
+var _office_cat: Control
+var _plan_screen: Control            # VBox that parents the upgrades label + scroll
+var _upgrades_label: Control
+var _upgrades_scroll: Control
+
+# Captured scene defaults (so "classic" restores byte-for-byte). Captured once, before any flip.
+var _captured := false
+var _orig_plan_ratio: float = 0.3
+var _orig_instrument_ratio: float = 0.3
+var _orig_watch_ratio: float = 0.4
+var _orig_cat_min: Vector2 = Vector2.ZERO
+var _orig_cat_hflags: int = 0
+var _orig_upgrades_scroll_min: Vector2 = Vector2.ZERO
+
+# The proposed-mode upgrades dock (a framed panel built on demand; freed on restore).
+var _dock_panel: PanelContainer = null
+
+# Proposed column split: tighten the instrument column (D5/D6 dead-zone) and hand the reclaimed
+# width to WATCH so the office floor breathes (P11). PLAN holds so the hand doesn't reflow.
+const _PROPOSED_PLAN_RATIO := 0.30
+const _PROPOSED_INSTRUMENT_RATIO := 0.24
+const _PROPOSED_WATCH_RATIO := 0.46
+
+
+func register_targets(plan_col: Control, instrument_col: Control, watch_col: Control,
+		office_cat: Control, plan_screen: Control, upgrades_label: Control,
+		upgrades_scroll: Control) -> void:
+	"""Hand the controller the existing nodes it reflows. Captures their scene-default values
+	on first call so classic can always restore them exactly."""
+	_plan_col = plan_col
+	_instrument_col = instrument_col
+	_watch_col = watch_col
+	_office_cat = office_cat
+	_plan_screen = plan_screen
+	_upgrades_label = upgrades_label
+	_upgrades_scroll = upgrades_scroll
+	_capture_defaults()
+
+
+func _capture_defaults() -> void:
+	if _captured:
+		return
+	if _plan_col != null:
+		_orig_plan_ratio = _plan_col.size_flags_stretch_ratio
+	if _instrument_col != null:
+		_orig_instrument_ratio = _instrument_col.size_flags_stretch_ratio
+	if _watch_col != null:
+		_orig_watch_ratio = _watch_col.size_flags_stretch_ratio
+	if _office_cat != null:
+		_orig_cat_min = _office_cat.custom_minimum_size
+		_orig_cat_hflags = _office_cat.size_flags_horizontal
+	if _upgrades_scroll != null:
+		_orig_upgrades_scroll_min = _upgrades_scroll.custom_minimum_size
+	_captured = true
+
+
+func is_proposed() -> bool:
+	return current == "proposed"
+
+
+func apply_layout(name: String) -> void:
+	"""Set the arrangement. Idempotent: restore classic, then (for proposed) layer the deltas.
+	Unknown names coerce to classic so a bad flag can never leave the UI half-reflowed."""
+	var target := name if name == "proposed" else "classic"
+	_restore_classic()
+	if target == "proposed":
+		_apply_proposed()
+	current = target
+	layout_changed.emit(current)
+
+
+func toggle() -> String:
+	"""Flip between the two arrangements and return the new one (for the dev hotkey)."""
+	apply_layout("classic" if current == "proposed" else "proposed")
+	return current
+
+
+# --- classic (restore captured scene defaults) --------------------------------------------
+
+func _restore_classic() -> void:
+	if not _captured:
+		return
+	if _plan_col != null:
+		_plan_col.size_flags_stretch_ratio = _orig_plan_ratio
+	if _instrument_col != null:
+		_instrument_col.size_flags_stretch_ratio = _orig_instrument_ratio
+	if _watch_col != null:
+		_watch_col.size_flags_stretch_ratio = _orig_watch_ratio
+	if _office_cat != null:
+		_office_cat.custom_minimum_size = _orig_cat_min
+		_office_cat.size_flags_horizontal = _orig_cat_hflags
+	_undock_upgrades()
+
+
+# --- proposed (P6 + P11 container deltas) --------------------------------------------------
+
+func _apply_proposed() -> void:
+	# P11: rebalance the columns -- reclaim the instrument dead-zone for the WATCH office floor.
+	if _plan_col != null:
+		_plan_col.size_flags_stretch_ratio = _PROPOSED_PLAN_RATIO
+	if _instrument_col != null:
+		_instrument_col.size_flags_stretch_ratio = _PROPOSED_INSTRUMENT_RATIO
+	if _watch_col != null:
+		_watch_col.size_flags_stretch_ratio = _PROPOSED_WATCH_RATIO
+	# P6: clamp the cat so it can't dominate the PLAN centre (no-op while it is hidden in the
+	# scene; the clamp bites the moment the ambient-office lane un-hides it).
+	if _office_cat != null:
+		_office_cat.custom_minimum_size = Vector2(0, 0)
+		_office_cat.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+	# P11: dock the orphaned upgrades list into a framed panel (D6 -- stops it reading as
+	# floating below the hand).
+	_dock_upgrades()
+
+
+func _dock_upgrades() -> void:
+	"""Wrap the upgrades label + scroll in a titled PanelContainer. This is the ONE reparent in
+	the harness (a single leaf subtree, exactly the doc-endorsed move): the object references
+	main_ui/plan_screen hold to upgrades_list stay valid because reparent moves nodes, not refs.
+	Fully reversible -- _undock_upgrades puts them back at the same index for pixel-identical
+	classic."""
+	if _dock_panel != null or _plan_screen == null or _upgrades_label == null or _upgrades_scroll == null:
+		return
+	var idx := _upgrades_label.get_index()
+	_dock_panel = PanelContainer.new()
+	_dock_panel.name = "UpgradesDock"
+	_dock_panel.size_flags_vertical = Control.SIZE_SHRINK_END
+	TerminalTheme.style_panel(_dock_panel, TerminalTheme.AMBER_DIM, TerminalTheme.PANEL_BG_DEEP)
+	var vb := VBoxContainer.new()
+	vb.add_theme_constant_override("separation", 2)
+	_dock_panel.add_child(vb)
+	_plan_screen.add_child(_dock_panel)
+	_plan_screen.move_child(_dock_panel, idx)
+	_upgrades_label.reparent(vb)
+	_upgrades_scroll.reparent(vb)
+	# Bound the scroll so a long upgrades list can't stretch back into the reclaimed dead-zone.
+	_upgrades_scroll.custom_minimum_size = Vector2(0, 132)
+
+
+func _undock_upgrades() -> void:
+	if _dock_panel == null:
+		return
+	var idx := _dock_panel.get_index()
+	if _upgrades_label != null and _plan_screen != null:
+		_upgrades_label.reparent(_plan_screen)
+		_plan_screen.move_child(_upgrades_label, idx)
+	if _upgrades_scroll != null and _plan_screen != null:
+		_upgrades_scroll.reparent(_plan_screen)
+		_plan_screen.move_child(_upgrades_scroll, idx + 1)
+		_upgrades_scroll.custom_minimum_size = _orig_upgrades_scroll_min
+	_dock_panel.queue_free()
+	_dock_panel = null

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -59,6 +59,10 @@ var event_dialog  # #622 L10: event dialog presenter (script-instantiated child)
 var ledger_screen  # #622 L10: Liability Ledger UI (leather palette + summary button + screen builder)
 var employee_panel  # #622 L10: employee roster + staff ID card (becomes L2's assignment surface)
 var screen_mode: ScreenModeController  # Lane 1 / Phase A: PLAN<->WATCH two-screen mode controller
+var layout_controller: LayoutController  # A/B layout harness (classic | proposed); container-reflow only
+var queue_gantt: QueueGantt              # P10 committed-queue gantt (proposed layout only; pure view)
+var _last_actions: Array = []            # last actions payload, re-rendered when the layout flips
+var _ui_layout: String = "classic"       # active A/B layout; gates P9 grouped hand + P10 gantt
 var _inflight_hiring_box: VBoxContainer  # in-flight hiring jobs + progress, mounted under the queue (VIEW-only)
 # EE-7 (ADR-0012 loss legibility): per-resource "last turn" delta chips beside the
 # money/compute/reputation/doom readouts. Snapshot at each turn boundary; a chip shows
@@ -309,6 +313,29 @@ func _setup_plan_watch_scaffold() -> void:
 	# Start in PLAN (the game opens at the month plan).
 	screen_mode.enter_plan()
 
+	# --- A/B layout harness (UI_PROPOSALS_2026-07-22 section 4) --------------------------------
+	# Container-reflow sibling to ScreenModeController: registers the existing columns/panels and
+	# flips their layout properties from GameConfig.ui_layout. "classic" is captured first so it
+	# stays pixel-identical; "proposed" assembles P6/P9/P10/P11. Flip live with the dev hotkey.
+	layout_controller = LayoutController.new()
+	add_child(layout_controller)
+	layout_controller.register_targets(
+		plan_screen, instruments, watch_screen,
+		instruments.office_cat, plan_screen, plan_screen.upgrades_label, plan_screen.upgrades_scroll)
+
+	# P10 gantt: mount under the shared queue panel in the instrument column (visible only in
+	# proposed). Pure view -- driven read-only from state via _refresh_gantt().
+	queue_gantt = QueueGantt.new()
+	queue_gantt.name = "QueueGantt"
+	instruments.add_child(queue_gantt)
+	instruments.move_child(queue_gantt, instruments.queue_panel.get_index() + 1)
+
+	# Re-skin the gantt register (amber PLAN / green WATCH + progress fill) on every mode flip.
+	screen_mode.mode_changed.connect(func(_m): _refresh_gantt())
+
+	# Apply the persisted layout (classic default -> a no-op restore, so first boot is unchanged).
+	_apply_ui_layout(GameConfig.ui_layout)
+
 
 func _unhandled_key_input(event: InputEvent):
 	"""Handle keyboard shortcuts for dialogs (runs after focus but before _unhandled_input)"""
@@ -344,6 +371,13 @@ func _input(event: InputEvent):
 		# TODO: remove before any release/PR if undesired (currently gated, so release-safe).
 		if OS.is_debug_build() and (event.keycode == KEY_PAGEUP or event.keycode == KEY_PAGEDOWN):
 			_debug_nudge_doom(10.0 if event.keycode == KEY_PAGEUP else -10.0)
+			get_viewport().set_input_as_handled()
+			return
+
+		# DEBUG: flip the A/B UI layout live (classic<->proposed) for Pip's iteration loop.
+		# Debug builds only -- release players use the Settings toggle. Persists the choice.
+		if OS.is_debug_build() and event.keycode == KEY_F9:
+			_toggle_ui_layout()
 			get_viewport().set_input_as_handled()
 			return
 
@@ -535,6 +569,44 @@ func _trigger_action_by_index(index: int):
 		if button and not button.disabled:
 			button.emit_signal("pressed")
 			log_message("[color=cyan]Keyboard shortcut: %d[/color]" % (index + 1))
+
+func _apply_ui_layout(name: String) -> void:
+	"""Flip the A/B layout (VIEW-only; ADR-0006). LayoutController reflows the containers (P6
+	cat clamp + P11 column split + upgrades dock); here we swap the classic one-line queue hint
+	for the P10 gantt and re-render the action hand grouped (P9) vs flat. Zero writes to game
+	state, zero RNG, no turn-logic -- pure presentation."""
+	var target := name if name == "proposed" else "classic"
+	_ui_layout = target
+	if layout_controller:
+		layout_controller.apply_layout(target)
+	var proposed := target == "proposed"
+	# P10: the gantt stands in for the one-line queue hint panel in proposed.
+	if queue_gantt:
+		queue_gantt.visible = proposed
+	if instruments and instruments.queue_panel:
+		instruments.queue_panel.visible = not proposed
+	# P9: re-render the hand in the new register (grouped vs flat), if we have a payload.
+	if not _last_actions.is_empty():
+		_on_actions_available(_last_actions)
+	_refresh_gantt()
+
+func _toggle_ui_layout() -> void:
+	"""Dev hotkey: flip classic<->proposed live and persist the choice (same iteration loop as
+	the debug doom-nudge). Debug-build gated at the call site."""
+	var next := "classic" if _ui_layout == "proposed" else "proposed"
+	_apply_ui_layout(next)
+	GameConfig.set_setting("ui_layout", next, true)  # persist so the choice survives a restart
+	log_message("[color=cyan]UI layout -> %s[/color]" % next)
+
+func _refresh_gantt() -> void:
+	"""Rebuild the P10 gantt rows from live state (committed strategic WIP + in-flight hiring +
+	the plan-time tentative queue). READ-ONLY: snapshots state, writes nothing. No-op in classic."""
+	if queue_gantt == null or _ui_layout != "proposed":
+		return
+	var state: Dictionary = game_manager.get_game_state() if game_manager else {}
+	var rows := QueueGantt.rows_from_state(state, queued_actions)
+	var watch_mode := screen_mode != null and screen_mode.current_mode == ScreenModeController.Mode.WATCH
+	queue_gantt.update_rows(rows, watch_mode)
 
 func _apply_balance_tooltips() -> void:
 	"""Rebuild the resource HUD tooltips that quote balance numbers from Balance,
@@ -766,6 +838,9 @@ func _on_game_state_updated(state: Dictionary):
 	# Refresh the PLAN attention gauge (allocated vs reserved pips) from the month plan.
 	if plan_screen:
 		plan_screen.update_reserve_gauge(state)
+
+	# P10 gantt (proposed layout): rebuild the operations tracker from live state. No-op in classic.
+	_refresh_gantt()
 
 	# Turn/time (Pip: "count turns and tell us the date"). ONE tidy element:
 	#   "Turn 14  -  Fri 21 Jul 2017"
@@ -1143,6 +1218,9 @@ func _on_actions_available(actions: Array):
 	"""Populate action list with icon buttons in a grid layout"""
 	print("[MainUI] Populating ", actions.size(), " actions as icon buttons")
 
+	# Remember the payload so a live layout flip can re-render the hand (P9).
+	_last_actions = actions
+
 	# Clear existing action buttons
 	for child in actions_list.get_children():
 		child.queue_free()
@@ -1196,6 +1274,14 @@ func _on_actions_available(actions: Array):
 		"funding": ThemeManager.get_category_color("funding"),
 		"other": Color(0.8, 0.8, 0.8)
 	}
+
+	# P9 (proposed layout): render the hand GROUPED -- one collapsible category section per the
+	# ABBBCCC sketch -- instead of the flat concatenated icon column. Classic falls through to the
+	# untouched flat renderer below, so it stays pixel-identical.
+	if _ui_layout == "proposed":
+		_render_actions_grouped(categories, category_order, category_colors, current_state)
+		_populate_upgrades()
+		return
 
 	# Create a single-column vertical stack for icons on left edge
 	var icon_stack = VBoxContainer.new()
@@ -1286,6 +1372,91 @@ func _on_actions_available(actions: Array):
 
 	# Also populate upgrades
 	_populate_upgrades()
+
+func _render_actions_grouped(categories: Dictionary, category_order: Array, category_colors: Dictionary, current_state: Dictionary) -> void:
+	"""P9 grouped hand (proposed layout only): each category is one A-header that expands/collapses
+	a B-list of its actions -- Pip's ABBBCCC sketch as inline collapsible sections. Fewer top-level
+	entries, real grouping, hiring folded into its own category (fixes D3/D4). The C context stays
+	the shared InfoBar on hover. VIEW-only: same press/hover handlers as the flat renderer."""
+	var stack := VBoxContainer.new()
+	stack.add_theme_constant_override("separation", 3)
+	stack.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	actions_list.add_child(stack)
+
+	var display_names := {
+		"hiring": "Hiring", "resources": "Resources", "research": "Research",
+		"funding": "Funding", "management": "Management", "influence": "Influence",
+		"strategic": "Strategic", "other": "Other",
+	}
+
+	for category_key in category_order:
+		if not categories.has(category_key):
+			continue
+		var category_actions: Array = categories[category_key]
+		if category_actions.is_empty():
+			continue
+		var accent: Color = category_colors.get(category_key, Color(0.8, 0.8, 0.8))
+		var label_name: String = display_names.get(category_key, String(category_key).capitalize())
+
+		# B-list built first so the header's toggle closure can capture it.
+		var blist := VBoxContainer.new()
+		blist.add_theme_constant_override("separation", 1)
+		blist.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+		# A-header: category name + count, toggles the B-list open/closed.
+		var header := Button.new()
+		header.toggle_mode = true
+		header.button_pressed = true
+		header.focus_mode = Control.FOCUS_NONE
+		header.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		header.alignment = HORIZONTAL_ALIGNMENT_LEFT
+		var cat_icon := IconLoader.get_action_icon(category_key)
+		if cat_icon:
+			header.icon = cat_icon
+		header.text = "v %s (%d)" % [label_name, category_actions.size()]
+		header.add_theme_color_override("font_color", accent)
+		header.tooltip_text = "Show / hide %s actions" % label_name
+		header.toggled.connect(func(on: bool):
+			blist.visible = on
+			header.text = "%s %s (%d)" % ["v" if on else ">", label_name, category_actions.size()])
+		stack.add_child(header)
+		stack.add_child(blist)
+
+		for action in category_actions:
+			var action_id: String = action.get("id", "")
+			var action_name: String = action.get("name", "Unknown")
+			var action_cost: Dictionary = action.get("costs", {})
+
+			# Affordability -- same rule as the flat renderer.
+			var can_afford := true
+			var missing_resources := []
+			for resource in action_cost.keys():
+				var cost = action_cost[resource]
+				var available = current_state.get(resource, 0)
+				if available < cost:
+					can_afford = false
+					missing_resources.append("%s (need %s, have %s)" % [resource, cost, available])
+
+			var row := Button.new()
+			row.focus_mode = Control.FOCUS_NONE
+			row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+			row.alignment = HORIZONTAL_ALIGNMENT_LEFT
+			row.clip_text = true
+			row.text = "  " + action_name
+			var icon_texture := IconLoader.get_action_icon(action_id)
+			if icon_texture:
+				row.icon = icon_texture
+			row.set_meta("action_id", action_id)  # submenu alignment (#510) + button lookup
+			if not can_afford:
+				row.disabled = true
+				row.modulate = Color(0.4, 0.4, 0.4)
+			else:
+				row.modulate = Color(0.9, 0.9, 0.9).lerp(accent, 0.4)
+			row.tooltip_text = action_name
+			row.pressed.connect(func(): _on_dynamic_action_pressed(action_id, action_name))
+			row.mouse_entered.connect(func(): _on_action_hover(action, can_afford, missing_resources))
+			row.mouse_exited.connect(func(): _on_action_unhover())
+			blist.add_child(row)
 
 func _populate_upgrades():
 	"""Populate upgrades list"""
@@ -3455,6 +3626,9 @@ func update_queued_actions_display():
 		clear_queue_button.disabled = queue_empty
 		end_turn_button.disabled = queue_empty
 		print("[MainUI] Updated button states: queue_size=%d, buttons_disabled=%s" % [queued_actions.size(), queue_empty])
+
+	# P10 gantt: mirror the tentative plan-time queue into the operations tracker. No-op in classic.
+	_refresh_gantt()
 
 func _on_event_dialog_opened(dialog: Control, buttons: Array) -> void:
 	"""EventDialog put its modal up (#622) -- route MainUI keyboard shortcuts to it.

--- a/godot/scripts/ui/queue_gantt.gd
+++ b/godot/scripts/ui/queue_gantt.gd
@@ -1,0 +1,165 @@
+class_name QueueGantt
+extends VBoxContainer
+## The committed-queue gantt / "operations underway" tracker (UI_PROPOSALS_2026-07-22 P10 /
+## BUILD_BRIEF_PLAN_WATCH_UI PLAN elem 2 + WATCH elem 4 -- the headline drift D2). One row per
+## in-flight / queued play: [#] name [====----] ETA. The fishing-line made visual.
+##
+## PURE VIEW (ADR-0006): reads a serialized state snapshot + the plan-time tentative queue and
+## renders; it NEVER writes game state, mutates the sim, or touches RNG. Shown only in the
+## "proposed" A/B layout; the classic one-line QueuePanel hint is untouched.
+##
+## Data source (read-only, per the task): month_plan.queued_strategic is the real gantt data --
+## each carries queued_on_turn + resolves_on_turn, so duration and ETA are exact and WATCH can
+## fill a true progress bar. state.hiring.jobs (in-flight interview/offer/connections) are
+## folded in with their ETA. The plan-time tentative queue (main_ui.queued_actions -- {id,name})
+## is appended as order-only "planned" rows so PLAN shows the month-ahead before you commit.
+##
+## Queue-order-as-priority: month_plan resolves strategic WIP by resolves_on_turn tick, NOT by
+## list order, and exposes no reorder method -- so the mechanic has NO engine surface. Per the
+## brief we therefore render the order READ-ONLY (a priority number, no reorder handle) and note
+## it; wiring reorder is a sim change out of scope for this UI-only harness.
+
+const _BAR_CELLS := 12
+
+
+func _ready() -> void:
+	add_theme_constant_override("separation", 2)
+
+
+## Extract gantt rows from a serialized game-state Dictionary (GameState.to_dict() shape) plus
+## the plan-time tentative queue. Static + tree-free so it is unit-testable in isolation. Each
+## row: {name:String, eta:int, duration:int, progress:float, kind:String, has_eta:bool}.
+static func rows_from_state(state: Dictionary, tentative: Array = []) -> Array:
+	var rows: Array = []
+	var cur := int(state.get("turn", 0))
+
+	# Committed strategic WIP -- the real duration + ETA + progress.
+	var mp: Dictionary = state.get("month_plan", {})
+	for item in mp.get("queued_strategic", []):
+		if not (item is Dictionary):
+			continue
+		var q := int(item.get("queued_on_turn", cur))
+		var r := int(item.get("resolves_on_turn", cur))
+		var dur: int = max(1, r - q)
+		var prog: float = clampf(float(cur - q) / float(dur), 0.0, 1.0)
+		rows.append({
+			"name": _pretty(String(item.get("action_id", "work"))),
+			"eta": r, "duration": dur, "progress": prog,
+			"kind": "strategic", "has_eta": true,
+		})
+
+	# In-flight hiring jobs (Phase B pipeline) -- ETA known; no queued_on_turn, so no fill.
+	var hiring: Dictionary = state.get("hiring", {})
+	for job in hiring.get("jobs", []):
+		if not (job is Dictionary):
+			continue
+		var r := int(job.get("resolves_on_turn", cur))
+		rows.append({
+			"name": _pretty(String(job.get("kind", "hire"))),
+			"eta": r, "duration": max(1, r - cur), "progress": 0.0,
+			"kind": "hiring", "has_eta": true,
+		})
+
+	# Plan-time tentative queue -- order only, no ETA until committed.
+	for t in tentative:
+		if not (t is Dictionary):
+			continue
+		rows.append({
+			"name": String(t.get("name", "?")),
+			"eta": -1, "duration": 0, "progress": 0.0,
+			"kind": "planned", "has_eta": false,
+		})
+	return rows
+
+
+## Rebuild the visible rows. `watch_mode` swaps the register (green/live vs amber/plan) and is
+## what makes the progress fill meaningful (in PLAN nothing has started, so bars read hollow).
+func update_rows(rows: Array, watch_mode: bool = false) -> void:
+	for child in get_children():
+		child.queue_free()
+
+	if rows.is_empty():
+		var hint := Label.new()
+		hint.text = "No operations underway -- queue plays in PLAN."
+		hint.add_theme_font_override("font", TerminalTheme.mono_font())
+		hint.add_theme_color_override("font_color", TerminalTheme.TEXT_DIM)
+		hint.add_theme_font_size_override("font_size", 10)
+		add_child(hint)
+		return
+
+	var accent: Color = TerminalTheme.GREEN if watch_mode else TerminalTheme.AMBER
+	var accent_dim: Color = TerminalTheme.GREEN_DIM if watch_mode else TerminalTheme.AMBER_DIM
+	var priority := 0
+	for row in rows:
+		priority += 1
+		add_child(_build_row(priority, row, accent, accent_dim, watch_mode))
+
+
+func row_count() -> int:
+	"""Number of built gantt rows (excludes the empty-state hint). For tests + the header."""
+	var n := 0
+	for child in get_children():
+		# queue_free() from a prior update is deferred -- old rows linger for a frame; exclude them.
+		if child.has_meta("gantt_row") and not child.is_queued_for_deletion():
+			n += 1
+	return n
+
+
+func _build_row(priority: int, row: Dictionary, accent: Color, accent_dim: Color, watch_mode: bool) -> Control:
+	var line := HBoxContainer.new()
+	line.set_meta("gantt_row", true)
+	line.add_theme_constant_override("separation", 6)
+
+	var num := Label.new()
+	num.text = "%d" % priority
+	num.custom_minimum_size = Vector2(16, 0)
+	num.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	num.add_theme_font_override("font", TerminalTheme.mono_font())
+	num.add_theme_color_override("font_color", accent)
+	num.add_theme_font_size_override("font_size", 11)
+	line.add_child(num)
+
+	var name_label := Label.new()
+	name_label.text = String(row.get("name", "?"))
+	name_label.custom_minimum_size = Vector2(96, 0)
+	name_label.clip_text = true
+	name_label.add_theme_font_override("font", TerminalTheme.mono_font())
+	name_label.add_theme_color_override("font_color", TerminalTheme.TEXT)
+	name_label.add_theme_font_size_override("font_size", 11)
+	line.add_child(name_label)
+
+	var bar := Label.new()
+	bar.text = _bar_string(row, watch_mode)
+	bar.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	bar.add_theme_font_override("font", TerminalTheme.mono_font())
+	bar.add_theme_color_override("font_color", accent_dim if not watch_mode else accent)
+	bar.add_theme_font_size_override("font_size", 11)
+	line.add_child(bar)
+
+	var eta := Label.new()
+	if bool(row.get("has_eta", false)):
+		eta.text = "T%d" % int(row.get("eta", 0))
+		eta.tooltip_text = "Lands on resolution tick (turn) %d." % int(row.get("eta", 0))
+	else:
+		eta.text = "queued"
+	eta.add_theme_font_override("font", TerminalTheme.mono_font())
+	eta.add_theme_color_override("font_color", accent_dim)
+	eta.add_theme_font_size_override("font_size", 10)
+	line.add_child(eta)
+
+	return line
+
+
+func _bar_string(row: Dictionary, watch_mode: bool) -> String:
+	if not bool(row.get("has_eta", false)):
+		return "[" + "-".repeat(_BAR_CELLS) + "]"  # planned, not committed -> hollow
+	var prog: float = clampf(float(row.get("progress", 0.0)), 0.0, 1.0) if watch_mode else 0.0
+	var filled: int = clampi(int(round(prog * _BAR_CELLS)), 0, _BAR_CELLS)
+	return "[" + "=".repeat(filled) + "-".repeat(_BAR_CELLS - filled) + ">"
+
+
+static func _pretty(raw: String) -> String:
+	"""Turn an action_id / job kind into a readable label (safe, no data lookup)."""
+	if raw.is_empty():
+		return "work"
+	return raw.replace("_", " ").capitalize()

--- a/godot/scripts/ui/settings_menu.gd
+++ b/godot/scripts/ui/settings_menu.gd
@@ -37,6 +37,9 @@ func _ready():
 	# Add the global-leaderboard opt-out under Gameplay (built in code, not the .tscn)
 	_add_global_leaderboard_toggle()
 
+	# Add the experimental A/B UI layout toggle under UI (built in code, not the .tscn)
+	_add_ui_layout_toggle()
+
 	# Connect theme dropdown
 	theme_dropdown.item_selected.connect(_on_theme_changed)
 
@@ -160,6 +163,34 @@ func _on_global_leaderboard_toggled(pressed: bool):
 	print("[SettingsMenu] Submit scores to global leaderboard: ", pressed)
 	GameConfig.set_setting("submit_scores_global", pressed, false)
 	NotificationManager.info("Global leaderboard submission " + ("enabled" if pressed else "disabled"))
+
+var ui_layout_checkbox: CheckButton = null
+
+func _add_ui_layout_toggle():
+	"""Append a 'Proposed UI layout (experimental)' toggle to the UI section. A/B scaffolding
+	(UI_PROPOSALS_2026-07-22): OFF = classic PLAN/WATCH; ON = the proposed grouped-hand + gantt +
+	reclaim assembly. Applies on the next game load; the in-game F9 hotkey flips it live."""
+	var ui_section = get_node_or_null("VBox/SettingsContainer/UISettings")
+	if ui_section == null:
+		return
+	var row = HBoxContainer.new()
+	var label = Label.new()
+	label.text = "Proposed UI layout (experimental)"
+	label.tooltip_text = "A/B test: proposed PLAN/WATCH (grouped actions, operations gantt, reclaimed space). Applies on next game load."
+	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(label)
+	ui_layout_checkbox = CheckButton.new()
+	ui_layout_checkbox.button_pressed = (GameConfig.ui_layout == "proposed")
+	ui_layout_checkbox.toggled.connect(_on_ui_layout_toggled)
+	row.add_child(ui_layout_checkbox)
+	ui_section.add_child(row)
+
+func _on_ui_layout_toggled(pressed: bool):
+	"""Handle the proposed-UI-layout toggle."""
+	var layout = "proposed" if pressed else "classic"
+	print("[SettingsMenu] UI layout: ", layout)
+	GameConfig.set_setting("ui_layout", layout, false)
+	NotificationManager.info("Proposed UI layout " + ("enabled" if pressed else "disabled") + " (applies on next game load)")
 
 func _on_colorblind_toggled(pressed: bool):
 	"""Handle colorblind mode toggle"""

--- a/godot/tests/unit/test_ui_layout.gd
+++ b/godot/tests/unit/test_ui_layout.gd
@@ -1,0 +1,144 @@
+extends GutTest
+## Unit tests for the A/B layout harness (UI_PROPOSALS_2026-07-22 section 4):
+## the GameConfig.ui_layout flag, LayoutController's container-reflow (both arrangements
+## instance + restore cleanly), and QueueGantt's read-only row extraction (P10 -- gantt
+## rows track the queued-action count). UI-layer only; no game state / RNG touched.
+
+# --- GameConfig.ui_layout flag ------------------------------------------------------------
+
+func test_ui_layout_defaults_to_classic():
+	# The scaffolding default must be classic so first boot is the untouched layout.
+	assert_true(GameConfig.UI_LAYOUTS.has("classic"), "classic is a known layout")
+	assert_true(GameConfig.UI_LAYOUTS.has("proposed"), "proposed is a known layout")
+
+func test_ui_layout_setter_accepts_known_and_rejects_garbage():
+	var original: String = GameConfig.ui_layout
+	GameConfig.set_setting("ui_layout", "proposed", false)
+	assert_eq(GameConfig.ui_layout, "proposed", "known layout is accepted")
+	GameConfig.set_setting("ui_layout", "nonsense", false)
+	assert_eq(GameConfig.ui_layout, "proposed", "garbage layout is rejected (value unchanged)")
+	GameConfig.set_setting("ui_layout", original, false)  # restore
+
+func test_ui_layout_persists_round_trip():
+	# The flag persists exactly the way GameConfig saves it -- an [interface] ConfigFile key.
+	var cf := ConfigFile.new()
+	cf.set_value("interface", "ui_layout", "proposed")
+	assert_eq(cf.get_value("interface", "ui_layout", "classic"), "proposed",
+		"ui_layout survives a ConfigFile save/load round-trip")
+
+# --- LayoutController: both arrangements instance + restore -------------------------------
+
+func _make_layout_fixture() -> Dictionary:
+	# A minimal stand-in for main.tscn's ContentArea: three columns + a plan screen that
+	# parents the upgrades label/scroll (the dock target).
+	var content := HBoxContainer.new()
+	var plan_col := Control.new()
+	plan_col.size_flags_stretch_ratio = 0.3
+	var instrument_col := Control.new()
+	instrument_col.size_flags_stretch_ratio = 0.3
+	var watch_col := Control.new()
+	watch_col.size_flags_stretch_ratio = 0.4
+	content.add_child(plan_col)
+	content.add_child(instrument_col)
+	content.add_child(watch_col)
+
+	var plan_screen := VBoxContainer.new()
+	var upgrades_label := Label.new()
+	var upgrades_scroll := ScrollContainer.new()
+	plan_screen.add_child(upgrades_label)
+	plan_screen.add_child(upgrades_scroll)
+	var office_cat := Control.new()
+	plan_col.add_child(plan_screen)
+	plan_col.add_child(office_cat)
+
+	add_child_autofree(content)
+	var lc := LayoutController.new()
+	add_child_autofree(lc)
+	lc.register_targets(plan_col, instrument_col, watch_col, office_cat,
+		plan_screen, upgrades_label, upgrades_scroll)
+	return {
+		"lc": lc, "plan_col": plan_col, "instrument_col": instrument_col,
+		"watch_col": watch_col, "plan_screen": plan_screen,
+		"upgrades_label": upgrades_label, "upgrades_scroll": upgrades_scroll,
+	}
+
+func test_classic_layout_is_a_noop_over_defaults():
+	var f := _make_layout_fixture()
+	f.lc.apply_layout("classic")
+	assert_eq(f.lc.current, "classic")
+	assert_almost_eq(f.plan_col.size_flags_stretch_ratio, 0.3, 0.001, "classic keeps plan ratio")
+	assert_almost_eq(f.instrument_col.size_flags_stretch_ratio, 0.3, 0.001, "classic keeps instrument ratio")
+	assert_almost_eq(f.watch_col.size_flags_stretch_ratio, 0.4, 0.001, "classic keeps watch ratio")
+
+func test_proposed_layout_reflows_columns_and_docks_upgrades():
+	var f := _make_layout_fixture()
+	f.lc.apply_layout("proposed")
+	assert_eq(f.lc.current, "proposed")
+	# P11: instrument column tightened, watch column widened.
+	assert_lt(f.instrument_col.size_flags_stretch_ratio, 0.3, "instrument column reclaimed")
+	assert_gt(f.watch_col.size_flags_stretch_ratio, 0.4, "watch column widened for the office floor")
+	# P11 dock: upgrades label/scroll moved out of the plan screen into a framed panel.
+	assert_ne(f.upgrades_label.get_parent(), f.plan_screen, "upgrades label docked into a panel")
+
+func test_layout_flip_restores_classic_pixel_identical():
+	var f := _make_layout_fixture()
+	f.lc.apply_layout("proposed")
+	f.lc.apply_layout("classic")
+	# Ratios restored exactly.
+	assert_almost_eq(f.plan_col.size_flags_stretch_ratio, 0.3, 0.001)
+	assert_almost_eq(f.instrument_col.size_flags_stretch_ratio, 0.3, 0.001)
+	assert_almost_eq(f.watch_col.size_flags_stretch_ratio, 0.4, 0.001)
+	# Upgrades subtree back under the plan screen (dock reversed).
+	assert_eq(f.upgrades_label.get_parent(), f.plan_screen, "upgrades label restored to plan screen")
+	assert_eq(f.upgrades_scroll.get_parent(), f.plan_screen, "upgrades scroll restored to plan screen")
+
+func test_toggle_cycles_between_the_two():
+	var f := _make_layout_fixture()
+	assert_eq(f.lc.toggle(), "proposed", "first toggle -> proposed")
+	assert_eq(f.lc.toggle(), "classic", "second toggle -> classic")
+
+# --- QueueGantt: rows track the queued-action count (P10) ---------------------------------
+
+func test_gantt_rows_from_state_empty():
+	assert_eq(QueueGantt.rows_from_state({}, []).size(), 0, "no state -> no rows")
+
+func test_gantt_rows_track_committed_strategic_count():
+	var state := {
+		"turn": 5,
+		"month_plan": {"queued_strategic": [
+			{"action_id": "deep_research", "queued_on_turn": 3, "resolves_on_turn": 9},
+			{"action_id": "field_building", "queued_on_turn": 4, "resolves_on_turn": 8},
+		]},
+	}
+	var rows := QueueGantt.rows_from_state(state, [])
+	assert_eq(rows.size(), 2, "one row per committed strategic play")
+	assert_true(rows[0]["has_eta"], "committed rows carry an ETA")
+	assert_eq(rows[0]["eta"], 9, "ETA is the resolution tick")
+	assert_true(rows[0]["progress"] > 0.0, "mid-flight play shows partial progress")
+
+func test_gantt_folds_in_tentative_and_hiring():
+	var state := {
+		"turn": 2,
+		"month_plan": {"queued_strategic": [
+			{"action_id": "deep_research", "queued_on_turn": 1, "resolves_on_turn": 6},
+		]},
+		"hiring": {"jobs": [
+			{"kind": "interview", "resolves_on_turn": 5},
+		]},
+	}
+	var tentative := [{"id": "scout", "name": "Scout"}]
+	var rows := QueueGantt.rows_from_state(state, tentative)
+	assert_eq(rows.size(), 3, "strategic + hiring + tentative all counted")
+	assert_false(rows[2]["has_eta"], "tentative plan-time row has no ETA yet")
+
+func test_gantt_builds_one_control_per_row():
+	var gantt := QueueGantt.new()
+	add_child_autofree(gantt)
+	var rows := [
+		{"name": "Deep Research", "eta": 9, "duration": 6, "progress": 0.3, "kind": "strategic", "has_eta": true},
+		{"name": "Scout", "eta": -1, "duration": 0, "progress": 0.0, "kind": "planned", "has_eta": false},
+	]
+	gantt.update_rows(rows, true)
+	assert_eq(gantt.row_count(), 2, "gantt renders one row control per queued entry")
+	gantt.update_rows([], false)
+	assert_eq(gantt.row_count(), 0, "empty queue renders no rows (hint only)")


### PR DESCRIPTION
## What

A container-reflow **A/B layout switch** so Pip can flip PLAN/WATCH arrangements in-game and iterate without rebuilds (UI_PROPOSALS_2026-07-22 section 4). Ships `classic` (today's layout, pixel-identical) + a `proposed` side assembling P6/P9/P10/P11.

> **Stacks on #774** (`fable/ux-quickfixes-r2`) to avoid `main_ui.gd` conflicts -- merge **after** #774. The diff here is only this feature's commit.

## Mechanism (follows `ScreenModeController`)

- **`LayoutController`** -- sibling to the mode controller. NO scene duplication; it registers the existing columns/panels, **captures their scene defaults**, and flips a handful of layout properties from a persisted `GameConfig.ui_layout` flag. `classic` restores the captured defaults (so it stays pixel-identical); `apply_layout` is idempotent (restore-then-layer) so flip->flip->flip never drifts.
- **Flip three ways:** persisted `GameConfig.ui_layout` (`[interface]` config key), a **Settings toggle** ("Proposed UI layout (experimental)", UI section), and a **debug `F9` hotkey** that flips live + persists (debug-build gated, like the PageUp/PageDown doom-nudge).

## Proposed side, by proposal id

- **P6** -- clamp the OfficeCat so it can't dominate the PLAN centre (no-op while the cat is hidden in the scene; the clamp bites when the ambient-office lane un-hides it).
- **P9** -- **grouped action hand**: each category is one A-header that expands/collapses a B-list of its actions (the ABBBCCC sketch as inline collapsible sections). Gated so classic's flat renderer is byte-for-byte untouched.
- **P10** -- **`QueueGantt`** committed-queue / "operations underway" tracker: one row per play, `[#] name [====---->] ETA`. **READ-ONLY** over `month_plan.queued_strategic` (real duration + ETA + WATCH progress fill), in-flight hiring jobs, and the plan-time tentative queue. Amber in PLAN, green + progress fill in WATCH.
- **P11** -- **space reclaim**: tighten the instrument column stretch ratio and hand the width to WATCH (office-floor room); **dock the orphaned upgrades list** into a framed panel.

## Gantt data-source findings

- `month_plan.queued_strategic` is the real gantt data -- each entry carries `queued_on_turn` + `resolves_on_turn`, so duration/ETA are exact and WATCH fills a true progress bar. It's already in `GameState.to_dict()`.
- **Queue-order-as-priority has NO engine surface**: `month_plan` resolves strategic WIP by `resolves_on_turn` tick, not list order, and exposes no reorder method. Per the brief the gantt therefore renders order **read-only** (priority number, no reorder handle). Wiring reorder is a sim change, out of scope for this UI-only harness.

## Constraints honored

UI layer only -- **zero writes to game state, zero RNG, no turn-logic** (ADR-0006 pure view). All strings ASCII, deadpan register. Theme via `TerminalTheme`, no inline palette. The one reparent (upgrades dock) is a single reversible leaf subtree; object references stay valid.

## Tests

- Fast gate green: **558 tests, 0 failures**.
- New `test_ui_layout.gd`: flag persists (round-trip + validation), both layouts instance + restore classic exactly, gantt rows track the queued-action count.
- Smoke: `main.tscn` boots clean under **both** layouts (action population runs, zero real script errors).

## Known rough edges for the flip-test

- Number-key shortcuts (1-9) map to the flat hand order; in the grouped hand they target headers/sections, so they're less meaningful there.
- P6 cat clamp is a no-op while the cat is `visible=false` in the current scene.
- Column ratios (`0.30 / 0.24 / 0.46`) and the docked-upgrades scroll height (132px) are first-pass numbers -- tune to taste.

**Do not merge** -- for Pip's review + flip-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)