### PR TITLE
refactor(ui): CARVE 1 -- extract R4 plan/attention/queue to PlanController (non-forking)

### DIFF
--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -50,8 +50,10 @@ extends VBoxContainer
 # Reference to GameManager
 var game_manager: Node
 
-# Track queued actions
-var queued_actions: Array = []
+# CARVE 1 (R4, docs/MAIN_UI_SEAM_MAP.md): the plan/attention/queue LOGIC lives in
+# PlanController now. main_ui is the thin view -- it renders plan_controller.queued_actions
+# and wires buttons to plan_controller.* calls; it owns no queue/cost/commit math.
+var plan_controller: PlanController
 var research_quality_selector  # Issue #500
 var doom_trend_graph  # #512 doom trend sparkline (script-instantiated)
 var doom_breakdown  # #578 colour-coded per-source doom "blow-by-blow" (script-instantiated)
@@ -144,6 +146,9 @@ func _ready():
 	# Get GameManager reference -- the autoload singleton is the ONE GameManager
 	# (L0 #620/#608: the duplicate scene-local node was removed from main.tscn)
 	game_manager = GameManager
+
+	# CARVE 1 (R4): stand up the plan/queue/attention controller over the same GameManager.
+	plan_controller = PlanController.new(game_manager)
 
 	# P0 rage-quit friction (playtest 2026-07-17): during a run, a window-close (X / Alt+F4)
 	# should return to the Main Menu instead of quitting straight to desktop. We take over the
@@ -646,7 +651,7 @@ func _refresh_gantt() -> void:
 	if queue_gantt == null or _ui_layout != "proposed":
 		return
 	var state: Dictionary = game_manager.get_game_state() if game_manager else {}
-	var rows := QueueGantt.rows_from_state(state, queued_actions)
+	var rows := QueueGantt.rows_from_state(state, plan_controller.queued_actions)
 	var watch_mode := screen_mode != null and screen_mode.current_mode == ScreenModeController.Mode.WATCH
 	queue_gantt.update_rows(rows, watch_mode)
 
@@ -688,11 +693,11 @@ func _on_reserve_ap_button_pressed():
 
 func _on_undo_last_button_pressed():
 	"""Undo (remove) the last queued action"""
-	if queued_actions.size() == 0:
+	if plan_controller.queued_actions.size() == 0:
 		return
 
 	# Get the last action
-	var last_action = queued_actions[-1]
+	var last_action = plan_controller.queued_actions[-1]
 	var action_id = last_action.get("id", "")
 	var action_name = last_action.get("name", "Unknown")
 
@@ -700,60 +705,40 @@ func _on_undo_last_button_pressed():
 	_remove_queued_action(action_id, action_name)
 
 func _on_clear_queue_button_pressed():
-	"""Clear all queued actions and refund AP"""
-	if queued_actions.size() == 0:
-		return
-
-	# Call GameManager to clear queue (refunds AP)
-	game_manager.clear_action_queue()
+	"""Clear all queued actions and refund AP. Queue mutation + refund is PlanController's job
+	(R4); the view keeps the empty-queue guard, the log line, and the redraw."""
+	if not plan_controller.clear_queue():
+		return  # already empty -- nothing to clear
 
 	# Update local display
-	queued_actions.clear()
 	update_queued_actions_display()
 
 	log_message("[color=yellow]Action queue cleared - AP refunded[/color]")
 
 func _remove_queued_action(action_id: String, action_name: String):
-	"""Remove a specific action from the queue"""
+	"""Remove a specific action from the queue. The queue mutation + Attention refund live in
+	PlanController (R4); the view keeps the debug/log lines and the redraw."""
 	print("[MainUI] Removing queued action: %s (id: %s)" % [action_name, action_id])
 
-	# Find and remove from local queue
-	var removed_index = -1
-	for i in range(queued_actions.size()):
-		if queued_actions[i].get("id") == action_id:
-			removed_index = i
-			break
-
-	if removed_index >= 0:
-		queued_actions.remove_at(removed_index)
-
-		# Tell GameManager to remove and refund AP
-		game_manager.remove_queued_action(action_id)
-
-		# Get AP cost for logging
-		var action_def = _get_action_by_id(action_id)
-		var ap_cost = action_def.get("costs", {}).get("action_points", 0)
-
+	var result := plan_controller.remove_action(action_id)
+	if result.get("removed", false):
+		var ap_cost: int = result.get("attention_cost", 0)
 		log_message("[color=yellow]Removed: %s (+%d AP)[/color]" % [action_name, ap_cost])
 		update_queued_actions_display()
 	else:
 		print("[MainUI] ERROR: Could not find action to remove: %s" % action_id)
 
 func _on_end_turn_button_pressed():
