### PR TITLE
docs: CREDITS.md (music close-out) -- READY, hold merge until deploy cooks

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,66 @@
+# Credits -- P(Doom)1
+
+P(Doom)1 -- a turn-based AI-safety strategy game.
+
+> This file is a repo document (it lives at the repo root, outside `godot/`, so
+> it is not bundled into the shipped build). Some fields are marked
+> **[Pip to fill]** -- placeholders for names/attributions only Pip can confirm.
+> An in-game credits screen, if wanted, is a separate follow-up.
+
+## Game
+
+- **Design, direction, and development:** Pip Foweraker  *(adjust name form as preferred)*
+- **Engine:** [Godot Engine](https://godotengine.org) 4.5.1 (MIT License)
+
+## Music
+
+**Original adaptive score** (the composed five-tier doom-band soundtrack + the
+victory, defeat, and menu cues that ship today):
+
+- **Composition, direction, and taste authority:** Pip Foweraker -- the musician
+  and director; every note judged by ear over the workshop sessions.
+- **Composed with:** Claude (Anthropic's Claude Code, "Fable"), as the
+  live-coding instrument and studio hand, under Pip's direction. The score was
+  workshopped in Strudel patches and rendered to the game's audio beds.
+- **Authoring tool:** [Strudel](https://strudel.cc) (live-codeable music in the browser).
+
+**Original placeholder tracks** (the ambient beds that stood in during
+development, now retired but preserved in `archive/audio/`):
+
+- **Written and performed by:** **[Pip to fill -- friend's name / handle / "prefers anonymity"]**
+  -- DJ-session ambient tracks, generously given to the project. Pip authored
+  the (AI-safety pun) track titles; project holds full usage rights.
+- With thanks for setting the sonic tone the composed score grew out of.
+
+## Playtesting
+
+- **[Pip to fill -- playtester name(s) / handle(s)]**
+
+## Tools and third-party components
+
+- [Godot Engine](https://godotengine.org) -- game engine (MIT)
+- [GUT](https://github.com/bitwes/Gut) -- Godot unit test framework (dev/CI, MIT)
+- [Strudel](https://strudel.cc) -- music authoring (composition sessions)
+- Art pipeline & attributions: **[Pip / art lane to fill]**  *(pixellab, image-gen tooling, etc.)*
+
+## Aesthetic gratitude
+
+The score learned from, but did not copy, a set of north-star artists (Master
+Musicians of Bukkake, Philip Glass, and others). They are inspirations only,
+with no affiliation or endorsement; the lineage is documented in
+`docs/audio/REFERENCE_TRACKS.md`.
+
+---
+
+### Notes for Pip (resolve before any public/shipped credits use)
+
+- [ ] Confirm your preferred credited name/handle (used "Pip Foweraker" above).
+- [ ] Fill your friend's name/handle for the original tracks -- or "prefers
+      anonymity" if that is their wish. Confirm the rights note in writing
+      (the music brief says you hold full rights; STEM_CATALOGUE.md suggests
+      capturing that as a saved message).
+- [ ] Fill playtester acknowledgement(s).
+- [ ] Decide how prominent the AI-collaboration credit should be -- the wording
+      above is honest-and-plain; dial up or down to taste.
+- [ ] Fill the art-pipeline attributions (owned by the art lane, not this session).
+- [ ] Decide whether an in-game credits screen is wanted (separate feature).


### PR DESCRIPTION
Root-level `CREDITS.md`. Sits outside `godot/`, so it does **not** ship in the .pck (no bloat to the release build).

**DO NOT MERGE until the 400mb build deploy finishes** -- Pip wants that to cook undisturbed. Nothing here touches main until you merge; new file, zero conflict risk.

Filled: game/engine, the composed adaptive score (Pip directing, composed with Claude/Fable in Strudel), the friend's retired original tracks acknowledged, tools.

Left for Pip (values calls, in the "Notes for Pip" checklist at the bottom of the file):
- [ ] your preferred credited name/handle
- [ ] your friend's name/handle -- or "prefers anonymity" (deliberately not invented; unnamed in-repo)
- [ ] playtester credit
- [ ] AI-credit prominence (wording is honest-and-plain; dial to taste)
- [ ] art-pipeline attributions (art lane's to fill)
- [ ] whether to build an in-game credits screen (separate feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)