### PR TITLE
test: land #747 regression-net -- headless UI scene-smoke + asset validation, reconciled onto the merged crash fix (#779)

### DIFF
--- a/godot/tests/unit/test_ui_scene_ready_smoke.gd
+++ b/godot/tests/unit/test_ui_scene_ready_smoke.gd
@@ -1,0 +1,131 @@
+extends GutTest
+## UI-scene _ready smoke test (anti-hollow uplift, ADR-0017).
+##
+## WHY THIS EXISTS: the v0.11.0-alpha release-blocker was a segfault while LOADING
+## the leaderboard scene on the game-over -> leaderboard transition. The existing
+## test_smoke_load_all.gd instantiate()s every scene but NEVER enters the SceneTree,
+## so _ready() never runs -- it cannot see a fault that happens at add-to-tree time.
+## This test closes that specific gap: it INSTANTIATES + ADDS-TO-TREE + runs _ready()
+## on every standalone UI screen and every scene under scenes/ui/**, asserting the
+## process survives (no crash) and the node is still valid after a frame.
+##
+## WHAT IT CATCHES: a null-deref / bad @onready path / autoload-contract break / any
+## GDScript fault that fires in _ready() and takes the process down. A hard native
+## crash kills the whole run -> the runner reports missing results -> RED (exactly the
+## signal we want for the leaderboard fault, IF it reproduces headlessly).
+##
+## RENDER-GATE LIMITATION (read before trusting a green here): headless Godot uses a
+## dummy rendering/audio driver. It does NOT GPU-decode textures, allocate real VRAM,
+## or run the platform's release-mode renderer. A crash that only manifests in a
+## release EXPORT with a real GPU (the class the v0.11.0 leaderboard segfault is
+## suspected to be) will NOT reproduce here. This test is a necessary gate, not a
+## sufficient one: the human release-build playtest (play -> lose -> leaderboard on a
+## real machine) remains the final ship gate. See docs/LEADERBOARD_CRASH_DIAGNOSIS.md.
+
+# Every scene under these roots is swept recursively.
+const SCENE_DIR_ROOTS := ["res://scenes/ui"]
+
+# Standalone top-level screens (navigation targets) added explicitly. main.tscn is
+# deliberately EXCLUDED: adding it to the tree boots the entire game (timers, audio,
+# turn manager) with side effects unsuitable for a smoke test; the existing
+# test_smoke_load_all.gd::test_main_scene_chain_instantiates covers its load path.
+const EXPLICIT_SCENES := [
+	"res://scenes/welcome.tscn",
+	"res://scenes/leaderboard_screen.tscn",
+	"res://scenes/pregame_setup.tscn",
+	"res://scenes/settings_menu.tscn",
+	"res://scenes/pause_menu.tscn",
+	"res://scenes/keybind_screen.tscn",
+	"res://scenes/player_guide.tscn",
+	"res://scenes/config_confirmation.tscn",
+]
+
+# Scenes whose _ready() self-navigates or hard-requires an in-progress game such that
+# adding them cold would disrupt the run. Each entry MUST carry a justification -- an
+# empty/undocumented skip is how a test goes hollow. (Empty today; kept as the
+# documented escape hatch so a future problem scene is skipped visibly, not silently.)
+const SKIP := {}
+
+# Floor so the sweep cannot pass vacuously if the tree is moved/renamed.
+const MIN_SCENES := 12
+
+
+func _collect(root: String, ext: String) -> Array:
+	var out: Array = []
+	var dir := DirAccess.open(root)
+	if dir == null:
+		return out
+	dir.list_dir_begin()
+	var name := dir.get_next()
+	while name != "":
+		if name == "." or name == "..":
+			name = dir.get_next()
+			continue
+		var path := root + "/" + name
+		if dir.current_is_dir():
+			out.append_array(_collect(path, ext))
+		elif name.ends_with(ext):
+			out.append(path)
+		name = dir.get_next()
+	dir.list_dir_end()
+	return out
+
+
+func _all_scenes() -> Array:
+	var scenes: Array = []
+	for root in SCENE_DIR_ROOTS:
+		scenes.append_array(_collect(root, ".tscn"))
+	for s in EXPLICIT_SCENES:
+		if not scenes.has(s):
+			scenes.append(s)
+	scenes.sort()
+	return scenes
+
+
+func test_ui_scenes_ready_without_crash():
+	var scenes := _all_scenes()
+	assert_gte(scenes.size(), MIN_SCENES,
+		"sweep found only %d UI scenes (< floor %d) -- the walk may be hollow" % [scenes.size(), MIN_SCENES])
+
+	var processed := 0
+	var failed: Array = []
+	for path in scenes:
+		if SKIP.has(path):
+			gut.p("  SKIP (%s): %s" % [SKIP[path], path])
+			continue
+
+		var packed = load(path)
+		if packed == null or not (packed is PackedScene) or not packed.can_instantiate():
+			failed.append("%s (load/can_instantiate failed)" % path)
+			continue
+
+		var inst = packed.instantiate()
+		if inst == null:
+			failed.append("%s (instantiate returned null)" % path)
+			continue
+
+		# add_child fires _ready(). If _ready() hard-crashes the engine, the whole
+		# process dies here and the runner reports missing results (RED) -- which is
+		# the intended detection for the leaderboard-class fault.
+		add_child(inst)
+		# Two frames: let _ready() run and one idle tick settle (deferred calls, first
+		# layout pass) before we tear the node down.
+		await get_tree().process_frame
+		await get_tree().process_frame
+
+		# Reaching here proves no hard crash. is_instance_valid guards the rare scene
+		# that legitimately frees itself in _ready (would be a false-negative to assert
+		# against); we only require that we survived and can clean up.
+		if is_instance_valid(inst):
+			remove_child(inst)
+			inst.free()
+		processed += 1
+
+	if not failed.is_empty():
+		for f in failed:
+			gut.p("  FAILED: %s" % f)
+	assert_eq(failed.size(), 0,
+		"%d UI scene(s) failed to instantiate/enter-tree (see list above)" % failed.size())
+	assert_gte(processed, MIN_SCENES,
+		"only %d UI scenes ran _ready (< floor %d)" % [processed, MIN_SCENES])
+	gut.p("ui-ready smoke: %d UI scenes entered the tree and ran _ready cleanly" % processed)

