### PR TITLE
fix(ui): dismiss bug-report before opening ledger -- prevents stacked-modal soft-lock

### DIFF
--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -2730,6 +2730,13 @@ func _show_ledger_screen():
 	"""BL-1/#601: open the full Liability Ledger screen. #622 L10: the panel itself is
 	built by LedgerScreen; this stays the single entry point (L key, summary click,
 	financing submenu, dev overlay) and owns the active_dialog bookkeeping."""
+	# fix/ledger-stacked-modal: the Bug Report panel is an independent modal with a
+	# focused LineEdit/TextEdit. The #575 text-focus gate suppresses global keys
+	# (Esc/L) while that field is focused, so a ledger stacked ON TOP of an open bug
+	# report becomes un-closeable (soft-lock). Dismiss the bug report first, releasing
+	# its text focus, so the ledger's own close keys keep working.
+	if bug_report_panel and bug_report_panel.visible:
+		bug_report_panel.hide_panel()
 	if active_dialog != null and is_instance_valid(active_dialog):
 		active_dialog.queue_free()
 		active_dialog = null


### PR DESCRIPTION
## Problem
The Liability Ledger and the Bug Report panel are two independent modal systems. The #575 text-focus gate ("ignore global keys while a LineEdit/TextEdit is focused") means that when the Bug Report form is open+focused UNDERNEATH the ledger, the ledger's own ESC/L close keys get suppressed, so the ledger appears un-closeable (soft-lock).

Reachable only one way: Bug Report opened first, then the ledger opened (by clicking its summary button) on top.

## Fix
At the top of `_show_ledger_screen()` in `godot/scripts/ui/main_ui.gd`, before the ledger is built/shown, dismiss the bug report panel if it is visible. `hide_panel()` releases the panel's text focus (and its mouse-capture), so the ledger's close keys keep working. This prevents the offending stack from forming rather than reworking the modal-key routing.

```gdscript
if bug_report_panel and bug_report_panel.visible:
    bug_report_panel.hide_panel()
```

## Verification
- Fast gate green: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> 607 tests, 0 failures, 68/68 files collected. GDScript syntax/import pass clean.

## Notes
- **Non-forking**: UI-only change, ladder stays **L2**. No data/schema/version touched.
- **Edge-case fix**: only affects the bug-report-then-ledger open order.
- A proper LIFO modal-stack fix (so any stacked modal closes top-first) is tracked separately for main; this is the minimal release-branch hotpatch.

Base branch is `release/v0.13` (CARVE-FREE pre-carve tree), not main.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)