### PR TITLE
docs(readme): de-stale version/download/nomenclature; version-agnostic download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## Download & Play
 
-**Latest version: v0.11.0** -- Windows build:
+Grab the **[latest release](https://github.com/PipFoweraker/pdoom1/releases/latest)** -- Windows build:
 
-- **[Windows](https://github.com/PipFoweraker/pdoom1/releases/download/v0.11.0/PDoom.exe)** -- download and run. No installer.
+- **[Windows](https://github.com/PipFoweraker/pdoom1/releases/latest/download/PDoom.exe)** -- download and run. No installer.
 
 Linux and macOS builds are not published yet. Until they are, run from source with Godot 4.5.1 (see [For Developers](#for-developers)).
 
@@ -31,7 +31,7 @@ You run an underfunded AI safety lab while better-resourced competitors race tow
 - BOOK **[How to Play](docs/PLAYERGUIDE.md)** - Game mechanics and strategy
 - HELP **[Discussions](https://github.com/PipFoweraker/pdoom1/discussions)** - Questions and community
 - GLOBAL **[Website](https://pdoom1.com)** - Guides, community, and updates
-- MAP **[Roadmap](docs/ROADMAP.md)** - Where the game is headed (milestones + quarterly pins)
+- MAP **[Roadmap](docs/ROADMAP.md)** - Where the game is headed (milestones + monthly Themes)
 - **Report a Bug** -- Press **`N`** in-game (or use the on-screen Report Bug button), or [open an issue](https://github.com/PipFoweraker/pdoom1/issues)
 
 ## Community & Contributing
@@ -53,7 +53,7 @@ Learn more: **[Contributor Rewards Program](docs/CONTRIBUTOR_REWARDS.md)**
 Want to contribute or build from source?
 
 - **[Contributing](CONTRIBUTING.md)** - Get started
-- **[Architecture](docs/developer/ARCHITECTURE.md)** - Codebase overview
+- **[Architecture](docs/ARCHITECTURE.md)** - Codebase overview
 - **[Full Changelog](CHANGELOG.md)** - Version history
 
 **Built with Godot 4.5.1** | **Source-available -- see [LICENSE](LICENSE)**


### PR DESCRIPTION
Fixes stale facts on the player-facing README (public repo front door), and makes the download section version-agnostic so it stops rotting every release/epoch.

## Stale items fixed
1. **Version line** -- was `**Latest version: v0.11.0**` (we ship 0.13.1). Reworded to drop the hardcoded number entirely: now links the words "latest release" to `releases/latest`, so it never goes stale again.
2. **Windows download link** -- was pinned at `releases/download/v0.11.0/PDoom.exe`. Now `releases/latest/download/PDoom.exe`, GitHub's auto-latest URL that always resolves to the newest published release's `PDoom.exe` asset.
3. **Roadmap nomenclature** -- "milestones + quarterly pins" -> "milestones + monthly Themes" ("quarterly pins" is retired nomenclature per docs/ROADMAP.md + docs/RELEASE_NOMENCLATURE.md).
4. **Architecture link** -- repointed from `docs/developer/ARCHITECTURE.md` to `docs/ARCHITECTURE.md`, the canonical maintained systems->code->ADR map that CLAUDE.md treats as READ-FIRST SSOT. (Both files exist; the developer/ copy is a shorter secondary overview -- pointing at the canonical one is the anti-staleness choice.)

## Preserved
- Voice, prose, structure, and the ASCII-chrome markers (BOOK/HELP/GLOBAL/MAP) -- all kept.
- License line left as-is ("Source-available -- see [LICENSE]") per instructions.

## Scanned, left alone (all verified to resolve)
- All other relative links checked and resolve: docs/PLAYERGUIDE.md, docs/ROADMAP.md, docs/CONTRIBUTOR_REWARDS.md, CONTRIBUTING.md, CHANGELOG.md, LICENSE, the screenshot. No other clear-cut stale factual claims found.

Diff is 4 lines changed, ASCII-only, all pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)