### PR TITLE
fix(ci): enforce-standards pre-commit only touches changed files, not the whole tree (#773)

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -38,7 +38,7 @@ jobs:
         python scripts/intelligent_ascii_converter.py --dry-run
         if [ $? -ne 0 ]; then
           echo "ASCII compliance violations found!"
-          echo "Run: python scripts/intelligent_ascii_converter.py to fix"
+          echo "Run: python scripts/intelligent_ascii_converter.py --apply to fix"
           exit 1
         fi
 

--- a/scripts/enforce_standards.py
+++ b/scripts/enforce_standards.py
@@ -176,7 +176,7 @@ class StandardsEnforcer:
                             print("[SUCCESS] All files are already ASCII compliant")
                         else:
                             print("[ACTION] Unicode characters found. Run the following to fix:")
-                            print(f"  python {converter_path}")
+                            print(f"  python {converter_path} --apply")
                             self.warnings.append(
                                 "Unicode content can be auto-fixed with intelligent ASCII converter"
                             )

--- a/scripts/intelligent_ascii_converter.py
+++ b/scripts/intelligent_ascii_converter.py
@@ -573,14 +573,29 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python intelligent_ascii_converter.py --dry-run
-  python intelligent_ascii_converter.py --file README.md
-  python intelligent_ascii_converter.py --directory docs/
+  python intelligent_ascii_converter.py                 # dry-run report (default; writes nothing)
+  python intelligent_ascii_converter.py --apply         # actually rewrite files
+  python intelligent_ascii_converter.py --file README.md --apply
+  python intelligent_ascii_converter.py --directory docs/ --apply
         """,
     )
 
+    # SAFETY DEFAULT (issue #773): a bare invocation is now DRY-RUN. Writing the
+    # whole tree used to be the default, so an accidental or hooked run -- or a
+    # later `git add -A` -- silently sprayed transliterated churn across ~190
+    # files and corrupted files whose Unicode is load-bearing (the python mapping
+    # tables). Files are rewritten ONLY when --apply is passed explicitly.
+    # Detection is unchanged: the dry run still reports every violation and
+    # returns non-zero, which is what CI (--dry-run) gates on.
     parser.add_argument(
-        "--dry-run", action="store_true", help="Show what would be changed without making changes"
+        "--apply",
+        action="store_true",
+        help="Actually rewrite files (default is a report-only dry run)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report only, make no changes (this is the default; kept for explicitness)",
     )
     parser.add_argument("--file", type=Path, help="Process a specific file")
     parser.add_argument(
@@ -595,6 +610,11 @@ Examples:
     )
 
     args = parser.parse_args()
+
+    # Resolve the effective mode: write ONLY when --apply is given without --dry-run.
+    # Everything downstream reads args.dry_run, so normalise onto it -- a bare run
+    # and an explicit --dry-run both stay read-only.
+    args.dry_run = args.dry_run or not args.apply
 
     # Initialize converter with logging
     converter = IntelligentASCIIConverter(verbose=args.verbose)
@@ -653,7 +673,7 @@ Examples:
                     print(f"  {message}")
 
             if args.dry_run:
-                print("\nDry run complete. Run without --dry-run to apply changes.")
+                print("\nDry run complete. Run with --apply to write these changes.")
                 converter.logger.info(
                     "Dry run completed", extra_data={"files_with_changes": len(results)}
                 )

--- a/scripts/pre_version_bump.py
+++ b/scripts/pre_version_bump.py
@@ -94,8 +94,10 @@ class PreVersionBumpChecker:
 
                     if self.auto_fix:
                         print("INFO Applying automatic ASCII fixes...")
+                        # --apply is required to write since #773 (the converter
+                        # is dry-run by default now); this is an explicit opt-in.
                         fix_result = subprocess.run(
-                            [sys.executable, str(converter_path)],
+                            [sys.executable, str(converter_path), "--apply"],
                             capture_output=True,
                             text=True,
                             cwd=self.project_root,
@@ -109,7 +111,7 @@ class PreVersionBumpChecker:
                             print(f"ERROR ASCII fix failed: {fix_result.stderr}")
                             return False
                     else:
-                        print("ACTION Run: python scripts/intelligent_ascii_converter.py")
+                        print("ACTION Run: python scripts/intelligent_ascii_converter.py --apply")
                         return False
             else:
                 print(f"ERROR ASCII check failed: {result.stderr}")


### PR DESCRIPTION
## Problem (#773)

`enforce_standards`'s ASCII auto-fixer could sweep and **write** the whole tree,
leaving transliterated UNSTAGED modifications across files that were never part of
the commit -- the root cause of the 2026-07-21/22 worktree-pollution incidents
(a mangled `generate_dq_index.py` working copy and ~190 spuriously-modified files),
and a landmine for `git add -A`.

## What I verified first

The pre-commit **CHECK** was already made incremental in `a274a09d`: the
`enforce-standards` hook runs `enforce_standards.py --incremental` with
`pass_filenames: true`, so `check_files_incremental()` reads ONLY the files
pre-commit passes as argv and never walks the tree. It is also read-only. So the
local pre-commit path was already changed-files-only.

The remaining defect was the **WRITE** path: `intelligent_ascii_converter.py`
defaulted to `dry_run=False` with `--directory` defaulting to `.`, so a bare or
accidental invocation rewrote the entire tree. `enforce_standards.check_ascii_compliance`
and CI already pass `--dry-run`, but `pre_version_bump.py --auto-fix` and any manual
`python scripts/intelligent_ascii_converter.py` ran it in write-the-whole-tree mode.

## Fix

- **`intelligent_ascii_converter.py`**: a bare run is now a report-only DRY RUN.
  Files are rewritten ONLY with an explicit `--apply`. `--dry-run` is kept as an
  explicit alias. Detection is unchanged -- the dry run still reports every violation
  and returns the same exit code CI gates on -- so enforcement is NOT weakened; only
  the silent mutation is now opt-in. This is the issue's own recommendation (make the
  auto-fixer check-only-by-default, like `check_no_emoji.py`).
- **`pre_version_bump.py`**: its `--auto-fix` path now passes `--apply` explicitly.
- **`enforce_standards.py` + `quality-checks.yml`**: the "run this to fix" hint strings
  now say `--apply` so they are not no-ops.

The full-tree scan stays in CI (`quality-checks.yml`: `--check-all` / `--dry-run`).

## Test

- Converter with **no flags** on a temp dir containing an em-dash file: file left
  byte-identical (md5 unchanged), prints `Run with --apply`. With `--apply`: file
  rewritten (em-dash -> ` -- `, md5 changes).
- `enforce_standards.py --incremental` on a single non-ASCII file: reports
  `U+2014`, exits 1, and leaves `git status --porcelain` byte-identical (no tree
  churn) with the probe file un-rewritten.
- `black --check` clean; commit passed the full pre-commit suite (isort, ruff,
  enforce-standards incremental, no-emoji).

DO NOT merge -- for Pip's review.

Generated with Claude Code.
