### PR TITLE
refactor(ui): CARVE 6 -- extract R6 event/result presentation to EventResultPresenter

### DIFF
--- a/docs/MAIN_UI_SEAM_MAP.md
+++ b/docs/MAIN_UI_SEAM_MAP.md
@@ -25,7 +25,7 @@ Grounded in the actual function inventory (2026-07-25). `main_ui.gd` conflates:
 | **R3** | Game-state reading | scattered `GameState`/`game_manager` reads inside render + handlers | No single read surface |
 | **R4** | **Planning / attention / queue** | `_on_commit_plan_button_pressed`, `_on_clear_queue_button_pressed`, `_remove_queued_action`, `_calculate_queued_costs`, `update_queued_actions_display`, `_on_action_executed`, `_on_actions_available`, `_setup_plan_watch_scaffold` | **DOMAIN LOGIC in the UI -- the hotpatch-bleed** |
 | **R5** | Submenu / dialog orchestration | `_show_hiring_submenu`, `_show_fundraising_submenu`, `_show_financing_submenu`, `_show_publicity_submenu`, `_show_strategic_submenu`, `_show_travel_submenu`, `_show_operations_submenu` + 7 matching `_on_*_option_selected` + `_decorate_active_submenu` / `_close_active_submenu` | **7 copy-pasted builders -- the single biggest line bloat** |
-| **R6** | Event / result presentation | `_hiring_action_result`, `_on_action_executed` (presentation half) | Presentation mixed with mutation |
+| **R6** | Event / result presentation -- **CARVED (CARVE 6 -> `event_result_presenter.gd`)** | `_hiring_action_result` (moved earlier w/ CARVE 3), `_on_action_executed` + `_on_achievement_unlocked` + `_on_error_occurred` (presentation) | Presentation mixed with mutation |
 
 ## 2. Target architecture
 
@@ -72,7 +72,19 @@ lane needs a new submenu.**
   Developments feed) from being an 8th copy-paste. Whichever WS-3 lane first adds
   a panel triggers this -- they build the generic component instead of copy #8.
 
-**CARVES 3+ -- R1/R2/R3/R6 opportunistic.** No speculative extraction. Each WS-3
+**CARVE 6 -- R6 -> EventResultPresenter. DONE.**
+- The event/result PRESENTATION (executed-action result, achievement unlock, engine
+  error -> feed-log lines + the PLAN error toast) pulled out of `main_ui` into
+  `godot/scripts/ui/event_result_presenter.gd` (RefCounted, holds a `host` ref back to
+  the view, matching the CARVE 1-5 controller pattern). `main_ui` keeps thin signal
+  shims (`_on_action_executed` / `_on_achievement_unlocked` / `_on_error_occurred`)
+  that forward to the presenter, and still owns the feed MODEL (`log_message` +
+  filters) the presenter writes through. `_hiring_action_result` was already moved with
+  CARVE 3 (HiringPanelController), so R6's remaining target was the three signal
+  handlers + the `_format_deltas` helper. Pure NON-FORKING move; fast gate green
+  (647 tests, 0 fail) before and after. `main_ui.gd`: 1974 -> 1940 lines.
+
+**CARVES 3+ -- R1/R2/R3 opportunistic.** No speculative extraction. Each WS-3
 lane that touches rendering/input tidies its own patch toward the thin-view target
 (boy-scout rule), guided by this map. Revisit for a formal pass only if a seam
 proves painful again after WS-3.

