### PR TITLE
feat(onboarding): first-launch welcome overlay + show_hints toggle (#720)

### DIFF
--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -33,6 +33,12 @@ var colorblind_mode: bool = false  # Adds patterns/symbols alongside colors
 # it. Display-only -- the underlying log content and simulation are unchanged.
 var show_rivals_feed: bool = true
 
+# Onboarding gameplay hints (issue #720). Master switch for in-play help surfaces
+# (the getting-started hint, the first-launch welcome overlay, and any future hint
+# surface). Default ON; players who find hints noisy can flip it off. View-only --
+# never touches game state, RNG, turn order, or scoring.
+var show_hints: bool = true
+
 # A/B UI layout switch (UI_PROPOSALS_2026-07-22 section 4). Scaffolding for Pip's
 # in-game iteration: "classic" = today's PLAN/WATCH arrangement (pixel-identical);
 # "proposed" = the P6/P9/P10/P11 assembly (constrained cat, grouped action submenus,
@@ -58,6 +64,12 @@ var pending_load_path: String = ""
 
 # Version tracking for What's New feature
 var last_seen_version: String = ""  # Empty = never seen patch notes
+
+# First-launch welcome overlay show-once gate (issue #720). Reuses the
+# last_seen_version show-once shape: once the welcome/help overlay has been shown
+# it is marked seen and PERSISTED, so it never re-appears on later launches -- even
+# if the player quits before finishing a game (which would leave games_played at 0).
+var welcome_seen: bool = false
 # Single source of truth for the game version is version.txt at the repo root.
 # This const is the runtime copy: it is STAMPED from version.txt by
 # tools/sync_version.py (metadata overrides hard values). Do not hand-edit --
@@ -119,6 +131,10 @@ func save_config() -> void:
 	# Interface section
 	config.set_value("interface", "show_rivals_feed", show_rivals_feed)
 	config.set_value("interface", "ui_layout", ui_layout)
+	config.set_value("interface", "show_hints", show_hints)
+
+	# Onboarding section (issue #720)
+	config.set_value("onboarding", "welcome_seen", welcome_seen)
 
 	# Leaderboard section
 	config.set_value("leaderboard", "submit_scores_global", submit_scores_global)
@@ -171,6 +187,10 @@ func load_config() -> void:
 	ui_layout = config.get_value("interface", "ui_layout", ui_layout)
 	if not UI_LAYOUTS.has(ui_layout):
 		ui_layout = "classic"  # guard against a stale/garbage persisted value
+	show_hints = config.get_value("interface", "show_hints", show_hints)
+
+	# Load onboarding settings (issue #720)
+	welcome_seen = config.get_value("onboarding", "welcome_seen", welcome_seen)
 
 	# Load leaderboard settings
 	submit_scores_global = config.get_value("leaderboard", "submit_scores_global", submit_scores_global)
@@ -242,6 +262,8 @@ func set_setting(key: String, value, save_immediately: bool = false) -> void:
 			apply_graphics_settings()
 		"colorblind_mode":
 			colorblind_mode = value
+		"show_hints":
+			show_hints = value
 		"submit_scores_global":
 			submit_scores_global = value
 		"ui_layout":
@@ -398,6 +420,21 @@ func mark_patch_notes_seen() -> void:
 ## Get the current game version
 func get_current_version() -> String:
 	return CURRENT_VERSION
+
+## Should the first-launch welcome/help overlay be shown? (issue #720)
+## True only on a genuine first launch (no games played yet), when it has never
+## been shown before, and while gameplay hints are enabled. The welcome_seen gate
+## makes this show-once even if the player quits before finishing a game.
+func should_show_welcome() -> bool:
+	return show_hints and games_played == 0 and not welcome_seen
+
+## Mark the welcome overlay as shown so it never re-appears (issue #720).
+func mark_welcome_seen() -> void:
+	if welcome_seen:
+		return
+	welcome_seen = true
+	save_config()
+	print("[GameConfig] Welcome overlay marked as seen")
 
 ## Debug print current configuration
 func print_config() -> void:

--- a/godot/scenes/ui/welcome_overlay.tscn
+++ b/godot/scenes/ui/welcome_overlay.tscn
@@ -1,0 +1,124 @@
+[gd_scene load_steps=4 format=3 uid="uid://welcomeoverlay720"]
+
+[ext_resource type="Script" path="res://scripts/ui/welcome_overlay.gd" id="1_welcome"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.09, 0.04, 0.11, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.91, 0.64, 0.24, 0.8)
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_button"]
+bg_color = Color(0.18, 0.145, 0.278, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.91, 0.64, 0.24, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="WelcomeOverlay" type="Control"]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("1_welcome")
+
+[node name="Overlay" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 0
+color = Color(0, 0, 0, 0.75)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="CenterContainer"]
+custom_minimum_size = Vector2(600, 0)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="MarginContainer" type="MarginContainer" parent="CenterContainer/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 30
+theme_override_constants/margin_top = 25
+theme_override_constants/margin_right = 30
+theme_override_constants/margin_bottom = 25
+
+[node name="VBox" type="VBoxContainer" parent="CenterContainer/PanelContainer/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 15
+
+[node name="TitleLabel" type="Label" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
+theme_override_font_sizes/font_size = 36
+text = "Welcome to P(Doom)1"
+horizontal_alignment = 1
+
+[node name="HSeparator" type="HSeparator" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+layout_mode = 2
+
+[node name="BodyLabel" type="RichTextLabel" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+custom_minimum_size = Vector2(0, 150)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_colors/default_color = Color(0.85, 0.88, 0.92, 1)
+theme_override_font_sizes/normal_font_size = 16
+bbcode_enabled = true
+text = "You run an AI safety lab racing to keep P(Doom) -- the probability of catastrophe -- from hitting 100%.
+
+New here? The [b][color=#f2a33d]Player Guide[/color][/b] walks you through the goal, the turn loop, and how your actions move doom, money, and reputation.
+
+[color=#aaaaaa]You can reopen it any time from the main menu, and toggle these hints off under Settings > Gameplay.[/color]"
+fit_content = true
+scroll_active = false
+
+[node name="HSeparator2" type="HSeparator" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+layout_mode = 2
+
+[node name="ButtonRow" type="HBoxContainer" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
+layout_mode = 2
+theme_override_constants/separation = 20
+alignment = 1
+
+[node name="GuideButton" type="Button" parent="CenterContainer/PanelContainer/MarginContainer/VBox/ButtonRow"]
+custom_minimum_size = Vector2(220, 45)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 18
+theme_override_styles/normal = SubResource("StyleBoxFlat_button")
+text = ">> Open Player Guide"
+
+[node name="CloseButton" type="Button" parent="CenterContainer/PanelContainer/MarginContainer/VBox/ButtonRow"]
+custom_minimum_size = Vector2(200, 45)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_hover_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 18
+theme_override_styles/normal = SubResource("StyleBoxFlat_button")
+text = "Got it  [ESC]"

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -942,9 +942,10 @@ func _on_game_state_updated(state: Dictionary):
 		# Show cat if adopted, hide if not
 		office_cat.visible = state.get("has_cat", false)
 
-	# Hide getting started hint after turn 3 (new player onboarding)
+	# Hide getting started hint after turn 3 (new player onboarding).
+	# Gated on GameConfig.show_hints (issue #720) so the hints toggle suppresses it.
 	if getting_started_hint:
-		getting_started_hint.visible = state.get("turn", 0) < 3
+		getting_started_hint.visible = GameConfig.show_hints and state.get("turn", 0) < 3
 
 	# Enable controls after first init
 	if state.get("turn", 0) >= 0:

--- a/godot/scripts/ui/settings_menu.gd
+++ b/godot/scripts/ui/settings_menu.gd
@@ -37,6 +37,9 @@ func _ready():
 	# Add the global-leaderboard opt-out under Gameplay (built in code, not the .tscn)
 	_add_global_leaderboard_toggle()
 
+	# Add the "Show gameplay hints" onboarding toggle under Gameplay (issue #720)
+	_add_show_hints_toggle()
+
 	# Add the experimental A/B UI layout toggle under UI (built in code, not the .tscn)
 	_add_ui_layout_toggle()
 
@@ -163,6 +166,33 @@ func _on_global_leaderboard_toggled(pressed: bool):
 	print("[SettingsMenu] Submit scores to global leaderboard: ", pressed)
 	GameConfig.set_setting("submit_scores_global", pressed, false)
 	NotificationManager.info("Global leaderboard submission " + ("enabled" if pressed else "disabled"))
+
+var show_hints_checkbox: CheckButton = null
+
+func _add_show_hints_toggle():
+	"""Append a 'Show gameplay hints' toggle to the Gameplay section (issue #720).
+	Master switch for onboarding help surfaces (getting-started hint + first-launch
+	welcome overlay). Respects the player's choice (GameConfig.show_hints). Default ON."""
+	var gameplay = get_node_or_null("VBox/SettingsContainer/GameplaySettings")
+	if gameplay == null:
+		return
+	var row = HBoxContainer.new()
+	var label = Label.new()
+	label.text = "Show gameplay hints"
+	label.tooltip_text = "Show onboarding help: the getting-started hint and the first-launch welcome overlay."
+	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(label)
+	show_hints_checkbox = CheckButton.new()
+	show_hints_checkbox.button_pressed = GameConfig.show_hints
+	show_hints_checkbox.toggled.connect(_on_show_hints_toggled)
+	row.add_child(show_hints_checkbox)
+	gameplay.add_child(row)
+
+func _on_show_hints_toggled(pressed: bool):
+	"""Handle the show-gameplay-hints toggle (issue #720)."""
+	print("[SettingsMenu] Show gameplay hints: ", pressed)
+	GameConfig.set_setting("show_hints", pressed, false)
+	NotificationManager.info("Gameplay hints " + ("enabled" if pressed else "disabled"))
 
 var ui_layout_checkbox: CheckButton = null
 

--- a/godot/scripts/ui/welcome_overlay.gd
+++ b/godot/scripts/ui/welcome_overlay.gd
@@ -1,0 +1,56 @@
+extends Control
+## Welcome Overlay - first-launch onboarding help layer (issue #720)
+##
+## A single dismissible welcome/help overlay shown ONCE on a genuine first launch
+## (GameConfig.should_show_welcome()). Points the player at the Player Guide.
+## Reuses the What's New modal shape + the last_seen_version show-once mechanism
+## (GameConfig.welcome_seen is persisted the moment the overlay is shown, so it
+## never re-appears -- even if the player quits before finishing a game).
+##
+## View-layer only: this touches no game state, RNG, turn order, or scoring.
+
+signal closed
+
+const PLAYER_GUIDE_SCENE = "res://scenes/player_guide.tscn"
+
+@onready var guide_button: Button = $CenterContainer/PanelContainer/MarginContainer/VBox/ButtonRow/GuideButton
+@onready var close_button: Button = $CenterContainer/PanelContainer/MarginContainer/VBox/ButtonRow/CloseButton
+
+func _ready():
+	# Hide by default; the welcome screen decides whether to show us.
+	visible = false
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+	guide_button.pressed.connect(_on_guide_pressed)
+	close_button.pressed.connect(_on_close_pressed)
+
+func _input(event: InputEvent):
+	# Only handle input while visible.
+	if not visible:
+		return
+	if event is InputEventKey and event.pressed and not event.echo:
+		if event.keycode == KEY_ESCAPE or event.keycode == KEY_ENTER or event.keycode == KEY_SPACE:
+			_on_close_pressed()
+			get_viewport().set_input_as_handled()
+
+## Show the overlay and mark it as seen (persisted show-once).
+func show_overlay() -> void:
+	visible = true
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	close_button.grab_focus()
+	# Mark seen immediately (like whats_new marks on show): even if the player then
+	# opens the Player Guide instead of dismissing, the overlay never re-appears.
+	GameConfig.mark_welcome_seen()
+
+## Hide the overlay.
+func hide_overlay() -> void:
+	visible = false
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	closed.emit()
+
+func _on_guide_pressed() -> void:
+	print("[WelcomeOverlay] Opening Player Guide...")
+	SceneTransition.go_to(PLAYER_GUIDE_SCENE)
+
+func _on_close_pressed() -> void:
+	hide_overlay()

--- a/godot/scripts/ui/welcome_overlay.gd.uid
+++ b/godot/scripts/ui/welcome_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://qmgpy7spj4ma

--- a/godot/scripts/ui/welcome_screen.gd
+++ b/godot/scripts/ui/welcome_screen.gd
@@ -20,6 +20,10 @@ extends Control
 var whats_new_modal: Control = null
 const WHATS_NEW_SCENE = preload("res://scenes/ui/whats_new_modal.tscn")
 
+# First-launch welcome overlay (issue #720)
+var welcome_overlay: Control = null
+const WELCOME_OVERLAY_SCENE = preload("res://scenes/ui/welcome_overlay.tscn")
+
 var menu_buttons: Array[Button] = []
 var selected_index: int = 0
 
@@ -73,8 +77,10 @@ func _ready():
 	# confirm which build he's on right from the welcome/loading screen.
 	add_child(DevBuildBadge.new())
 
-	# Initialize What's New modal
-	_setup_whats_new_modal()
+	# Initialize the first-launch onboarding overlays (welcome + What's New).
+	# The welcome overlay (issue #720) takes priority on a genuine first launch so the
+	# two modals never stack; What's New handles returning players after an update.
+	_setup_onboarding_overlays()
 
 	# Enable input processing for keyboard navigation
 	set_process_input(true)
@@ -181,17 +187,32 @@ func _on_whats_new_pressed():
 	if whats_new_modal:
 		whats_new_modal.show_all_notes()
 
-func _setup_whats_new_modal():
-	"""Initialize the What's New modal and check for unseen patch notes"""
-	# Instance the modal
+func _setup_onboarding_overlays():
+	"""Instance both first-launch overlays, then auto-show at most ONE.
+
+	Priority: on a genuine first launch (GameConfig.should_show_welcome()) show the
+	welcome/help overlay (issue #720) and silently mark patch notes seen -- a brand
+	new player does not need a change-log, and this stops the two modals stacking.
+	Otherwise fall back to the What's New modal for returning players after an update."""
+	# Instance the What's New modal
 	whats_new_modal = WHATS_NEW_SCENE.instantiate()
 	add_child(whats_new_modal)
-
-	# Connect the closed signal to restore focus
 	whats_new_modal.closed.connect(_on_whats_new_closed)
 
-	# Check if we should show the modal automatically (first launch after update)
-	if GameConfig.has_unseen_patch_notes():
+	# Instance the welcome overlay
+	welcome_overlay = WELCOME_OVERLAY_SCENE.instantiate()
+	add_child(welcome_overlay)
+	welcome_overlay.closed.connect(_on_whats_new_closed)
+
+	if GameConfig.should_show_welcome():
+		print("[WelcomeScreen] First launch detected! Showing welcome overlay...")
+		# A brand-new player does not need patch notes; mark them seen so What's New
+		# does not also fire (now or on the next launch).
+		GameConfig.mark_patch_notes_seen()
+		# Delay slightly to ensure UI is ready
+		await get_tree().create_timer(0.3).timeout
+		welcome_overlay.show_overlay()  # marks welcome_seen (persisted show-once)
+	elif GameConfig.has_unseen_patch_notes():
 		print("[WelcomeScreen] New version detected! Showing What's New modal...")
 		# Delay slightly to ensure UI is ready
 		await get_tree().create_timer(0.3).timeout


### PR DESCRIPTION
Closes #720. Onboarding help-layer skeleton for tonight's v0.12.0 friends-and-family build.

## What this builds
- **`GameConfig.show_hints`** (bool, default `true`), PERSISTED in the `interface` section and round-tripped through `save_config`/`load_config`. Exposed as a **"Show gameplay hints"** toggle in **Settings > Gameplay** (built in code, same pattern as the global-leaderboard toggle).
- **First-launch welcome overlay** (`scenes/ui/welcome_overlay.tscn` + `scripts/ui/welcome_overlay.gd`): one dismissible welcome/help modal pointing at the Player Guide (an **Open Player Guide** button navigates via `SceneTransition.go_to`, plus a **Got it [ESC]** dismiss). Reuses the What's New modal shape.
- **Show-once, persisted:** new `welcome_seen` flag (persisted in a new `onboarding` section) + `should_show_welcome()` / `mark_welcome_seen()` mirroring the `last_seen_version` pattern. The overlay marks itself seen the moment it is shown, so it never re-appears -- even if the player quits before finishing a game (which leaves `games_played == 0`).
- **No modal stacking:** on a genuine first launch the welcome overlay takes priority and silently marks patch notes seen; What's New only auto-shows for returning players after an update.
- **Toggle respected everywhere:** `getting_started_hint` in `main_ui.gd` is now gated on `GameConfig.show_hints`, and `should_show_welcome()` also checks it.

## Scope / safety
View-layer only. No game state, RNG, turn order, scoring, determinism, or replay/leaderboard surface is touched -- ships as a non-gameplay item, does not fork the ladder. Scene nav is exclusively via `SceneTransition`.

## Logic walk-through
- Overlay shows iff `show_hints and games_played == 0 and not welcome_seen`.
- On show -> `mark_welcome_seen()` persists `welcome_seen = true` -> never re-appears.
- Toggle OFF suppresses both the welcome overlay and the getting-started hint.
- `show_hints` and `welcome_seen` both round-trip through `save_config`/`load_config`.

## How to test manually
1. Delete `%APPDATA%/Godot/app_userdata/<project>/config.cfg` (or `user://config.cfg`) to simulate first launch, run the game -> welcome overlay appears on the menu; click **Open Player Guide** (opens the guide) or **Got it**; restart -> it does NOT reappear.
2. Settings > Gameplay -> toggle **Show gameplay hints** off, Apply -> start a game -> the turn<3 getting-started hint is suppressed; toggle back on -> it returns.

## Verification
- `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **PASS: 562 tests, 0 failures, 64/64 files** (includes the scene-smoke sweep, which now instantiates + `_ready`s the new overlay scene without crashing).
- `python tools/check_scene_nav.py` -> **exit 0**.
- Pre-commit (no-emoji / ASCII, scene-nav, version-sync) all passed.

Do NOT merge -- for admin review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)