-	if queued_actions.size() == 0 or (game_manager.state != null and game_manager.state.queued_actions.is_empty()):
+	if plan_controller.needs_pass_fallback():
 		# Issue #733 (+ overbook soft-lock): an empty ACCEPTED queue no longer hard-errors --
-		# phantom UI tiles could previously suppress this net. Route through the existing
+		# phantom UI tiles could previously suppress this net. PlanController routes the existing
 		# pass-action path (identical to the Do Nothing button) so COMMIT THE MONTH always
 		# advances. Determinism-safe: no new RNG and no turn-step reordering -- select_action()
 		# only queues the canonical pass id, and end_month() below plays it out exactly as a
 		# planned month would.
 		log_message("[color=gray]Nothing planned -- the month proceeds.[/color]")
-		var pass_action := GameActions.get_pass_action()
-		var pass_id: String = pass_action.get("id", GameActions.PASS_ACTION_ID)
-		var pass_name: String = pass_action.get("name", "Do Nothing")
-		queued_actions.append({"id": pass_id, "name": pass_name})
+		plan_controller.queue_pass_fallback()
 		update_queued_actions_display()
-		game_manager.select_action(pass_id)
 
 	# Check for danger zones and warn player
 	var current_state = game_manager.state
@@ -791,16 +776,18 @@ func _on_end_turn_button_pressed():
 		log_message("[color=gray]Press Space/Enter again to confirm, or C to revise queue[/color]")
 		# Note: Simplified version - in full implementation, would require double-confirm
 
-	log_message("[color=cyan]Committing month plan (%d actions) -- playing the month out...[/color]" % queued_actions.size())
+	log_message("[color=cyan]Committing month plan (%d actions) -- playing the month out...[/color]" % plan_controller.queue_size())
 
-	# Clear queued actions (will be repopulated after turn processes)
-	queued_actions.clear()
+	# Clear the UI mirror (NO refund -- the backend queue is consumed by the commit below;
+	# repopulated after the turn processes). reset_mirror() is the commit-path clear, distinct
+	# from the clear-queue button's refunding path.
+	plan_controller.reset_mirror()
 	update_queued_actions_display()
 
 	# L1 (ADR-0009): End Turn commits the MONTH plan and hands control to day-tick
 	# playback (auto-pause on response windows, month review at the boundary). The old
 	# single day-step lives on ONLY behind the DEV MODE overlay ("Day step (dev)").
-	game_manager.end_month()
+	plan_controller.commit_month()
 	# Phase A: COMMIT THE MONTH is the PLAN->WATCH transition.
 	if screen_mode:
 		screen_mode.enter_watch()
@@ -811,34 +798,22 @@ func _on_commit_plan_button_pressed():
 	var available_ap = current_state.get("available_ap", 0)
 
 	# If there are queued actions, commit them + reserve balance
-	if queued_actions.size() > 0:
-		log_message("[color=cyan]Committing %d queued actions + reserving %d remaining AP...[/color]" % [queued_actions.size(), available_ap])
+	if plan_controller.queue_size() > 0:
+		log_message("[color=cyan]Committing %d queued actions + reserving %d remaining AP...[/color]" % [plan_controller.queue_size(), available_ap])
 	else:
-		# No queued actions - just reserve all AP (reactive strategy)
+		# No queued actions - just reserve all AP (reactive strategy). PlanController owns the
+		# reserve-all queue mutation (mirror entry + backend pass id); the view just logs + redraws.
 		log_message("[color=cyan]Committing plan: Reserving all %d AP for reactive responses...[/color]" % available_ap)
-
-		# Queue the pass action to represent reactive strategy (L0 #620: was the
-		# twin id "pass_turn"; ONE id now -- GameActions.PASS_ACTION_ID)
-		var reserve_action = {
-			"id": GameActions.PASS_ACTION_ID,
-			"name": "Reserve All AP",
-			"description": "No planned actions - keep all AP available for responding to events",
-			"ap_cost": 0,
-			"money_cost": 0
-		}
-		queued_actions.append(reserve_action)
+		plan_controller.append_reserve_all()
 		update_queued_actions_display()
 
-		# Directly append to game state queue (bypass select_action validation)
-		# -- a virtual "reserve all AP" entry; pass costs {} so no AP is committed
-		game_manager.state.queued_actions.append(GameActions.PASS_ACTION_ID)
-
-	# Clear local queue (will be repopulated after turn processes)
-	queued_actions.clear()
+	# Clear the UI mirror (NO refund -- backend consumed by the commit; repopulated after the
+	# turn processes). Commit-path clear, distinct from the clear-queue button's refunding path.
+	plan_controller.reset_mirror()
 	update_queued_actions_display()
 
 	# Commit the plan -- the L1 month path (see _on_end_turn_button_pressed).
