### PR TITLE
docs(legal): interim source-available LICENSE; fix false MIT claim in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,6 +285,14 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/):
   proves a freshness marker is in the `.pck` before emitting. NEVER hand-run a
   raw `godot --export` (stale-cache risk that burned many cycles in v0.11.0).
 
+## License of contributions
+
+By submitting a contribution (code, content, or assets) you grant the project a
+perpetual, irrevocable license to use, modify, and relicense it under whatever
+license the project later adopts. The current interim terms are in the root
+[LICENSE](LICENSE) file; a formal open-source license for the engine is planned
+around the 1.0 release.
+
 ## Getting Help
 
 - **Questions**: Open a [Discussion](https://github.com/PipFoweraker/pdoom1/discussions)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,12 @@
+P(Doom)1 -- Interim License (pre-1.0)
+Copyright (c) 2026 Pip Foweraker. All rights reserved.
+
+Source is provided for reference, evaluation, and contribution. No license is
+granted to redistribute, sell, or make commercial use of this software or its
+assets. A formal open-source license for the ENGINE is planned around the 1.0
+release; game content and all visual/audio assets are expected to remain
+all-rights-reserved.
+
+By submitting a contribution you grant the project a perpetual, irrevocable
+license to use, modify, and relicense it under whatever license the project
+later adopts (see CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Want to contribute or build from source?
 - **[Architecture](docs/developer/ARCHITECTURE.md)** - Codebase overview
 - **[Full Changelog](CHANGELOG.md)** - Version history
 
-**Built with Godot 4.5.1** | **Open Source (MIT License)**
+**Built with Godot 4.5.1** | **Source-available -- see [LICENSE](LICENSE)**
 
 ---
 


### PR DESCRIPTION
## Why

The repo is public and has **no LICENSE file** (GitHub reports `licenseInfo: null`), yet `README.md` claimed **"Open Source (MIT License)"**. That is a false licensing statement. This lands an honest interim posture.

## Changes

1. **New `LICENSE`** (repo root): interim, pre-1.0, all-rights-reserved-with-stated-intent. Source provided for reference/evaluation/contribution; no redistribution or commercial-use grant. States the intent to OSS-license the *engine* around 1.0 while content/assets remain all-rights-reserved. Includes the contribution relicensing grant. This is intentionally **not** an OSI license.
2. **`README.md`**: replaced `**Open Source (MIT License)**` with `**Source-available -- see [LICENSE](LICENSE)**` (rest of the line unchanged).
3. **`CONTRIBUTING.md`**: added a "License of contributions" section documenting that contributors grant a perpetual, irrevocable license to use/modify/relicense their contributions under whatever license the project later adopts.

ASCII-only; passed enforce-standards + no-emoji pre-commit gates.

Not for auto-merge -- for Pip's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)