### PR TITLE
docs: 2026-07-25 planning artifacts + DreamObjects masters archive

### DIFF
--- a/docs/CONTENT_DISTRIBUTION_SYSTEM.md
+++ b/docs/CONTENT_DISTRIBUTION_SYSTEM.md
@@ -1,5 +1,16 @@
 # P(Doom) Content Distribution System
 
+> **STATUS: OUTDATED (flagged 2026-07-25).** This document predates the
+> `pdoom1` <-> `pdoom1-website` split. It proposes running the *publishing
+> engine itself* (Reddit/forum/website pipelines, `content_publisher.py`) from
+> inside `pdoom1`, which now contradicts the agreed direction: publishing lives
+> in `pdoom1-website`, which PULLS raw material from `pdoom1`. See the active
+> contract at `docs/copy/README.md`.
+>
+> **Pip to revise** during doc uplift and approve the updated version; may be
+> moved to `pdoom1-website` if that turns out correct. Retained meanwhile
+> because its diff history is useful. Do NOT build from this as-is.
+
 **Status**: Design Phase
 **Created**: 2025-11-25
 **Purpose**: Automated content publishing to Reddit, Forums, Dashboard, and Website

--- a/docs/MAIN_UI_SEAM_MAP.md
+++ b/docs/MAIN_UI_SEAM_MAP.md
@@ -1,0 +1,100 @@
+# main_ui.gd -- Seam Map + Refactor Plan
+
+**Status:** ACTIVE PLAN (2026-07-25). Steering artifact for the incremental
+de-monolithing of `godot/scripts/ui/main_ui.gd` (~3k lines). WS-3 build lanes and
+any agent touching `main_ui` MUST read this first and extract along these seams
+rather than piling onto the monolith.
+
+**Governing decision (Pip, 2026-07-25):** NOT a big-bang "sortie." One targeted
+carve now (R4), a map for the rest, and incremental extraction distributed across
+WS-3 lanes -- each seam pulled when the feature that touches it lands. Refactors
+here are **non-forking** (internal structure, no gameplay/RNG/scoring change ->
+build patch, not ladder epoch) but MUST be test-gated: fast gate (300+ tests)
+green before AND after each carve. GDScript breaks silently.
+
+---
+
+## 1. The six responsibilities tangled in main_ui.gd
+
+Grounded in the actual function inventory (2026-07-25). `main_ui.gd` conflates:
+
+| Seam | Responsibility | Representative functions (current) | Why it hurts |
+|---|---|---|---|
+| **R1** | Layout / rendering | `_render_actions_grouped`, `_build_candidate_card`, `_build_onboarding_card`, `update_queued_actions_display` | View churn risks logic |
+| **R2** | Input / hover | `_on_dynamic_action_pressed`, `_on_action_hover`, `_on_action_unhover`, `_trigger_action_by_index` | Input tangled with state reads |
+| **R3** | Game-state reading | scattered `GameState`/`game_manager` reads inside render + handlers | No single read surface |
+| **R4** | **Planning / attention / queue** | `_on_commit_plan_button_pressed`, `_on_clear_queue_button_pressed`, `_remove_queued_action`, `_calculate_queued_costs`, `update_queued_actions_display`, `_on_action_executed`, `_on_actions_available`, `_setup_plan_watch_scaffold` | **DOMAIN LOGIC in the UI -- the hotpatch-bleed** |
+| **R5** | Submenu / dialog orchestration | `_show_hiring_submenu`, `_show_fundraising_submenu`, `_show_financing_submenu`, `_show_publicity_submenu`, `_show_strategic_submenu`, `_show_travel_submenu`, `_show_operations_submenu` + 7 matching `_on_*_option_selected` + `_decorate_active_submenu` / `_close_active_submenu` | **7 copy-pasted builders -- the single biggest line bloat** |
+| **R6** | Event / result presentation | `_hiring_action_result`, `_on_action_executed` (presentation half) | Presentation mixed with mutation |
+
+## 2. Target architecture
+
+`main_ui.gd` becomes a **thin view**: it renders model state and emits *intents*;
+it owns no domain logic. Two controllers absorb the domain seams:
+
+```
+  main_ui.gd (thin view)
+    |  renders <- reads model
+    |  emits intents ->
+    |
+    +-- PlanController        (R4: the plan/attention/queue model + ops)
+    |     owns: queued actions, attention spend, cost calc, commit/clear
+    |     wraps/uses existing MonthPlan + MonthController
+    |
+    +-- SubmenuController     (R5: one data-driven submenu component)
+          owns: open/close, option list from data, option-selected -> intent
+          replaces the 7 hand-rolled _show_*_submenu / _on_*_option_selected pairs
+```
+
+R1/R3/R6 stay in the view for now (they ARE view work); they get tidied opportunistically as lanes touch them. R2 input routes through the two controllers as intents.
+
+## 3. Extraction order (and who triggers each)
+
+**CARVE 1 -- R4 -> PlanController. DO NOW (quiet window). Priority.**
+- Pull the queue/attention/cost/commit logic out of `main_ui` into a
+  `PlanController` that wraps the existing `MonthPlan` / `MonthController`.
+- `main_ui` keeps only: render the plan, wire buttons to `PlanController` calls.
+- **Why first:** it is the actively-hotpatched seam AND the natural prerequisite
+  for the per-tick resolution spike (`spike-resolve-time-spend`) -- per-tick IS a
+  change to how the queue resolves, so the queue logic wants a clean home before
+  per-tick lands on it. Do the carve, then per-tick sits on `PlanController`, not
+  on the monolith.
+- Test-gate: the queue/attention unit tests must stay green; add characterization
+  tests for `_calculate_queued_costs` behaviour before moving it if coverage is thin.
+
+**CARVE 2 -- R5 -> SubmenuController. HIGH-VALUE, LOW-RISK. Do when the first WS-3
+lane needs a new submenu.**
+- The 7 `_show_*_submenu` builders are ~near-identical: build a dialog, list
+  options, decorate, wire `_on_*_option_selected`. Collapse to ONE data-driven
+  `SubmenuController.open(submenu_id)` reading option lists from data/config.
+- **Why high-value:** biggest single line reduction, pure UI pattern (low
+  regression risk), and it stops the next submenu (people&money roster panel,
+  Developments feed) from being an 8th copy-paste. Whichever WS-3 lane first adds
+  a panel triggers this -- they build the generic component instead of copy #8.
+
+**CARVES 3+ -- R1/R2/R3/R6 opportunistic.** No speculative extraction. Each WS-3
+lane that touches rendering/input tidies its own patch toward the thin-view target
+(boy-scout rule), guided by this map. Revisit for a formal pass only if a seam
+proves painful again after WS-3.
+
+## 4. Lane tagging (fill in at WS-3 scoping, #811)
+
+| WS-3 lane / feature | Seam it naturally triggers |
+|---|---|
+| Per-tick resolution (spike-resolve-time-spend) | depends on CARVE 1 (R4) |
+| People & money roster panel (#833) | triggers CARVE 2 (R5) |
+| Developments / rival feed UI (SEED_RIVAL_AND_DEVELOPMENTS) | reuses CARVE 2 (R5) |
+| Onboarding advisor / lever-pointer (#801) | opportunistic R1/R6 |
+
+## 5. Non-negotiables
+
+- **Non-forking.** No carve changes gameplay/RNG/scoring. Ladder stays put; these
+  ship in build patches.
+- **Test-gated.** `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`
+  green before and after every carve. Touch simulation code -> also run `--simulation`.
+- **Scene-nav rule still applies.** Any extracted controller changing scenes goes
+  through `SceneTransition` (never `change_scene_to_file` from input/signals).
+- **One carve per PR.** Keep each extraction reviewable; do not bundle R4 + R5.
+
+**Related:** `docs/game-design/WORKSHOP_3_PREP.md` (WS-3 scoping), `spike-resolve-time-spend`
+branch (per-tick prototype), `PEOPLE_AND_MONEY_COHESION.md` (#833), `docs/game-design/SEED_RIVAL_AND_DEVELOPMENTS.md`.

--- a/docs/RELEASE_NOMENCLATURE.md
+++ b/docs/RELEASE_NOMENCLATURE.md
@@ -1,0 +1,104 @@
+# Release & League Nomenclature
+
+**Status:** CANONICAL (2026-07-25, Pip). The precise definitions of every clock,
+counter, and name the project uses to schedule and ship. If another doc
+disagrees with this one, this one wins; fix the other. Runbook (the operational
+how-to) lives in `docs/RELEASE_AND_LEAGUE_CYCLE.html`.
+
+---
+
+## The one-paragraph version
+
+The game evolves on a **monthly rhythm**: each month is a named **Theme** -- one
+new mechanical direction plus QoL and balance -- shipped as a **minor-version
+bump that forks the leaderboard** (a new Epoch). Within each month, a fresh
+weekly **Seed** gives a new board on unchanged rules. Cosmetic fixes ship any
+time as **Patches** without forking. Occasionally a **Big Milestone** (public
+alpha, rivals-go-live) spans several monthly Themes -- those complete when done,
+not on a fixed date, and are the only "quarter-ish" objects.
+
+**Design intent (Pip, 2026-07-25):** small monthly increments along a theme, with
+QoL touch-ups and balance, is the healthy sustainable shape while in development
+(~one decent feature a week is the current pace). Quarterly/big-block planning
+actually *slows* this down. Players see what's coming, and choose when to patch
+and re-join.
+
+---
+
+## The rhythm (fast to slow)
+
+| Unit | Cadence | What it is | Forks? | Version move |
+|---|---|---|---|---|
+| **Seed** | weekly (every Fri) | a fresh board on UNCHANGED rules (new `seed`, same `ladder_version`) | No | none |
+| **Epoch = Monthly Theme** | monthly (1st Fri) | THE evolution unit: one named theme (new mechanic + QoL + balance). The forking cut. | **Yes, by definition** | minor +1 (`0.13->0.14`) AND ladder +1 (`L2->L3`) |
+| **Patch** | any time | cosmetic / honesty hotpatch, no rules change | No | patch +1 (`0.14.0->0.14.1`) |
+| **Big Milestone** | occasional, multi-month | a large capability spanning several monthly Themes (e.g. "First Contact", "Rivals & News"). Completes when done, not date-locked. | n/a (a container) | (a range of minors) |
+
+A Theme forks *by definition* -- it changes how the game plays. A pure-QoL month
+with no gameplay change is just Patches, not an Epoch (ladder holds).
+
+## The two version numbers
+
+| Number | SSOT | Bumps when | Forks the board? |
+|---|---|---|---|
+| **minor** (`0.X`) | `version.txt` | each MONTHLY Theme / Epoch | **Yes** (with the ladder) |
+| **patch** (`0.X.Y`) | `version.txt` | cosmetic within-month hotpatch | No |
+| **ladder** (`LN`) | `ladder_version.txt` | each forking monthly Epoch (+ any rare mid-month fork) | it IS the fork counter |
+
+Minor and ladder move **together**, monthly. Patch **never** touches the ladder.
+Board key = `(seed, ladder_version)`. `sync_version.py --check` gates the two
+`version.txt` fields from drifting.
+
+## The fork rule (the only question that matters at ship time)
+
+> **"Could two identical runs, played the same way, produce a different score,
+> trajectory, or RNG stream across this change?"**
+>
+> - **YES** -> it forks. It's an Epoch. Bump **minor + ladder** (monthly).
+> - **NO** -> it doesn't. Bump only **patch**. Ship any time.
+
+Not breaking the ladder is a **discipline, not a hard rule** (Pip, 2026-07-23): a
+strictly-dominated change (e.g. removing a do-nothing money sink) may ship as a
+Patch even though it technically touches the action space, because no scoring run
+is affected. Judgement, declared, not pretended away.
+
+## Naming decision
+
+- **Monthly Themes get a minor version + a short name** (e.g. `v0.14 "Per-tick &
+  People"`). This is the primary unit.
+- **Big Milestones get a NAME only** (First Contact, Rivals & News) and span
+  several monthly Themes. Tracked as GitHub milestones.
+- **Nothing is quarterly-locked.** The old "one minor version per quarter" pin
+  was a planning artifact from before the current build pace; it is retired.
+  Versions move on the monthly Theme clock.
+
+---
+
+## Dated calendar (2026 H2)
+
+Epoch = first Friday of the month; Seed = every Friday. Today = Sat 2026-07-25
+(AEST). Theme names for v0.14+ are provisional -- Pip names them. Confirm
+operational details against `RELEASE_AND_LEAGUE_CYCLE.html`.
+
+| Date | Day | Beat | Unit | Ver / Ladder | Forks? |
+|---|---|---|---|---|---|
+| Jul 24 | Fri | Build **0.13.0** shipped | Epoch | 0.13 / **L2** | shipped |
+| ~Jul 27-28 | Mon-Tue | **0.13.1** hotpatch (quirks, subtitle, office, READMEs) | Patch | 0.13.1 / L2 | **No** |
+| **Jul 29** | **Wed** | **Workshop 3** (mechanics) -- #811 | design | -- | -- |
+| Jul 31 | Fri | Weekly Seed | Seed | -- / L2 | No |
+| **Aug 7** | **Fri** | **Theme `v0.14` "Per-tick & People" (prov.)** -- per-tick resolution + people&money + WS-3 builds | Epoch+Seed | 0.14 / **L3** | **Yes** |
+| Aug 14/21/28 | Fri | Weekly Seeds | Seed | -- / L3 | No |
+| **Sep 4** | **Fri** | **Theme `v0.15` (prov.)** | Epoch+Seed | 0.15 / **L4** | **Yes** |
+| Sep 11/18/25 | Fri | Weekly Seeds | Seed | -- / L4 | No |
+| **Sep 29** | Tue | Big Milestone **"First Contact"** target (spans v0.13-v0.15) | Milestone | -- | -- |
+| **Oct 2** | **Fri** | **Theme `v0.16` (prov.)** | Epoch+Seed | 0.16 / **L5** | Yes |
+| ...monthly... | | Themes `v0.17`, `v0.18` through Q4 | Epoch | -- | -- |
+| **Dec 30** | Wed | Big Milestone **"Rivals & News"** target | Milestone | -- | -- |
+
+## Open reconciliation flag (owe Pip)
+
+- **`ROADMAP.md` quarterly-pins table** still maps one-minor-version-per-quarter.
+  Under this model that recasts to **monthly Themes** (a named minor each month),
+  with only the two Big Milestones (First Contact, Rivals & News) surviving as
+  coarse multi-month groupings. Pip to re-cast the table and name the upcoming
+  Themes (`v0.14`+). Left for Pip; not rewritten unilaterally.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,17 +11,26 @@
 > effort-days per week (Friday/Saturday project days plus agent-assisted
 > weekday increments). Pins are sized to that cadence, not to burst weeks.
 
+> **Nomenclature (2026-07-25):** precise definitions of Theme / Epoch / Seed and
+> the version numbers live in [`RELEASE_NOMENCLATURE.md`](RELEASE_NOMENCLATURE.md).
+> Ruling: the game evolves on a **MONTHLY** rhythm -- each month is a named Theme
+> = a minor-version bump = a forking Epoch. Quarterly planning is retired (it slows
+> the real ~feature-a-week pace). The "Quarterly pins" table below is therefore
+> **pending re-cast** into monthly Themes; only the two Big Milestones (First
+> Contact, Rivals & News) survive as coarse multi-month groupings. Left for Pip
+> to re-cast + name the upcoming Themes (`v0.14`+).
+
 ## Now (committed) -- GitHub milestones
 
 The live execution roadmap is the milestone pages; issues move, the milestone
 reflects it. This file does not duplicate their contents.
 
-- [v0.12 -- First Contact](https://github.com/PipFoweraker/pdoom1/milestone/12)
+- [First Contact](https://github.com/PipFoweraker/pdoom1/milestone/12)
   (target: end Q3 2026). Public alpha readiness: first-contact UX fixes
   (SmartScreen metadata, commit-always-advances, first-launch help), onboarding
   phases 0-2, the share loop (copy result + seed), remote leaderboard enabled
   and hardened, monthly league v0.
-- [v0.13 -- Rivals and News](https://github.com/PipFoweraker/pdoom1/milestone/13)
+- [Rivals & News](https://github.com/PipFoweraker/pdoom1/milestone/13)
   (target: end Q4 2026). Rivals become a strategic surface: intel panel,
   capability-race display, poaching rework (#648), News channel v1 (DQ-32),
   the voice re-skin of generic event content, tutorial mode, and the DQ-22

--- a/docs/adr/0004-self-describing-data.md
+++ b/docs/adr/0004-self-describing-data.md
@@ -1,0 +1,77 @@
+# ADR-0004: Self-describing data files (schema declared by the file, not inferred from location)
+
+**Status:** Accepted (2026-07-25, Pip)
+**Deciders:** Pip
+**Context tags:** tooling, data-architecture, anti-rot, futureproofing
+
+## Context
+
+The data-validation CI (`scripts/validate_historical_data.py`) globs a directory
+(`godot/data/researchers/*.json`) and validates **every** file in it against ONE
+schema (`researcher.schema.json`, which requires a top-level `researchers`
+array). When a second file *shape* -- `quirks.json`, a quirk catalogue with a
+top-level `quirks` key -- landed in that folder, validation hard-failed
+(`quirks.json/root: 'researchers' is a required property`) and reddened CI on
+every PR (issue #807).
+
+**Root cause is structural, not a typo:** the validator assumes
+`directory == schema type`. One folder, one shape. That assumption breaks
+silently the moment a folder holds two shapes, and it does not scale.
+
+This matters beyond one file. The game is deliberately **data-driven** (events,
+actions, scenarios, researchers, quirks, balance -- all JSON) and Pip is steering
+toward **scale**: `pdoom-data` treated as a data lake, good metadata, downstream
+ingestion, then balance-shaping inside this repo, targeting **hundreds-to-
+thousands of events managed with minimal drift, wrongness, and operator
+insanity**. Directory-inferred schema is a landmine that detonates more often as
+the data grows.
+
+## Decision
+
+**Data files declare their own type; tooling dispatches on the declaration.**
+
+1. Each validated JSON data file carries an explicit type discriminator -- a
+   native `"$schema"` reference (path or id) or a `"schema_type": "<name>"`
+   field -- naming the schema it must satisfy.
+2. Validation tooling reads the declaration and selects the schema from a
+   registry. It NEVER infers schema from directory or filename.
+3. A file with no declaration is either (a) skipped with a logged notice, or
+   (b) failed as "undeclared" -- chosen per tool, but never mis-validated
+   against a wrong schema.
+4. **Migration is incremental, not a big bang.** New data files self-declare
+   from now on. Existing files are migrated folder-by-folder during tidy lanes,
+   not under release pressure.
+5. **Immediate unblock (v0.13.1, non-forking, tooling-only):** make the current
+   researcher loop skip files lacking a `researchers` key (or explicitly skip
+   `quirks.json`) so CI goes green now. This is the stopgap; the self-declaration
+   migration is the real fix (tracked as a follow-up tech-debt issue).
+
+## Consequences
+
+**Positive**
+- Adding a new data file-type never again requires editing the validator or
+  dodging a glob assumption -- the file says what it is.
+- Consistent with the repo's existing **anti-rot principle**: `DQ_INDEX` is
+  *generated from source, not hand-maintained*; version is *one SSOT, synced*
+  (`sync_version.py`). Self-declaration extends "the source describes itself;
+  tooling reads the description" to all game data. It cannot drift from its
+  validator the way a central manifest can (the stale `decisions/README.md` is
+  that drift failure mode).
+- Scales toward the data-lake vision: thousands of events, each self-typed,
+  ingestible downstream by `pdoom-data` on a stable declared contract.
+
+**Negative / cost**
+- Every data file gains one metadata field (small, one-time).
+- A schema registry must exist and be kept complete (but it is small, central,
+  and additive -- far less drift-prone than per-directory glob assumptions).
+- Migration touches many files over time (done incrementally, low-risk).
+
+**Non-forking:** this is tooling + data-metadata only. No gameplay/RNG/scoring
+change. Ladder unaffected.
+
+## Related
+- Issue #807 (the quirks.json CI failure that triggered this).
+- `CLAUDE.md` anti-rot pattern (generated indexes; version SSOT).
+- Cross-repo: `pdoom-data` data-lake direction (metadata + downstream ingestion),
+  balance-shaping consumed back into this repo.
+- Follow-up: file a tech-debt issue for the `data/**` self-declaration migration.

--- a/docs/art/ART_MASTERS_POLICY.md
+++ b/docs/art/ART_MASTERS_POLICY.md
@@ -8,12 +8,20 @@ is regenerable for cents. Git LFS was considered and REJECTED (quota cost +
 per-clone friction to version a cache; two lanes independently declined
 raising the 1MB cap -- permanent history bloat).
 
-Masters archive: Pip's own hosting (pdoom infrastructure, a few GB, cheap;
-NOT a public web path -- keep outside the docroot or auth-protected).
+Masters archive: **DreamObjects** (DreamHost's S3-compatible object storage;
+RULED 2026-07-25). Chosen over MinIO-on-instance / external R2/B2 because it
+consolidates billing on existing hosting, is S3-compatible (rclone/boto),
+decoupled from the compute instance's lifecycle, and ~$1/mo at this scale
+(2.5c/GB, upload free; DreamCompute also includes 100GB Ceph if a self-host
+path is ever preferred). Keep the bucket NON-public (auth-only, not a web
+path). Sync with `python tools/archive_masters.py --push` (rclone remote
+'dreamobjects'; see that script's header for one-time setup).
+
 Interim staging on the dev machine: G:/tmp/pdoom1-art-masters/ -- agents
-producing oversized masters copy them there (or note their worktree
-location) until Pip syncs the folder to hosting. Migration later is trivial
-by design: it is a plain folder of regenerable files.
+producing oversized masters copy them there (or note their worktree location)
+until synced. Durability note: DreamObjects is one provider/one copy; for a
+true 3-2-1 posture add a second off-site copy (R2/B2) once masters warrant it.
+Migration stays trivial by design: a plain folder of regenerable files.
 
 Agent rule: never commit files over the hook cap, never use --no-verify for
 size, never delete masters without them being staged in the archive first.

--- a/docs/copy/README.md
+++ b/docs/copy/README.md
@@ -1,0 +1,58 @@
+# docs/copy/ -- the Voice Seam (SOURCE, not published copy)
+
+**Status:** ACTIVE POLICY (2026-07-25). This is the interface contract between
+`pdoom1` (this repo) and `pdoom1-website`. Edit it as policy, not as notes --
+its diff history is part of the record.
+
+---
+
+## What this folder is
+
+The canonical SOURCE of P(Doom)1's voice, positioning, and copy raw material.
+
+- **`pdoom1` (this repo) = SOURCE.** It owns MECHANICS, DESIGN, and PHILOSOPHY,
+  and the *raw* voice/positioning material derived from them. Nothing in this
+  repo is final, approved, or published copy.
+- **`pdoom1-website` = PUBLISHER.** It PULLS the canonical source files below,
+  EDITS/COLLATES them into finished posts, and PUBLISHES to the website /
+  LinkedIn / LessWrong / other channels. Final, approved copy lives THERE.
+
+## The contract (both repos' agents read this)
+
+1. **Direction is one-way.** `pdoom1-website` reads `pdoom1`. `pdoom1` never
+   depends on `pdoom1-website`. If you are an agent in `pdoom1` reaching into
+   the website repo for content, stop -- you have the direction backwards.
+2. **Commentary originates here only when the mechanics/design demand it.** A
+   design decision, a philosophy shift, a new mechanic's framing -- those are
+   born here because they are downstream of the game. The *finished words* that
+   sell/explain them live in `pdoom1-website`.
+3. **Nothing here is published copy.** Treat everything in the voice seam as raw
+   material with provenance, not as approved marketing. Voice tags (`[PIP]` /
+   `[PIP-idea / Claude-prose]` / `[CLAUDE]`) mark confidence and authorship.
+
+## Canonical source files (the "voice seam" pdoom1-website pulls)
+
+- `docs/copy/COPY_CORPUS.md` -- catalogued raw copy, taglines, provenance, voice
+  tags. The primary pull target.
+- `docs/game-design/DESIGN_PHILOSOPHY.md` -- the "why", verbatim Pip quotes.
+- `docs/PRODUCT_STRATEGY_RATIONALE.md` -- two-products / open-dataset strategy,
+  the B2B/public-good framing.
+- `docs/game-design/WORLD_AND_LORE.md` -- personas (Mogul/Hustler/Operator),
+  tone north star, Antagonist_Lab.
+
+These four are the seam. If a fifth source becomes load-bearing for public
+copy, add it here so the website agent knows it is fair game.
+
+## Pull mechanism
+
+**Agent-manual, for now.** The `pdoom1-website` agent reads these files directly
+from the `pdoom1` repo (clone/fetch) and hand-collates. No sync script, no
+submodule -- deliberately, until content volume justifies automation. When it
+does, this section is where the automated pull (submodule / sync job) gets
+specified.
+
+## Related
+
+- `docs/CONTENT_DISTRIBUTION_SYSTEM.md` -- OUTDATED predecessor (proposed
+  publishing *from* pdoom1). Superseded in spirit by this contract; flagged for
+  Pip's revision during doc uplift. Retained for diff history.

--- a/docs/game-design/SEED_RIVAL_AND_DEVELOPMENTS.md
+++ b/docs/game-design/SEED_RIVAL_AND_DEVELOPMENTS.md
@@ -1,0 +1,166 @@
+# SEED: The Rival + Narrative Pressure ("Developments") -- design seed
+
+> **What this is.** A LOSSLESS capture of Pip's 2026-07-25 brain dump on (a) the
+> rival antagonist system and (b) the narrative-pressure layer he wants to call
+> **"Developments"** (rival-specific subtype: **"Sightings"**). This is a RAW
+> DESIGN SEED, not decided canon. It exists so nothing is lost before it can be
+> workshopped.
+>
+> **Feeds:** WS-3 mechanics workshop (issue #811, Wed 2026-07-30).
+>
+> **Voice tags** (same convention as `docs/copy/COPY_CORPUS.md`):
+> `[PIP]` = verbatim quote from Pip; `[CLAUDE-note]` = agent inference /
+> secretariat synthesis, reword or discard freely.
+
+---
+
+## 1. The Rival
+
+**Default first action = start a lab.** [PIP]
+> "our rival can take multiple important actions through the game, and their
+> most likely action in the fully-designed game is to start a lab. Let's have
+> them do that as the first action we'll have them take by default, but I want
+> to very carefully leave room for the lab to do other things if we give the
+> player other things to do as well"
+
+**Rock-paper-scissors / Pokemon-style meta (visible, mentally-modellable
+advantage).** [PIP]
+> "if a rock-paper-scissors type meta emerges, just like in Pokemon, I want our
+> rival to be able to pick the same thing as us and essentially get a visible
+> baked-in advantage that the player can mentally model well because they're
+> familiar with the trimvirate or polyvirate rules of the game and can feel it's
+> mechanically 'fair' that, oh yes, Politics beats Money even if Money beats
+> Technology and Technology would have made it easier to beat Politics if I'd
+> have picked that"
+
+**The flavour vignette (target feel, NOT the literal copy).** [PIP]
+> "I picked Money and I went outside and saw my rival set up a shop over the
+> road advertising Politics, bother"
+> (Pip's own caveat: "although probably not that blunt and obvious lol")
+
+**Three-act rival presence.** [PIP]
+- **Early game:** "we feel them mostly as a procedural force in the early game
+  as both players build a power base"
+- **Midgame:** "we feel them indirectly in the midgame as perhaps envoys and
+  things happen"
+- **Late game:** "we confront them more directly in the late game as we get to
+  outright conflict level mechanics as more and more power comes to bear and the
+  stakes get higher"
+
+**Representation:** rival stays abstract / in silhouette (Carmen Sandiego
+framing, established 2026-07-24) -- hints, stickers, pamphlets, glimpses of
+people going into meeting rooms; the player mostly infers the rival rather than
+sees them.
+
+---
+
+## 2. Narrative Pressure -- "Developments" (umbrella) / "Sightings" (rival subtype)
+
+Naming decided for now: **Developments** = the general narrative-pressure engine;
+**Sightings** = the rival-specific skin of it.
+
+**Booker's Seven Basic Plots as the structural reference.** [PIP]
+> "I spent like 2 years reading Booker's The Seven Basic Plots and while I don't
+> necessarily want to get too monomyth-y, you know how that has a bunch of
+> archetypal elements that recur as motifs the same way a Rags to Riches or a
+> Tragedy will have recognisable beats?"
+
+**Why beats need to be presented as options (the flaw-recognition point).** [PIP]
+> "We don't feel as sad unless the person has multiple chances to recognise and
+> overcome their flaws, so they have to be presented with those options, yes?"
+
+**Our beat archetypes (the game's equivalent of Start / Kind Stranger / lose-to-
+the-Dragon-but-survive / training).** [PIP]
+> "maybe it's each player gets, like a Cat Encounter, a Stroke of good Luck, an
+> Ally, an Early Success, a Local Problem, an Office Crisis, and then something
+> allows them to Step Up a bit, leading to early-midgame and we shift out of
+> startup-era to office-era"
+
+**Era shift drives the event pools.** [PIP]
+> "this then signifies changes in the styles of events that the event pools can
+> draw from, and so on -- these can be interleaved so it's a bit more subtle for
+> players"
+
+---
+
+## 3. The design north star (the "thumb on the scale")
+
+**Respond to the world, don't script it; add spookiness; make the player feel
+they matter.** [PIP]
+> "we don't want to control what happens, we want the narrative flow of the world
+> to feel like it's responding to real world events (like the real world did!)
+> but with the slight layer of spookiness and things filtering into the game
+> world that makes us feel like the player is having a difference."
+
+**Deliberate optimism bias vs a "perfectly representative sim."** [PIP]
+> "this means that the player is likely to experience more success than will be
+> like correct for a perfectly representative sim, because most things are
+> rejected etc etc etc, so there will be some thumbs on the scales kind of baked
+> in there"
+
+**Narrative-progression payoff ranking (what feels better).** [PIP]
+> "a game where the player basically becomes a respected junior researcher and
+> then works as a small part of a larger and larger team is less payoff than a
+> player who ends up managing a company or leading a team of researchers or
+> running the world's only doom-reducing frontier lab are all giving us better
+> narrative progression feelings."
+
+---
+
+## 4. Secretariat notes -- connections & open questions [CLAUDE-note]
+
+**Structural synergies (why these aren't three separate systems):**
+- **Shared surface:** the rival gets revealed on the SAME "go outside to find
+  contacts / recruit" loop as the people & money cohesion spine (#833). Leaving
+  the office is what both exposes the rival AND drives recruitment. One surface,
+  two payoffs.
+- **Era shift == "the world starts shooting back":** the startup-era -> office-era
+  transition is the same seam as the existing DESIGN_PHILOSOPHY midgame line
+  ("the midgame begins when the world starts shooting back"). "Developments" IS
+  the midgame-interaction engine, not a separate feature.
+- **The polyvirate needs a named axis set.** Pip's example uses **Politics /
+  Money / Technology** (Politics beats Money, Money beats Technology, Technology
+  beats Politics). Candidate triumvirate -- confirm at WS-3. This axis set would
+  also want to be the rival's action space AND (maybe) the player's strategic
+  posture, so the RPS is legible.
+
+**Open questions for WS-3 (#811):**
+1. Is the rival ONE persistent silhouette (a modelled agent with its own moves /
+   doom contribution) or a faceless procedural force with narrative dressing?
+   (Pip leans: procedural early -> indirect mid -> direct late, so likely it
+   GRADUATES from force to agent as the game progresses.)
+2. Do "Developments" carry mechanical teeth (change game state) from day one, or
+   ship flavour-first and gain teeth later?
+3. Is the Politics/Money/Technology triumvirate the real axis set, or a
+   placeholder? Does the player pick a posture on the same axes the rival does?
+4. How are the beat archetypes (Cat Encounter, Ally, Office Crisis, Step Up...)
+   represented in data? A beat-tag on events + an era-gate on the event pool?
+5. How is the "thumb on the scale" implemented without lying to the player -- an
+   explicit acceptance-bias on world-event injection? Where does it live so it's
+   tunable and honest?
+
+**Related docs:** `docs/copy/COPY_CORPUS.md` (voice), `docs/game-design/DESIGN_PHILOSOPHY.md`
+("world shoots back", "the sim never lies; characters do"), `docs/game-design/WORLD_AND_LORE.md`
+(Antagonist_Lab, the Mogul/Hustler/Operator personas), `PEOPLE_AND_MONEY_COHESION.md` (#833, shared recruitment surface).
+
+---
+
+## Appendix: unrelated WS-3 flavour seeds captured in passing
+
+Not rival-related; parked here so they reach the WS-3 agenda (#811). Migrate to
+the workshop backlog when it's stood up.
+
+**Office upkeep / janitor (the retired "Office Maintenance" money-sink, reborn as
+flavour).** [PIP, 2026-07-25]
+> "It was a proof of concept money sink about 1,300 commits ago. abandon
+> mechanism, lightly hold onto mechanical idea. I am thinking here of little
+> people walking around SimPark and reliably dropping trash that a little
+> janitor would wander around and collect, but at a lower scale / probably only
+> relevant once we get larger offices, maybe?"
+
+Design note [CLAUDE]: the mechanical seed is *ambient upkeep that scales with
+org size* -- an office-era (not startup-era) cost that emerges only once you have
+a larger office/team, tying it to the startup->office era shift above. The
+current `office_maintenance` action (pays $5000, does nothing) is being REMOVED
+from the action board in v0.13.1; this note preserves the idea for a real
+implementation later.

--- a/docs/game-design/WORKSHOP_3_PREP.md
+++ b/docs/game-design/WORKSHOP_3_PREP.md
@@ -10,6 +10,29 @@
 
 ---
 
+## 0. Steering docs added since drafting (WS-3 lanes MUST read)
+
+Added 2026-07-25 after the prep pack. Any WS-3 build lane reads these before
+starting so refactors and new UI land along agreed seams, not on the monolith:
+
+- **`docs/MAIN_UI_SEAM_MAP.md`** -- the incremental de-monolithing plan for
+  `main_ui.gd`. CARVE 1 (R4 planning/attention/queue -> `PlanController`) is
+  slated for the quiet pre-WS-3 window and is the prerequisite for the per-tick
+  spike. CARVE 2 (the 7 copy-pasted submenus -> one data-driven
+  `SubmenuController`) triggers the first time a lane adds a panel -- build the
+  generic component, do NOT copy-paste an 8th submenu. All carves are non-forking
+  and test-gated.
+- **`docs/game-design/SEED_RIVAL_AND_DEVELOPMENTS.md`** -- captured design seed for
+  the rival system + narrative-pressure layer ("Developments" umbrella,
+  "Sightings" rival subtype). Feeds the DQ-22 rivals cluster (Theme E / the
+  midgame lane). Note the structural synergy: the rival is revealed on the same
+  "go outside to recruit" surface as the people & money spine (#833).
+- **`docs/adr/0004-self-describing-data.md`** -- data files declare their own
+  schema; tooling never infers schema from directory. Relevant to any lane adding
+  new data files (events/actions): self-declare the type.
+
+---
+
 ## 1. Purpose + how these workshops work
 
 Pip runs periodic **mechanics-design workshops**. Each produces a batch of ADRs

--- a/tools/archive_masters.py
+++ b/tools/archive_masters.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Sync the local art-masters cache to off-site object storage (DreamObjects).
+
+Masters are a regenerable convenience cache (see docs/art/ART_MASTERS_POLICY.md),
+kept OUT of git. This pushes the local staging folder to a DreamObjects
+(S3-compatible) bucket so the only copy is not the dev machine's disk.
+
+Prereqs (one-time):
+  1. Install rclone: https://rclone.org/install/
+  2. Configure a remote named 'dreamobjects' (S3-compatible):
+       rclone config
+       - type: s3, provider: Other / S3-compatible
+       - endpoint: objects-us-east-1.dream.io (or your region's endpoint)
+       - access_key_id / secret_access_key from the DreamHost panel
+  3. Create the bucket once:
+       rclone mkdir dreamobjects:pdoom1-art-masters
+
+Usage:
+  python tools/archive_masters.py            # dry-run (shows what WOULD sync)
+  python tools/archive_masters.py --push     # actually sync
+  python tools/archive_masters.py --push --local G:/tmp/pdoom1-art-masters
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+
+DEFAULT_LOCAL = "G:/tmp/pdoom1-art-masters"
+REMOTE = "dreamobjects:pdoom1-art-masters"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sync art masters to DreamObjects.")
+    parser.add_argument("--local", default=DEFAULT_LOCAL, help="local masters folder")
+    parser.add_argument("--push", action="store_true", help="sync (default: dry-run)")
+    args = parser.parse_args()
+
+    if shutil.which("rclone") is None:
+        print("ERROR: rclone not found. Install: https://rclone.org/install/")
+        return 1
+
+    cmd = ["rclone", "sync", args.local, REMOTE, "--progress"]
+    if not args.push:
+        cmd.append("--dry-run")
+        print("DRY RUN (no changes). Re-run with --push to sync.")
+
+    print("Running:", " ".join(cmd))
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Lands today's planning docs + the DreamObjects masters-archive tooling. Docs + tooling only, non-forking. See commit body for the file list.

Generated with Claude Code