-	game_manager.end_month()
+	plan_controller.commit_month()
 	# Phase A: committing the plan is the PLAN->WATCH transition.
 	if screen_mode:
 		screen_mode.enter_watch()
@@ -1136,10 +1111,10 @@ func _on_turn_phase_changed(phase_name: String):
 		phase_color = "lime"
 		phase_display = "SELECT ACTIONS - Click actions or press 1-9"
 		# End turn requires actions, commit plan is always available
-		end_turn_button.disabled = (queued_actions.size() == 0)
+		end_turn_button.disabled = plan_controller.is_queue_empty()
 		commit_plan_button.disabled = false
-		undo_last_button.disabled = (queued_actions.size() == 0)
-		clear_queue_button.disabled = (queued_actions.size() == 0)
+		undo_last_button.disabled = plan_controller.is_queue_empty()
+		clear_queue_button.disabled = plan_controller.is_queue_empty()
 		# Phase A: reaching the plan phase (game start / after month review) returns to PLAN.
 		# Mid-month window pauses emit "turn_start", not "action_selection", so WATCH is kept.
 		if screen_mode:
@@ -1715,8 +1690,8 @@ func _on_dynamic_action_pressed(action_id: String, action_name: String):
 	# Track queued action -- #821: only add the UI tile when the backend accepts
 	# (select_action returns false on Attention overbook + emits the error), so a
 	# rejected action no longer leaves a phantom queue tile.
-	if game_manager.select_action(action_id):
-		queued_actions.append({"id": action_id, "name": action_name})
+	if plan_controller.select_action(action_id):
+		plan_controller.queue_action(action_id, action_name)
 		update_queued_actions_display()
 
 func _get_action_by_id(action_id: String) -> Dictionary:
@@ -1857,23 +1832,8 @@ func _show_doom_trend_expanded() -> void:
 	dialog.z_index = 1000
 	dialog.z_as_relative = false
 
