### PR TITLE
docs: ratify #775 release-branch protocol + devblog seed

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,64 @@
+# RELEASING -- P(Doom)1 release & branch protocol
+
+**Status:** ACTIVE PROTOCOL (ratified 2026-07-25, issue #775). Hold to this.
+Companion: `docs/RELEASE_NOMENCLATURE.md` (the clocks + version numbers);
+`docs/adr/0001-retire-develop-branch.md` (why there is no `develop`).
+
+## The model (one screen)
+
+- **`main` is trunk.** All development velocity and every impulse lands on `main`
+  via PR. `main` IS the stash -- there is NO `develop` branch (retired by
+  ADR-0001; do not recreate it).
+- **Each monthly epoch, cut a release branch.** At the epoch (1st Friday --
+  see RELEASE_NOMENCLATURE.md), cut `release/v0.X` from the epoch commit and tag
+  `v0.X.0`. That branch is the stable line for the whole month.
+- **Ship from the release branch, never from churny `main`.** Builds and tags
+  come off `release/v0.X`; `main` keeps absorbing the next epoch's work.
+- **Hotpatches: `main` first, then cherry-pick.** A fix lands on `main`, then is
+  cherry-picked to `release/v0.X` ONLY if it meets the hotpatch criteria below.
+  Point releases (`v0.X.Y`) are tagged off the release branch.
+- **The train runs forward only.** `main` -> next release cut. NEVER merge a
+  release branch back into `main` (cherry-pick individual fixes if `main` needs
+  them too).
+
+## Hotpatch criteria (what may cherry-pick to a LIVE release)
+
+A fix earns a hotpatch to `release/v0.X` only if it is one of:
+
+1. **Crash / hang** -- the build crashes or locks up.
+2. **Data-loss / corruption** -- saves, leaderboard, or replay integrity at risk.
+3. **Blocking-UX** -- a player cannot progress (soft-lock, dead-end, unusable
+   control).
+4. **First-impression integrity** -- the shipped build visibly lies about itself
+   on the opening screens (a stale "Prototype" subtitle; a button that charges
+   money and does nothing). Launch-facing only.
+
+Everything else -- new mechanics, refactors, polish, balance -- waits for the
+next monthly epoch on `main`. **If in doubt, it waits.** A hotpatch is an
+exception, not a convenience.
+
+## Version discipline
+
+- `version.txt` on `release/v0.X` = the release version (e.g. `0.13.1`);
+  `ladder_version.txt` is fixed for the epoch's life.
+- On `main`, `version.txt` carries the in-development number; the epoch cut is
+  what stamps the new minor + bumps the ladder (RELEASE_NOMENCLATURE.md).
+- `python tools/sync_version.py --check` still gates both, on every branch.
+
+## How CI ships it
+
+`.github/workflows/enhanced-release.yml` triggers on **tag push** (+ manual
+dispatch). So the release flow is: cherry-pick the fix onto `release/v0.X`, bump
+`version.txt`, tag `v0.X.Y`, push the tag -> the workflow builds and publishes.
+No branch-trigger plumbing needed.
+
+## Worked example -- v0.13
+
+- `release/v0.13` was cut from tag `v0.13.0` (the pristine epoch baseline -- it
+  EXCLUDES the CARVE 1/2 `main_ui` refactors, which are v0.14 work living on
+  `main`).
+- The **v0.13.1** honesty pass (subtitle, dead-button removal, quirks CI fix,
+  README refresh) meets criterion 4 (first-impression integrity) -> cherry-pick
+  onto `release/v0.13`, bump to `0.13.1`, tag `v0.13.1`, build.
+- CARVE 1/2, per-tick, people&money: they stay on `main` for the v0.14 epoch and
+  never touch `release/v0.13`.

--- a/docs/devblog/DEV_STORY_SEEDS.md
+++ b/docs/devblog/DEV_STORY_SEEDS.md
@@ -1,47 +1,64 @@
 # Dev-Story Seeds
 
-> Raw material for future Pip-written devblog / dev-story posts. NOT posts themselves —
+> Raw material for future Pip-written devblog / dev-story posts. NOT posts themselves --
 > quotes, moments, and lessons captured while fresh so the assembly is cheap later.
 > Pip writes the actual posts; this is the quote-and-moment lumberyard.
+
+## The backlog as a time-capsule (2026-07-25, WS-3 triage)
+
+**The moment:** a triage of the oldest open issues (#186-#520, some written ~8
+months ago) surfaced a cluster of ideas that were *correct but premature* --
+articulated long before the engine existed to hold them. The standout: **#476,
+"accounting software reduces the AP cost of ledger chores,"** written months
+before the ledger (ADR-0003) and the effort/Attention economy (ADR-0011) existed
+to give it any meaning -- and it turns out to be almost exactly the mechanic the
+first external playtest (#574) later asked for, unprompted.
+
+**Why it's a story:** the satisfying inversion of "tech debt." A backlog isn't
+only a pile of unpaid obligations; it's a time-capsule of ideas you had before
+you could build them. The pleasure of building the engine is watching long-parked
+back-of-mind niggles quietly become tractable -- the substrate catching up to the
+intuition. Blog angle: *"the ideas were right; the engine wasn't ready yet"* -- on
+parking ideas without guilt and letting the platform mature into them.
 
 ## The repatching / fallback-divergence lesson (2026-07-16, issue #646)
 
 **The moment:** the overnight architecture-map lane, drafting `ARCHITECTURE.md`, ran a
 coherence check and found that the nine-stream doom code (`doom_system.gd`) carried
-*hardcoded fallback* coefficients ~66× off from the calibrated `defaults.json` shipped
-alongside it. Normal play loads the JSON so it never bites — but `Balance.gd` promises
+*hardcoded fallback* coefficients ~66x off from the calibrated `defaults.json` shipped
+alongside it. Normal play loads the JSON so it never bites -- but `Balance.gd` promises
 "a missing/broken file degrades to exactly the shipped behavior," and that promise had
 quietly become a lie for the new keys.
 
 **Why it's a story, not just a bug:** it's a clean example of a *repatching hazard* that
-appears whenever balance lives in data but ships with code defaults — the two drift, and
+appears whenever balance lives in data but ships with code defaults -- the two drift, and
 the drift is invisible until the data path fails. It pairs with the session's
-exploit-vs-strategy ruling: an exploit is engine misbehaviour, and a silent 66× fallback
+exploit-vs-strategy ruling: an exploit is engine misbehaviour, and a silent 66x fallback
 is exactly the buglike behaviour a dev must get ahead of. The fix is trivial (match the
-numbers); the *lesson* is the interesting part — "data-driven balance needs a test that
+numbers); the *lesson* is the interesting part -- "data-driven balance needs a test that
 the code fallbacks equal the shipped data," which is a generalizable discipline.
 
-**Blog angle:** "The bug that only exists when the config file is missing" — on why
+**Blog angle:** "The bug that only exists when the config file is missing" -- on why
 data-driven design needs its degrade-path tested, not just its happy path.
 
 ## Other seeds from the L1 build wave (2026-07-13..16)
 
-- **"I watched as I lost."** Pip's first playtest of the day-tick month playback — the
+- **"I watched as I lost."** Pip's first playtest of the day-tick month playback -- the
   resolution spectacle delivered ADR-0004's *tragedy* loss-feeling for free, unplanned.
   The engine change that was about pacing turned out to be about emotion.
-- **Attention = the founder currency, named in 2017 — the year of "Attention Is All You
+- **Attention = the founder currency, named in 2017 -- the year of "Attention Is All You
   Need."** The joke that is also the thesis.
-- **The 50× calibration.** Pre-calibration, every bot died before the first month
-  boundary (rival doom billed per day-tick, ~23× over). One re-denomination pass and
-  baseline runs lasted ~50× longer. The game's whole feel was gated behind an accounting
+- **The 50x calibration.** Pre-calibration, every bot died before the first month
+  boundary (rival doom billed per day-tick, ~23x over). One re-denomination pass and
+  baseline runs lasted ~50x longer. The game's whole feel was gated behind an accounting
   artifact nobody had looked at.
-- **The CI that was green while running zero tests.** #629 — the fresh-checkout import
+- **The CI that was green while running zero tests.** #629 -- the fresh-checkout import
   gap meant GUT quit(0) before collecting a single test, and the runner trusted the
   exit code. The repo's most dangerous lie, live for who-knows-how-long.
 - **Doom became nine streams.** The thesis moment: doom stopped being a number things
   bump and became a computed rate over named world-state, so "what makes doom go up" is
-  finally a single inspectable, arguable function — the game's executable argument about
+  finally a single inspectable, arguable function -- the game's executable argument about
   AI risk.
 - **The desperation lever is a trap that reads as help.** The solver proved it:
   pulling it is monotonically worse, and it silently converts doom deaths into ledger
-  deaths — ADR-0003's "every mitigation is a loan" proving itself in the sweep data.
+  deaths -- ADR-0003's "every mitigation is a loan" proving itself in the sweep data.


### PR DESCRIPTION
Ratifies #775: main=trunk, release/v0.X per epoch, hotpatch criteria, tag-driven CI. release/v0.13 already cut from the v0.13.0 tag. Also ASCII-cleans DEV_STORY_SEEDS. Closes #775. Generated with Claude Code