### PR TITLE
docs(strategy): IP/openness/monetization premortem + metabolic data-openness re-scope

### DIFF
--- a/docs/TRIUMVIRATE_METABOLIC_CYCLE.md
+++ b/docs/TRIUMVIRATE_METABOLIC_CYCLE.md
@@ -25,8 +25,10 @@ Grounding (decided things this doc builds ON, not re-decides):
   day/week founder ops budget) + `docs/adr/0004-self-describing-data.md`
   (files declare their schema; tooling dispatches on the declaration).
 - `docs/CAPABILITY_UPLIFT_SCAN.md` BET 3 -- "close the telemetry loop":
-  run artifacts flowing home, landing in pdoom-data as the first real
-  ingestion feed. This proposal folds that in as the RETURN leg.
+  run artifacts flowing home. This proposal folds that in as the RETURN
+  leg -- RE-SCOPED 2026-07-25 (Pip ruling): the public leg is
+  confirmations + error-correction only; run summaries land in a PRIVATE
+  lake, not in pdoom-data. See "Data-openness posture" below.
 
 ---
 
@@ -37,12 +39,15 @@ AI-safety events (the public, fact-only data lake); **pdoom1** ingests a
 curated monthly pack and balance-shapes it into in-game content (opinion
 layer: weights, doom modifiers, event framing -- all of which stay HERE);
 **pdoom1-website** pulls the voice seam + roadmap + release notes and
-publishes the outward presentation. The RETURN leg closes the loop:
-anonymized run artifacts (seed, version, turns survived, death attribution,
-which events fired) flow home from players to pdoom-data, so next month's
-curation is steered by what actually happened in play. One full turn of the
-cycle = one Epoch month. Reality becomes the map generator; play becomes
-the curation signal.
+publishes the outward presentation. The RETURN leg closes the loop -- but
+RE-SCOPED (Pip ruling 2026-07-25, section "Data-openness posture" below):
+for now only CONFIRMATIONS + ERROR-CORRECTION flow up publicly (bug
+reports, install ping, "pack event X rendered wrongly" corrections), while
+anonymized run summaries accumulate in a PRIVATE lake that steers next
+month's curation internally. Broad publishing of aggregate play data is
+DEFERRED to ~1.0. One full turn of the cycle = one Epoch month. Reality
+becomes the map generator; play becomes the (privately held) curation
+signal.
 
 ## 2. The cycle diagram
 
@@ -58,9 +63,9 @@ the curation signal.
 +-----------+                                            +-----------+
       ^                                                        |
       |                                                        | HOP B:
-      | RETURN LEG: Run Artifact feed                          | voice seam +
-      | (anonymized telemetry,                                 | roadmap +
-      |  event-in-play signals)                                | release notes
+      | RETURN LEG (re-scoped 2026-07-25):                     | voice seam +
+      | confirmations + error-correction UP;                   | roadmap +
+      | run summaries -> PRIVATE lake only                     | release notes
       |                                                        v
       |                                                  +-----------+
       +--------------------------------------------------|  pdoom1-  |
@@ -134,32 +139,74 @@ contracts and adds the monthly rhythm:
   pdoom-data's serveable layer directly [INFERRED -- pdoom-data has a
   `serveable/` dir that looks built for exactly this; confirm with Pip].
 
-### Contract 3 -- the Run Artifact feed (pdoom1 -> pdoom-data, the RETURN leg)
+### Contract 3 -- the Return leg (pdoom1 -> home), RE-SCOPED 2026-07-25
 
-**What crosses:** the capability scan's BET 3, made a standing organ.
-The engine already computes, per run, deterministically: seed, version,
-ladder, turns survived, death-attribution root cause, replay hash
-(ADR-0006). Today those die on the player's disk. [PROPOSED]:
+**Re-scoped per Pip's data-openness ruling (see the "Data-openness
+posture" section below).** The original proposal routed anonymized run
+artifacts into pdoom-data as an ingestion feed. The ruling narrows the
+PUBLIC leg and privatizes the rest:
 