--- a/godot/scripts/ui/event_result_presenter.gd
+++ b/godot/scripts/ui/event_result_presenter.gd
@@ -1,0 +1,106 @@
+class_name EventResultPresenter
+extends RefCounted
+## CARVE 6 (docs/MAIN_UI_SEAM_MAP.md, seam R6): event / result PRESENTATION pulled out of the
+## main_ui.gd monolith. This owns the "engine event/result -> on-screen feedback" translation:
+## an executed action's result, an achievement unlock, and an engine error each become feed-log
+## lines (and, for errors, the PLAN-screen toast). main_ui is now a thin view -- it wires the
+## GameManager/achievements signals to one-line shims that forward here.
+##
+## This is a NON-FORKING extraction: every statement below is a VERBATIM move of presentation
+## that previously lived inline in main_ui (_on_action_executed / _on_achievement_unlocked /
+## _on_error_occurred + the _format_deltas helper). No gameplay/RNG/scoring change -- the same
+## result Dictionaries produce the same feed lines. Ladder stays put.
+##
+## What this owns (was inline in the view):
+##   * present_action_result(result)  -- was _on_action_executed's body: main feed line (honouring
+##                                        the "flavour" channel so the arxiv-flood filter can
+##                                        collapse it), the EE-7 delta summary, and any extra
+##                                        `messages`.
+##   * present_achievement(achievement) -- was _on_achievement_unlocked: the L8 unlock feed line.
+##   * present_error(error_msg)         -- was _on_error_occurred: the red ERROR feed line plus the
+##                                        PLAN-screen toast (surfaced where the player is acting).
+##   * _format_deltas(deltas)           -- the EE-7 BBCode delta formatter, used only here.
+##
+## What STAYS in the view (main_ui), on purpose -- these are NOT event/result presentation:
+##   * log_message / _feed_lines / _render_feed / _feed_passes_filter and the feed-filter toggle
+##     handlers -- the feed MODEL + rendering substrate that this presenter WRITES INTO. It is
+##     shared by dozens of call sites across the view (phase changes, hiring, etc.), so it stays
+##     in the view and the presenter writes through `host.log_message(...)`, exactly as
+##     ActionBarRenderer (CARVE 5) writes through host for the surfaces it does not own.
+##   * plan_screen -- the view owns the PLAN screen node; present_error reaches it via
+##     host.plan_screen.flash_error(...), unchanged.
+
+var host  # MainUI node (untyped: avoids a class_name coupling cycle main_ui <-> presenter)
+
+
+func _init(h = null) -> void:
+	host = h
+
+
+# --- Executed-action result (was main_ui._on_action_executed) -----------------------------
+
+func present_action_result(result: Dictionary) -> void:
+	print("[MainUI] Action executed: ", result)
+
+	var message = result.get("message", "Action completed")
+	# P0: FEED items carry a channel ("flavour" for the arxiv stream) so the feed filter can
+	# collapse the spam. FEED lines are already BBCode-coloured; don't re-wrap them in lime.
+	var channel := String(result.get("channel", "normal"))
+	if channel != "normal":
+		host.log_message(message, channel)
+	else:
+		host.log_message("[color=lime]" + message + "[/color]")
+
+	# EE-7: resource-affecting events/actions state their applied deltas explicitly
+	var deltas: Dictionary = result.get("deltas", {})
+	if not deltas.is_empty():
+		host.log_message("[color=gray]  `- delta[/color] " + _format_deltas(deltas))
+
+	# Show any additional messages from action
+	if result.has("messages"):
+		for msg in result.get("messages", []):
+			host.log_message("[color=white]  " + str(msg) + "[/color]")
+
+	# Note: GameManager now handles auto-starting next turn
+
+
+# --- Achievement unlock (was main_ui._on_achievement_unlocked) ----------------------------
+
+func present_achievement(achievement: Dictionary) -> void:
+	"""L8 (#619): surface unlocks in the message log. Recognition only (ADR-0002)."""
+	host.log_message("[color=gold]* Achievement -- %s:[/color] [color=gray]%s[/color]" % [
+		achievement.get("title", "?"), achievement.get("flavor", "")])
+
+
+# --- Engine error (was main_ui._on_error_occurred) ----------------------------------------
+
+func present_error(error_msg: String) -> void:
+	print("[MainUI] Error: ", error_msg)
+	host.log_message("[color=red]ERROR: " + error_msg + "[/color]")
+	# Also surface it ON the PLAN screen where the player is acting (playtest 2026-07-24): the
+	# feed above is WATCH-only (hidden in PLAN mode), so an action-queue rejection like "Not
+	# enough Attention" / "Cannot afford ..." was previously invisible while planning. The toast
+	# is hidden unless PLAN is the active screen, so this is additive, not duplicate noise.
+	if host.plan_screen != null and is_instance_valid(host.plan_screen):
+		host.plan_screen.flash_error(error_msg)
+
+
+# --- Delta formatting helper (was main_ui._format_deltas) ---------------------------------
+
+func _format_deltas(deltas: Dictionary) -> String:
+	"""EE-7: BBCode-coloured 'money +$20k, doom +3.0' summary for the message log --
+	resource-affecting events state their deltas instead of burying them in prose."""
+	var order := ["money", "compute", "research", "papers", "reputation", "doom"]
+	var parts := []
+	for key in order:
+		if not deltas.has(key):
+			continue
+		var d: float = float(deltas[key])
+		var txt: String
+		if key == "money":
+			txt = ("+" if d > 0.0 else "-") + GameConfig.format_money(absf(d))
+		else:
+			txt = "%+.1f" % d
+		var good: bool = (d < 0.0) if key == "doom" else (d > 0.0)
+		parts.append("[color=%s]%s %s[/color]" % ["lime" if good else "red", key, txt])
+	return ", ".join(parts)