--- a/godot/tests/unit/test_ui_scene_ready_smoke.gd.uid
+++ b/godot/tests/unit/test_ui_scene_ready_smoke.gd.uid
@@ -1,0 +1,1 @@
+uid://cbpp7k52cno6g

--- a/godot/tools/validate_assets_probe.gd
+++ b/godot/tools/validate_assets_probe.gd
@@ -1,0 +1,86 @@
+extends SceneTree
+## Asset-import validation probe (run headless via tools/validate_assets.py).
+##
+## PURPOSE: catch a bad-asset landmine BEFORE it ships -- a corrupt/undecodable texture
+## or resource that imports "successfully" but fails to load, which is exactly the kind
+## of silent time-bomb that could crash a release build. It walks res://assets, LOADS
+## every importable resource, and asserts each one resolves to a non-null resource of a
+## sane type. A failure names the file and sets a non-zero exit code.
+##
+## HEADLESS-SAFE CHECKS ONLY: textures are validated by metadata (get_width/get_height
+## > 0), NOT by get_image() -- VRAM-compressed textures legitimately discard their CPU
+## image under the headless dummy renderer, so a get_image() check would false-fail. So
+## this proves the resource is STRUCTURALLY loadable; it does NOT GPU-decode. That last
+## mile is the human release-build playtest (see docs/LEADERBOARD_CRASH_DIAGNOSIS.md).
+
+const ASSET_ROOT := "res://assets"
+
+# Extensions we treat as loadable Godot resources. (.import sidecars and .uid are meta.)
+const LOADABLE_EXT := [
+	"png", "jpg", "jpeg", "webp", "svg", "bmp", "tga",   # textures
+	"ogg", "wav", "mp3",                                  # audio
+	"ttf", "otf", "woff", "woff2",                        # fonts
+	"tres", "res",                                        # packed resources
+]
+
+# Floor so a moved/emptied asset tree fails LOUDLY instead of passing vacuously.
+const MIN_ASSETS := 200
+
+
+func _collect(root: String) -> Array:
+	var out: Array = []
+	var dir := DirAccess.open(root)
+	if dir == null:
+		return out
+	dir.list_dir_begin()
+	var name := dir.get_next()
+	while name != "":
+		if name == "." or name == "..":
+			name = dir.get_next()
+			continue
+		var path := root + "/" + name
+		if dir.current_is_dir():
+			out.append_array(_collect(path))
+		else:
+			var ext := name.get_extension().to_lower()
+			if LOADABLE_EXT.has(ext):
+				out.append(path)
+		name = dir.get_next()
+	dir.list_dir_end()
+	return out
+
+
+func _init():
+	print("[validate_assets] walking %s ..." % ASSET_ROOT)
+	var assets := _collect(ASSET_ROOT)
+	assets.sort()
+	print("[validate_assets] found %d loadable asset files" % assets.size())
+
+	var failures: Array = []
+	var checked := 0
+	for path in assets:
+		var res = ResourceLoader.load(path)
+		if res == null:
+			failures.append("%s (ResourceLoader.load returned null -- corrupt or failed import)" % path)
+			continue
+		if res is Texture2D:
+			var tex := res as Texture2D
+			if tex.get_width() <= 0 or tex.get_height() <= 0:
+				failures.append("%s (Texture2D has non-positive size %dx%d)" % [path, tex.get_width(), tex.get_height()])
+				continue
+		checked += 1
+
+	print("[validate_assets] checked=%d  failed=%d" % [checked, failures.size()])
+	for f in failures:
+		printerr("[validate_assets][FAIL] %s" % f)
+
+	if assets.size() < MIN_ASSETS:
+		printerr("[validate_assets][FATAL] found only %d assets (< floor %d) -- the walk itself may be hollow" % [assets.size(), MIN_ASSETS])
+		quit(2)
+		return
+	if not failures.is_empty():
+		printerr("[validate_assets][FATAL] %d asset(s) failed to load -- DO NOT SHIP" % failures.size())
+		quit(1)
+		return
+	print("[validate_assets][PASS] all %d assets loaded structurally cleanly" % checked)
+	quit(0)