-func _calculate_queued_costs() -> Dictionary:
-	"""Calculate total costs of all queued actions for turn preview"""
-	var total_costs: Dictionary = {}
-
-	for queued_action in queued_actions:
-		var action_id = queued_action.get("id", "")
-		var action_def = _get_action_by_id(action_id)
-		var costs = action_def.get("costs", {})
-
-		for resource in costs.keys():
-			if resource == "action_points":
-				continue  # AP is already tracked separately
-			if not total_costs.has(resource):
-				total_costs[resource] = 0
-			total_costs[resource] += costs[resource]
-
-	return total_costs
+# CARVE 1 (R4): _calculate_queued_costs moved verbatim to
+# PlanController.calculate_queued_costs(). The view calls it in update_queued_actions_display.
 
 func _show_hiring_submenu():
 	"""Phase-B hiring pipeline panel (source -> interview -> offer -> onboard). PURE VIEW:
@@ -2620,8 +2580,8 @@ func _on_fundraising_option_selected(action_id: String, action_name: String, dia
 	# backend accepts (select_action returns false on Attention overbook), so a
 	# rejected action no longer leaves a phantom queue tile.
 	print("[MainUI] Calling game_manager.select_action(%s)" % action_id)
-	if game_manager.select_action(action_id):
-		queued_actions.append({"id": action_id, "name": action_name})
+	if plan_controller.select_action(action_id):
+		plan_controller.queue_action(action_id, action_name)
 		update_queued_actions_display()
 
 func _show_financing_submenu():
@@ -2719,8 +2679,8 @@ func _on_financing_option_selected(action_id: String, action_name: String, dialo
 	log_message("[color=cyan]Financing: %s[/color]" % action_name)
 	# #821: only add the UI tile when the backend accepts (select_action returns
 	# false on Attention overbook), so a rejected action leaves no phantom tile.
-	if game_manager.select_action(action_id):
-		queued_actions.append({"id": action_id, "name": action_name})
+	if plan_controller.select_action(action_id):
+		plan_controller.queue_action(action_id, action_name)
 		update_queued_actions_display()
 
 func _show_ledger_screen():
@@ -2926,8 +2886,8 @@ func _on_publicity_option_selected(action_id: String, action_name: String, dialo
 	# backend accepts (select_action returns false on Attention overbook), so a
 	# rejected action no longer leaves a phantom queue tile.
 	print("[MainUI] Calling game_manager.select_action(%s)" % action_id)
-	if game_manager.select_action(action_id):
-		queued_actions.append({"id": action_id, "name": action_name})
+	if plan_controller.select_action(action_id):
+		plan_controller.queue_action(action_id, action_name)
 		update_queued_actions_display()
 
 func _show_strategic_unlock_fanfare() -> void:
@@ -3102,8 +3062,8 @@ func _on_strategic_option_selected(action_id: String, action_name: String, dialo
 	# backend accepts (select_action returns false on Attention overbook), so a
 	# rejected action no longer leaves a phantom queue tile.
 	print("[MainUI] Calling game_manager.select_action(%s)" % action_id)
-	if game_manager.select_action(action_id):
-		queued_actions.append({"id": action_id, "name": action_name})
+	if plan_controller.select_action(action_id):
+		plan_controller.queue_action(action_id, action_name)
 		update_queued_actions_display()
 
 # === TRAVEL & CONFERENCES SUBMENU (Issue #468) ===
@@ -3732,12 +3692,12 @@ func update_queued_actions_display():
 		if child != queue_hint:
 			child.queue_free()
 
-	if queued_actions.size() > 0:
+	if plan_controller.queue_size() > 0:
 		# Hide hint, show queue items
 		queue_hint.visible = false
 
 		# Create visual queue items
-		for action in queued_actions:
+		for action in plan_controller.queued_actions:
 			var action_name = action.get("name", "Unknown")
 			var action_id = action.get("id", "")
 
@@ -3782,8 +3742,8 @@ func update_queued_actions_display():
 
 			queue_container.add_child(item)
 
-		# Calculate and display turn preview (total costs from queued actions)
-		var total_costs = _calculate_queued_costs()
+		# Calculate and display turn preview (total costs from queued actions -- R4 logic in PlanController)
+		var total_costs = plan_controller.calculate_queued_costs()
 		if not total_costs.is_empty():
 			var preview_panel = PanelContainer.new()
 			preview_panel.custom_minimum_size = Vector2(150, 60)
@@ -3817,9 +3777,9 @@ func update_queued_actions_display():
 
 		# Log message
 		var action_names = []
-		for action in queued_actions:
+		for action in plan_controller.queued_actions:
 			action_names.append(action.get("name", "Unknown"))
-		log_message("[color=lime]Queued actions (%d): %s[/color]" % [queued_actions.size(), ", ".join(action_names)])
+		log_message("[color=lime]Queued actions (%d): %s[/color]" % [plan_controller.queue_size(), ", ".join(action_names)])
 	else:
 		# Show hint, hide items
 		queue_hint.visible = true
@@ -3828,11 +3788,11 @@ func update_queued_actions_display():
 	# Update button states based on queue (case-insensitive phase check)
 	var phase_upper = current_turn_phase.to_upper()
 	if phase_upper == "ACTION_SELECTION":
-		var queue_empty = queued_actions.size() == 0
+		var queue_empty = plan_controller.is_queue_empty()
 		undo_last_button.disabled = queue_empty
 		clear_queue_button.disabled = queue_empty
 		end_turn_button.disabled = queue_empty
-		print("[MainUI] Updated button states: queue_size=%d, buttons_disabled=%s" % [queued_actions.size(), queue_empty])
+		print("[MainUI] Updated button states: queue_size=%d, buttons_disabled=%s" % [plan_controller.queue_size(), queue_empty])
 
 	# P10 gantt: mirror the tentative plan-time queue into the operations tracker. No-op in classic.
 	_refresh_gantt()
@@ -4123,8 +4083,8 @@ func _on_operations_option_selected(action_id: String, action_name: String, dial
 	# (select_action returns false on Attention overbook), so a rejected action
 	# no longer leaves a phantom queue tile.
 	print("[MainUI] Calling game_manager.select_action(%s)" % action_id)
-	if game_manager.select_action(action_id):
-		queued_actions.append({"id": action_id, "name": action_name})
+	if plan_controller.select_action(action_id):
+		plan_controller.queue_action(action_id, action_name)
 		update_queued_actions_display()
 
 # === COMMAND ZONE - PASS ACTION ===
@@ -4157,6 +4117,6 @@ func _on_pass_button_pressed():
 	# (select_action returns false if e.g. events are pending), so a rejected pass
 	# no longer leaves a phantom queue tile. Pass is free, so overbook never blocks it.
 	print("[MainUI] Calling game_manager.select_action(%s)" % action_id)
-	if game_manager.select_action(action_id):
-		queued_actions.append({"id": action_id, "name": action_name})
+	if plan_controller.select_action(action_id):
+		plan_controller.queue_action(action_id, action_name)
 		update_queued_actions_display()

--- a/godot/scripts/ui/plan_controller.gd
+++ b/godot/scripts/ui/plan_controller.gd
@@ -1,0 +1,162 @@
+class_name PlanController
+extends RefCounted
+## CARVE 1 (docs/MAIN_UI_SEAM_MAP.md, seam R4): the plan / attention / queue LOGIC pulled
+## out of the main_ui.gd monolith. main_ui is now a thin view -- it RENDERS the plan and
+## WIRES buttons to the calls here; it no longer owns queue/attention/cost math.
+##
+## This is a NON-FORKING extraction: every method below is a verbatim move of behaviour that
+## previously lived in main_ui, wrapping the SAME existing engine surface
+## (GameManager -> MonthPlan / MonthController). No gameplay/RNG/scoring change.
+##
+## What this owns:
+##   * queued_actions -- the UI-facing MIRROR of the plan queue (Array of {id, name}). It is
+##     the tentative plan the player is assembling on the PLAN screen; the authoritative
+##     backend queue is state.queued_actions inside GameManager. The two are kept in step by
+##     the mutation methods here (each mirror op has a matching GameManager op), exactly as
+##     the pre-carve main_ui did inline.
+##   * calculate_queued_costs() -- the turn-preview cost aggregation.
+##   * the queue mutation primitives (queue / remove / clear / reset / reserve-all / pass net)
+##     and the month commit, each wrapping the GameManager call the view used to make itself.
+##
+## What stays in the view (main_ui): all rendering (queue tiles, cost preview, buttons),
+## danger-zone warnings, message-log lines, and PLAN<->WATCH screen transitions. Those read
+## this controller's state and call these methods; they are not plan LOGIC.
+
+var game_manager  # GameManager (untyped: it is an autoload-instanced node, no class_name coupling)
+
+# The tentative plan-time queue the player is building. UI mirror only -- {id, name} entries.
+# Rendering reads this directly (main_ui.update_queued_actions_display / QueueGantt); the
+# authoritative attention/queue accounting lives in GameManager + MonthPlan.
+var queued_actions: Array = []
+
+
+func _init(gm = null) -> void:
+	game_manager = gm
+
+
+# --- Cost aggregation (was main_ui._calculate_queued_costs) -------------------------------
+
+func calculate_queued_costs() -> Dictionary:
+	"""Total the projected costs of every queued action for the turn preview. action_points is
+	tracked separately as Attention, so it is skipped here (verbatim from the pre-carve view)."""
+	var total_costs: Dictionary = {}
+	for queued_action in queued_actions:
+		var action_id = queued_action.get("id", "")
+		var action_def: Dictionary = GameActions.get_action_by_id(action_id)
+		var costs = action_def.get("costs", {})
+		for resource in costs.keys():
+			if resource == "action_points":
+				continue  # AP is already tracked separately
+			if not total_costs.has(resource):
+				total_costs[resource] = 0
+			total_costs[resource] += costs[resource]
+	return total_costs
+
+
+# --- Queue mutations ----------------------------------------------------------------------
+
+func queue_action(action_id: String, action_name: String) -> void:
+	"""Add an accepted action tile to the UI mirror. Callers gate on select_action() first
+	(the backend accept/overbook check), exactly as the pre-carve view did -- so a rejected
+	action never leaves a phantom tile (#821)."""
+	queued_actions.append({"id": action_id, "name": action_name})
+
+
+func select_action(action_id: String) -> bool:
+	"""Backend accept gate for a founder action (Attention overbook check lives here). Returns
+	false and emits the error via GameManager when the action cannot be committed."""
+	return game_manager.select_action(action_id)
+
+
+func remove_action(action_id: String) -> Dictionary:
+	"""Remove a specific action from the queue and refund its Attention (via GameManager).
+	Returns {removed: bool, attention_cost: int} so the view can log the refund. Mutates the
+	UI mirror first, then the backend queue -- the two lists are independent (matched by id),
+	so the order is behaviour-neutral; preserved as the pre-carve view had it."""
+	var removed_index := -1
+	for i in range(queued_actions.size()):
+		if queued_actions[i].get("id") == action_id:
+			removed_index = i
+			break
+	if removed_index < 0:
+		return {"removed": false, "attention_cost": 0}
+	queued_actions.remove_at(removed_index)
+	game_manager.remove_queued_action(action_id)
+	var action_def: Dictionary = GameActions.get_action_by_id(action_id)
+	var attention_cost: int = action_def.get("costs", {}).get("action_points", 0)
+	return {"removed": true, "attention_cost": attention_cost}
+
+
+func clear_queue() -> bool:
+	"""Clear-queue button path: drop every tentative action and REFUND the committed Attention
+	(GameManager.clear_action_queue), then clear the UI mirror. Returns false (no-op) on an
+	already-empty queue so the view can skip its log line."""
+	if queued_actions.is_empty():
+		return false
+	game_manager.clear_action_queue()  # refunds Attention on the backend queue
+	queued_actions.clear()
+	return true
+
+
+func reset_mirror() -> void:
+	"""Clear ONLY the UI mirror, with NO refund. Used on COMMIT: the backend queue is consumed
+	by end_month(), so refunding here would be wrong. This is the deliberate counterpart to
+	clear_queue() -- the two 'clears' are NOT interchangeable (was two distinct inline paths
+	in the pre-carve view)."""
+	queued_actions.clear()
+
+
+func queue_pass_fallback() -> String:
+	"""COMMIT THE MONTH with nothing planned (#733 + overbook soft-lock net): queue the canonical
+	pass action so the month always advances. Mirrors the tile AND routes select_action() so the
+	backend queue is non-empty. Determinism-safe: pass mints no RNG. Returns the pass action name
+	for the view's log line."""
+	var pass_action := GameActions.get_pass_action()
+	var pass_id: String = pass_action.get("id", GameActions.PASS_ACTION_ID)
+	var pass_name: String = pass_action.get("name", "Do Nothing")
+	queued_actions.append({"id": pass_id, "name": pass_name})
+	game_manager.select_action(pass_id)
+	return pass_name
+
+
+func needs_pass_fallback() -> bool:
+	"""True when COMMIT THE MONTH would otherwise submit an empty ACCEPTED queue (either the UI
+	mirror or the backend queue is empty). Guards the pass net -- verbatim condition from the
+	pre-carve view (phantom UI tiles must not suppress this net)."""
+	if queued_actions.size() == 0:
+		return true
+	return game_manager.state != null and game_manager.state.queued_actions.is_empty()
+
+
+func append_reserve_all() -> void:
+	"""COMMIT PLAN with no queued actions == reactive strategy: hold all Attention for response
+	windows. Adds a virtual 'Reserve All AP' mirror entry and appends the pass id straight onto
+	the backend queue (costs {} -> no Attention committed). Verbatim from the pre-carve view
+	(L0 #620: ONE pass id)."""
+	var reserve_action := {
+		"id": GameActions.PASS_ACTION_ID,
+		"name": "Reserve All AP",
+		"description": "No planned actions - keep all AP available for responding to events",
+		"ap_cost": 0,
+		"money_cost": 0
+	}
+	queued_actions.append(reserve_action)
+	# Directly append to game state queue (bypass select_action validation) -- a virtual
+	# "reserve all AP" entry; pass costs {} so no AP is committed.
+	game_manager.state.queued_actions.append(GameActions.PASS_ACTION_ID)
+
+
+func commit_month() -> void:
+	"""Commit the assembled plan and hand control to day-tick playback (L1 / ADR-0009:
+	auto-pause on windows, month review at the boundary). Wraps GameManager.end_month()."""
+	game_manager.end_month()
+
+
+# --- Read-through for the view ------------------------------------------------------------
+
+func is_queue_empty() -> bool:
+	return queued_actions.is_empty()
+
+
+func queue_size() -> int:
+	return queued_actions.size()

--- a/godot/scripts/ui/plan_controller.gd.uid
+++ b/godot/scripts/ui/plan_controller.gd.uid
@@ -1,0 +1,1 @@
+uid://cttbimom864nk

--- a/godot/tests/unit/test_plan_controller.gd
+++ b/godot/tests/unit/test_plan_controller.gd
@@ -1,0 +1,81 @@
+extends GutTest
+## CARVE 1 (docs/MAIN_UI_SEAM_MAP.md, R4): characterization + regression lock for the
+## plan/queue/cost logic extracted out of main_ui.gd into PlanController.
+##
+## The cost-aggregation contract (was main_ui._calculate_queued_costs) is a NON-FORKING
+## refactor target: these tests pin the CURRENT behaviour so the extraction cannot drift it.
+## Behaviour under test, verbatim from the pre-carve code:
+##   - sum every cost resource across the queued actions,
+##   - EXCEPT "action_points" (tracked separately as Attention), which is skipped,
+##   - an unknown action id resolves to {} costs and contributes nothing,
+##   - an empty queue yields {}.
+
+const MainUIScript: GDScript = preload("res://scripts/ui/main_ui.gd")
+const PlanControllerScript: GDScript = preload("res://scripts/ui/plan_controller.gd")
+
+
+func _controller(queue: Array) -> PlanController:
+	# game_manager is not needed for the pure cost path; pass null.
+	var pc: PlanController = PlanControllerScript.new(null)
+	pc.queued_actions = queue
+	return pc
+
+
+# --- Cost aggregation contract (PlanController.calculate_queued_costs) --------------------
+
+func test_money_costs_sum_and_ap_is_skipped():
+	# buy_compute {money:50000}; team_building {money:10000, action_points:1}
+	var costs: Dictionary = _controller([
+		{"id": "buy_compute", "name": "Buy Compute"},
+		{"id": "team_building", "name": "Team Building"},
+	]).calculate_queued_costs()
+	assert_eq(costs.get("money", 0), 60000, "money costs sum across queued actions")
+	assert_false(costs.has("action_points"), "action_points is tracked as Attention, never summed here")
+
+
+func test_non_money_resource_costs_sum():
+	# safety_research {research:10, ap:1}; publish_paper {research:20, ap:1}
+	var costs: Dictionary = _controller([
+		{"id": "safety_research", "name": "Safety Research"},
+		{"id": "publish_paper", "name": "Publish Paper"},
+	]).calculate_queued_costs()
+	assert_eq(costs.get("research", 0), 30, "research costs aggregate")
+	assert_false(costs.has("action_points"), "AP still skipped for research-costing actions")
+
+
+func test_reputation_cost_surfaces():
+	# fundraise_small {action_points:1, reputation:2}
+	var costs: Dictionary = _controller([
+		{"id": "fundraise_small", "name": "Small Fundraise"},
+	]).calculate_queued_costs()
+	assert_eq(costs.get("reputation", 0), 2, "reputation cost is a real projected cost")
+	assert_eq(costs.size(), 1, "only reputation remains once AP is skipped")
+
+
+func test_unknown_action_contributes_nothing():
+	var costs: Dictionary = _controller([
+		{"id": "does_not_exist", "name": "Phantom"},
+	]).calculate_queued_costs()
+	assert_eq(costs.size(), 0, "an unknown id resolves to empty costs and adds nothing")
+
+
+func test_empty_queue_is_empty_costs():
+	assert_eq(_controller([]).calculate_queued_costs().size(), 0, "no queued actions -> no costs")
+
+
+func test_ap_only_action_yields_empty_costs():
+	# take_loan {action_points:1} -- the only cost is AP, which is skipped.
+	var costs: Dictionary = _controller([
+		{"id": "take_loan", "name": "Take Loan"},
+	]).calculate_queued_costs()
+	assert_eq(costs.size(), 0, "an AP-only action projects no non-Attention cost")
+
+
+# --- The extraction preserves the view-facing algorithm ----------------------------------
+# main_ui must NOT keep its own copy of the cost math; it delegates to the controller.
+# (Guards against a re-introduced _calculate_queued_costs drifting from the controller.)
+
+func test_main_ui_no_longer_declares_its_own_cost_calc():
+	var src: String = FileAccess.get_file_as_string("res://scripts/ui/main_ui.gd")
+	assert_false(src.contains("func _calculate_queued_costs"),
+		"cost logic lives in PlanController now, not as a private method on the view")

--- a/godot/tests/unit/test_plan_controller.gd.uid
+++ b/godot/tests/unit/test_plan_controller.gd.uid
@@ -1,0 +1,1 @@
+uid://cj7fgoc5sac6r


### PR DESCRIPTION
## CARVE 1 -- R4 -> PlanController (non-forking)

Executes CARVE 1 from `docs/MAIN_UI_SEAM_MAP.md`: pull the planning / attention / queue
**logic** out of the ~4.1k-line `godot/scripts/ui/main_ui.gd` into a new **`PlanController`**
(`godot/scripts/ui/plan_controller.gd`) that wraps the **existing** `GameManager` ->
`MonthPlan` / `MonthController` surface. `main_ui` becomes a thinner view: it renders
`plan_controller.queued_actions` and wires buttons to `plan_controller.*` calls; it no longer
owns queue/attention/cost/commit math.

Structure-only, **non-forking**: no gameplay/scoring/RNG change. Ladder stays **L2**. Ships in
a build patch, not an epoch.

### What moved (to PlanController)
- `calculate_queued_costs()` -- verbatim move of `_calculate_queued_costs` (the turn-preview
  cost aggregation: sum every cost resource across the queue, skip `action_points`).
- The UI-mirror queue (`queued_actions`) and its mutation primitives, each wrapping the same
  `GameManager` call the view used to make inline:
  - `queue_action(id, name)` -- mirror append (gated by `select_action`, so no phantom tile, #821).
  - `select_action(id)` -- backend accept/overbook gate (`GameManager.select_action`).
  - `remove_action(id)` -- mirror remove + `GameManager.remove_queued_action` (Attention refund).
  - `clear_queue()` -- **refunding** clear (Clear-Queue button): `clear_action_queue` + mirror clear.
  - `reset_mirror()` -- **non-refunding** clear (COMMIT path): mirror-only; backend consumed by
    `end_month()`. The two "clears" are deliberately distinct and stay distinct.
  - `append_reserve_all()` -- reactive "Reserve All AP" commit (mirror entry + backend pass id).
  - `needs_pass_fallback()` / `queue_pass_fallback()` -- the empty-commit soft-lock net (#733).
  - `commit_month()` -- wraps `GameManager.end_month()`.

### What stayed (in main_ui, the view)
All rendering (`update_queued_actions_display` tile/preview build, action-bar population,
submenu builders), danger-zone warnings, message-log lines, and PLAN<->WATCH screen transitions.
These read `plan_controller.queued_actions` / call `plan_controller.*`; they are not plan logic.

Functions listed in the seam map that are **pure view/input** and correctly stayed put (with the
logic half, where any, routed through the controller): `_trigger_action_by_index` (input: finds a
button, emits `pressed`), `_on_action_executed` (pure presentation -- no plan-state half to move),
`_on_actions_available` (action-bar rendering + unlock fanfare -- render state, not queue/attention
logic), `_setup_plan_watch_scaffold` (builds banners/screens/registers -- UI scaffold, no R4 logic).

### Behavior-preservation reasoning (the sensitive commit/queue/attention path)
- **Overbook guard (#821):** the dynamic-action path is still `if select_action(id): queue_action(...)`
  -- a backend rejection still prevents the tile. Unchanged.
- **Attention refund timing:** `remove_action` / `clear_queue` call the same `GameManager` refund
  methods; mirror-vs-backend removal order is behaviour-neutral (independent lists matched by id).
- **Commit vs clear distinction preserved:** COMMIT clears the mirror **without** refunding
  (`reset_mirror`, backend consumed by `end_month`); the Clear button refunds (`clear_queue`).
  This subtlety -- the pre-carve code had two different "clears" -- is kept exact.
- **Empty-commit soft-lock net (#733):** `needs_pass_fallback()` is the verbatim condition
  (`mirror empty OR backend queue empty`); `queue_pass_fallback()` queues the canonical pass id
  and routes `select_action` -- no new RNG, no turn-step reorder.
- **One intentional micro-reordering:** the pass/reserve helpers now do `mirror-append; backend-op`
  and the view calls `update_queued_actions_display()` **after**, whereas pre-carve the redraw sat
  between. This is provably behaviour-neutral: `update_queued_actions_display` reads only the mirror
  (identical before/after the backend op) and `current_turn_phase`; the backend op's own
  `game_state_updated`-driven render is independent of ordering.

### Tests
- Added `godot/tests/unit/test_plan_controller.gd` -- characterization + regression lock for the
  cost-aggregation contract (money/research/reputation sums, AP skipped, unknown id -> nothing,
  empty queue -> `{}`, AP-only -> `{}`) plus a guard that `main_ui` no longer declares its own
  cost calc.
- **Fast gate green before AND after:** baseline `607 tests, 0 fail`; post-carve
  `614 tests, 0 fail, 69/69 files` (`python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`).
- Simulation tier not run: it drives the core headless **without** the UI, so it exercises no
  PlanController code; and no core/sim/economy/replay code was touched (the extraction only rewraps
  unchanged `GameManager`/`MonthPlan` calls). Not applicable to this change.

### Full vs partial
**Full** carve of the R4 queue/attention/cost/commit logic. Nothing left partial. The controller is
now the clean home the per-tick resolution spike (`spike-resolve-time-spend`) can sit on, per the
seam map.

### Rebase note
A separate v0.13.1 hotpatch PR also edits `main_ui.gd` (adds `office_maintenance` to
`HIDDEN_FROM_ACTION_BAR_IDS`). That hotpatch **merges FIRST**; expect a trivial rebase here (the
hotpatch touches the `HIDDEN_FROM_ACTION_BAR_IDS` constant / the `_on_actions_available` filter,
which this PR leaves in the view -- no logical conflict with the extracted queue logic).

**DO NOT merge** (Pip reviews agent PRs first).

Generated with Claude Code.