--- a/godot/scripts/ui/event_result_presenter.gd.uid
+++ b/godot/scripts/ui/event_result_presenter.gd.uid
@@ -1,0 +1,1 @@
+uid://b4nbvfrgrifb5

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -72,6 +72,11 @@ var travel_panel: TravelPanelController
 # _on_actions_available() shim (stores _last_actions for layout flips) and still owns input
 # (_on_dynamic_action_pressed), hover (_on_action_hover), and the shared delegates.
 var action_bar: ActionBarRenderer
+# CARVE 6 (R6, docs/MAIN_UI_SEAM_MAP.md): the event/result PRESENTATION -- turning an executed
+# action's result, an achievement unlock, or an engine error into feed-log lines (+ the PLAN
+# error toast) -- lives in EventResultPresenter now. main_ui keeps thin signal shims that forward
+# here and still owns the feed MODEL/rendering (log_message) the presenter writes through.
+var event_result_presenter: EventResultPresenter
 var research_quality_selector  # Issue #500
 var doom_trend_graph  # #512 doom trend sparkline (script-instantiated)
 var doom_breakdown  # #578 colour-coded per-source doom "blow-by-blow" (script-instantiated)
@@ -160,6 +165,11 @@ func _ready():
 	# first-lever nudge / strategic-unlock fanfare. Variant-ready: a dev-mode display variant plugs
 	# into render()'s layout dispatch (see action_bar_renderer.gd VARIANT PLUG POINT).
 	action_bar = ActionBarRenderer.new(self)
+
+	# CARVE 6 (R6): stand up the event/result presenter (executed-action result, achievement
+	# unlock, engine error -> feed feedback). It composes this view: it writes through
+	# host.log_message() and reaches host.plan_screen for the error toast.
+	event_result_presenter = EventResultPresenter.new(self)
 
 	# P0 rage-quit friction (playtest 2026-07-17): during a run, a window-close (X / Alt+F4)
 	# should return to the Main Menu instead of quitting straight to desktop. We take over the
@@ -1087,24 +1097,6 @@ func _render_delta_chip(key: String, d: float) -> void:
 	chip.add_theme_color_override("font_color", _DELTA_GOOD if good else _DELTA_BAD)
 
 
-func _format_deltas(deltas: Dictionary) -> String:
-	"""EE-7: BBCode-coloured 'money +$20k, doom +3.0' summary for the message log --
-	resource-affecting events state their deltas instead of burying them in prose."""
-	var order := ["money", "compute", "research", "papers", "reputation", "doom"]
-	var parts := []
-	for key in order:
-		if not deltas.has(key):
-			continue
-		var d: float = float(deltas[key])
-		var txt: String
-		if key == "money":
-			txt = ("+" if d > 0.0 else "-") + GameConfig.format_money(absf(d))
-		else:
-			txt = "%+.1f" % d
-		var good: bool = (d < 0.0) if key == "doom" else (d > 0.0)
-		parts.append("[color=%s]%s %s[/color]" % ["lime" if good else "red", key, txt])
-	return ", ".join(parts)
-
 func _on_turn_phase_changed(phase_name: String):
 	print("[MainUI] Phase changed: ", phase_name)
 
@@ -1142,43 +1134,17 @@ func _on_turn_phase_changed(phase_name: String):
 	log_message("[color=magenta]Turn Phase: " + phase_name + "[/color]")
 
 func _on_action_executed(result: Dictionary):