--- a/godot/tools/validate_assets_probe.gd.uid
+++ b/godot/tools/validate_assets_probe.gd.uid
@@ -1,0 +1,1 @@
+uid://dn1ccjxw0ogji

--- a/tools/validate_assets.py
+++ b/tools/validate_assets.py
@@ -1,0 +1,115 @@
+# !/usr/bin/env python3
+"""
+validate_assets.py -- pre-release asset-import validation gate.
+
+WHY THIS EXISTS: a corrupt or undecodable texture/resource can import "successfully"
+in the editor yet fail to load at runtime -- a silent landmine that could crash a
+release build the first time a scene references it. This gate reimports the project
+from a clean asset cache and then LOADS every resource under godot/assets, failing
+loudly (non-zero exit) if any asset does not resolve. Run it before cutting a build.
+
+WHAT IT DOES:
+    1. (default) `godot --import` so the asset cache reflects the current tree.
+    2. Runs godot/tools/validate_assets_probe.gd headless, which walks res://assets,
+       ResourceLoader.load()s each importable file, and checks textures have a sane
+       size. The probe exits non-zero on any failure or if the walk finds too few
+       assets (anti-hollow floor).
+
+LIMITATION (honest): headless validation proves each asset is STRUCTURALLY loadable;
+it does NOT GPU-decode textures (the dummy renderer discards VRAM-compressed CPU
+images). The human release-build playtest remains the final gate.
+
+Usage:
+    python tools/validate_assets.py
+    python tools/validate_assets.py --no-import        # skip the reimport pass (faster)
+    python tools/validate_assets.py --godot-path "C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe"
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_GODOT_CANDIDATES = [
+    Path("C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe"),
+    Path("C:/Program Files/Godot/Godot.exe"),
+    Path.home() / "Godot" / "Godot_v4.5.1-stable_win64.exe",
+    Path("/usr/bin/godot"),
+    Path("/usr/local/bin/godot"),
+    Path("/Applications/Godot.app/Contents/MacOS/Godot"),
+]
+
+PROBE = "res://tools/validate_assets_probe.gd"
+
+
+def find_godot(explicit: Optional[str]) -> Path:
+    if explicit:
+        p = Path(explicit)
+        if not p.exists():
+            print(f"[validate_assets][FATAL] --godot-path does not exist: {p}", file=sys.stderr)
+            sys.exit(2)
+        return p
+    for cand in DEFAULT_GODOT_CANDIDATES:
+        if cand.exists():
+            return cand
+    which = shutil.which("godot")
+    if which:
+        return Path(which)
+    print("[validate_assets][FATAL] Godot executable not found; pass --godot-path", file=sys.stderr)
+    sys.exit(2)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--godot-path", default=None)
+    ap.add_argument("--project", default=None, help="Godot project dir (default: <repo>/godot).")
+    ap.add_argument(
+        "--no-import", action="store_true", help="Skip the reimport pass before validating."
+    )
+    args = ap.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    project = Path(args.project).resolve() if args.project else (repo_root / "godot")
+    if not (project / "project.godot").exists():
+        print(f"[validate_assets][FATAL] no project.godot under {project}", file=sys.stderr)
+        return 2
+
+    godot = find_godot(args.godot_path)
+    print(f"[validate_assets] Godot:   {godot}")
+    print(f"[validate_assets] Project: {project}")
+
+    if not args.no_import:
+        print("[validate_assets] reimport pass ...")
+        r = subprocess.run(
+            [str(godot), "--headless", "--path", str(project), "--import"],
+            text=True,
+            check=False,
+        )
+        # Import may exit non-zero on cold class-cache noise; the probe is the real gate.
+        if r.returncode != 0:
+            print(f"[validate_assets] import returned {r.returncode} (tolerated; running probe).")
+
+    print("[validate_assets] running probe ...")
+    r = subprocess.run(
+        [str(godot), "--headless", "--path", str(project), "--script", PROBE],
+        text=True,
+        check=False,
+    )
+    if r.returncode == 0:
+        print("[validate_assets][PASS] all assets loaded structurally cleanly.")
+    else:
+        print(
+            f"[validate_assets][FAIL] probe exited {r.returncode} -- see [FAIL] lines above. DO NOT SHIP.",
+            file=sys.stderr,
+        )
+    return r.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this is

Reconciles the UNIQUE defensive tooling from PR #747
(`fix/leaderboard-crash-deep-diagnosis`) onto `main` **after** #779 already
merged the canonical leaderboard crash fix (`SceneTransition` deferred-nav +
scene-nav chokepoint + CI hardening). This PR brings ONLY the regression-net
files #747 has that main lacks -- it does not touch, revert, or duplicate
anything #779 landed.

**#747 should be closed as superseded** once this merges.

## Kept from #747 (the regression net)

- `godot/tests/unit/test_ui_scene_ready_smoke.gd` (+ `.uid`) -- headless test
  that instantiates, adds-to-tree, and runs `_ready()` on every UI scene.
  Guards the exact add-to-tree crash class that #779 fixed (the existing
  `test_smoke_load_all.gd` only `instantiate()`s and never enters the tree, so
  `_ready()` never runs there).
- `tools/validate_assets.py` -- asset-import validation gate.
- `godot/tools/validate_assets_probe.gd` (+ `.uid`) -- the Godot-side probe
  `validate_assets.py` drives (walks `res://assets`, `ResourceLoader.load()`s
  each importable file).

## Dropped from #747 (deliberately)

- `tools/build_release.py`, `docs/LEADERBOARD_CRASH_DIAGNOSIS.md`,
  `docs/POSTMORTEM_v0.11.0_ALPHA.md` -- **main's #779 versions are canonical**;
  bringing #747's would revert/duplicate. Left exactly as-is on main.
- `godot/scenes/leaderboard_screen_minimal.tscn` /
  `godot/scripts/ui/leaderboard_screen_min_stub.gd` (+ uid) -- throwaway
  diagnostic fixtures **not referenced** by the smoke test (verified: the test
  sweeps `res://scenes/ui/**` + a list of real standalone screens; no stub).
- `godot/scripts/ui/leaderboard_screen.gd` -- only `printerr` trace-stamp
  diagnostics from the investigation; not a regression net, and the crash it
  probed is already fixed by #779.
- `godot/autoload/theme_manager.gd` -- **skipped**. It deletes two entries
  (`tex_cyan_ispf`, `tex_oxidized_copper`) from a texture-path lookup map as
  part of the *disproven* texture-segfault theory. That is more than harmless
  dead-string cleanup (it removes dictionary keys), and textures are now
  exonerated, so it is optional -- skipped to avoid any behavior change.

## Verification (run on this branch, i.e. current `main` post-#779)

- `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`
  -> **PASS**: 551 tests, 0 failures, 63/63 files collected (includes the new
  `test_ui_scenes_ready_without_crash` scene-smoke -- confirms the merged fix
  holds and no UI scene regressed).
- `python tools/validate_assets.py` -> **PASS** (all assets resolve
  structurally clean).
- `python tools/check_scene_nav.py` -> **exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)