### PR TITLE
fix(ui): free prior active_dialog when an event opens over it (main) -- non-forking

### DIFF
--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -1784,6 +1784,12 @@ func _on_event_dialog_opened(dialog: Control, buttons: Array) -> void:
 	"""EventDialog put its modal up (#622) -- route MainUI keyboard shortcuts to it.
 	The dialog carries the is_event_dialog meta, so ESC handling keeps refusing to
 	close it (#452)."""
+	# An event can fire while a submenu/ledger is already open. Overwriting active_dialog
+	# without freeing the prior panel ORPHANS it (visible with its input barrier, but
+	# untracked -> Esc/L/N no longer close it). Free it first so the visible overlay and
+	# the tracked slot can never diverge. (Mirrors _on_employee_dialog_opened.)
+	if active_dialog != null and is_instance_valid(active_dialog) and active_dialog != dialog:
+		active_dialog.queue_free()
 	active_dialog = dialog
 	active_dialog_buttons = buttons
 


### PR DESCRIPTION
Main-branch counterpart of #883 (which landed the same fix on release/v0.13).

## The bug
`_on_event_dialog_opened(dialog, buttons)` in `godot/scripts/ui/main_ui.gd` did a bare `active_dialog = dialog` without freeing the prior occupant. An event firing while a submenu/ledger is already open orphans that panel into a visible-but-uncloseable state (its input barrier stays up, but the tracked slot no longer points at it, so Esc/L/N cannot close it).

A static audit confirmed `main` carries the identical bug (line numbers differ from release/v0.13 -- `main` is the carved version; the function is at line 1783 here).

## The fix (minimal, non-forking)
Insert the proven free-first guard immediately before the `active_dialog = dialog` assignment, copying the idiom already used by the sibling `_on_employee_dialog_opened` in the same file. The visible overlay and the tracked slot can no longer diverge.

## Verification
- `_on_event_dialog_opened` confirmed present and previously lacking the guard.
- `_on_employee_dialog_opened` confirmed as the source of the copied pattern.
- Fast gate green: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> 647 tests, 0 failures, 74/74 files.

Chokepoint follow-up tracked in #877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)