-	print("[MainUI] Action executed: ", result)
-
-	var message = result.get("message", "Action completed")
-	# P0: FEED items carry a channel ("flavour" for the arxiv stream) so the feed filter can
-	# collapse the spam. FEED lines are already BBCode-coloured; don't re-wrap them in lime.
-	var channel := String(result.get("channel", "normal"))
-	if channel != "normal":
-		log_message(message, channel)
-	else:
-		log_message("[color=lime]" + message + "[/color]")
-
-	# EE-7: resource-affecting events/actions state their applied deltas explicitly
-	var deltas: Dictionary = result.get("deltas", {})
-	if not deltas.is_empty():
-		log_message("[color=gray]  `- delta[/color] " + _format_deltas(deltas))
-
-	# Show any additional messages from action
-	if result.has("messages"):
-		for msg in result.get("messages", []):
-			log_message("[color=white]  " + str(msg) + "[/color]")
-
-	# Note: GameManager now handles auto-starting next turn
+	# CARVE 6 (R6): thin view shim. Result -> feed presentation lives in EventResultPresenter now.
+	event_result_presenter.present_action_result(result)
 
 func _on_achievement_unlocked(achievement: Dictionary) -> void:
-	"""L8 (#619): surface unlocks in the message log. Recognition only (ADR-0002)."""
-	log_message("[color=gold]* Achievement -- %s:[/color] [color=gray]%s[/color]" % [
-		achievement.get("title", "?"), achievement.get("flavor", "")])
+	# CARVE 6 (R6): thin view shim. Unlock -> feed presentation lives in EventResultPresenter now.
+	event_result_presenter.present_achievement(achievement)
 
 func _on_error_occurred(error_msg: String):
-	print("[MainUI] Error: ", error_msg)
-	log_message("[color=red]ERROR: " + error_msg + "[/color]")
-	# Also surface it ON the PLAN screen where the player is acting (playtest 2026-07-24): the
-	# feed above is WATCH-only (hidden in PLAN mode), so an action-queue rejection like "Not
-	# enough Attention" / "Cannot afford ..." was previously invisible while planning. The toast
-	# is hidden unless PLAN is the active screen, so this is additive, not duplicate noise.
-	if plan_screen != null and is_instance_valid(plan_screen):
-		plan_screen.flash_error(error_msg)
+	# CARVE 6 (R6): thin view shim. Error -> feed + PLAN-toast presentation lives in
+	# EventResultPresenter now.
+	event_result_presenter.present_error(error_msg)
 
 func _notification(what: int) -> void:
 	# P0 rage-quit friction: intercept the window-manager close during a run and route to the


### PR DESCRIPTION
## CARVE 6 -- R6 event/result presentation -> EventResultPresenter

Sixth carve of the `main_ui.gd` de-monolithing (docs/MAIN_UI_SEAM_MAP.md). Extracts the **R6 "Event / result presentation"** seam into a new RefCounted `godot/scripts/ui/event_result_presenter.gd`, following the CARVE 1-5 controller pattern (holds a `host` ref back to the view; `main_ui` instantiates and delegates).

### What moved
- `present_action_result(result)` -- was `_on_action_executed` body (main feed line honouring the `flavour` channel, the EE-7 delta summary, extra `messages`).
- `present_achievement(achievement)` -- was `_on_achievement_unlocked` (L8 unlock line).
- `present_error(error_msg)` -- was `_on_error_occurred` (red ERROR line + PLAN-screen toast).
- `_format_deltas(deltas)` -- the EE-7 BBCode delta formatter (used only here).

`main_ui` keeps thin signal shims (`_on_action_executed` / `_on_achievement_unlocked` / `_on_error_occurred`) that forward to the presenter, and still owns the feed MODEL (`log_message` + filters) the presenter writes through -- exactly as ActionBarRenderer (CARVE 5) writes through host for surfaces it does not own. The signal wiring is unchanged.

R6's other listed function, `_hiring_action_result`, already moved with CARVE 3 (HiringPanelController); the seam map was stale on that point and is corrected here.

### Non-forking
Every moved statement is verbatim -- the same result Dictionaries produce the same feed lines. No gameplay/RNG/scoring change; ships as a build patch, ladder stays put.

### Test gate (fast, `--quick --ci-mode --min-tests 300`)
- **Before:** 647 tests, 0 failures (GREEN)
- **After:** 647 tests, 0 failures (GREEN)

### Line count
`main_ui.gd`: **1974 -> 1940** (-34). New `event_result_presenter.gd`: 106 lines.

Seam map updated: R6 marked CARVED with the new controller file + line count.

Do NOT merge -- Pip reviews agent PRs first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)