### PR TITLE
docs: coherence sweep 2026-07-25

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -86,7 +86,7 @@ docs/strategy/HOSTING_AND_RELEASE.md.
 ## Later -- the design horizon
 
 Not listed here on purpose. The design question register is
-[docs/game-design/DQ_INDEX.md](game-design/DQ_INDEX.md) (generated; 27 open),
+[docs/game-design/DQ_INDEX.md](game-design/DQ_INDEX.md) (generated; 32 open),
 sourced from WORKSHOP_2_BACKLOG.md. Design advances through workshop beats
 (next candidates: DQ-19 + DQ-23; DQ-22 + DQ-31 + DQ-32 as one conversation).
 Longer-horizon intents that have pins above: content-pool ladder (DQ-33),

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,13 +1,13 @@
 # Architecture Decision Records (ADRs)
 
-This directory holds **Architecture Decision Records** — short, dated, immutable notes capturing a
+This directory holds **Architecture Decision Records** -- short, dated, immutable notes capturing a
 significant decision, *why* it was made, and its consequences. The format follows
 [Michael Nygard's original ADR pattern](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
 
 ## Why we keep these
 
 P(Doom)'s documentation has drifted over time because decisions were made but the *reasoning* lived
-only in commit messages, chat, or someone's head — so later docs silently contradicted earlier ones.
+only in commit messages, chat, or someone's head -- so later docs silently contradicted earlier ones.
 ADRs fix the **time axis**: each decision is recorded once, dated, and never edited after acceptance.
 If a decision is later reversed, we add a *new* ADR that supersedes the old one (and mark the old one
 `Superseded`), rather than rewriting history.
@@ -16,8 +16,8 @@ If a decision is later reversed, we add a *new* ADR that supersedes the old one 
 
 - Filenames: `NNNN-short-kebab-title.md` (zero-padded, sequential).
 - Each ADR has: **Status**, **Context**, **Decision**, **Consequences**.
-- **Status** is one of `Proposed` → `Accepted` → `Superseded by ADR-NNNN` / `Deprecated`.
-- Once `Accepted`, the Context/Decision are **not edited**. New information → new ADR.
+- **Status** is one of `Proposed` -> `Accepted` -> `Superseded by ADR-NNNN` / `Deprecated`.
+- Once `Accepted`, the Context/Decision are **not edited**. New information -> new ADR.
 
 ## Index
 
@@ -26,3 +26,4 @@ If a decision is later reversed, we add a *new* ADR that supersedes the old one 
 | [0001](0001-retire-develop-branch.md) | Retire the `develop` branch (trunk-based on `main`) | Accepted |
 | [0002](0002-win-condition-survival-spine.md) | Win condition: survival spine with a rare apex victory | Accepted |
 | [0003](0003-godot-migration.md) | Runtime: migrate from pygame/Python to Godot 4.5.1 / GDScript | Accepted |
+| [0004](0004-self-describing-data.md) | Self-describing data files (schema declared by the file, not inferred from location) | Accepted |

--- a/docs/game-design/decisions/README.md
+++ b/docs/game-design/decisions/README.md
@@ -4,7 +4,7 @@ Lightweight decision log for P(Doom)1 game-design and mechanics choices. One fil
 decision, numbered. Captures the *decision and its reasoning* so later implementation
 agents (and future-Pip) inherit intent, not just outcome.
 
-Status values: `PROPOSED` → `ACCEPTED` / `REJECTED` / `SUPERSEDED-BY-000X`.
+Status values: `PROPOSED` -> `ACCEPTED` / `REJECTED` / `SUPERSEDED-BY-000X`.
 
 Copy `ADR-TEMPLATE.md` for new records. Keep them short: the *why* and the *rejected
 alternatives* matter more than the *what*.
@@ -13,13 +13,13 @@ alternatives* matter more than the *what*.
 
 | # | Title | Status | Summary |
 |---|---|---|---|
-| [0001](ADR-0001-spending-buys-sight.md) | Situational Awareness as the primary sink ("spending buys sight") | ACCEPTED (as amended by ADR-0004) | SA is the flagship sink for the source-rich/sink-poor economy — spending money/reputation buys visibility into doom sources. |
+| [0001](ADR-0001-spending-buys-sight.md) | Situational Awareness as the primary sink ("spending buys sight") | ACCEPTED (as amended by ADR-0004) | SA is the flagship sink for the source-rich/sink-poor economy -- spending money/reputation buys visibility into doom sources. |
 | [0002](ADR-0002-scoring-turns-survived.md) | Scoring: turns survived, lexicographic doom-integral tiebreak, flows only | ACCEPTED | Replaces the three-copy ad hoc score formula with turns-survived as primary, a doom-integral tiebreak, and no money/hoarding term. |
-| [0003](ADR-0003-liability-ledger.md) | The Liability Ledger (two-sided): every mitigation is a loan | ACCEPTED (build first) | Every doom mitigation is modeled as a loan with a repayment/consequence chain, not a free action — the flagship new system. |
+| [0003](ADR-0003-liability-ledger.md) | The Liability Ledger (two-sided): every mitigation is a loan | ACCEPTED (build first) | Every doom mitigation is modeled as a loan with a repayment/consequence chain, not a free action -- the flagship new system. |
 | [0004](ADR-0004-sa-channels-lead-time.md) | SA amended: channels with provenance, lead-time semantics, decision-flip test | ACCEPTED (amends & accepts ADR-0001; build second) | Refines SA into provenance-tagged channels with lead time, gated by a decision-flip acceptance test rather than a raw admin/god-mode view. |
 | [0005](ADR-0005-emergent-waves-seed-schedules.md) | Emergent doom waves: author causes, never outcomes; seed = RNG + schedule | ACCEPTED | Doom waves emerge from opponent behavior and the player's ledger (not authored timings); designers author causes, seeded by RNG + schedule. |
 | [0006](ADR-0006-replay-artifact-backend.md) | The replay string is the canonical run artifact; backend wiring order | ACCEPTED | The seeded-RNG + hash-chain replay backend (already ~80% built) is confirmed as the canonical run artifact, with a wiring order for the rest. |
-| [0007](ADR-0007-alliances-third-client.md) | Alliances: the third client of Ledger + SA (treaty = shared liability + shared sight) | ACCEPTED (build third, after ADR-0003/0004) | Alliances are un-deferred and built as a third client of the Ledger and SA systems — a treaty shares liability and sight between parties. |
+| [0007](ADR-0007-alliances-third-client.md) | Alliances: the third client of Ledger + SA (treaty = shared liability + shared sight) | ACCEPTED (build third, after ADR-0003/0004) | Alliances are un-deferred and built as a third client of the Ledger and SA systems -- a treaty shares liability and sight between parties. |
 | [0008](ADR-0008-deferrals-and-rejections.md) | Deferrals, folds, and rejections (the negative space of workshop #1) | ACCEPTED | Records what workshop #1 explicitly deferred, folded into other ADRs, or rejected, each with its revisit trigger, so decisions aren't silently lost. |
 | [0009](ADR-0009-plan-months-two-speeds.md) | Turn structure: plan-months, two decision speeds, day as resolution tick | ACCEPTED | Formalizes the drift from week-based planning to day-tick resolution: a MONTH is the decision-cadence layer over day-grain sim ticks. |
 | [0010](ADR-0010-adoption-routing.md) | Adoption routing (soft-with-teeth): doom bends where work is adopted | ACCEPTED | Safety work no longer bends doom directly/privately; it must be adopted (routed through conferences/papers/orgs) to have effect, killing the safety-spam dominant strategy. |
@@ -29,3 +29,4 @@ alternatives* matter more than the *what*.
 | [0014](ADR-0014-conferences-presence-location.md) | Conferences, presence, and minimal location | ACCEPTED (v1 shape; yields/numbers owed to the sweep) | Defines what "attending a conference" is (v1: minimal presence/location mechanic, not a full subgame) as the adoption chain's socialization step. |
 | [0015](ADR-0015-no-printed-doom-deltas.md) | No printed doom deltas: doom is computed from world state | ACCEPTED (intermediary vocabulary owed) | Retires hardcoded doom bumps on event/action definitions; doom becomes a computed function of named world-state intermediary streams (see doom_system.gd). |
 | [0016](ADR-0016-league-metabolism.md) | League metabolism: the game trails reality by one month | ACCEPTED (shape; pipeline build + league-notes format owed) | Moves scouting/meta variance out of the RNG seed and into time: the game runs a month behind real time so real-world events and balance patches can feed in. |
+| [0017](ADR-0017-anti-hollow-test-strategy.md) | Anti-hollow test strategy: load-time smoke + property-based invariants | ACCEPTED | Targets "hollow" tests that pass without exercising what they protect (zero-test CI, UI-parse-error-with-436-passing); adds load-time smoke and property-based invariants so a green suite means the code actually ran. |


### PR DESCRIPTION
## docs: coherence sweep 2026-07-25

Coherence pass over DESIGN + STRATEGY + ROADMAP docs after the ~15 docs that
landed 2026-07-25, checking against the new canon (RELEASE_NOMENCLATURE.md
monthly-Theme model, ADR-0002 survival spine, the First Contact / Rivals & News
Big-Milestone rename). Scope: docs/ROADMAP.md, docs/game-design/**, docs/*.md
(strategy/design/nomenclature), docs/adr/**, docs/copy/**. Did NOT touch
TECH_DEBT_REGISTER.md or CLAUDE.md, and moved/archived nothing (other agents own
those).

### Safe fixes made (this PR)

1. **docs/adr/README.md** -- index listed only ADR-0001..0003; added the missing
   **ADR-0004 (self-describing data)** row. (Also transliterated pre-existing
   em-dash/arrow chars in this file to ASCII, forced by the now-blocking
   incremental enforce-standards hook.)
2. **docs/game-design/decisions/README.md** -- index stopped at ADR-0016; added
   the missing **ADR-0017 (anti-hollow test strategy)** row. (Same forced ASCII
   transliteration of pre-existing chars.) Verified against WS3_FINISH_OR_DROP.md
   that ADR-0010/0011/0014/0016 all remain ACCEPTED, so no existing status rows
   were stale.
3. **docs/ROADMAP.md** -- DQ open-count `27 open` -> `32 open` to match the
   generated DQ_INDEX.md (32 rows marked `open`).

### Coherence confirmed clean (no change needed)

- **Zero broken relative links** across the core lane (ROADMAP, game-design/**,
  adr/**, copy/**, strategy/**). No `[[wikilinks]]` anywhere in scope.
- DESIGN_PHILOSOPHY.md, PRODUCT_STRATEGY_RATIONALE.md, copy/README.md carry no
  win-condition / version / theme contradictions with ADR-0002 or the new
  nomenclature.
- ROADMAP's "Now (committed)" section already uses the Big-Milestone framing
  correctly (First Contact = milestone 12 end-Q3; Rivals & News = milestone 13
  end-Q4), consistent with RELEASE_NOMENCLATURE.md.

### FLAGS for Pip (judgment calls -- NOT changed)

**A. ROADMAP "Quarterly pins to v0.15" table needs the monthly-Theme re-cast
(the big one).** RELEASE_NOMENCLATURE.md already flags this and says leave it for
Pip. The table (ROADMAP.md lines ~39-49) still maps one-version-per-quarter with
version==theme:

| Quarter | Version | Theme (old table) |
|---|---|---|
| Q3 2026 | v0.12 | First Contact |
| Q4 2026 | v0.13 | Rivals and News |
| Q1 2027 | v0.14 | The World Shoots Back |
| Q2 2027 | v0.15 | Beta / Steam Coming Soon |

Under the canonical model this is doubly stale: (i) we already shipped **v0.13.1**,
so the version column is behind; (ii) "First Contact" and "Rivals & News" are now
**Big Milestones spanning several monthly Themes**, not single versions.

Proposed re-cast (for Pip to confirm/name -- I did not write it in):

- Replace the quarterly table with a **monthly Themes** table: one named minor per
  first-Friday (v0.14 "Per-tick & People" Aug 7 is already named in the
  nomenclature calendar; v0.15 Sep 4, v0.16 Oct 2, ... provisional/unnamed).
- Keep only **two coarse groupings** as Big Milestones: **First Contact** (spans
  v0.13-v0.15, target Sep 29) and **Rivals & News** (target Dec 30).
- Fold the old table's "headline contents" (onboarding, share loop, Liability
  Ledger UI, DQ-22 aggro, Steam page, char-creation DQ-19, etc.) into the
  milestone bullets / individual monthly Themes rather than quarter cells.
- The old theme name **"The World Shoots Back"** (Q1 2027) has no home in the new
  model -- decide whether it becomes a monthly Theme name or is retired.

**B. Downstream docs still say `v0.12 "First Contact"` / `v0.13 "Rivals and
News"` (version==theme).** Left unchanged because they await your ROADMAP re-cast
and several are dated point-in-time artifacts:
- `docs/game-design/CAT_COSMETICS_DOOM_ORACLE_IDEAS.md` (lines 4, 53): `v0.13
  "Rivals and News"`.
- `docs/game-design/WORKSHOP_3_PREP.md` (lines 187, 216, 274, 286, 356): `v0.12
  "First Contact"` / `v0.13 "Rivals and News"`.
Once you set the canonical version<->milestone mapping, these can be swept to
match in one pass.

**C. Immutable-ADR stale references (do not edit the ADRs; flagging only).**
`docs/GAME_DESIGN_CANON.md` and `docs/STEAM_INTEGRATION_ROADMAP.md` were archived
(to `docs/archive/...`), but accepted ADRs still point at the old paths:
- `docs/adr/0002-win-condition-survival-spine.md:12,18,49` -> GAME_DESIGN_CANON /
  STEAM_INTEGRATION_ROADMAP.
- `docs/adr/0003-godot-migration.md:34,40` -> `docs/developer/ARCHITECTURE.md`
  (real path is `docs/ARCHITECTURE.md`) and `GAME_DESIGN_CANON`.
Per the ADR convention (accepted ADRs are immutable) these are historical context
and I left them. If you want the links live, the clean move is a superseding note,
not an in-place edit.

**D. `docs/STEAM_INTEGRATION_SUMMARY.md` (out of core lane).** Broken link line
171 -> `STEAM_INTEGRATION_ROADMAP.md` (now at `archive/STEAM_INTEGRATION_ROADMAP.md`),
AND the doc's premise is stale ("we can ship on Steam in ~2 weeks; the game is
ready") vs the roadmap's Steam = Q2 2027 beta. Left untouched -- it reads like an
archival candidate, which the archive-owning agent handles.

**E. Minor cross-ref drift already self-corrected.** `WORKSHOP_3_PREP.md` maps
WS-3 lane "L3 (#615)"; `WS3_FINISH_OR_DROP.md` (companion, verified via gh)
corrects this to **L3 = #614, L4 = #615**. The correction is loudly recorded in
the companion, so I left the dated prep doc as-is rather than retro-edit it.

**F. Anti-rot note.** ROADMAP hardcodes an exact DQ open-count (now 32), which
re-rots on every backlog change despite the doc's own "link, never copy" rule.
Consider dropping the number (just link DQ_INDEX.md) so it can't drift again.

Generated with Claude Code
