### PR TITLE
fix(ui): free prior active_dialog when an event opens over it -- fixes orphaned un-closeable ledger (non-forking, L2)

### DIFF
--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -3844,6 +3844,12 @@ func _on_event_dialog_opened(dialog: Control, buttons: Array) -> void:
 	"""EventDialog put its modal up (#622) -- route MainUI keyboard shortcuts to it.
 	The dialog carries the is_event_dialog meta, so ESC handling keeps refusing to
 	close it (#452)."""
+	# An event can fire while a submenu/ledger is already open. Overwriting active_dialog
+	# without freeing the prior panel ORPHANS it (visible at z=1000 with its input barrier,
+	# but untracked -> Esc/L/N no longer close it). Free it first so the visible overlay and
+	# the tracked slot can never diverge. (Mirrors _on_employee_dialog_opened.)
+	if active_dialog != null and is_instance_valid(active_dialog) and active_dialog != dialog:
+		active_dialog.queue_free()
 	active_dialog = dialog
 	active_dialog_buttons = buttons
 


### PR DESCRIPTION
## Root cause

An event can fire while the ledger (or any submenu dialog) is already open. `_on_event_dialog_opened(dialog, buttons)` in `godot/scripts/ui/main_ui.gd` overwrote the single `active_dialog` slot **without freeing the prior occupant**. The old panel stayed on screen at z=1000 with its input barrier still live, but was no longer the *tracked* `active_dialog`, so Esc / L / N could no longer close it -- a visible-but-un-closeable orphan, i.e. the ledger soft-lock.

## The fix

Adds a free-first guard immediately before the `active_dialog = dialog` assignment, mirroring the proven idiom already used by the sibling `_on_employee_dialog_opened`:

```gdscript
if active_dialog != null and is_instance_valid(active_dialog) and active_dialog != dialog:
    active_dialog.queue_free()
active_dialog = dialog
```

This keeps the visible overlay and the tracked slot from ever diverging. The existing `active_dialog_buttons = buttons` line is untouched.

This is the **correct root-cause fix** for the ledger soft-lock and **supersedes the insufficient guard in #879** (which did not free the prior panel, so the orphan could still occur). See #877 for the proper scene/dialog chokepoint follow-up.

## Ladder / release

**Non-forking** -- pure UI-state fix, no data/version/board-key change, so the update ladder stays **L2**.

## Test

Fast gate GREEN: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **607 tests, 0 failures, 68/68 files**.

Do NOT merge -- for Pip's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)