-- **Payload v0:** the run summary only (no full replays yet) --
-  `{seed, ladder_version, game_version, turns_survived, outcome,
-  death_root_cause, events_fired[], replay_hash}` -- anonymous by default,
-  riding the same consent posture as the #799 install ping.
+**What flows UP publicly, for now: confirmations + error-correction
+ONLY.**
+
+- Bug reports transmitting for real (#800 honest-transmit fix) and the
+  install ping / update check (#799).
+- Crash/error artifacts and content corrections ("pack event X displays
+  wrongly", broken source url) -- i.e. signals that help FIX things, not
+  signals that describe the meta.
+
+**What accumulates PRIVATELY: the run-summary lake.**
+
+- **Payload v0 (unchanged shape):** `{seed, ladder_version, game_version,
+  turns_survived, outcome, death_root_cause, events_fired[], replay_hash}`
+  (all already computed deterministically per ADR-0006) -- anonymous by
+  default, riding the same consent posture as the #799 install ping, with
+  the consent line written NOW to permit future aggregate publication.
 - **Transport:** the same phone-home path `leaderboard_sync.gd` already
-  uses [INFERRED -- endpoint design is exactly the open question the scan
-  says to start early]. Landing zone: a `telemetry/` (or `runs/`) inlet in
-  pdoom-data, schema-validated on arrival, SEPARATE from the fact lake
-  (`raw/` vs curated facts -- run data is evidence about the GAME, not
-  about reality; it must never leak into the fact layer).
-- **What it feeds:** the monthly curation. "Which events fired and how
-  runs ended" tells next month's pack author which content is load-bearing,
-  stale, or never-seen. Bot sweeps say what is POSSIBLE; telemetry says
-  what is HAPPENING (scan's framing). Together they are the league's
-  steering signal.
+  uses [INFERRED -- endpoint design still the open question]. Landing
+  zone: a PRIVATE store owned by pdoom1 (private repo/bucket -- location
+  TBD with the #800 endpoint decision). Explicitly NOT an inlet in the
+  public pdoom-data repo: run data is fingerprint-adjacent at current
+  playerbase size, changes meaning with every daily balance change, and
+  must never leak into the public fact lake (the firewall applies here
+  too -- run telemetry is game-opinion data, never AI-safety fact).
+- **What it feeds:** the monthly curation, INTERNALLY. "Which events
+  fired and how runs ended" tells next month's pack author which content
+  is load-bearing, stale, or never-seen. Bot sweeps say what is POSSIBLE;
+  telemetry says what is HAPPENING (scan's framing). The digest is an
+  internal artifact, not a publication.
 
-**Privacy note:** anonymized, aggregate-oriented, opt-in-visible. The
-firewall applies here too -- run telemetry is game-opinion data and is
-never presented as AI-safety fact.
+## 3b. Data-openness posture (Pip ruling 2026-07-25)
+
+The ruling that re-scopes Contract 3, written down so pipeline convenience
+cannot erode it (full reasoning: `docs/strategy/IP_AND_OPENNESS_PREMORTEM.md`
+section 5):
+
+1. **No auto-publishing of gameplay metadata while in dev.** Three
+   independent reasons: balances change daily, so published play data is
+   instantly stale and misleading; the playerbase is small enough that run
+   rows (seed + version + events_fired) are FINGERPRINTABLE; and the
+   surface-then-retract trap -- data once published becomes an
+   entitlement, and withdrawing it costs more community trust than never
+   publishing (the Path of Exile lesson).
+2. **The downward flow (pdoom-data -> game) runs at full speed.** Hop A
+   is unaffected; world-update packs are public facts already.
+3. **The public return leg is confirmations + error-correction only**
+   (Contract 3 above) for now.
+4. **pdoom1 accumulates a slowly-growing PRIVATE lake of run summaries.**
+   Broad publishing of aggregate play data is DEFERRED to ~1.0, once the
+   sim has real strategic depth and the numbers mean something durable.
+5. **The meta-display / ladder-analytics layer is HOPED to emerge from
+   the community** (the Path of Building pattern: the definitive solver
+   was community-built), not pushed from the center. Seeds laid now to
+   enable that without committing: a stable, documented run-artifact
+   schema; versioned payloads; a consent line that already permits future
+   aggregate publication; and a local "export my own runs" facility so
+   players can share their OWN data voluntarily -- player-chosen openness
+   is immune to the retract trap.
+
+Amending this posture follows the same ratification loop as the rest of
+this doc (change proposed here, legs confirm).
 
 ## 4. The monthly beat (Aug-Oct 2026, on the Epoch clock)
 
@@ -172,13 +219,13 @@ The cycle turns once per league month. Within a month [PROPOSED]:
 | E-2..E-0 | pdoom1 pulls pack, balance-shapes, PR, fast gate green | pdoom1 lane |
 | E (first Friday) | Epoch ships: minor+ladder bump, new baseline seed, league notes | pdoom1 (existing train) |
 | E+1..E+4 | Website pulls release notes + league notes + any voice-seam changes; publishes the monthly post | pdoom1-website lane |
-| continuous | Run artifacts trickle home (once Contract 3 is live) | players -> pdoom-data |
-| E-9 (approx) | Telemetry digest of the CLOSING month summarized for the next pack draft | pdoom-data lane |
+| continuous | Confirmations/error-corrections up; run summaries -> PRIVATE lake (once Contract 3 is live) | players -> private lake |
+| E-9 (approx) | INTERNAL telemetry digest of the CLOSING month (from the private lake) summarized for the next pack draft | pdoom1/pdoom-data lane |
 
 Who pulls what: every arrow is a PULL by the downstream repo (pdoom1 pulls
-the pack; website pulls the copy; pdoom-data receives pushed telemetry but
-PULLS nothing from the game repo). Signals are commits + cross-repo issues,
-same as the roadmap protocol.
+the pack; website pulls the copy; the PRIVATE lake receives pushed
+confirmations/run summaries but nothing pulls from the game repo). Signals
+are commits + cross-repo issues, same as the roadmap protocol.
 
 ### The three months, concretely
 
@@ -205,27 +252,30 @@ build the organs. Confidence: Aug is grounded; Sep ~70%; Oct is direction
 **September (v0.15, ships Sep 4, L4 -- public-alpha hardening month):**
 
 - pdoom-data: first REAL pack (August's events), Pip-approved on the E-2
-  beat. Stand up the telemetry landing zone (schema + inlet dir), even if
-  nothing flows yet.
+  beat. (The telemetry landing zone moves OFF pdoom-data per the re-scoped
+  Contract 3 -- the private lake stands up wherever the #800 endpoint
+  decision lands, not as a pdoom-data inlet.)
 - pdoom1: consume the pilot/September pack into the event pool as a
   low-stakes trial (a handful of shaped events, clearly provenance-tagged).
   v0.15 is the hardening month (leaderboard, install ping #799, bug
   reporter #800) -- exactly the infrastructure the return leg rides. If
   #799/#800 land, run-summary telemetry v0 goes live behind the same
-  consent.
+  consent, flowing to the PRIVATE lake (with the
+  future-aggregate-publication consent line included from day one).
 - pdoom1-website: monthly post now includes "real events that entered the
   world" as a section -- the outward face of the reality-tether.
 
 **October (v0.16 "Sightings" prov., ships Oct 2, L5 -- first full turn):**
 
-- pdoom-data: September pack drafted WITH the first telemetry digest
-  (if v0 flowed) -- the loop's first closed turn. Pack now the roadmap's
-  promised "wider event pool" feedstock.
+- pdoom-data: September pack drafted WITH the first INTERNAL telemetry
+  digest from the private lake (if v0 flowed) -- the loop's first closed
+  turn. Pack now the roadmap's promised "wider event pool" feedstock.
 - pdoom1: v0.16 ships with the pdoom-data-fed pool expansion (roadmap
   commitment). Frontier advances; league notes name the real events.
-- pdoom1-website: full-cycle monthly post: new Theme + new world events +
-  (if presentable) first aggregate play stats. By now the post has a
-  stable template -- candidate for the copy corpus.
+- pdoom1-website: full-cycle monthly post: new Theme + new world events.
+  (NO aggregate play stats -- publishing play data is deferred to ~1.0
+  per the data-openness posture.) By now the post has a stable template --
+  candidate for the copy corpus.
 
 ## 5. Manual-first vs automatable
 
@@ -266,9 +316,10 @@ Modeled on the roadmap -> website signal that already worked
 2. **Two cross-repo issues** (filed AFTER Pip merges, not before):
    - pdoom-data: "Confirm your leg of the triumvirate metabolic cycle" --
      links this doc; asks: fact-schema + pack-schema ownership, firewall
-     cleanup, pilot pack in Aug, telemetry landing zone in Sep. pdoom-data
-     answers with ITS OWN doc/issue-plan; disagreements come back as
-     comments on this doc.
+     cleanup, pilot pack in Aug. (Telemetry landing zone REMOVED from the
+     ask per the re-scoped Contract 3 -- the private lake is not a
+     pdoom-data concern.) pdoom-data answers with ITS OWN doc/issue-plan;
+     disagreements come back as comments on this doc.
    - pdoom1-website: same shape -- monthly post beat, league-notes pull,
      doom-clock question. Website already carries #164's re-projection
      habit; this extends it to a monthly rhythm.
@@ -298,11 +349,15 @@ Modeled on the roadmap -> website signal that already worked
    feature work, the ramp stretches (Oct full-turn slips to Nov) --
    probability of exactly that slip: ~40% [INFERRED from the scan's ~60%
    slip estimate on BET 3 alone].
-3. **Telemetry privacy posture is undecided.** Anonymous-by-default is
-   the #799 framing; run telemetry proposed to ride the same consent. But
-   `events_fired[]` + seed + version is fingerprint-adjacent for a tiny
-   playerbase. Needs a ruling before Contract 3 goes live: what fields,
-   what retention, where stated to players.
+3. **Telemetry privacy posture -- RULED 2026-07-25** (was: undecided).
+   The fingerprint risk (`events_fired[]` + seed + version on a tiny
+   playerbase) is one of the three reasons the return leg got re-scoped:
+   run summaries go to a PRIVATE lake only, nothing play-derived is
+   published before ~1.0. Still owed before Contract 3 goes live: exact
+   field list, retention window, and the player-facing consent wording
+   (which must already permit future aggregate publication) -- see
+   `docs/strategy/IP_AND_OPENNESS_PREMORTEM.md` section 5; wording is a
+   check-with-a-professional item.
 4. **League-notes format is still owed** (ADR-0016 open question). Hop B's
    monthly post depends on it. Cheap to settle: one template, first used
    at the v0.15 or v0.16 Epoch.
@@ -322,11 +377,12 @@ Modeled on the roadmap -> website signal that already worked
    namespace" is my proposal [INFERRED as the natural firewall-preserving
    split]; pdoom-data's confirming issue should explicitly accept or
    counter it.
-8. **Which repo hosts the telemetry endpoint?** The scan says
-   "website/endpoint + pdoom-data landing zone + client" -- three moving
-   parts across all three repos. The website relaying to pdoom-data keeps
-   the game repo out of ops [INFERRED]; but Pip may prefer the leaderboard
-   server host it since that path already exists. Decide with the #800 fix.
+8. **Where does the private lake live?** The scan's original shape was
+   "website/endpoint + pdoom-data landing zone + client"; the re-scoped
+   Contract 3 rules OUT a pdoom-data landing zone (the lake is private,
+   pdoom-data is public). Remaining options: the leaderboard server path
+   (already exists) writing to private storage, or a private repo/bucket
+   the website endpoint relays into [INFERRED]. Decide with the #800 fix.
 
 ---
 

--- a/docs/strategy/IP_AND_OPENNESS_PREMORTEM.md
+++ b/docs/strategy/IP_AND_OPENNESS_PREMORTEM.md
@@ -1,0 +1,533 @@
+# IP / Openness / Monetization / Data-sharing Premortem -- 2026-07-25
+
+> **Status: decisions-FOR-Pip strategy doc. PROPOSED, not ratified.**
+>
+> **THIS IS NOT LEGAL ADVICE AND NOT TAX/ENTITY ADVICE.** The author is an
+> LLM agent, not a lawyer, not a registered tax agent, not an IP attorney in
+> any jurisdiction. Every place below where a real license text gets adopted,
+> a trademark gets filed, an entity receives grant money, or IP gets assigned
+> between entities is flagged `[LAWYER]` -- those are the points where a real
+> professional signs off before anything is executed. This doc's job is to
+> get the STRATEGY decisions made cold so the professional conversation is
+> short and cheap.
+>
+> Frame (matching SUCCESS_PREMORTEM_2026-07-20.md): it is mid-2027. The game
+> found its "30 nerds who play long enough to form a community"
+> (DESIGN_PHILOSOPHY target) and maybe a few hundred more. Which IP/openness
+> choices made in 2026 turned out to be the expensive ones? Pip's explicit
+> steer: worry about the MIDDLE ground, not the tails. Nobody is litigating a
+> viral hit; nobody cares about a dead repo. The middle -- mild success, real
+> community, a trickle of money, other people building on the work -- is
+> where ambiguous licensing and reflexive posturing actually cost.
+
+Grounding (decided things this doc builds ON, not re-decides):
+
+- `docs/PRODUCT_STRATEGY_RATIONALE.md` -- two products, one data backbone;
+  the fact/opinion firewall; "the moat is curation, not secret formulas";
+  the Path of Exile model; open dataset as NGO credibility.
+- `docs/copy/README.md` -- the repo-split SOURCE/PUBLISHER contract.
+- `docs/TRIUMVIRATE_METABOLIC_CYCLE.md` -- the 3-repo metabolism (revised in
+  this same PR to carry the data-openness ruling in section 6 below).
+- `docs/CAPABILITY_UPLIFT_SCAN.md` -- BET 3 (telemetry loop), the Balance
+  Observatory.
+- `docs/game-design/DESIGN_PHILOSOPHY.md` -- small durable community over
+  large audience; patch-as-heartbeat.
+- `docs/strategy/SUCCESS_PREMORTEM_2026-07-20.md` -- the attention-armor
+  frame; founder-hours as the binding constraint.
+
+---
+
+## 0. Ground truth (verified 2026-07-25)
+
+Checked against the repo and GitHub the day of writing:
+
+1. **The repo is PUBLIC and carries NO license.** `gh repo view` returns
+   `"license": null, "visibility": "PUBLIC"`. There is no LICENSE file at
+   the repo root (`git ls-files | grep -i licen` finds only
+   `godot/addons/godotsteam/license.md` and `godot/addons/gut/LICENSE.md`
+   -- third-party addons' own MIT texts).
+2. **README.md line 59 claims otherwise:** "**Built with Godot 4.5.1** |
+   **Open Source (MIT License)**". A public statement of MIT with no MIT
+   text anywhere is the worst of both worlds: it may function as a license
+   grant people reasonably relied on `[LAWYER -- whether a README badge
+   constitutes a grant is exactly a lawyer question]`, while giving none of
+   MIT's actual terms (attribution requirement, warranty disclaimer). This
+   is the single most urgent item in this doc -- see section 3.4.
+3. `CONTRIBUTING.md` says nothing about licensing of contributions. Every
+   outside PR merged so far has ambiguous IP status `[LAWYER]`. At current
+   contributor volume (approximately zero external) this is cheap to fix
+   and expensive to fix later.
+4. The Manifund application draft exists (`docs/copy/MANIFUND_DRAFT.md`);
+   Pip's stated likely path is taking Manifund money INTO his for-profit
+   company for IP protection + control, with a possible later pivot to a
+   fully-nonprofit model (section 9).
+5. The strategy doc already rules the big shape: "open the historical
+   events data ... keep the game-mechanics integration as the protected
+   layer. The ONE thing to actually prevent is a wholesale clone of the
+   entire game if it goes viral on Steam."
+
+## 1. The premortem: five ways mid-2027 goes wrong in the middle
+
+- **F1 -- License-vacuum drift.** The public repo keeps accumulating value
+  with no license. In 2027 someone forks it, or builds a mod, or reuses the
+  event data, and asks "am I allowed?". Any answer given then is improvised
+  under social pressure, and the README's MIT badge means the permissive
+  interpretation has already been promised. Retracting a promise costs more
+  community trust than never making it (the surface-then-retract trap,
+  section 4.2, applies to licenses too).
+- **F2 -- The sticker-seller.** Someone sells P(Doom) merch / reskins the
+  game on itch with the name and logo. Financial damage at Pip's scale:
+  tens of dollars. Emotional damage: the exact "ripped off while I did the
+  labour" feeling Pip named. The cheap pre-commitment (trademark posture,
+  section 3.5) is what makes 2027-Pip shrug instead of seethe.
+- **F3 -- Surface-then-retract on data.** Gameplay telemetry gets
+  auto-published during dev because the pipeline made it easy; balance
+  changes daily so the data is instantly stale and misleading; the tiny
+  playerbase means rows are fingerprintable; when it gets pulled, the
+  community reads retraction as betrayal. Pip has already ruled against
+  this (section 6) -- the premortem's job is to keep the ruling from being
+  eroded by pipeline convenience.
+- **F4 -- Reflexive greed on a success spike.** A good month (streamer
+  pickup, HN post) triggers "lock it all down / charge for everything"
+  moves that burn the small durable community the whole design philosophy
+  optimizes for. Antidote: the written covenant in section 8.2, adopted
+  cold, now.
+- **F5 -- Entity-shape lock-in.** Manifund money lands in the for-profit,
+  IP ownership is never written down, and the later nonprofit pivot
+  requires untangling who owns what with money already spent `[LAWYER]`.
+  Cheap now-action in section 9.
+
+Everything below is organized as decisions that close off these failures.
+
+---
+
+## 2. Decision 1 -- Licensing: four separate levers, not one
+
+The load-bearing insight: "the license" is not one decision. CODE, ART and
+ASSETS, DATA, and TRADEMARK are four independent levers with different
+default legal regimes, different threats, and different costs to Pip. Most
+indie licensing pain comes from pulling one lever and assuming it covered
+all four.
+
+### 2.1 The lever map
+
+| Lever | What it covers here | Default if silent | Real threat at Pip's scale | Cheapest effective posture |
+|---|---|---|---|---|
+| CODE | GDScript engine + sim core, Python tooling | All rights reserved (but README badge muddies) `[LAWYER]` | Wholesale Steam clone (strategy doc's ONE thing) | License the ENGINE permissively-or-copyleft, keep it separable from the shipped GAME (open-core split, 2.2) |
+| ART / ASSETS | pixellab sprites, generated icons, music, tilesets | All rights reserved | Reskin-clone shipping YOUR art | Do NOT open-license; "all rights reserved, mod-use permitted" written policy |
+| DATA | pdoom-data facts; godot/data balance JSON | Facts largely uncopyrightable in US; database rights differ by jurisdiction (EU sui generis; AU follows copyright-in-compilation case law) `[LAWYER]` | None worth money; the WIN is people using it | CC-BY 4.0 (or ODC-BY) on pdoom-data; balance JSON rides the code license |
+| TRADEMARK | "P(Doom)1" name, logo | Unregistered marks get thin passing-off protection only `[LAWYER]` | The sticker-seller; a confusing clone using the NAME | The one lever worth actual money (2.4) |
+
+### 2.2 Code options, priced at Pip's scale (few $k/yr ceiling)
+
+- **Permissive (MIT/Apache-2.0).** Buys: maximum "build things off my
+  labour" (Pip's stated want (c)); zero friction for community tools.
+  Costs: a Steam clone is fully legal, including of the shipped game, if
+  the whole repo is MIT -- this is the one outcome the strategy doc says to
+  prevent. Verdict: right for the ENGINE, wrong for the whole repo.
+- **Copyleft (GPLv3/AGPL).** Buys: clones must open their source (most
+  commercial cloners just walk away); community forks stay open. Costs:
+  approximately nothing at this scale -- the "GPL scares business" concern
+  is a big-company problem. Key evidence that copyleft does not kill
+  indie revenue: **Mindustry** (GPLv3, source free on GitHub, sells on
+  Steam) and **Shattered Pixel Dungeon** (GPLv3, sells on Google
+  Play/Steam) both sustain exactly the few-$k-to-modest-living band by
+  charging for CONVENIENCE (builds, updates, workshop, leaderboards) while
+  the source sits open [confidence: high, well-known projects; verify
+  current terms before citing publicly].
+- **Open-core split.** Engine/sim (deterministic core, the genuinely
+  reusable thing) under an open license; game-layer (content integration,
+  balance opinion, art) under a restrictive one. Buys: want (c) served
+  precisely where Pip wants to serve it; the anti-clone layer is the layer
+  the strategy doc already calls the moat. Costs: a repo-boundary
+  discipline tax (the triumvirate split already practices this muscle).
+- **Source-available (BSL-style: "converts to open license after N years",
+  or PolyForm Noncommercial).** Buys: readable + moddable now, no
+  commercial clones, automatic future openness. Costs: NOT open source by
+  OSI definition -- the README badge would still be a lie; some community
+  goodwill discount; more exotic license = more explaining. Verdict: a
+  reasonable MODERATE posture for the game-layer specifically.
+- **Dual-license.** Irrelevant at this scale -- dual-licensing pays when
+  businesses want to buy out of copyleft; no such buyer exists here.
+
+### 2.3 The three postures
+
+- **MINIMAL (do this week, near-zero cost):** Delete or amend the README
+  MIT badge to match reality; add a root `LICENSE.md` that says, honestly:
+  "Source-available for reading, learning, and modding. No license is
+  granted yet to redistribute the game or ship derivative games; a real
+  license split (engine vs game vs assets vs data) is planned -- see
+  docs/strategy/IP_AND_OPENNESS_PREMORTEM.md." Plus one CONTRIBUTING.md
+  line: contributions are licensed to the project under the project's
+  eventual license `[LAWYER for exact wording -- this is a lightweight
+  inbound-license clause, not a CLA]`. This closes F1 without committing
+  to anything.
+- **MODERATE (decide by ~v1.0):** Execute the open-core split. Engine/sim
+  core -> MIT or GPLv3 (Pip's taste: MIT maximizes want (c), GPL maximizes
+  anti-clone; at this scale my recommendation is **GPLv3 for the engine**
+  -- it still lets everyone build and mod, and it is the cheapest real
+  anti-wholesale-clone device that requires zero enforcement budget
+  [INFERRED from the Mindustry/SPD precedent]). Game content + art: all
+  rights reserved with a short written MOD POLICY ("mods, tools,
+  datamining, videos: yes, encouraged; redistributing the game or assets:
+  no"). pdoom-data: CC-BY 4.0 (section 7). `[LAWYER before any license
+  text ships]`
+- **AMBITIOUS (only if the platform/B2B leg materializes):** Formal IP
+  assignment into the entity, registered trademarks in AU + US, per-repo
+  license audit, partner data-feed contracts. Not worth starting until a
+  B2B conversation is real.
+
+### 2.4 Trademark -- the cheapest real protection against sticker-sellers
+
+Copyright does nothing against someone selling "P(Doom) stickers" with a
+self-drawn logo; trademark is the lever built for exactly that. Mechanics,
+priced [figures from memory, verify current fees before filing]:
+
+- AU: IP Australia registration runs roughly AU$250-400 per class
+  (TM Headstart pre-check slightly more). Relevant classes: 9 (downloadable
+  games), 41 (entertainment services), maybe 16/25 (printed matter/apparel)
+  if merch is real.
+- US: USPTO TEAS roughly US$250-350 per class.
+- An UNREGISTERED mark still gets passing-off / consumer-protection
+  protection in AU and common-law trademark in the US -- weaker, but not
+  nothing, and it costs $0 `[LAWYER]`.
+
+Posture recommendation: **do not file yet.** At few-$k/yr scale, the
+registered mark buys a cease-and-desist letterhead for a threat that
+costs tens of dollars. Instead: (a) date-stamped evidence of use (the
+site, releases, this repo's history -- already exists), (b) a one-line
+public brand policy ("the name and logo are not open; ask first"), and
+(c) a pre-decided tripwire: **file in AU the month merch revenue or a
+confusing clone actually appears** -- filing after a specific threat
+materializes is only mildly worse than filing before, and infinitely
+better than deciding under emotional load. The failure F2 is mostly an
+EMOTIONAL injury; the covenant to consult section 8.2 before reacting is
+the true mitigation. `[LAWYER before filing or sending anything that
+smells like a legal threat]`
+
+---
+
+## 3. Decision 2 -- The Path of Exile model, examined before adopted
+
+The strategy doc already names "the Path of Exile model: make core
+mechanics discoverable but not trivially cloneable, and let players build
+solver tools." Worth unpacking what GGG actually did, what it bought and
+cost them, and what transfers to a solo dev at 1/100,000th the scale.
+[All game-industry claims below are from general knowledge, not fresh
+research; confidence tags inline; verify before quoting publicly.]
+
+### 3.1 What GGG actually does [confidence: high on shape, medium on details]
+
+- Ships a client whose data files (GGPK) the community datamines within
+  hours of every patch; GGG has never seriously fought this.
+- Publishes OFFICIAL APIs for trade and ladders -- the SOCIAL data -- while
+  keeping drop weights and internal numbers unpublished.
+- **Path of Building**, the build-solver the strategy doc alludes to, was
+  built by a community member (Openarl), later maintained as the
+  open-source PoB Community fork. GGG neither built nor blessed it
+  initially; they simply did not kill it. It became infrastructure that
+  sells the game (theorycrafting IS the endgame for many players).
+- The costs, in the observable record: recurring community rage cycles
+  when hidden numbers are discovered to be worse than assumed (loot/drop
+  controversies where GGG eventually disclosed hidden mechanics under
+  pressure [confidence: medium on specifics]); developer harassment during
+  nerf cycles; a playerbase that now treats every undisclosed number as
+  presumptively hostile. Once a community norm of disclosure exists,
+  each NON-disclosure is read as concealment.
+
+### 3.2 The surface-then-retract trap (the transferable warning)
+
+The pattern that transfers directly: **information you publish becomes an
+entitlement; withdrawing it costs more trust than never publishing it.**
+GGG-scale example: publish a stat, later hide it, community assumes the
+worst. Pip-scale example: auto-publish run telemetry during dev, pull it
+when fingerprinting or misreading becomes a problem, and the 30-nerd
+community -- whose whole culture is data-argumentation -- reads it as the
+project going closed. This is the strongest argument FOR the section 6
+ruling: do not start publishing until the publishing posture can be
+permanent.
+
+### 3.3 Other comparables, one line each of what transfers
+
+- **Factorio (Wube):** closed source, but a STABLE modding API + mod
+  portal + relentlessly transparent dev blog (FFF). Lesson: openness of
+  PROCESS and INTERFACES substitutes almost fully for openness of source.
+  The patch-as-heartbeat principle is already FFF-shaped.
+- **RimWorld (Ludeon):** closed source; mods work by runtime patching;
+  EULA simply permits it. Lesson: a one-paragraph written mod policy is
+  enough legal scaffolding for a thriving mod scene.
+- **Minecraft (Mojang):** shipped obfuscated, community deobfuscated
+  anyway for a decade, Mojang eventually published official mappings.
+  Lesson: obfuscation against a motivated community only decides WHO
+  makes the tools, not WHETHER.
+- **Dwarf Fortress (Bay 12):** closed source, free for 16 years, then the
+  Steam release monetized CONVENIENCE + PRESENTATION on top of the same
+  free game. Lesson: the moat was always the accumulated labour and
+  curation -- nobody clones DF because nobody can clone the 20 years.
+  This is the strongest version of Pip's own "moat is curation" thesis.
+- **Mindustry / Shattered Pixel Dungeon:** fully GPL, still get paid
+  (section 2.2). Lesson: at indie scale, people pay for convenience and
+  to support the author, not for exclusion.
+- **id Software (Doom/Quake):** GPL'd engines years after release; the
+  source releases created source ports, longevity, and goodwill without
+  cannibalizing anything. Lesson for the AMBITIOUS tier: time-delayed
+  openness is a proven move (BSL is the contractual version of it).
+
+### 3.4 The extracted strategy for P(Doom)1
+
+1. Treat dataminers as the community-tools wing, never as adversaries
+   (they arrive within days of any real community forming; the design
+   already assumes this).
+2. Publish INTERFACES deliberately (run-artifact schema, replay format,
+   ladder API) -- that is where a PoB-analogue would grow from -- while
+   never promising to publish internal NUMBERS on a schedule.
+3. Never publish a number you are not prepared to publish forever.
+4. Openness of process (dev blog, patch notes, design docs -- all already
+   public in this repo) is the Factorio move and is already being made;
+   count it as openness spend before adding data-openness spend.
+
+---
+
+## 4. Decision 3 -- Easter eggs and dev-tool posture in an open build
+
+### 4.1 What is actually hideable in a Godot client: approximately nothing
+
+Honest technical baseline: Godot packs the entire `godot/` tree into the
+`.pck` (already a known trap, CLAUDE.md), and community tooling (gdsdecomp
+/ Godot RE Tools) reconstructs a near-complete project -- including
+GDScript close to source form -- from any shipped build [confidence: high].
+PCK encryption exists but the key must live in the binary, so it is
+extractable by anyone determined; it raises the effort floor from "minutes"
+to "an afternoon", once, for one person who then posts the result. The
+strategy doc's posture already accepts this ("fully expects and welcomes
+the community reverse-engineering balance"). So the design question is
+never "can hardcore players be stopped" -- they cannot -- it is "what
+keeps surprises alive for REGULAR players after the hardcore have
+datamined everything."
+
+### 4.2 The toolkit, ranked by what actually survives datamining
+
+1. **Not-yet-shipped content (the only true secrecy).** Content delivered
+   in a later patch cannot be datamined from the current build. The
+   monthly Epoch train is a NATURAL late-delivery channel: an easter egg
+   that ships IN the epoch patch it activates in is secret right up to
+   patch day. Cost: zero new infrastructure. This should carry most of
+   the load.
+2. **Server-delivered payloads.** A tiny remote blob (the leaderboard
+   phone-home path already exists) fetched at a date/condition. True
+   secrecy until served, then instantly public. Worth it only for a
+   marquee surprise; adds an availability dependency to an otherwise
+   offline game -- use sparingly, never for anything load-bearing.
+3. **Hash commitments (the fun one for this audience).** Ship a SHA-256
+   of the secret content now; ship the content later. Dataminers find
+   the hash, KNOW something is coming, cannot know what -- which converts
+   datamining energy into anticipation instead of spoilers, and proves
+   non-retcon when revealed. Extremely cheap; on-brand for an
+   AI-safety-nerd audience.
+4. **Seed/condition-gated experiential content.** Content whose data is
+   visible but whose MEANING only lands in play (a specific seed's event
+   confluence, an ending variant conditional on a rare state). Dataminers
+   publish "there is a secret ending"; regular players still get the
+   experience fresh. This is spoiler-RESISTANT design rather than
+   secrecy, and it is the only kind that survives a wiki.
+5. **Mild obfuscation of dev tools.** Shipping dev/debug tooling
+   compiled-out or flag-gated (the existing dev-mode pattern) keeps
+   regular players from stumbling into the machinery; assume hardcore
+   players will find and even use it -- that is free QA, not a breach.
+
+### 4.3 The posture in one line
+
+Secrecy budget goes to TIMING (late delivery via the Epoch train +
+occasional server blob + hash teasers); surprise budget goes to DESIGN
+(experiential, seed-gated content that a wiki spoiler cannot actually
+spoil); zero budget goes to fighting dataminers.
+
+---
+
+## 5. Decision 4 -- Data openness: the ruling and its seeds
+
+Pip's live steer, now written down (and folded into
+`docs/TRIUMVIRATE_METABOLIC_CYCLE.md` as "Data-openness posture"):
+
+1. **No auto-publishing of gameplay metadata while in dev.** Three
+   reasons, each sufficient: balance changes daily so published data is
+   instantly stale and misleads; the playerbase is small enough that run
+   rows (seed + version + events_fired) are FINGERPRINTABLE (already
+   flagged as Risk 3 in the metabolic-cycle doc); and the
+   surface-then-retract trap (3.2) -- publishing now creates an
+   entitlement that dev-phase reality cannot honor.
+2. **The downward flow (pdoom-data -> game) runs at full speed** -- the
+   world-update packs are unaffected; that data is already public facts.
+3. **The return leg carries only confirmations + error-correction for
+   now:** bug reports (#800 honest-transmit), install ping (#799),
+   crash/error artifacts, "pack event X displayed wrongly" corrections.
+   Run summaries still flow home under the same consent -- but into a
+   PRIVATE lake, not the public one.
+4. **pdoom1 accumulates the private lake slowly.** Broad publishing of
+   aggregate play data is DEFERRED to ~1.0, when the sim has real
+   strategic depth and the numbers mean something durable.
+5. **The meta-display / ladder-analytics layer is HOPED to emerge from
+   the community** (the PoB pattern: the best solver was built by a
+   player), not pushed from the center.
+
+### Seeds to lay now (enable later openness without committing to it)
+
+- **Stabilize and document the run-artifact SCHEMA** (the fields already
+  exist deterministically: seed, version, turns, outcome, death
+  attribution, replay hash -- ADR-0006). A community tool needs the
+  INTERFACE, not Pip's data.
+- **Version every payload** so a future published corpus can exclude
+  pre-1.0 noise cleanly.
+- **Write the consent line NOW to permit later aggregate publication**
+  ("anonymized run data may be published in aggregate form in future") so
+  ~1.0 publishing does not require re-consent from years of players
+  `[LAWYER for the actual privacy-policy wording; AU Privacy Act
+  applicability at this scale is exactly a verify-with-professional item]`.
+- **Local export:** let a player dump their OWN runs to a file. Voluntary
+  player sharing (players posting their runs to a community tool) gets a
+  PoB-pattern ecosystem started without Pip publishing anything --
+  openness by player choice is immune to the retract trap.
+- **Keep the private lake tidy from day one** (schema-validated on
+  arrival) so the ~1.0 publishing decision is a switch, not a cleanup
+  project.
+
+---
+
+## 6. Decision 5 -- What to give away most easily
+
+Candidates, per the task and the strategy doc: pdoom-data (the curated
+public dataset) and/or the engine.
+
+- **pdoom-data: give it away NOW, fully.** It is already public-by-design
+  (NGO credibility, research value, the fact/opinion firewall makes it
+  safe). Recommended license: **CC-BY 4.0** (attribution keeps the
+  curation labour visible -- the one currency that matters at this scale)
+  or ODC-BY if a data-specific text is preferred. Note: bare facts are
+  largely uncopyrightable in the US and AU protection of compilations is
+  case-law-dependent, so the license here mostly functions as a NORM
+  statement, not a wall -- which is fine, norms are what this community
+  runs on `[LAWYER if the B2B data-feed product ever charges for the same
+  data]`. CC0 is the maximally-generous alternative; rejected here only
+  because attribution is the mechanism by which the dataset builds the
+  NGO's name.
+- **The engine: second, and later.** The deterministic sim core is the
+  genuinely reusable artifact for want (c) ("let people make their own
+  games off my labour"). Give it away at the MODERATE tier (section 2.3)
+  under GPLv3 -- open enough for anyone to build on, copyleft enough that
+  a wholesale commercial clone must open its own source. Timing: after
+  the open-core repo split exists; giving away the engine today means
+  giving away the whole repo, art and balance opinion included, which is
+  the one thing the strategy doc rules out.
+- **Never in the giveaway pile:** the art/assets, the balance-shaping
+  opinion layer, the name/logo, and the private telemetry lake.
+
+Recommendation in one line: **data first (now, CC-BY), engine second (at
+the repo split, GPLv3), art/name never** -- generosity concentrated
+exactly where the strategy doc says the moat is not.
+
+---
+
+## 7. Worked dollars at Pip's scale + the anti-greed guardrail
+
+### 7.1 The honest numbers [all illustrative, order-of-magnitude]
+
+- Steam at the target community size: 300-1,000 sales x US$10 x ~65%
+  after Valve/VAT = roughly **US$2k-6.5k, mostly one-time** -- squarely
+  Pip's own "few $k/year at most".
+- Merch: at 30-300 engaged players, stickers/shirts are
+  **tens-to-hundreds of dollars a year**. A rogue sticker-seller
+  therefore costs single-digit dollars of displaced revenue; the injury
+  is dignity, not money -- which is why the mitigation (2.4) is a
+  pre-decided tripwire + covenant, not upfront legal spend.
+- B2B platform leg: $0 until it isn't; ignore in all 2026 decisions
+  except keeping the data backbone clean (already ruled).
+- Against the FATFire frame: the ENTIRE realistic game revenue is noise
+  relative to the established ceiling. The money's real function, per
+  Pip: **a success funds the OTHER art/creative projects in the
+  business.** That framing is itself the anti-greed device -- the game
+  never needs to be squeezed, because it was never the retirement plan.
+
+### 7.2 The "don't get reflexively greedy" guardrail, made mechanical
+
+Failure F4 is a decision made HOT. The fix is the same attention-armor
+move as the success premortem: decide cold, write it down, and make
+future-Pip's job "follow the written policy" instead of "resist
+temptation." Proposed covenant (adopt by merging; amend only by PR, never
+in the week of a success spike):
+
+1. No license on any already-shipped version ever gets more restrictive
+   retroactively. (Relicensing FORWARD is allowed; clawing back is not.)
+2. Anything published (data, schema, API) stays published; see 3.2.
+3. Community tools, mods, videos, datamining: always permitted, never
+   monetized against.
+4. Any monetization change (price, DLC, merch, data products) waits a
+   **two-week cooling period** from the triggering event, and gets checked
+   against this doc first.
+5. The game's revenue purpose is fixed: fund the other creative work.
+   Any plan that only makes sense if the game becomes the main income is
+   out of scope by definition.
+
+---
+
+## 8. The entity question (Manifund -> for-profit, possible nonprofit pivot)
+
+`[LAWYER + ACCOUNTANT -- this whole section is flags, not advice. Grant
+money into a for-profit, IP assignment between entities, and any later
+for-profit -> nonprofit conversion have real tax and charity-law
+consequences in AU that an LLM must not be the last word on.]`
+
+The premortem risk (F5) is not the choice itself -- taking Manifund money
+into the for-profit for IP protection + control is a coherent, common
+choice -- it is the UNDOCUMENTED state: money in one entity, IP created
+across personal/company boundaries, and a pivot later that has to
+archaeologize who owns what.
+
+Cheap now-actions that keep BOTH doors open:
+
+1. **Write down, today, which entity owns what** (one page: code
+   copyright, art, the name, the domains, the data curation). Unwritten
+   IP ownership defaults are jurisdiction- and employment-status-
+   dependent and messy `[LAWYER]`.
+2. **Keep the grant's purpose paper-trail clean** (what the Manifund
+   money is FOR, spent from a separable account) -- this is what makes a
+   later nonprofit pivot auditable instead of forensic
+   `[ACCOUNTANT/registered tax agent -- explicitly out of scope for this
+   doc]`.
+3. **Prefer licenses over transfers while undecided:** if the nonprofit
+   pivot is live-possible, the for-profit LICENSING the IP (to itself, to
+   a future NGO) is more reversible than assigning it `[LAWYER]`.
+4. Note the alignment: the section 2.3 MODERATE posture (open engine +
+   open data, reserved game layer) reads WELL in either entity shape --
+   open artifacts are exactly what an NGO wants to point at, and the
+   reserved game layer is exactly what a for-profit wants to hold. The
+   licensing strategy does not force the entity decision. [INFERRED]
+
+---
+
+## 9. Decision summary for Pip
+
+| # | Decision | MINIMAL (now) | MODERATE (by ~1.0) | Flag |
+|---|---|---|---|---|
+| 1 | Code license | Fix README/LICENSE contradiction with honest source-available placeholder + CONTRIBUTING line | Open-core split: engine GPLv3, game layer reserved + written mod policy | `[LAWYER]` before any text ships |
+| 2 | Trademark | $0: brand-policy line + evidence of use + written tripwire | File AU class 9/41 the month merch or a confusing clone is real | `[LAWYER]` before filing/threatening |
+| 3 | PoE model | Publish interfaces not numbers; never publish what can't stay published | Stable run-artifact schema + ladder API as the community-tool substrate | -- |
+| 4 | Easter eggs | Epoch-train late delivery + seed-gated experiential design | Hash commitments; rare server blob for marquee moments | -- |
+| 5 | Data openness | Ruling adopted: confirmations/error-correction up only; private lake; consent line written for future aggregate publishing | ~1.0: publish aggregates; hope the PoB-pattern tool emerges | `[LAWYER]` privacy wording |
+| 6 | Giveaways | pdoom-data -> CC-BY 4.0 now | Engine -> GPLv3 at repo split; art/name never | `[LAWYER]` if B2B charges for same data |
+| 7 | Anti-greed | Adopt the section 7.2 covenant by merging this doc | Re-read it during any success spike, before acting | -- |
+| 8 | Entity | One-page IP ownership inventory; clean grant paper-trail | License-don't-assign while the nonprofit door is open | `[LAWYER + ACCOUNTANT]` -- the load-bearing flag of this doc |
+
+**The single most important professional-boundary flag:** the Manifund
+money -> for-profit -> possible nonprofit pivot chain (section 8). License
+files can be fixed with a PR; entity and grant-money structure, done
+wrong, is the one item here that compounds into real legal/tax cost and
+cannot be repaired by editing a file. Get a lawyer and a registered tax
+agent on that one before the money moves.
+
+---
+
+*Drafted 2026-07-25 by a strategy lane. Repo-state claims (public
+visibility, null license, README line 59, CONTRIBUTING silence) verified
+same day via gh + git. Game-industry comparables are from general
+knowledge with inline confidence tags -- verify before quoting publicly.
+PROPOSED; Pip amends and ratifies by merge.*


### PR DESCRIPTION
## What

Two documents, one steer.

### New: `docs/strategy/IP_AND_OPENNESS_PREMORTEM.md`

Decisions-FOR-Pip strategy premortem on IP / openness / monetization /
data-sharing. **Explicitly NOT legal or tax advice** -- every real license,
trademark, or entity decision is flagged `[LAWYER]` / `[ACCOUNTANT]` for
professional sign-off.

- **Ground truth (verified 2026-07-25):** the repo is PUBLIC with NO
  license file (`gh` reports `license: null`), while README.md line 59
  claims "Open Source (MIT License)". Fixing that contradiction is the
  MINIMAL action.
- **Licensing = four separate levers** (code / art+assets / data /
  trademark), each priced at Pip's few-$k/yr scale, with
  MINIMAL / MODERATE / AMBITIOUS postures. Recommendation: honest
  source-available placeholder now; open-core split by ~1.0 (engine GPLv3,
  game layer reserved + written mod policy); trademark = $0 posture with a
  pre-decided filing tripwire.
- **PoE / mod-friendly comparables** (GGG+PoB, Factorio, RimWorld,
  Minecraft, Dwarf Fortress, Mindustry/Shattered Pixel Dungeon, id):
  publish INTERFACES not NUMBERS; never publish what can't stay published
  (the surface-then-retract trap); dataminers are the community-tools wing.
- **Easter eggs in an open Godot build:** honest baseline (gdsdecomp
  recovers everything); secrecy budget goes to TIMING (Epoch-train late
  delivery, hash commitments, rare server blob), surprise budget to
  experiential seed-gated design, zero budget to fighting dataminers.
- **Data openness ruling written down** + the seeds that enable a future
  community meta-tool (PoB pattern) without committing to publishing.
- **Giveaway recommendation:** pdoom-data first (CC-BY 4.0, now), engine
  second (GPLv3, at repo split), art/name never.
- **Worked dollars + anti-greed covenant** (no retroactive restriction, no
  retraction of published things, two-week cooling period on monetization
  changes).
- **Entity flags:** the Manifund -> for-profit -> possible-nonprofit chain
  is the single most important get-a-professional item in the doc.

### Revised: `docs/TRIUMVIRATE_METABOLIC_CYCLE.md`

Re-scoped per Pip's data-openness ruling (2026-07-25):

- Return leg (Contract 3) = **confirmations + error-correction ONLY** for
  now (#800 honest-transmit, #799 install ping, content corrections).
- Run summaries flow to a **PRIVATE lake** owned by pdoom1 -- explicitly
  NOT a pdoom-data inlet (fingerprinting risk, daily balance churn,
  retract-trap).
- **Broad publishing of aggregate play data DEFERRED to ~1.0**; meta-display
  hoped to EMERGE from the community rather than be pushed.
- New section "3b. Data-openness posture (Pip ruling 2026-07-25)".
- Hop A / Hop B / the monthly beat left intact; Risks 3 and 8 updated;
  Sep/Oct month plans and the pdoom-data ratification ask adjusted to match.

## Verification

- Both files pass `grep -nP '[^\x00-\x7F]'` (ASCII-only clean).
- All pre-commit hooks passed (enforce-standards, no-emoji, line endings).
- Docs-only change; no code, no tests affected.

Generated with Claude Code