### PR TITLE
docs: release/league cycle runbook + tension audit (2026-07-23)

### DIFF
--- a/docs/RELEASE_AND_LEAGUE_CYCLE.html
+++ b/docs/RELEASE_AND_LEAGUE_CYCLE.html
@@ -1,0 +1,357 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>P(Doom) Release &amp; League Cycle -- internal runbook</title>
+<style>
+  :root {
+    --bg: #f7f6f3;
+    --panel: #ffffff;
+    --ink: #1c1d21;
+    --muted: #5c5f66;
+    --line: #e2e0da;
+    --accent: #b4531f;        /* burnt orange -- the "epoch fork" colour */
+    --accent-soft: #f3e7dd;
+    --good: #2f6b41;
+    --good-soft: #e4efe6;
+    --warn: #9a6a00;
+    --warn-soft: #f6ecd4;
+    --danger: #a12a26;
+    --danger-soft: #f6e0de;
+    --code-bg: #f0eee9;
+    --mono: ui-monospace, "Cascadia Code", "Consolas", monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #16171a; --panel: #1e2024; --ink: #e9e8e4; --muted: #9a9ea6;
+      --line: #2f3238; --accent: #e0864f; --accent-soft: #33261d;
+      --good: #7fc496; --good-soft: #1c2a21; --warn: #d9ad55; --warn-soft: #2b2416;
+      --danger: #e88a86; --danger-soft: #2c1a19; --code-bg: #26282d;
+    }
+  }
+  :root[data-theme="dark"] {
+      --bg: #16171a; --panel: #1e2024; --ink: #e9e8e4; --muted: #9a9ea6;
+      --line: #2f3238; --accent: #e0864f; --accent-soft: #33261d;
+      --good: #7fc496; --good-soft: #1c2a21; --warn: #d9ad55; --warn-soft: #2b2416;
+      --danger: #e88a86; --danger-soft: #2c1a19; --code-bg: #26282d;
+  }
+  :root[data-theme="light"] {
+      --bg: #f7f6f3; --panel: #ffffff; --ink: #1c1d21; --muted: #5c5f66;
+      --line: #e2e0da; --accent: #b4531f; --accent-soft: #f3e7dd;
+      --good: #2f6b41; --good-soft: #e4efe6; --warn: #9a6a00; --warn-soft: #f6ecd4;
+      --danger: #a12a26; --danger-soft: #f6e0de; --code-bg: #f0eee9;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: var(--sans); line-height: 1.55;
+    font-size: 16px;
+  }
+  .wrap { max-width: 900px; margin: 0 auto; padding: 2.5rem 1.25rem 5rem; }
+  header.doc { border-bottom: 2px solid var(--accent); padding-bottom: 1rem; margin-bottom: 2rem; }
+  header.doc h1 { font-size: 1.9rem; margin: 0 0 .35rem; letter-spacing: -.01em; text-wrap: balance; }
+  .sub { color: var(--muted); font-size: .95rem; }
+  .pin { display: inline-block; background: var(--accent-soft); color: var(--accent);
+         border: 1px solid var(--accent); border-radius: 4px; padding: .05rem .45rem;
+         font-family: var(--mono); font-size: .8rem; font-weight: 600; }
+  h2 { font-size: 1.35rem; margin: 2.5rem 0 .75rem; padding-top: .5rem;
+       border-top: 1px solid var(--line); letter-spacing: -.01em; }
+  h2 .n { color: var(--accent); font-family: var(--mono); font-size: 1rem; margin-right: .5rem; }
+  h3 { font-size: 1.05rem; margin: 1.5rem 0 .4rem; }
+  p { margin: .5rem 0; }
+  code { font-family: var(--mono); background: var(--code-bg); padding: .08rem .32rem;
+         border-radius: 3px; font-size: .88em; }
+  pre { background: var(--code-bg); border: 1px solid var(--line); border-radius: 6px;
+        padding: .85rem 1rem; overflow-x: auto; font-family: var(--mono);
+        font-size: .85rem; line-height: 1.5; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: .92rem; }
+  th, td { text-align: left; padding: .55rem .7rem; border-bottom: 1px solid var(--line);
+           vertical-align: top; }
+  th { font-size: .78rem; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+  td code { white-space: nowrap; }
+  .tablewrap { overflow-x: auto; }
+  .card { background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+          padding: 1rem 1.2rem; margin: 1rem 0; }
+  .callout { border-left: 4px solid; border-radius: 0 6px 6px 0; padding: .8rem 1rem;
+             margin: 1.1rem 0; }
+  .callout .lbl { font-weight: 700; font-size: .8rem; text-transform: uppercase;
+                  letter-spacing: .05em; display: block; margin-bottom: .25rem; }
+  .callout.danger { background: var(--danger-soft); border-color: var(--danger); }
+  .callout.danger .lbl { color: var(--danger); }
+  .callout.warn { background: var(--warn-soft); border-color: var(--warn); }
+  .callout.warn .lbl { color: var(--warn); }
+  .callout.good { background: var(--good-soft); border-color: var(--good); }
+  .callout.good .lbl { color: var(--good); }
+  .pill { font-family: var(--mono); font-size: .78rem; font-weight: 600; padding: .05rem .4rem;
+          border-radius: 4px; white-space: nowrap; }
+  .pill.fork { background: var(--accent-soft); color: var(--accent); }
+  .pill.nofork { background: var(--good-soft); color: var(--good); }
+  ol.steps { counter-reset: step; list-style: none; padding-left: 0; }
+  ol.steps > li { counter-increment: step; position: relative; padding: .1rem 0 .9rem 2.6rem;
+                  border-left: 2px solid var(--line); margin-left: .9rem; }
+  ol.steps > li::before { content: counter(step); position: absolute; left: -0.95rem; top: 0;
+      width: 1.8rem; height: 1.8rem; background: var(--accent); color: #fff;
+      border-radius: 50%; display: grid; place-items: center; font-weight: 700;
+      font-family: var(--mono); font-size: .9rem; }
+  ol.steps > li:last-child { border-left-color: transparent; }
+  .muted { color: var(--muted); }
+  .foot { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--line);
+          color: var(--muted); font-size: .85rem; }
+  .toc { columns: 2; column-gap: 2rem; font-size: .9rem; margin: 1rem 0 0; }
+  .toc a { color: var(--ink); text-decoration: none; }
+  .toc a:hover { color: var(--accent); text-decoration: underline; }
+  @media (max-width: 620px) { .toc { columns: 1; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="doc">
+  <h1>P(Doom) Release &amp; League Cycle</h1>
+  <div class="sub">Internal runbook -- nomenclature, cadence, the fork rule, and the
+  epoch-cut process. So future devs (and future Claude) do not mangle an epoch shift.</div>
+  <p style="margin-top:.8rem"><span class="pin">PINNED 2026-07-24</span>
+     &nbsp;<span class="muted">Reflective review due on/after 2026-08-24 (see issue in footer).
+     Provisional until then -- especially the weekly-league cadence.</span></p>
+</header>
+
+<div class="card">
+  <strong>Read me first.</strong> There are two version numbers and two cadences. Keeping
+  them apart is the whole point. If you change one thing before an epoch cut, let it be
+  this: <em>the ladder bump and the gameplay it scopes must ship in the same build.</em>
+  <nav class="toc">
+    <a href="#nom">1. Nomenclature (the six words)</a><br>
+    <a href="#cadence">2. The two cadences</a><br>
+    <a href="#fork">3. The fork rule (what starts a new epoch)</a><br>
+    <a href="#labels">4. Issue labels</a><br>
+    <a href="#runbook">5. Epoch-cut runbook (L1 -&gt; L2)</a><br>
+    <a href="#cheat">6. Cheat card</a>
+  </nav>
+</div>
+
+<h2 id="nom"><span class="n">1</span>Nomenclature -- the six words</h2>
+<p>Use these exactly. The confusion this doc exists to kill is treating "version",
+"epoch", "league", and "board" as the same thing. They are not.</p>
+<div class="tablewrap">
+<table>
+<thead><tr><th>Word</th><th>What it is</th><th>Where it lives</th><th>Changes the board?</th></tr></thead>
+<tbody>
+<tr><td><strong>build_version</strong></td>
+    <td>Identifies the binary / <code>.pck</code>. Bumps every release and patch. Semver, e.g. <code>0.13.0</code>.</td>
+    <td><code>version.txt</code> -&gt; stamped into <code>game_config.gd CURRENT_VERSION</code></td>
+    <td><strong>No.</strong> Cosmetic bumps must not fork the board.</td></tr>
+<tr><td><strong>ladder_version</strong></td>
+    <td>The ruleset. A small integer, rendered <code>L2</code>. Bumps only when gameplay / scoring / seed-generation rules change.</td>
+    <td><code>ladder_version.txt</code> -&gt; stamped into <code>game_config.gd LADDER_VERSION</code></td>
+    <td><strong>Yes.</strong> This is the board scope (<code>get_board_version()</code>).</td></tr>
+<tr><td><strong>epoch</strong></td>
+    <td>One value of <code>ladder_version</code>. "The game's current rules." Scores are comparable within an epoch, never across.</td>
+    <td>= the current <code>ladder_version</code></td>
+    <td>Is the rotation.</td></tr>
+<tr><td><strong>league</strong></td>
+    <td>A promoted / featured <strong>seed</strong> on the current epoch. "This week's race." A fresh league = a new base seed, same rules.</td>
+    <td>backend featured-board pointer + a promoted seed</td>
+    <td>New board, <em>same epoch</em>.</td></tr>
+<tr><td><strong>seed</strong></td>
+    <td>The RNG root for one run/board. Anyone can share a seed; the promoted one is the league.</td>
+    <td><code>get_weekly_seed()</code> / manual promotion</td>
+    <td>New seed = new board.</td></tr>
+<tr><td><strong>board</strong></td>
+    <td>The leaderboard for one <code>(seed, ladder_version)</code> pair.</td>
+    <td>local JSON + PHP score API</td>
+    <td>--</td></tr>
+</tbody>
+</table>
+</div>
+<p class="muted">Board key = <code>(seed, ladder_version)</code>. New seed rotates one board;
+a ladder bump rotates <em>all</em> boards.</p>
+
+<h2 id="cadence"><span class="n">2</span>The two cadences</h2>
+<p>Two clocks, deliberately decoupled. This is the resolution of "how do we stay fresh
+without scattering scores."</p>
+
+<div class="tablewrap">
+<table>
+<thead><tr><th>Clock</th><th>What moves</th><th>Cadence</th><th>Forks the ladder?</th><th>Ceremony</th></tr></thead>
+<tbody>
+<tr><td><strong>LEAGUE</strong> (the seed)</td>
+    <td>A new promoted base seed. Same rules, fresh board -- "this week's ladder."</td>
+    <td>~weekly, <strong>manual at Pip's call for now</strong></td>
+    <td><span class="pill nofork">NO -- same epoch</span></td>
+    <td>Low. Post a seed, point the featured board at it.</td></tr>
+<tr><td><strong>GAME</strong> (the epoch)</td>
+    <td>Balance patch + world-clock advance + any new gameplay. <code>ladder_version</code> bump.</td>
+    <td>~monthly</td>
+    <td><span class="pill fork">YES -- new epoch</span></td>
+    <td>High. This is the legible heartbeat: patch notes, meta rotation, argue about it.</td></tr>
+</tbody>
+</table>
+</div>
+
+<div class="callout good">
+  <span class="lbl">Why this works</span>
+  A new seed does not change the rules, so weekly league rotation keeps competition fresh
+  <em>without</em> making scores incomparable -- last week's board and this week's are both
+  valid, just different races (chess.com-daily style). Only the monthly GAME change rotates
+  the ruleset. Fragmentation was only ever a risk if <em>rules</em> forked weekly; seeds
+  forking weekly is the intended freshness engine ("a league is just a promoted seed").
+</div>
+
+<h3>Rulings pinned 2026-07-24</h3>
+<ul>
+<li><strong>Game changes monthly, league (seed) rotates weekly.</strong></li>
+<li><strong>Rotation is manual (Pip's call), not clock-locked</strong> -- until we learn how
+    long a league actually stays fresh. Do not hard-code a weekly timer yet.</li>
+<li><strong>World-clock patching is regular and predictable</strong> (advance the sim
+    calendar ~a month, inject the month's real-world events). Because new events change the
+    reachable game, this rides the monthly GAME change (it forks -- see section 3).</li>
+<li><strong>Weekly auto-rotation is blocked on a bug:</strong> <code>get_weekly_seed()</code>
+    is frozen at <code>weekly-2026-w0</code> (it reads ms-since-boot, not the date). While
+    rotation is manual this does not bite; fix it before automating weekly promotion.</li>
+</ul>
+
+<h2 id="fork"><span class="n">3</span>The fork rule -- what starts a new epoch</h2>
+<div class="card" style="border-color:var(--accent)">
+  <strong>The one question.</strong> Could two identical runs -- same seed, same player
+  choices -- produce a <em>different score, world trajectory, or RNG stream</em> under this
+  change?
+  <div style="margin-top:.6rem">
+    <span class="pill fork">YES</span> &rarr; it forks. Bump <code>ladder_version</code>.
+    Queue it for the next monthly epoch (do not ship on merge).<br>
+    <span class="pill nofork">NO</span> &rarr; it is cosmetic. Bump <code>version.txt</code>
+    only. Ship any time. Everyone stays on the same board.
+  </div>
+</div>
+
+<div class="tablewrap">
+<table>
+<thead><tr><th><span class="pill fork">FORKS</span> (epoch, monthly-batched)</th>
+           <th><span class="pill nofork">DOES NOT FORK</span> (patch, any time)</th></tr></thead>
+<tbody>
+<tr><td>Scoring rules (turn accrual, doom-integral tiebreak, thresholds)</td>
+    <td>UI layout, panels, colours, fonts</td></tr>
+<tr><td>Balance numbers that change outcomes (action costs, doom deltas, event probabilities, finance)</td>
+    <td>Music, SFX, audio mix</td></tr>
+<tr><td>Seed schedule / wave changes; advancing the world-clock; new events on existing seeds</td>
+    <td>Art, icons, sprites, banners</td></tr>
+<tr><td>RNG-stream changes (add/remove/reorder a draw, change turn order) -- breaks replays</td>
+    <td>Copy / text / patch notes / onboarding wording</td></tr>
+<tr><td>New content reachable in an existing seed's run; mortality-mechanism changes</td>
+    <td>Bugfixes with NO behaviour change; tooling / CI / docs</td></tr>
+</tbody>
+</table>
+</div>
+<p class="muted">Tie-break for the unsure author: if a saved replay from the previous epoch
+would fail to reproduce under your change, it forks -- by construction.</p>
+
+<h2 id="labels"><span class="n">4</span>Issue labels (derived from the fork rule)</h2>
+<p>The label is a function of the fork rule, not a vibe. Assign it by answering section 3.</p>
+<div class="tablewrap">
+<table>
+<thead><tr><th>Label</th><th>Meaning</th><th>PR must...</th></tr></thead>
+<tbody>
+<tr><td><code>league:&lt;epoch&gt;</code> (e.g. <code>league:v0.13</code>)</td>
+    <td>A forking change, queued for the next monthly epoch.</td>
+    <td>touch <code>ladder_version.txt</code> (or be batched into the epoch commit that does).</td></tr>
+<tr><td><code>patch:ui</code> / <code>patch:fix</code></td>
+    <td>Non-forking, ships mid-week.</td>
+    <td>NOT touch <code>ladder_version.txt</code>.</td></tr>
+<tr><td><code>infra</code> / <code>build</code></td>
+    <td>Non-forking, non-UI (packaging, telemetry, CI).</td>
+    <td>NOT touch <code>ladder_version.txt</code>.</td></tr>
+</tbody>
+</table>
+</div>
+<div class="callout warn">
+  <span class="lbl">Known mislabels to fix (2026-07-24 audit)</span>
+  <code>#789</code> is tagged both <code>league:v0.13</code> AND <code>ship:hotpatch-48h</code>
+  -- a forking change cannot be a non-forking hotpatch; keep the league tag, drop the
+  hotpatch one. <code>#788</code> (dev-badge = scoring integrity), <code>#799</code> (telemetry),
+  <code>#805</code> (builds) are mislabelled <code>patch:ui</code>. <code>#735</code>/<code>#700</code>/<code>#648</code>
+  are scoring-critical but untiered. Full list: <code>docs/game-design/TENSION_AUDIT_2026-07-23.md</code> sec 4.
+</div>
+
+<h2 id="runbook"><span class="n">5</span>Epoch-cut runbook: L1 -&gt; L2</h2>
+
+<div class="callout danger">
+  <span class="lbl">Pinned numbering -- do not improvise</span>
+  <strong>L1 = the legacy v0.12.0 board</strong> (aliased, read-only -- what the friends-and-family
+  cohort is playing now).<br>
+  <strong>L2 = the v0.13 gameplay epoch</strong> (#789 hiring stitch + the build/ladder split live).
+</div>
+
+<div class="callout danger">
+  <span class="lbl">The one hazard that scatters scores</span>
+  NEVER cut a v0.13 gameplay build while <code>ladder_version.txt</code> still reads <code>1</code>.
+  It would key boards <code>L1</code> and dump new-gameplay scores onto the aliased old-gameplay
+  board -- the exact lie the split exists to prevent. <strong>The ladder bump and the #789
+  gameplay ride the SAME build.</strong>
+</div>
+
+<ol class="steps">
+<li><strong>Prereq: PR #806 merged to main.</strong> That lands the split with
+    <code>ladder_version = 1</code>, so the current live board is now epoch <code>L1</code>,
+    and #789 gameplay is present in the tree.</li>
+<li><strong>Choose the new base seed</strong> for L2's first league (manual promotion).</li>
+<li><strong>One release commit bumps BOTH numbers.</strong>
+    <pre># in version.txt:        0.12.0 -> 0.13.0
+# in ladder_version.txt:      1 -> 2
+python tools/sync_version.py          # stamps CURRENT_VERSION + LADDER_VERSION</pre>
+    Atomic. Both bumps, one commit, same build as the #789 gameplay.</li>
+<li><strong>Verify before building.</strong>
+    <pre>python tools/sync_version.py --check   # drift == fatal; must pass
+# confirm GameConfig.get_board_version() now returns "L2"</pre></li>
+<li><strong>Build and smoke-test.</strong>
+    <pre>python tools/build_release.py          # nukes .godot, proves the freshness marker</pre>
+    Run the exe once; play a turn; open the leaderboard and confirm the subtitle shows the
+    L2 epoch.</li>
+<li><strong>Backend (external, ssh to DreamCompute).</strong>
+    <pre># make the legacy board readable under its new epoch name:
+cp board_&lt;seed&gt;__v0.12.0.json  board_&lt;seed&gt;__L1.json
+# confirm the score API accepts L2; point the featured board at (new seed, L2)</pre>
+    Tracked in pdoom1-website #151.</li>
+<li><strong>Publish and announce.</strong>
+    <pre>gh release create v0.13.0 --target main ...</pre>
+    Then the friends / website / Rektango announcement. Kill stragglers on L1 mercilessly
+    (they can hotpatch up).</li>
+</ol>
+
+<div class="callout good">
+  <span class="lbl">Sanity check after the cut</span>
+  A player on the L2 build who dies posts to board <code>(&lt;new seed&gt;, L2)</code>. A player
+  still on the old v0.12 build posts to <code>(&lt;old seed&gt;, L1)</code>. The two never mix.
+  If a v0.13 score ever appears on an L1 board, step 3 was split across two builds -- stop and
+  re-cut.
+</div>
+
+<h2 id="cheat"><span class="n">6</span>Cheat card</h2>
+<div class="card">
+<pre>Is my change cosmetic (UI/art/music/copy/no-behaviour fix)?
+   YES -> bump version.txt only. Label patch:*. Ship mid-week. Same board.
+   NO  -> it forks. bump ladder_version.txt too. Label league:&lt;epoch&gt;.
+          Queue for the next MONTHLY epoch. Boards rotate.
+
+Fresh competition without new rules?
+   -> promote a new SEED (a new league). Same epoch, new board. Weekly-ish, manual.
+
+Cutting the epoch?
+   -> version.txt AND ladder_version.txt bump in ONE commit, same build as the gameplay.
+      L1 = legacy v0.12 (read-only).  L2 = v0.13.
+      sync_version.py --check must pass.  Alias old board.  Point featured board at (new seed, L2).</pre>
+</div>
+
+<div class="foot">
+  <p><strong>Provenance.</strong> Distilled from <code>docs/game-design/BUILD_VS_LADDER_VERSION_SPLIT.md</code>,
+  <code>PHASE3_DEPLOY_RECON.md</code>, ADR-0002 / ADR-0016, and the 2026-07-24 tension audit
+  (<code>docs/game-design/TENSION_AUDIT_2026-07-23.md</code>). Rulings by Pip 2026-07-24.</p>
+  <p><strong>Review gate.</strong> This is provisional. A time-gated GitHub issue tracks a
+  reflective review on/after 2026-08-24 -- re-examine the nomenclature, the weekly-league
+  cadence (does a league stay fresh a week? two?), and whether rotation should lock to a
+  clock. Do not treat the weekly cadence as canon before that review.</p>
+</div>
+
+</div>
+</body>
+</html>

--- a/docs/game-design/TENSION_AUDIT_2026-07-23.md
+++ b/docs/game-design/TENSION_AUDIT_2026-07-23.md
@@ -1,0 +1,406 @@
+# Tension Audit -- 2026-07-23 (overnight)
+
+> **What this is.** An emergent-tension sweep across the durable design philosophy
+> (DESIGN_PHILOSOPHY.md + ADRs), the recent decisions (2026-07-20..23: version
+> split, cold-open, distribution, #789, cat/cosmetics, WS-3 prep, AP baseline),
+> and the live build lanes (issues + metabolic labels). Goal: surface where recent
+> commitments pull against older ones or against each other, so future-us is not
+> surprised. Requested by Pip 2026-07-23 ("I'm particularly interested in any
+> emergent tensions").
+>
+> **Method.** Three parallel doc-readers (philosophy/ADRs; recent decisions;
+> build lanes/backlog) + a first-person read of DESIGN_PHILOSOPHY.md and the
+> version-split spec + code verification of the flagged victory contradiction.
+> Quotes are exact where they sharpen the point.
+>
+> **Status.** ANALYSIS ONLY. Nothing here is ruled. No GitHub labels were changed
+> (the metabolic tiers are Pip's taxonomy; this recommends, does not mutate). No
+> code changed. Written off the merge commit; lives clear of PR #806.
+>
+> **Severity key.** T1-class = structural-integrity or Friday-critical; T2-class =
+> design coherence / latent landmine; T3-class = known / philosophy-internal /
+> watch. Probabilities are my calibrated guesses, not measured.
+
+---
+
+## Section 0 -- FRIDAY-CRITICAL (read before the v0.13 epoch cut)
+
+These three could bite the 2026-07-24 epoch cut specifically. Everything else can
+wait for a workshop.
+
+### F1. The L1 -> L2 ladder bump MUST ride in the SAME build as the #789 gameplay, or v0.13 scores land on the v0.12 board. (deploy-sequence hazard)
+
+- The live v0.12.0 build friends are playing keys boards the OLD way (`v0.12.0`);
+  it has no ladder split. PHASE3_DEPLOY_RECON aliases that live board to L1:
+  *"copy `board_weekly-2026-w0__v0.12.0.json` -> `board_weekly-2026-w0__L1.json`."*
+- PR #806 ships `game_config.gd` with `LADDER_VERSION = "1"` (L1). If the Friday
+  v0.13 build (which contains #789 -- an Attention-economy gameplay change) is cut
+  while `ladder_version.txt` still reads `1`, it keys boards `L1` and **mixes new
+  gameplay scores into the aliased old-gameplay board.** That is exactly the lie
+  ADR-0002 #5 forbids.
+- PHASE3 already knows this -- *"epoch cut: also bump `ladder_version.txt` -> 2, IF
+  the ladder split has landed."* The hazard is the ordering dependency: **#806 must
+  merge (establishing L1 = the legacy board), THEN the v0.13 release commit bumps
+  ladder -> 2 in the same build as the #789 gameplay.** If those two steps separate,
+  boards contaminate silently (no error, wrong board).
+- **Severity: HIGH / p(happens if not pinned) ~ 35%.** It is a two-step sequence
+  with no gate enforcing the order.
+- **Resolution:** make the L1->L2 bump part of the v0.13 *release commit* checklist,
+  not a separate step; the `check_ladder_bump.py` heuristic should hard-flag "gameplay
+  files changed (#789 touched core/) but ladder still 1". Confirm the numbering
+  reconciliation in F2 first.
+
+### F2. Epoch numbering: is the Friday cut L1 or L2? Two docs say different things.
+
+- Version-split spec sec 5.2: *"recommend seeding it so the first ladder epoch is a
+  ROUND, memorable number (e.g. `L1`)"* and treat pre-split boards as "legacy /
+  epoch 0."
+- PHASE3_DEPLOY_RECON: aliases the *legacy v0.12 board* to **L1** and cuts the new
+  v0.13 epoch as **L2**.
+- These reconcile IF you read it as: **L1 = the current v0.12 live board (retroactively
+  named), L2 = Friday's v0.13 epoch.** That is coherent and is what PHASE3 assumes.
+  But the split spec's words ("first epoch = L1") read as if L1 should be the *new*
+  epoch. Pin it explicitly before Friday or the alias/bump could be off by one.
+- **Severity: MEDIUM but Friday-blocking-adjacent.** One-line decision.
+- **Resolution (recommended):** ratify "L1 = legacy v0.12 board (aliased, read-only),
+  L2 = v0.13 gameplay epoch (#789)." Update the split spec sec 5.2 example from L1 to
+  match so the docs stop disagreeing.
+
+### F3. #789 routes the accept-prompt through the RESPONSE-WINDOW pipeline -- the exact channel the AP baseline says is scarcest (budget ~3/mo). (shipping Friday)
+
+- BUILD_BRIEF_789 sec 3 recommends *"Option A for the pause-and-pay beat"* -- reusing
+  the response-window pipeline.
+- EARLY_AP_ECONOMY_BASELINE sec 6 warns the opposite: *"Prefer routing new
+  hiring/mentoring/conference steps through PLANNED Attention spend, not windows"*
+  because *"if any #789/#803 step surfaces as a response WINDOW ... it competes against
+  this budget of 3 ... the overwhelm threshold arrives far sooner."*
+- Philosophy names this channel the scarce one: *"The scarce channel is
+  acknowledgment, not information ... decision demands are what flood."* Response
+  windows ARE the acknowledgment channel.
+- So #789's implementation choice loads the flood-prone channel the same week we are
+  trying to fix Rick's "not enough direction / overwhelm" onboarding feedback. #789
+  is replay-safe (sec 8.3, no new RNG draws) -- the concern is feel, not determinism.
+- **Severity: MEDIUM-HIGH / p(opening feels spammy) ~ 40%.** It is the Friday build.
+- **Resolution:** review #789 before the cut -- can the accept-prompt be a PLANNED-
+  Attention beat (spend at the month boundary) rather than an interrupt window? If it
+  must ship as a window for time reasons, cap it to ONE window per hire and watch the
+  first playtest for overwhelm.
+
+---
+
+## Section 1 -- TIER-1 TENSIONS (structural / process)
+
+### T1. The metabolic dev cycle has a mechanism but no written tier rule -- and the labels are already leaking.
+
+**The two poles.**
+- Philosophy wants stable boards on a slow, legible cadence: league metabolism is
+  MONTHLY (ADR-0016 sec 3: *"World-updates are monthly, light ... Balance patches are
+  slower and legible-event-grade"*); the patch is *"the community's heartbeat --
+  legible events people argue about"*, explicitly *not frequent*; and the whole
+  point is *"this can't take up more than 1 day a week of effort"* (ADR-0016 sec 5).
+- The version-split gives a crisp BUMP rule (sec 3: bump iff same inputs could diverge
+  in score/trajectory/RNG). Good. But **there is no canonical document defining the
+  `league:v0.13 / patch:ui / league:next` tiers** -- the recent-decisions sweep
+  confirmed "no literal metabolic dev cycle string exists in the repo." The tiers
+  Pip applied this session are ad-hoc labels not derived from the bump rule.
+
+**Why they conflict / the evidence it is leaking.** Without a written tier rule,
+the labels drift. Already observed:
+- **#789** is tagged BOTH `league:v0.13` (forking) AND `ship:hotpatch-48h`
+  (non-forking mid-week). A forking mechanics change cannot also be a non-forking
+  hotpatch. Direct contradiction.
+- **#788** (leaderboard dev-mode badge -- a scoring-INTEGRITY surface) is tagged
+  `patch:ui` (cosmetic).
+- **#799** (install-ping + update infra) and **#805** (mac/Linux builds) are tagged
+  `patch:ui` -- neither is UI.
+- **#735** (enable remote board), **#700** (add_score dedupe), **#648** (uncapped-
+  stacking exploit fix) are scoring-critical or forking, yet carry NO metabolic tier.
+
+The metabolic proof-of-concept is the thing Pip is deliberately building; if the
+tiers are hand-applied without a rule, they will keep misclassifying, and a forking
+change will eventually ride a mid-week lane and fork the board off-schedule --
+defeating the board-stability the split exists to protect.
+
+- **Severity: HIGH / p(a mislabel forks a board within 2 epochs) ~ 30%.**
+- **Resolution:** write the tier rule ONCE, derived mechanically from the split's
+  bump checklist (sec 3.3), and home it in #775 (release-branching model). The rule is
+  basically: tier = f(does it bump the ladder?). `league:*` iff any bump-checklist
+  answer is yes; `patch:*` iff all no; infra/build/telemetry get their own non-UI
+  label. Then relabel the six issues above (see Section 4). Consider a CI check that
+  a `league:*` issue's PR touches `ladder_version.txt` and a `patch:*` PR does not.
+
+### T2. "Numbers patch freely" (light, frequent) vs "any outcome-altering change forks the ladder" (heavy, board-rotating).
+
+**The two poles.**
+- Philosophy: *"Structure is never-patch; numbers patch freely"* -- and the lighter-
+  check intent: *"pure number changes ... shift balance but mint no new mechanical
+  surface, so they ride a lighter check."*
+- The version-split bump rule (sec 3.1) makes ANY outcome-altering number change (action
+  costs, doom deltas, event probabilities, finance numbers) BUMP the ladder -- i.e.
+  rotate every board, scatter scores, start a new epoch.
+
+**Why they conflict.** "Patch numbers freely" and "every number-patch forks the
+board" cannot both be true operationally. If you tune balance often (which the game
+needs during alpha), you either fork boards often (fragmentation) or you batch tuning
+into rare epochs (numbers do NOT patch freely -- they patch monthly). The split doc's
+own DECISION C recommendation ("batch into one v0.13 epoch ... testers accumulate
+scores against a stable ruleset for LONGER") quietly resolves this toward batching --
+which means the honest statement is **"numbers patch freely WITHIN an epoch's dev
+window, and land in batches AT epoch boundaries,"** not "numbers patch freely."
+
+This is the same root as T1: the cadence/queue discipline is the real design object,
+and it is unwritten. Every queued gameplay/balance item (hiring, cat, rivals #804,
+WS-3 mechanics, #648 exploit, #791 economy) wants an epoch; the design wants few.
+
+- **Severity: HIGH (it is the load-bearing tension of the whole liveops model) /
+  p ~ n/a (it is a definitional gap, not an event).**
+- **Resolution:** state the epoch-train rule explicitly: balance/gameplay changes
+  QUEUE for the next scheduled monthly epoch; they do not ship on merge. The Friday
+  v0.13 cut is epoch N; the next epoch is ~a month out, not next week. Write this
+  where the lanes can see it (ROADMAP or #775), because two forces (queue pressure +
+  the every-number-forks rule) push toward more-frequent forking, and the philosophy's
+  "1 day/week, small durable community, legible heartbeat" all degrade if cadence
+  creeps weekly.
+
+---
+
+## Section 2 -- TIER-2 TENSIONS (coherence / latent landmines)
+
+### T3. "No victory, only time bought" (never-patch structure) is HALF-implemented: vestigial victory scaffolding + a stale runtime ADR remain.
+
+**Verified in code (not just docs).**
+- Philosophy + game-design ADR-0002: *"you cannot win, only buy time"* / "There is
+  no victory condition."
+- Current `check_win_lose()` (`game_state.gd:525-530`) HONORS this: it only ends the
+  run on `doom >= 100` or `reputation <= 0`, both setting `victory = false`. **No code
+  path in the play loop sets `victory = true`** (grep of `godot/scripts` finds only
+  `victory = false` assignments).
+- BUT vestigial victory plumbing survives, wired to a flag nothing sets:
+  `turn_manager.gd:716` still emits *"VICTORY! p(doom) reached 0!"*;
+  `game_over_screen.gd:137` sets `"VICTORY!"`; `main_ui.gd:991` logs
+  *"VICTORY! You survived!"*; `death_attribution.gd:40` and `baseline_simulator`
+  branch on `state.victory`.
+- AND the RUNTIME `docs/adr/ADR-0002` still declares *"Victory: doom <= 0 ... a real
+  but rare apex victory for mastery play"* -- contradicting BOTH the game-design ADR
+  AND the actual code, and contradicting the philosophy's *"ASI won't be survivable."*
+
+**Why it matters.** Two failure modes. (1) Latent landmine: if any refactor,
+save-load path, or debug toggle ever sets `victory = true`, the game shows a
+"VICTORY!" screen the design says must not exist. (2) Doc drift: a live ADR documents
+a win condition as canonical that the code has already removed -- a future
+contributor could "restore" it in good faith.
+
+- **Severity: MEDIUM (latent, not live) / p(a code path resurrects victory) ~ 15%.**
+- **Resolution:** finish the removal -- strip the vestigial victory branches (or
+  gate them behind an explicit, never-set feature flag with a comment), and reconcile
+  runtime ADR-0002 with game-design ADR-0002 (mark the win condition retired, or add
+  a superseding note). Non-forking (no play-loop behavior changes). Good `patch:ui`
+  or tech-debt item.
+
+### T4. The metabolic cycle promises mid-week non-forking hotpatches -- but the DELIVERY mechanism for direct-download users (L3 pck-patcher) is unbuilt AND maybe-cancelled.
+
+**The two poles.**
+- The whole point of the version split + metabolic cycle is that cosmetic/UI fixes
+  ship mid-week without forking the board. That implies a way to DELIVER a mid-week
+  patch to players.
+- DISTRIBUTION_AND_PATCHING self-contradicts on whether that mechanism gets built:
+  D3/TIMING commit to L3 (*"SIGN WITH L3"*, *"L3 next version increment"*), but the
+  Steam section says *"L3 (custom pck-patcher): probably do NOT build it. Steam
+  depots delta-patch natively."*
+
+**Why they conflict.** If L3 is skipped (betting on Steam), then between now and
+Steam there is **no delivery path for the mid-week cosmetic hotpatches the metabolic
+cycle promises** -- direct-download users would have to re-download a full build for
+a font fix. So "we'll UI-patch mid-week" (T1's `patch:ui` lane) has no wire to the
+direct channel yet. The cycle's forking side (epoch = new full build) works; the
+non-forking side (mid-week small patch) has no delivery.
+
+- **Severity: MEDIUM / p(mid-week patch has no delivery path when first needed) ~ 50%.**
+- **Resolution:** decide the direct-channel patch story explicitly. Options: (a)
+  build a minimal L3 pck-swap for direct users pre-Steam; (b) accept "direct users
+  re-download full builds; only Steam gets delta-patches" and tell testers that; (c)
+  keep the friend cohort small enough that full re-download mid-week is fine (it is
+  ~5 people now -- (c) may be the honest cheapest answer for this month). Pin which.
+
+### T5. The balance instrument that would validate #789/#803 pacing cannot see the Attention economy it is changing.
+
+- EARLY_AP_ECONOMY_BASELINE sec 7.1: *"the instrument we reach for ... literally cannot
+  see Attention. It would green-light pacing it never tested."* And sec 5/sec 8.2: *"passive
+  is immortal in this harness ... no non-ledger mortality floor."*
+- Philosophy expects the opposite of passive-immortal in the long run (*"the
+  background of Doom is nearly always going to be trending up"*) -- so a harness where
+  passive never dies is either mis-measuring or exposing a difficulty-floor gap; and
+  either way it is blind to Attention, the currency #789 loads.
+
+**Why it matters.** We are shipping #789 (an Attention-economy change) Friday and
+plan #803/#804 next, validated by a sweep instrument that does not model Attention.
+Any "balance looks fine" signal from it about the new economy is uninformed.
+
+- **Severity: MEDIUM / p(we ship a pacing regression the sweep couldn't catch) ~ 30%.**
+- **Resolution:** before leaning on the sweep to sign off #789/#803 pacing, give it
+  an Attention-aware policy (even a crude "spend all planned Attention greedily"
+  baseline). Until then, treat #789 pacing as human-playtest-validated only, not
+  sweep-validated -- and say so in the release notes.
+
+### T6. The cat wants to be two different design objects: a doom-sight INSTRUMENT (aligned) and a mechanical-BONUS holder (fights minmax + instrument purity).
+
+- The cat-as-higher-resolution-doom-oracle (CAT sec 1) is BEAUTIFULLY aligned with the
+  philosophy and worth calling out as a POSITIVE resonance: *"instrumentation as
+  progression"*, *"what's earned is resolution"*, *"no printed doom deltas"*, *"SA is
+  channels with provenance, personified."* A diegetic, observation-rewarding doom
+  sensor is on-thesis.
+- The cat-adoption-vs-rival-steal giving *"2 STACKING modifiers"* (CAT sec 2) is the
+  part in tension -- Pip already self-flagged it against *"don't force minmaxers,
+  leave room for nonoptimal fun."* Sharpening: a modifier-holding cat also converts an
+  INSTRUMENT into a RESOURCE, cutting against *"SA buys lead time, not power"* and
+  *"progression lives in the org, not the hero."*
+
+**Why it matters.** Bundling the two roles means the beloved doom-oracle drags a
+minmax-y adopt-or-lose-a-swing decision along with it. Splitting them lets the oracle
+ship clean.
+
+- **Severity: LOW (explicitly next-epoch) / p ~ n/a.**
+- **Resolution (WS-3 / DQ-22):** keep the cat's doom-oracle role as the primary,
+  on-thesis design; make any mechanical bonus MODEST (per Pip's own sec 2 rec) or drop
+  it, so the oracle is not hostage to the modifier. Decide as part of the rivals
+  workshop where the rival-cat lives.
+
+### T7. ADR-0015 "no printed doom deltas" is enforced only by a resolve-clobber; the literal delta data still exists and can be resurrected by a refactor.
+
+- WS-3 prep sec 2 Decision 2B: *"ADR-0015's data strip is unfinished -- the fiction still
+  says '-3 doom' and 40 literal fields survive as inert no-ops. Any refactor that
+  drops the resolve-clobber silently resurrects printed doom."*
+- ADR-0015 is a structural claim (*"only world state touches doom"*). It is currently
+  true only because something clobbers the literal deltas at resolve time; the deltas
+  are still in the data.
+
+- **Severity: MEDIUM (latent landmine on a structural claim) / p(a refactor trips it)
+  ~ 20%.**
+- **Resolution:** finish the ADR-0015 data strip (delete the 40 inert delta fields)
+  so the invariant is enforced by absence, not by a clobber. Non-forking cleanup.
+
+### T8. The cold-open onboarding trains a "watch narrative" posture before the "actively scout" posture the early game depends on.
+
+**Largely resolved, residual flagged.** The onboarding design already dodges the
+obvious version of this: ONBOARDING_STORY_DESIGN rejects a forced tutorial (*"a
+POINTER to a LEVER, not a LEASH"*), teaches lever-legibility not goal-narrative, is
+skippable (`play_intros` + `INTRO_VERSION` decoupled from `CURRENT_VERSION`), and is
+non-score. So it does not violate *"the quiet opening is intended"* for veterans.
+
+The residual: the cold-open still delivers a scripted linear sequence
+(phone->passcode->apps->Stranger) on first play, and the early-game's replayability
+engine is *scouting* -- *"re-gathering information about this seed"*, active, opt-in.
+Does the onboarding END by handing the player a scouting CHOICE ("go read / go to
+meetups / who do you look into first?"), or does it end on a narrative beat? If the
+first thing the game teaches is "narrative arrives at you," it mis-primes the
+"you must go look" core loop.
+
+- **Severity: LOW-MEDIUM / p(onboarding mis-primes scouting posture) ~ 25%.**
+- **Resolution (WS-3):** ensure the cold-open's final beat hands the player an active
+  scouting decision, not a narrative conclusion -- the handoff from scripted intro to
+  opt-in scouting is the pedagogically load-bearing seam.
+
+---
+
+## Section 3 -- TIER-3 (known / philosophy-internal / watch)
+
+These are already logged by Pip or are internal to the philosophy; listed for
+completeness, not action.
+
+- **T9. Doom floor: negative-legal vs sustained-fall-is-a-bug.** *"Doom rate may
+  legally go negative"* vs *"persistently achievable downward trends probably mean
+  I've failed to make the game hard enough."* The boundary between "impressive dip"
+  and "difficulty failure" is asserted but not operationally drawn. Home: the
+  exploit-sweep invariant (no bot policy sustains an N-month decline) -- pick N.
+- **T10. Founding-location weight vs fast replays.** Pip's own logged open tension:
+  *"the early game must carry strategic commitment AND be quick to re-play ... Civ
+  never solved this; we have to."* Owned by the pacing question (ADR-0008).
+- **Launcher vs Steam (DISTRIBUTION).** The separate-launcher decision (D2) partly
+  fights the eventual Steam channel (*"Steam DISCOURAGES third-party launchers"*).
+  Resolved only by "right-size it." Watch when Steam gets real.
+- **Save-scum identity fork (WS-3 prep sec 3d).** *"Orb-of-Regret branch mechanic vs
+  one-run discipline is a genuine fork with leaderboard-integrity consequences; not
+  yet chosen."* WS-3 material.
+
+---
+
+## Section 4 -- BUILD-LANE MISLABELS (recommended relabels -- Pip's call, not actioned)
+
+Surfaced by the backlog sweep. NOT changed on GitHub; some may be intentional. Each
+is "current tier -> suggested tier, because."
+
+**Tier contradictions / misfits:**
+- **#789** `league:v0.13` + `ship:hotpatch-48h` -> pick ONE. It forks (AP economy),
+  so `league:v0.13` is right; drop `ship:hotpatch-48h` (a forking change is not a
+  non-forking hotpatch). If the intent was "forking but urgent," that needs a distinct
+  label, not the hotpatch one.
+- **#788** dev-mode badge, `patch:ui` -> a `league:*` tier. It alters leaderboard
+  legitimacy display = scoring-integrity, not cosmetic.
+- **#799** install-ping + update infra, `patch:ui` -> an infra/telemetry label. Zero
+  UI.
+- **#805** mac/Linux builds, `patch:ui` -> a build/packaging label. Zero UI.
+
+**Scoring-critical work sitting UNTIERED:**
+- **#735** enable remote board (`ship:tonight`, no tier) -> `league:*`. Most
+  scoring-critical open item.
+- **#700** add_score dedupe (`ship:hotpatch-48h`, no tier) -> leaderboard correctness;
+  tier it.
+- **#648** uncapped-stacking exploit fix (`ship:next-release`, no tier) -> exploit
+  fixes are forking by definition; `league:next` at least.
+
+**Clusters worth consolidating (four onboarding issues across three tiers):**
+- Onboarding: **#801** + **#789** + **#721** + **#722** all touch onboarding/tutorial
+  across `league:v0.13` and `ship:next-release`. One lane, one owner.
+- Bug reporter: **#800** + **#603** are the same broken reporter, split across tiers.
+- PLAN action-grouping: **#795** + **#798** + **#794** are one PLAN-screen pass split
+  across `patch:ui` and `ship:next-release`.
+- Cross-repo sync: **#545** + **#723** + **#724** (#724 "folds into #545") -- collapse.
+
+**Sequencing hazard (not a mislabel):** several `ship:next-release` UI issues
+(**#707, #601, #578, #577**) target screens that L2 (**#613**) will restructure. The
+backlog's own rule is "hold UI polish until L2 restructures these screens." Building
+them now risks polishing soon-to-be-deleted layouts. #622 (main_ui decomposition)
+likely precedes them.
+
+---
+
+## Section 5 -- Feed into Workshop 3
+
+WS-3's scoping is itself unresolved (prep sec 5: *"Which milestone does WS-3 serve --
+v0.12 or v0.13? Everything else falls out of this"*). This audit suggests an agenda
+ordered by what is load-bearing:
+
+1. **Cadence + epoch-train discipline (T1, T2).** The single highest-leverage ruling:
+   write the tier rule and pin the monthly epoch cadence. Everything about board
+   stability and the "1 day/week" liveops promise depends on it. Not a mechanics
+   question -- a process ruling, could be settled before WS-3 even convenes.
+2. **The mid-week delivery gap (T4).** Decide the direct-channel patch story so the
+   `patch:ui` lane is real, not aspirational.
+3. **Onboarding -> scouting handoff (T8)** and **cat oracle-vs-modifier split (T6)**
+   -- both fold naturally into the DQ-22 rivals / early-game workshop material.
+4. **Instrument blindness (T5)** and **ADR-0015 data strip (T7)** -- tooling/tech-debt
+   prerequisites; do them before trusting sweep sign-off or refactoring doom.
+5. Carry the known Tier-3 items (T9 doom-floor N, T10 founding-vs-replay, save-scum
+   fork) as standing agenda, per Pip's "finish-or-drop, don't stack" WS-3 rule.
+
+The "crisp parts, brutal decisions" WS-3 thesis is consistent with everything here:
+most of these tensions are about keeping the ENGINE crisp (one tier rule, one epoch
+train, one delivery path, no vestigial victory, no latent doom-deltas) so the
+DIFFICULTY can live in the decisions, not in the plumbing.
+
+---
+
+## Method notes & caveats
+
+- Three background doc-readers + first-person reads of DESIGN_PHILOSOPHY.md and
+  BUILD_VS_LADDER_VERSION_SPLIT.md + a code check of `check_win_lose()` and the
+  victory plumbing. The victory finding was DOWNGRADED after reading code (grep alone
+  implied a live win-against-thesis; the code showed vestigial scaffolding + doc drift
+  instead) -- a reminder to verify before ranking.
+- Probabilities are calibrated guesses, unmeasured. Severities are mine.
+- No "metabolic dev cycle" doc exists in the repo; the tier taxonomy is carried
+  implicitly by the version-split bump rule + issue labels. That absence IS T1.
+- Not exhaustive. High-confidence coverage of philosophy, recent decisions, and open
+  issues; lighter on the older balance docs (DOOM_STREAMS, DESPERATION_SOLVER,
+  OPENING_BOOK -- 2026-07-13/14, pre-window) which may hide further number-level
+  tensions.


### PR DESCRIPTION
Lands the two docs authored during the Friday deployment push:
- `docs/RELEASE_AND_LEAGUE_CYCLE.html` -- the release-train + league-metabolism runbook (calendar SSOT).
- `docs/game-design/TENSION_AUDIT_2026-07-23.md` -- emergent-tensions audit.

Both are additive (new files), docs-only, non-forking.

Generated with Claude Code