### PR TITLE
fix(ui): tie staff-card blocker to panel lifetime -- fixes ESC dead-mouse soft-lock

### DIFF
--- a/godot/scripts/ui/employee_panel.gd
+++ b/godot/scripts/ui/employee_panel.gd
@@ -196,11 +196,15 @@ func show_staff_id_card(data: Dictionary) -> void:
 	blocker.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	blocker.z_index = 998
 
-	# Click on blocker closes panel
+	# Click on blocker closes panel. Free the blocker FIRST (and guard both frees) so a
+	# panel that was already freed out from under us can't strand the blocker (see the
+	# tree_exited tie-off below -- this lambda is the belt to that suspenders).
 	blocker.gui_input.connect(func(event):
 		if event is InputEventMouseButton and event.pressed:
-			perks_panel.queue_free()
-			blocker.queue_free()
+			if is_instance_valid(blocker):
+				blocker.queue_free()
+			if is_instance_valid(perks_panel):
+				perks_panel.queue_free()
 			dialog_closed.emit()
 	)
 
@@ -211,10 +215,23 @@ func show_staff_id_card(data: Dictionary) -> void:
 	perks_panel.z_index = 999
 	perks_panel.visible = true
 
+	# Tie the blocker's lifetime to the panel it belongs to. When the panel leaves the
+	# tree via ANY path -- ESC (host's _close_active_submenu frees active_dialog only),
+	# a replacing dialog's queue_free, or the close/click lambdas below -- free the
+	# blocker too. Without this the ESC path frees perks_panel but leaves the z=998
+	# MOUSE_FILTER_STOP blocker swallowing every click forever (dead UI). Mirrors
+	# main_ui.gd _present_modal_dialog's `dialog.tree_exited.connect(barrier.queue_free)`.
+	perks_panel.tree_exited.connect(func():
+		if is_instance_valid(blocker):
+			blocker.queue_free()
+	)
+
 	# Connect signals
 	perks_panel.close_requested.connect(func():
-		perks_panel.queue_free()
-		blocker.queue_free()
+		if is_instance_valid(blocker):
+			blocker.queue_free()
+		if is_instance_valid(perks_panel):
+			perks_panel.queue_free()
 		dialog_closed.emit()
 	)
 


### PR DESCRIPTION
## The bug (solo-reachable ship-blocker, found by adversarial fuzz -- #886)

Open a staff/employee ID card (hire someone -> click their roster entry -> `EmployeePanel` opens), then press **ESC**.

- MainUI's ESC handler calls `_close_active_submenu()`, which frees `active_dialog` (== the perks panel) but **nothing else**.
- `EmployeePanel` also raises its OWN full-rect `z=998` `MOUSE_FILTER_STOP` blocker behind the panel.
- That blocker was torn down ONLY by the panel's own click/close lambdas -- and those lambdas free `perks_panel` first, capturing the now-freed panel.
- So on the ESC path the panel is freed out from under the lambdas; the blocker is **orphaned** and swallows every mouse click forever = **dead UI**. Double-opening the card stacks two unclosable blockers.

## The fix

Tie the blocker's lifetime to the panel it belongs to, mirroring the codebase's own correct idiom in `main_ui.gd::_present_modal_dialog` (`dialog.tree_exited.connect(barrier.queue_free)`):

```gdscript
perks_panel.tree_exited.connect(func():
    if is_instance_valid(blocker):
        blocker.queue_free()
)
```

Now the blocker is freed whenever the panel leaves the tree by **ANY** path (ESC, a replacing dialog's `queue_free`, click-outside, or the close button).

Belt-and-suspenders: the existing click/close lambdas are also hardened -- each `queue_free()` is guarded with `is_instance_valid(...)`, and the blocker is freed **before** the panel, so a freed panel can't strand the blocker even without the signal.

## Why ESC now tears down the blocker

`_close_active_submenu()` -> `active_dialog.queue_free()` frees `perks_panel` -> Godot emits `perks_panel.tree_exited` when it leaves the tree -> the connected lambda frees the blocker. Dead-mouse gone.

## Scope / risk

- **Non-forking**: pure UI-lifecycle fix in `employee_panel.gd` only. No game-state, economy, or leaderboard board-key impact. L2.
- No other dialogs touched.

## Verification

Fast gate GREEN: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **607 tests, 0 failures, 68/68 files collected.**

Refs #886 (adversarial fuzz found it), #877 (scene-nav / chokepoint follow-up).

Do NOT merge -- Pip reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)