### PR TITLE
chore(tools): home art-review pipeline in tools/art_review + README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,14 @@ generated_icons/
 asset_gallery.html
 # Local art-review app state (per-reviewer verdicts/notes; written by serve_review.py)
 tools/art_review/review_state.json
+# Art-review pipeline regenerable artifacts (see tools/art_review/README.md).
+# The generators + analyzer + art_source/pixellab_verdicts.json ARE tracked;
+# these outputs are re-created by re-running the tools, so keep them out of git.
+art_source/pixellab_contact_sheet.html
+art_source/promote_list.txt
+art_source/favour_list.txt
+art_source/disfavour_dislike_list.txt
+art_generated/hero_gallery.html
 test_output.png
 test_openai_api.py
 generate_icons.py

--- a/art_source/pixellab_verdicts.json
+++ b/art_source/pixellab_verdicts.json
@@ -1,0 +1,2498 @@
+{
+  "pixellab_2026-07-16/08-V8-fullcolor-chibi-hightopdown_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/08-V8-fullcolor-chibi-hightopdown_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/08-V8-fullcolor-chibi-hightopdown_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/08-V8-fullcolor-chibi-hightopdown_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/09-V9-heroic-fullcolor_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/09-V9-heroic-fullcolor_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/09-V9-heroic-fullcolor_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/09-V9-heroic-fullcolor_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/10-C1-V4-cozywarm_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/10-C1-V4-cozywarm_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/10-C1-V4-cozywarm_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/10-C1-V4-cozywarm_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/11-C2-V5-cozygrim-chibi_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/11-C2-V5-cozygrim-chibi_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/11-C2-V5-cozygrim-chibi_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/11-C2-V5-cozygrim-chibi_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/12-C3-cast-burnedout-senior_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/12-C3-cast-burnedout-senior_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/12-C3-cast-burnedout-senior_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/12-C3-cast-burnedout-senior_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/13-C4-cast-eccentric-junior_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/13-C4-cast-eccentric-junior_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/13-C4-cast-eccentric-junior_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/13-C4-cast-eccentric-junior_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/14-C5-cast-south-asian-man_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/14-C5-cast-south-asian-man_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/14-C5-cast-south-asian-man_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/14-C5-cast-south-asian-man_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/15-Cat1-singed-tabby_east.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/15-Cat1-singed-tabby_north.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/15-Cat1-singed-tabby_south.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/15-Cat1-singed-tabby_west.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/16-Cat2-spooky-doom_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/16-Cat2-spooky-doom_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/16-Cat2-spooky-doom_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/16-Cat2-spooky-doom_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/19-Cat1-tophat_east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/19-Cat1-tophat_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/19-Cat1-tophat_south.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/19-Cat1-tophat_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/20-Cat2-spooky-tophat_east.png": [
+    "favour"
+  ],
+  "pixellab_2026-07-16/20-Cat2-spooky-tophat_north.png": [
+    "favour"
+  ],
+  "pixellab_2026-07-16/20-Cat2-spooky-tophat_south.png": [
+    "favour"
+  ],
+  "pixellab_2026-07-16/20-Cat2-spooky-tophat_west.png": [
+    "favour"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_0.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_5.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_6.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_7.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_8.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_0.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_5.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_6.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_7.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_8.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_0.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_5.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_6.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_7.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_8.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_0.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_5.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_6.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_7.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_8.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_0.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_1.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_2.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_3.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_4.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_5.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_6.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_7.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_8.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_0.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_1.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_2.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_3.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_4.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_5.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_6.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_7.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_8.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_0.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_1.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_2.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_3.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_4.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_5.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_6.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_7.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_8.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_0.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_1.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_2.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_3.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_4.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_5.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_6.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_7.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_8.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_eldritch_1.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_eldritch_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_purple_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_eldritch_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_purple_4.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_purple_3.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_purple_2.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/cast_woman_lead_older_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/cast_woman_lead_older_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/cast_woman_lead_older_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/cast_woman_lead_older_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/founder_silhouette_1.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/founder_silhouette_2.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/founder_silhouette_3.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/founder_silhouette_4.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_1.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_1_north-east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_1_north-west.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_1_north.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_south-east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_south-west.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_west.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_north-west.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_north-east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_north-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_north-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_south-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_south-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_north-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_north-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_south-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_south-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2_east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2_north-east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2_north-west.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2_north.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_east.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_north-east.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_north-west.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_north.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_south-east.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_south-west.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_west.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/characters/cast_eccentric_genius_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/characters/cast_eccentric_genius_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/characters/cast_eccentric_genius_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/characters/cast_eccentric_genius_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/founder/founder_2.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/founder/founder_1.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/founder/founder_3.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/founder/founder_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_north-east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_north-west.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_north.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_south-east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_south-west.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_west.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_north-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_north-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_south-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_south-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_2_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/floor_carpet.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/floor_concrete.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/floor_lino.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/wall_decent.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/wall_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/floor_carpet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/floor_concrete_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/floor_lino_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/wall_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/wall_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/floor_carpet.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/floor_concrete.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/floor_lino.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/wall_decent.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/wall_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/17-Operator-silhouette_east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/17-Operator-silhouette_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/17-Operator-silhouette_south.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/17-Operator-silhouette_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/18-Hat-tall.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_medium_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_medium_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_medium_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_medium_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_sports_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_sports_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_sports_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_sports_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/headphones_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/headphones_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/headphones_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/headphones_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lab_coat_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lab_coat_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lab_coat_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lab_coat_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lanyard_badge_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lanyard_badge_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lanyard_badge_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lanyard_badge_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/hat_medium_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/hat_medium_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/hat_sports_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/hat_sports_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/lab_coat_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/lab_coat_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/bookshelf.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/chair.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/coat_rack.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/couch.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/plant.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/server_rack.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/water_cooler.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/whiteboard.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/cat_bed_basket.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/cat_litter_box.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/coffee_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/coffee_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/desk_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/desk_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/fridge_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/fridge_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/hat_tall.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/monitor_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/monitor_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/pc_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/pc_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/window_clean.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/props/window_scummy.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_decent_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_decent_2.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_decent_3.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_decent_4.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_scummy_1.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_scummy_2.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_scummy_3.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_scummy_4.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_carpet_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_carpet_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_carpet_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_concrete_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_concrete_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_concrete_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_concrete_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_lino_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_lino_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_lino_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_lino_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_decent_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_decent_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_decent_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_decent_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_scummy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_scummy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_scummy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_clear_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_clear_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_clear_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_clear_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_doomy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_doomy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_doomy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_doomy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_storm_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_storm_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_storm_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_storm_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_decent_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_decent_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/coat_rack_reroll_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/coat_rack_reroll_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/coat_rack_reroll_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/coat_rack_reroll_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/desk_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/desk_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/desk_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/desk_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/filing_cabinet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/filing_cabinet_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/filing_cabinet_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/filing_cabinet_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_decent_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_decent_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_scummy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_scummy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_scummy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/meeting_table_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/meeting_table_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/meeting_table_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/meeting_table_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/monitor_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/monitor_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/monitor_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/monitor_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/pc_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/pc_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/pc_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/pc_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/printer_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/printer_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/printer_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/printer_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/server_cluster_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/server_cluster_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/server_cluster_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/server_cluster_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/trash_can_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/trash_can_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/trash_can_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/trash_can_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/water_cooler_reroll_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/water_cooler_reroll_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/water_cooler_reroll_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/water_cooler_reroll_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_compute_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_compute_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_compute_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_compute_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_doom_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_doom_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_doom_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_doom_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_indicator_dot_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_indicator_dot_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_indicator_dot_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_indicator_dot_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_texture_tile_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_texture_tile_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_texture_tile_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_texture_tile_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_compute_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_compute_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_compute_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_compute_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_doom_1.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_doom_2.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_doom_3.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_doom_4.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/chair_decent_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/chair_decent_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/chair_decent_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/chair_decent_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/coat_rack_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/coat_rack_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/coat_rack_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/coat_rack_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/desk_mega_screen_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/desk_mega_screen_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/desk_mega_screen_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/desk_mega_screen_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/filing_cabinet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/filing_cabinet_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/filing_cabinet_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/filing_cabinet_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_decent_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_decent_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_scummy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_scummy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_scummy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/meeting_table_1.png": [
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/objects/meeting_table_2.png": [
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/objects/meeting_table_3.png": [
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/objects/meeting_table_4.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/monitor_mega_startup_1.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/monitor_mega_startup_2.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/monitor_mega_startup_3.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/monitor_mega_startup_4.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/pc_mega_1.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/pc_mega_2.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/pc_mega_3.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/pc_mega_4.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/server_cluster_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/server_cluster_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/server_cluster_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/server_cluster_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/trash_recycling_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/trash_recycling_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/trash_recycling_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/trash_recycling_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/water_cooler_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/water_cooler_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/water_cooler_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/water_cooler_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_clear_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_clear_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_clear_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_clear_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_doomy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_doomy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_doomy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_doomy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_storm_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_storm_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_storm_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_storm_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/window_frame_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/window_frame_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/window_frame_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/window_frame_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/armchair_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/bookshelf_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/box_stack_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/cable_spool_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/cardboard_box_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/chair_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/chair_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/chair_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/coat_rack_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/coffee_machine_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/corkboard_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/couch_waiting_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/desk_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/desk_lamp_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/desk_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/desk_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/exit_sign_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/filing_cabinet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/filing_cabinet_tall_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/fire_extinguisher_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/floor_lamp_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/kitchen_bench_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/kitchen_bench_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/laptop_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/microwave_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/mini_fridge_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/monitor_doomcurve_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/monitor_dual_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/monitor_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/monitor_single_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/office_phone_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/pc_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/pc_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/plant_dead_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/plant_small_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/plant_tall_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/printer_mega_copier_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/printer_small_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/recycling_bin_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/server_cluster_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/server_rack_single_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/snack_table_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/standing_whiteboard_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/trash_can_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/wall_clock_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/water_cooler_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/whiteboard_blank_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/whiteboard_equations_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/chairs/chair_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/chairs/chair_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/chairs/chair_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/chairs/chair_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/kitchen/kitchen_bench_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/kitchen/kitchen_bench_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/coat_rack_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/coat_rack_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/desk_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/desk_mega_screen_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/door_scummy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/door_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/filing_cabinet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/monitor_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/monitor_mega_startup_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/pc_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/pc_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/printer_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/printer_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/server_cluster_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/trash_recycling_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/trash_recycling_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_clear_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_clear_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_doomy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_doomy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_storm_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_storm_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/window_frame_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/window_frame_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/window_frame_3.png": [
+    "like",
+    "promote"
+  ]
+}

--- a/tools/art_review/README.md
+++ b/tools/art_review/README.md
@@ -1,0 +1,144 @@
+# Art review pipeline
+
+Status: LIVE
+
+The end-to-end loop for triaging generated pixel-sprite art and turning an
+owner's opinions into an actionable generation queue. Everything here is local
+review tooling -- it never runs in CI or in the game. Python 3.11, stdlib only,
+ASCII only.
+
+Home for the tools is `tools/art_review/`; the data they read/write lives under
+`art_source/` (kept in git for art <= 1MB, per `docs/art/ART_MASTERS_POLICY.md`).
+
+## The 5-step flow
+
+```
+(1) generate contact sheet  ->  (2) triage in browser  ->  (3) export JSON
+        gen_contact_sheet.py         pixellab_contact_sheet.html      save to
+                                                                 pixellab_verdicts.json
+                                                                       |
+(5) generate toward the GAPS  <-  (4) analyze verdicts  <---------------+
+    (office sandbox / next round)     analyze_verdicts.py
+                                      -> promote/favour/prune lists
+```
+
+### 1. Generate the contact sheet
+
+```
+python tools/art_review/gen_contact_sheet.py
+```
+
+Scans `art_source/pixellab_*/` for images and writes a single self-contained
+`art_source/pixellab_contact_sheet.html` (all CSS/JS inline; thumbnails are
+`<img>` refs to the sprite files, so keep the HTML sitting inside `art_source/`
+so the relative paths resolve). Also prints a category/run breakdown to stdout.
+
+- Input:  `art_source/pixellab_*/**/*.{png,jpg,jpeg,gif,webp}`
+- Output: `art_source/pixellab_contact_sheet.html` (regenerable, gitignored)
+- Optional arg: a path to a different `art_source` dir
+  (`python tools/art_review/gen_contact_sheet.py /some/other/art_source`).
+  With no arg it resolves `art_source/` two levels up from the script, so it
+  works from any cwd.
+
+### 2. Triage in the browser
+
+Open `art_source/pixellab_contact_sheet.html` in a browser. Per sprite you can
+apply any of **5 verdict tags**:
+
+| verdict     | meaning                                             |
+|-------------|-----------------------------------------------------|
+| `like`      | good enough to keep                                 |
+| `dislike`   | bad; a prune candidate                              |
+| `favour`    | shortlist -- prefer this within its subtype         |
+| `disfavour` | de-prioritise; a prune candidate                    |
+| `promote`   | pull into the game / next generation round          |
+
+Selection + bulk tooling: per-tile checkbox, shift-click for ranges,
+"select group" / "select" (per run / per category), "select all visible", then a
+bulk apply/remove bar to stamp a verdict across the whole selection. Filter by
+filename/category/folder and by verdict. Click a thumbnail to enlarge (Esc
+closes). Verdicts persist to the browser's `localStorage`; if that is off a
+warning shows and you must Export to keep them.
+
+### 3. Export the JSON
+
+Click **export JSON** in the sheet. It downloads `pixellab_verdicts.json`.
+**Save it to `art_source/pixellab_verdicts.json`** (overwriting the tracked
+copy). This file is the valuable, non-regenerable human decision data -- it is
+tracked in git.
+
+Export JSON schema -- a flat object mapping a sprite's `art_source`-relative,
+POSIX-slash path to its list of tags:
+
+```json
+{
+  "pixellab_2026-07-16/08-V8-fullcolor-chibi_east.png": ["like", "promote"],
+  "pixellab_2026-07-17/reroll/objects/desk_decent_1.png": ["favour"]
+}
+```
+
+(There is also an "export CSV" and per-verdict "copy PROMOTE / copy FAVOUR"
+clipboard buttons for quick ad-hoc use; the analyzer below only reads the JSON.)
+
+### 4. Analyze the verdicts
+
+```
+python tools/art_review/analyze_verdicts.py
+```
+
+Reads `art_source/pixellab_verdicts.json`, re-scans the on-disk inventory (same
+classification logic as the contact sheet, so categories match exactly), and
+prints an imbalance + coverage-gap report:
+
+- verdict totals, and PROMOTE/FAVOUR broken down by category and finer subtype
+  (so `props/coat_rack 40` vs `props/bin 2` is obvious);
+- over-represented promoted subtypes per category, and under-/zero-promote
+  subtypes that DO exist in inventory (the gaps to generate toward);
+- STALE verdict paths (tagged but no longer on disk) and never-triaged counts.
+
+It also writes three actionable path lists, each grouped by `# category/subtype`:
+
+- Input:  `art_source/pixellab_verdicts.json` (+ the `art_source/pixellab_*/`
+  inventory)
+- Outputs (all regenerable, gitignored):
+  - `art_source/promote_list.txt`            -- office sandbox + generation queue
+  - `art_source/favour_list.txt`             -- shortlist
+  - `art_source/disfavour_dislike_list.txt`  -- prune / ignore
+- Optional arg: a path to a different `art_source` dir (same as the generator).
+- `--selftest` runs a synthetic self-check of the classification/aggregation
+  logic (no disk scan; used as a cheap sanity gate).
+
+### 5. Feed the gaps into the next round
+
+Take `art_source/promote_list.txt` into the office sandbox / next pixellab
+generation round, and generate toward the GAPS the analyzer surfaces (the
+under-/zero-promote subtypes), not just more of what is already over-represented.
+
+## Sibling: hero gallery
+
+`art_generated/hero_gallery.html` (if present) is a separate promoted-hero
+gallery view. `art_generated/` is gitignored wholesale, so that HTML is a
+regenerable artifact, not tracked source. (Its generator currently lives outside
+this dir; home it here if it earns a permanent place.)
+
+## What is tracked vs regenerable
+
+Tracked source (commit these):
+
+- `tools/art_review/gen_contact_sheet.py`  -- contact-sheet generator
+- `tools/art_review/analyze_verdicts.py`   -- verdict analyzer
+- `art_source/pixellab_verdicts.json`      -- the owner's triage opinions (data)
+- this `README.md`
+
+Regenerable artifacts (gitignored -- never commit; re-run the tools):
+
+- `art_source/pixellab_contact_sheet.html`
+- `art_source/promote_list.txt`
+- `art_source/favour_list.txt`
+- `art_source/disfavour_dislike_list.txt`
+- `art_generated/hero_gallery.html`
+
+Note: this dir also contains an OLDER, separate review app (`serve_review.py`,
+`build.py`, `apply_review.py`, `verdicts.json`, and the various `*.html`) from a
+prior icon/style pass. That is a different pipeline; the contact-sheet flow
+documented here is the current one for pixellab sprite triage.

--- a/tools/art_review/analyze_verdicts.py
+++ b/tools/art_review/analyze_verdicts.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""Analyze a pixellab contact-sheet triage export (verdicts JSON).
+
+Reads the verdict tags a reviewer saved from the contact sheet
+(art_source/pixellab_contact_sheet.html -> "export JSON") and cross-references
+them against the full sprite inventory on disk. Produces:
+
+  1. A verdict summary (totals + PROMOTE/FAVOUR broken down by category and by
+     the finer subtype), so an imbalance like "props/coat_rack 40, props/bin 2"
+     is obvious.
+  2. Imbalance + coverage gaps: over-represented promoted subtypes per category,
+     under-/zero-promote subtypes that DO exist in the inventory, stale verdict
+     paths (tagged but no longer on disk), and never-triaged sprites per category.
+  3. Three actionable path lists under art_source/ (promote / favour /
+     disfavour+dislike) grouped by "# category/subtype".
+
+Classification logic is copied from the contact-sheet generator
+(G:/tmp/gen_contact_sheet.py) so categories match the sheet exactly. If that
+file is gone the equivalent folder-based rules are re-implemented here (see
+categorize / categorize_by_name below) -- this script is self-contained and does
+not import it.
+
+stdlib only, Python 3.11, ASCII only. Local review tool -- not committed.
+
+Usage:
+  python tools/art_review/analyze_verdicts.py            # real run
+  python tools/art_review/analyze_verdicts.py --selftest # synthetic self-check
+"""
+import collections
+import json
+import os
+import sys
+
+# --- paths -----------------------------------------------------------------
+# Repo-relative: this script lives at <repo>/tools/art_review/, so art_source/
+# is two levels up. Override with a single CLI arg pointing at an art_source dir.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DEFAULT_ART_DIR = os.path.normpath(os.path.join(_HERE, "..", "..", "art_source"))
+ART_DIR = (
+    os.path.abspath(sys.argv[1])
+    if len(sys.argv) > 1 and not sys.argv[1].startswith("-")
+    else _DEFAULT_ART_DIR
+)
+VERDICTS_PATH = os.path.join(ART_DIR, "pixellab_verdicts.json")
+PROMOTE_OUT = os.path.join(ART_DIR, "promote_list.txt")
+FAVOUR_OUT = os.path.join(ART_DIR, "favour_list.txt")
+PRUNE_OUT = os.path.join(ART_DIR, "disfavour_dislike_list.txt")
+
+EXTS = (".png", ".jpg", ".jpeg", ".gif", ".webp")
+VERDICTS = ["like", "dislike", "favour", "disfavour", "promote"]
+CATS = ["characters", "cats", "props", "tilesets", "cosmetics", "other"]
+TOP_N = 8  # how many over-represented subtypes to list per category
+
+# tokens stripped from the tail of a filename stem to reach the "item" identity
+_DIRS = {
+    "east",
+    "west",
+    "north",
+    "south",
+    "up",
+    "down",
+    "north-east",
+    "north-west",
+    "south-east",
+    "south-west",
+    "ne",
+    "nw",
+    "se",
+    "sw",
+}
+_UNWRAP = {"reroll", "sweep"}  # container run-subfolders to skip
+_STRIP_LEAF = {"rotations"}  # trailing folder segs that aren't identity
+
+
+# --- classification (copied from gen_contact_sheet.py) ---------------------
+def categorize(rel_parts):
+    """Category from the folder segments (all segments below the run root)."""
+    segs = [s.lower() for s in rel_parts]
+
+    def has(*names):
+        return any(any(n in s for n in names) for s in segs)
+
+    if has("tileset"):
+        return "tilesets"
+    if has("cat"):
+        return "cats"
+    if has("cosmetic", "overlay"):
+        return "cosmetics"
+    if has(
+        "window",
+        "prop",
+        "object",
+        "kitchen",
+        "chair",
+        "library",
+        "environment",
+        "ui_filler",
+        "ui-filler",
+        "icon",
+    ):
+        return "props"
+    if has(
+        "character",
+        "founder",
+        "era_ladder",
+        "era-ladder",
+        "style_matrix",
+        "style-matrix",
+        "researcher",
+        "worker",
+        "genius",
+    ):
+        return "characters"
+    return None
+
+
+def categorize_by_name(fname):
+    """Fallback category for loose root sprites, from the filename."""
+    n = fname.lower()
+    if "cat" in n:
+        return "cats"
+    if "tileset" in n or "floor_" in n or "wall_" in n:
+        return "tilesets"
+    if "hat" in n or "silhouette" in n:
+        return "cosmetics"
+    return "characters"
+
+
+# --- subtype derivation ----------------------------------------------------
+def file_item(fname):
+    """Object identity from a filename: strip extension, then strip trailing
+    direction tokens (east/north-west/...) and pure-number variant tokens
+    (_1, _2). 'chair_decent_1_east.png' -> 'chair_decent';
+    'east.png' -> '' (rotation frame, identity lives in the folder)."""
+    stem = os.path.splitext(fname)[0].lower()
+    toks = stem.split("_")
+    while toks and (toks[-1] in _DIRS or toks[-1].isdigit()):
+        toks.pop()
+    return "_".join(toks)
+
+
+def unwrap_segs(dir_segs):
+    """Drop reroll/sweep container prefixes and a trailing 'rotations' seg."""
+    segs = [s for s in dir_segs if s.lower() not in _UNWRAP]
+    while segs and segs[-1].lower() in _STRIP_LEAF:
+        segs.pop()
+    return segs
+
+
+def subtype_of(cat, dir_segs, fname):
+    """Finer subtype label 'category/<item>'. Prefer the filename-derived item
+    (so props/objects splits into desk_decent, coat_rack, bin, ...); fall back
+    to the immediate folder leaf when the filename is direction-only (character
+    and cat rotation frames, whose identity is the folder name)."""
+    item = file_item(fname)
+    if not item:
+        segs = unwrap_segs(dir_segs)
+        item = segs[-1].lower() if segs else "misc"
+    return "{}/{}".format(cat, item)
+
+
+def classify_record(dir_segs, fname):
+    """Return (category, subtype) for one sprite. dir_segs are the folder
+    segments below the run root ([] for a loose root sprite)."""
+    cat = categorize(dir_segs) if dir_segs else None
+    if cat is None:
+        cat = categorize_by_name(fname)
+    if cat not in CATS:
+        cat = "other"
+    return cat, subtype_of(cat, dir_segs, fname)
+
+
+# --- inventory scan --------------------------------------------------------
+def build_inventory(art_dir):
+    """Scan art_source/pixellab_* for images. Returns list of record dicts:
+    {rel, run, cat, subtype, fn}. rel is POSIX-style, relative to art_dir
+    (matching the verdict-JSON key form)."""
+    records = []
+    if not os.path.isdir(art_dir):
+        return records
+    runs = sorted(
+        d
+        for d in os.listdir(art_dir)
+        if d.startswith("pixellab_") and os.path.isdir(os.path.join(art_dir, d))
+    )
+    for run in runs:
+        run_root = os.path.join(art_dir, run)
+        for dirpath, dirnames, filenames in os.walk(run_root):
+            dirnames.sort()
+            for fn in sorted(filenames):
+                if not fn.lower().endswith(EXTS):
+                    continue
+                abs_path = os.path.join(dirpath, fn)
+                rel = os.path.relpath(abs_path, art_dir).replace("\\", "/")
+                sub = os.path.relpath(dirpath, run_root).replace("\\", "/")
+                dir_segs = [] if sub == "." else sub.split("/")
+                cat, subtype = classify_record(dir_segs, fn)
+                records.append(
+                    {
+                        "rel": rel,
+                        "run": run,
+                        "cat": cat,
+                        "subtype": subtype,
+                        "fn": fn,
+                    }
+                )
+    return records
+
+
+def load_verdicts(path):
+    """Return {rel: [tags]} with POSIX keys and known tags only, or None if the
+    file is missing. Raises ValueError on a malformed (non-object) file."""
+    if not os.path.isfile(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        obj = json.load(f)
+    if not isinstance(obj, dict):
+        raise ValueError("verdicts JSON must be an object {path: [tags]}")
+    out = {}
+    for k, v in obj.items():
+        key = str(k).replace("\\", "/")
+        if isinstance(v, str):
+            v = [v]
+        tags = [t for t in (v or []) if t in VERDICTS]
+        if tags:
+            out[key] = tags
+    return out
+
+
+# --- aggregation (pure; unit-tested by --selftest) -------------------------
+def summarize(verdicts, records):
+    """Cross-reference verdicts against the inventory.
+
+    verdicts: {rel: [tags]}          records: list of inventory record dicts
+    Returns a dict of aggregates (see keys assembled at the end)."""
+    inv_by_rel = {r["rel"]: r for r in records}
+
+    verdict_counts = collections.Counter()
+    # per-verdict breakdowns, only for on-disk sprites
+    by_cat = {v: collections.Counter() for v in VERDICTS}
+    by_sub = {v: collections.Counter() for v in VERDICTS}
+    # actionable path lists keyed (cat, subtype) -> [rel...]
+    lists = {v: collections.defaultdict(list) for v in VERDICTS}
+    stale = collections.Counter()  # rel -> tags present but not on disk
+    stale_paths = {}
+
+    tagged_rels = set()
+    for rel, tags in verdicts.items():
+        tagged_rels.add(rel)
+        rec = inv_by_rel.get(rel)
+        for t in tags:
+            verdict_counts[t] += 1
+        if rec is None:
+            stale_paths[rel] = tags
+            for t in tags:
+                stale[t] += 1
+            continue
+        for t in tags:
+            by_cat[t][rec["cat"]] += 1
+            by_sub[t][rec["subtype"]] += 1
+            lists[t][(rec["cat"], rec["subtype"])].append(rel)
+
+    # inventory-side coverage: every subtype that exists, per category, plus its
+    # promote count (0 if never promoted).
+    inv_subtypes = collections.defaultdict(set)  # cat -> {subtype}
+    inv_sub_count = collections.Counter()  # subtype -> inventory size
+    for r in records:
+        inv_subtypes[r["cat"]].add(r["subtype"])
+        inv_sub_count[r["subtype"]] += 1
+
+    promote_by_sub = by_sub["promote"]
+    # per category: over-represented (top N promoted) and under/zero-promote
+    over = {}  # cat -> [(subtype, promote_count)] desc
+    under = {}  # cat -> [(subtype, promote_count, inv_count)] promote<=1
+    for cat in sorted(inv_subtypes):
+        subs = inv_subtypes[cat]
+        ranked = sorted(
+            ((s, promote_by_sub.get(s, 0)) for s in subs),
+            key=lambda x: (-x[1], x[0]),
+        )
+        over[cat] = [t for t in ranked if t[1] > 0][:TOP_N]
+        under[cat] = sorted(
+            (
+                (s, promote_by_sub.get(s, 0), inv_sub_count[s])
+                for s in subs
+                if promote_by_sub.get(s, 0) <= 1
+            ),
+            key=lambda x: (x[1], -x[2], x[0]),
+        )
+
+    # never-triaged sprites (on disk, no verdict at all), by category
+    untouched_by_cat = collections.Counter()
+    untouched_total = 0
+    for r in records:
+        if r["rel"] not in tagged_rels:
+            untouched_by_cat[r["cat"]] += 1
+            untouched_total += 1
+
+    return {
+        "total_tagged": len(tagged_rels),
+        "verdict_counts": verdict_counts,
+        "by_cat": by_cat,
+        "by_sub": by_sub,
+        "lists": lists,
+        "stale": stale,
+        "stale_paths": stale_paths,
+        "over": over,
+        "under": under,
+        "untouched_by_cat": untouched_by_cat,
+        "untouched_total": untouched_total,
+        "inv_total": len(records),
+    }
+
+
+# --- reporting -------------------------------------------------------------
+def _fmt_counter(counter, indent="    "):
+    lines = []
+    for name, n in sorted(counter.items(), key=lambda x: (-x[1], x[0])):
+        lines.append("{}{:5d}  {}".format(indent, n, name))
+    return lines or ["{}(none)".format(indent)]
+
+
+def render_report(agg, inv_total):
+    L = []
+    p = L.append
+    p("=" * 70)
+    p("PIXELLAB VERDICT ANALYSIS")
+    p("=" * 70)
+    p("inventory on disk : {} sprites".format(inv_total))
+    p("tagged (triaged)  : {}".format(agg["total_tagged"]))
+    p("never triaged     : {}".format(agg["untouched_total"]))
+    p("")
+    p("-- 1. VERDICT SUMMARY " + "-" * 48)
+    p("verdict tag counts:")
+    vc = agg["verdict_counts"]
+    for v in VERDICTS:
+        p("    {:5d}  {}".format(vc.get(v, 0), v))
+    stale = agg["stale"]
+    if sum(stale.values()):
+        p("  (of which STALE -- tag on a path not on disk:)")
+        for v in VERDICTS:
+            if stale.get(v):
+                p("    {:5d}  {} (stale)".format(stale[v], v))
+
+    for v in ("promote", "favour"):
+        p("")
+        p("  {} by CATEGORY:".format(v.upper()))
+        L.extend(_fmt_counter(agg["by_cat"][v], "      "))
+        p("  {} by SUBTYPE (desc):".format(v.upper()))
+        L.extend(_fmt_counter(agg["by_sub"][v], "      "))
+
+    p("")
+    p("-- 2. IMBALANCE + COVERAGE GAPS " + "-" * 38)
+    for cat in sorted(agg["over"]):
+        over = agg["over"][cat]
+        under = agg["under"][cat]
+        if not over and not under:
+            continue
+        p("  [{}]".format(cat))
+        p("    over-represented promoted subtypes (top {}):".format(TOP_N))
+        if over:
+            for s, n in over:
+                p("      {:5d}  {}".format(n, s))
+        else:
+            p("      (nothing promoted in this category)")
+        p("    under-/zero-promote subtypes present in inventory:")
+        zero = [(s, n, inv) for (s, n, inv) in under if n == 0]
+        one = [(s, n, inv) for (s, n, inv) in under if n == 1]
+        if zero:
+            p("      ZERO promotes ({} asset types):".format(len(zero)))
+            for s, n, inv in zero:
+                p("        {}  (inventory x{})".format(s, inv))
+        if one:
+            p("      only 1 promote:")
+            for s, n, inv in one:
+                p("        {}  (inventory x{})".format(s, inv))
+        if not zero and not one:
+            p("      (every subtype here has >=2 promotes)")
+
+    stale_paths = agg["stale_paths"]
+    p("")
+    p("  STALE verdict paths (tagged but not on disk): {}".format(len(stale_paths)))
+    for rel in sorted(stale_paths)[:40]:
+        p("      {}  {}".format(",".join(stale_paths[rel]), rel))
+    if len(stale_paths) > 40:
+        p("      ... and {} more".format(len(stale_paths) - 40))
+
+    p("")
+    p("  NEVER-TRIAGED sprites by category:")
+    L.extend(_fmt_counter(agg["untouched_by_cat"], "      "))
+    return "\n".join(L)
+
+
+def write_list_file(path, list_map, header):
+    """list_map: {(cat, subtype): [rel...]}. Writes paths grouped under a
+    '# category/subtype' header per group (subtype already contains category)."""
+    groups = sorted(list_map.items(), key=lambda kv: (kv[0][0], kv[0][1]))
+    total = 0
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write("# {}\n".format(header))
+        f.write("# generated by tools/art_review/analyze_verdicts.py\n\n")
+        for (cat, subtype), rels in groups:
+            f.write("# {}\n".format(subtype))
+            for rel in sorted(rels):
+                f.write(rel + "\n")
+                total += 1
+            f.write("\n")
+    return total
+
+
+def write_outputs(agg):
+    lists = agg["lists"]
+    n_prom = write_list_file(
+        PROMOTE_OUT, lists["promote"], "PROMOTE -- office sandbox + generation queue"
+    )
+    n_fav = write_list_file(FAVOUR_OUT, lists["favour"], "FAVOUR -- shortlist")
+    # prune list: disfavour + dislike merged, keyed the same way
+    prune_map = collections.defaultdict(list)
+    for v in ("disfavour", "dislike"):
+        for key, rels in lists[v].items():
+            prune_map[key].extend(rels)
+    for key in prune_map:
+        prune_map[key] = sorted(set(prune_map[key]))
+    n_prune = write_list_file(PRUNE_OUT, prune_map, "DISFAVOUR + DISLIKE -- prune / ignore")
+    return {PROMOTE_OUT: n_prom, FAVOUR_OUT: n_fav, PRUNE_OUT: n_prune}
+
+
+# --- selftest --------------------------------------------------------------
+def selftest():
+    # classification checks against real folder shapes
+    assert classify_record(["reroll", "objects"], "chair_decent_1.png") == (
+        "props",
+        "props/chair_decent",
+    ), classify_record(["reroll", "objects"], "chair_decent_1.png")
+    assert classify_record(["characters", "worker_hoodie_m", "rotations"], "east.png") == (
+        "characters",
+        "characters/worker_hoodie_m",
+    )
+    assert classify_record(["characters", "cat_black", "rotations"], "north-east.png") == (
+        "cats",
+        "cats/cat_black",
+    )
+    assert classify_record(["reroll", "cats"], "cat_eldritch_1_south-west.png") == (
+        "cats",
+        "cats/cat_eldritch",
+    )
+    assert classify_record(["tilesets"], "floor_carpet_1.png") == (
+        "tilesets",
+        "tilesets/floor_carpet",
+    )
+    assert classify_record(["cosmetics"], "hat_medium_1.png") == (
+        "cosmetics",
+        "cosmetics/hat_medium",
+    )
+    assert classify_record([], "cat_ginger_east.png") == ("cats", "cats/cat_ginger")
+
+    # synthetic inventory + verdicts exercising every aggregate
+    records = []
+
+    def add(rel, cat, subtype, fn):
+        records.append({"rel": rel, "run": "pixellab_x", "cat": cat, "subtype": subtype, "fn": fn})
+
+    # props: coat_rack promoted 3x (over), bin exists but never promoted (zero gap)
+    add("pixellab_x/objects/coat_rack_1.png", "props", "props/coat_rack", "coat_rack_1.png")
+    add("pixellab_x/objects/coat_rack_2.png", "props", "props/coat_rack", "coat_rack_2.png")
+    add("pixellab_x/objects/coat_rack_3.png", "props", "props/coat_rack", "coat_rack_3.png")
+    add(
+        "pixellab_x/objects/bin_1.png", "props", "props/bin", "bin_1.png"
+    )  # untouched + zero-promote
+    add("pixellab_x/objects/desk_1.png", "props", "props/desk", "desk_1.png")  # 1 promote (under)
+    add("pixellab_x/cats/cat_black_1.png", "cats", "cats/cat_black", "cat_black_1.png")
+    verdicts = {
+        "pixellab_x/objects/coat_rack_1.png": ["promote", "favour"],
+        "pixellab_x/objects/coat_rack_2.png": ["promote"],
+        "pixellab_x/objects/coat_rack_3.png": ["promote", "like"],
+        "pixellab_x/objects/desk_1.png": ["promote"],
+        "pixellab_x/cats/cat_black_1.png": ["favour", "like"],
+        "pixellab_x/GONE/ghost_1.png": ["promote", "favour"],  # stale (not on disk)
+        "pixellab_x/objects/bad_1.png": ["dislike"],  # stale dislike
+    }
+    # bad_1 is stale too (not in inventory) -> that's fine, still counted
+    agg = summarize(verdicts, records)
+
+    assert agg["total_tagged"] == 7, agg["total_tagged"]
+    assert agg["verdict_counts"]["promote"] == 5, agg["verdict_counts"]
+    assert agg["verdict_counts"]["favour"] == 3, agg["verdict_counts"]
+    # promote by subtype: coat_rack 3, desk 1 (ghost is stale, excluded from by_sub)
+    assert agg["by_sub"]["promote"]["props/coat_rack"] == 3, agg["by_sub"]["promote"]
+    assert agg["by_sub"]["promote"]["props/desk"] == 1
+    assert agg["by_cat"]["promote"]["props"] == 4, agg["by_cat"]["promote"]
+    # stale: ghost has promote+favour, bad has dislike
+    assert (
+        agg["stale"]["promote"] == 1
+        and agg["stale"]["favour"] == 1
+        and agg["stale"]["dislike"] == 1
+    )
+    assert len(agg["stale_paths"]) == 2
+    # over-represented props: coat_rack first
+    over_props = agg["over"]["props"]
+    assert over_props and over_props[0] == ("props/coat_rack", 3), over_props
+    # zero-promote gap: bin present with 0 promotes
+    under_props = dict((s, n) for (s, n, inv) in agg["under"]["props"])
+    assert under_props.get("props/bin") == 0, under_props
+    assert under_props.get("props/desk") == 1
+    assert "props/coat_rack" not in under_props  # 3 promotes -> not under
+    # untouched: bin_1 (never tagged) + cat_black is tagged; coat_racks tagged; desk tagged
+    assert agg["untouched_by_cat"]["props"] == 1, agg["untouched_by_cat"]
+    assert agg["untouched_total"] == 1
+
+    # grouping/list assembly
+    lists = agg["lists"]
+    assert set(lists["promote"].keys()) == {("props", "props/coat_rack"), ("props", "props/desk")}
+    assert sorted(lists["promote"][("props", "props/coat_rack")]) == [
+        "pixellab_x/objects/coat_rack_1.png",
+        "pixellab_x/objects/coat_rack_2.png",
+        "pixellab_x/objects/coat_rack_3.png",
+    ]
+    # render must not throw and must mention the imbalance
+    rep = render_report(agg, len(records))
+    assert "props/coat_rack" in rep and "STALE" in rep and "ZERO promotes" in rep
+    print("selftest OK: classification, aggregation, gaps, stale, grouping all pass")
+    return 0
+
+
+# --- main ------------------------------------------------------------------
+def main(argv):
+    if "--selftest" in argv:
+        return selftest()
+
+    try:
+        verdicts = load_verdicts(VERDICTS_PATH)
+    except (ValueError, json.JSONDecodeError) as e:
+        print("ERROR: could not parse {}\n  {}".format(VERDICTS_PATH, e))
+        print('Expected a flat object: { "relative/path.png": ["promote", ...] }')
+        return 1
+
+    if verdicts is None:
+        print("No verdicts file found at:")
+        print("  {}".format(VERDICTS_PATH))
+        print("")
+        print("Open the contact sheet (art_source/pixellab_contact_sheet.html),")
+        print("tag sprites, click 'export JSON', and SAVE the downloaded")
+        print("pixellab_verdicts.json to the path above. Then re-run:")
+        print("  python tools/art_review/analyze_verdicts.py")
+        return 0
+
+    records = build_inventory(ART_DIR)
+    if not records:
+        print(
+            "WARNING: no sprites found under {}/pixellab_* -- report will be empty.".format(ART_DIR)
+        )
+    agg = summarize(verdicts, records)
+
+    print(render_report(agg, len(records)))
+
+    print("")
+    print("-- 3. ACTIONABLE FILES " + "-" * 46)
+    written = write_outputs(agg)
+    for path, n in written.items():
+        print("    wrote {:4d} paths -> {}".format(n, path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/art_review/gen_contact_sheet.py
+++ b/tools/art_review/gen_contact_sheet.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""Generate a self-contained pixellab contact-sheet / triage HTML. Local review tool."""
+import collections
+import json
+import os
+import sys
+
+# Repo-relative: this script lives at <repo>/tools/art_review/, so art_source/
+# is two levels up. Override with a single CLI arg pointing at an art_source dir.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DEFAULT_ART_DIR = os.path.normpath(os.path.join(_HERE, "..", "..", "art_source"))
+ART_DIR = os.path.abspath(sys.argv[1]) if len(sys.argv) > 1 else _DEFAULT_ART_DIR
+OUT = os.path.join(ART_DIR, "pixellab_contact_sheet.html")
+EXTS = (".png", ".jpg", ".jpeg", ".gif", ".webp")
+
+
+def categorize(rel_parts):
+    segs = [s.lower() for s in rel_parts]
+
+    def has(*names):
+        return any(any(n in s for n in names) for s in segs)
+
+    if has("tileset"):
+        return "tilesets"
+    if has("cat"):
+        return "cats"
+    if has("cosmetic", "overlay"):
+        return "cosmetics"
+    if has(
+        "window",
+        "prop",
+        "object",
+        "kitchen",
+        "chair",
+        "library",
+        "environment",
+        "ui_filler",
+        "ui-filler",
+        "icon",
+    ):
+        return "props"
+    if has(
+        "character",
+        "founder",
+        "era_ladder",
+        "era-ladder",
+        "style_matrix",
+        "style-matrix",
+        "researcher",
+        "worker",
+        "genius",
+    ):
+        return "characters"
+    return None
+
+
+def categorize_by_name(fname):
+    n = fname.lower()
+    if "cat" in n:
+        return "cats"
+    if "tileset" in n or "floor_" in n or "wall_" in n:
+        return "tilesets"
+    if "hat" in n or "silhouette" in n:
+        return "cosmetics"
+    return "characters"
+
+
+CATS = ["characters", "cats", "props", "tilesets", "cosmetics", "other"]
+
+records = []
+cat_counts = collections.Counter()
+run_counts = collections.Counter()
+run_cat_counts = collections.defaultdict(collections.Counter)
+
+runs = sorted(
+    d
+    for d in os.listdir(ART_DIR)
+    if d.startswith("pixellab_") and os.path.isdir(os.path.join(ART_DIR, d))
+)
+
+for run in runs:
+    run_root = os.path.join(ART_DIR, run)
+    for dirpath, dirnames, filenames in os.walk(run_root):
+        dirnames.sort()
+        for fn in sorted(filenames):
+            if not fn.lower().endswith(EXTS):
+                continue
+            abs_path = os.path.join(dirpath, fn)
+            rel = os.path.relpath(abs_path, ART_DIR).replace("\\", "/")
+            sub = os.path.relpath(dirpath, run_root).replace("\\", "/")
+            dir_segs = [] if sub == "." else sub.split("/")
+            cat = categorize(dir_segs) if dir_segs else None
+            if cat is None:
+                cat = categorize_by_name(fn)
+            if cat not in CATS:
+                cat = "other"
+            subfolder = "/".join(dir_segs) if dir_segs else "(root)"
+            records.append({"rel": rel, "run": run, "cat": cat, "sub": subfolder, "fn": fn})
+            cat_counts[cat] += 1
+            run_counts[run] += 1
+            run_cat_counts[run][cat] += 1
+
+total = len(records)
+
+print("TOTAL:", total)
+print("BY CATEGORY:")
+for c in CATS:
+    if cat_counts[c]:
+        print(f"  {cat_counts[c]:5d}  {c}")
+print("BY RUN:")
+for r in runs:
+    print(f"  {run_counts[r]:5d}  {r}")
+    for c in CATS:
+        if run_cat_counts[r][c]:
+            print(f"          {run_cat_counts[r][c]:4d}  {c}")
+
+CAT_COLORS = {
+    "characters": "#e0a34a",
+    "cats": "#c98b3f",
+    "props": "#8fae6b",
+    "tilesets": "#6ba3b0",
+    "cosmetics": "#b57fb0",
+    "other": "#8a8375",
+}
+VERDICTS = ["like", "dislike", "favour", "disfavour", "promote"]
+VERDICT_COLORS = {
+    "like": "#6fae5a",
+    "dislike": "#cc5a4a",
+    "favour": "#e0a34a",
+    "disfavour": "#7a7268",
+    "promote": "#5a8fc0",
+}
+
+data = [
+    {"r": rec["rel"], "u": rec["run"], "c": rec["cat"], "s": rec["sub"], "f": rec["fn"]}
+    for rec in records
+]
+data_json = json.dumps(data, separators=(",", ":"))
+
+chips = "".join(
+    f'<button class="chip" data-cat="{c}">{c} <span class="chip-n">{cat_counts[c]}</span></button>'
+    for c in CATS
+    if cat_counts[c]
+)
+vchips = "".join(
+    f'<button class="vchip" data-v="{v}" style="--vc:{VERDICT_COLORS[v]}">{v} '
+    f'<span class="chip-n" id="vcount-{v}">0</span></button>'
+    for v in VERDICTS
+)
+
+css = """
+:root{--bg:#141210;--bg2:#1c1916;--bg3:#252019;--fg:#e8e0d2;--dim:#9a9081;
+--amber:#e0a34a;--amber2:#ffcf7a;--line:#3a332a;
+--like:#6fae5a;--dislike:#cc5a4a;--favour:#e0a34a;--disfavour:#7a7268;--promote:#5a8fc0;}
+*{box-sizing:border-box;}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);
+font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;overflow-x:hidden;}
+.mono,h1,h2{font-family:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;}
+header{position:sticky;top:0;z-index:20;background:linear-gradient(180deg,#1c1916,#141210);
+border-bottom:1px solid var(--line);padding:12px 18px 10px;box-shadow:0 2px 12px #0008;}
+.title-row{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;}
+h1{font-size:17px;margin:0;color:var(--amber);letter-spacing:.5px;}
+h1 .sub{color:var(--dim);font-weight:normal;font-size:12px;}
+.badge{background:var(--bg3);border:1px solid var(--line);color:var(--amber2);
+padding:3px 9px;border-radius:12px;font-size:12px;font-family:monospace;}
+.controls{display:flex;gap:8px;align-items:center;margin-top:9px;flex-wrap:wrap;}
+.row-label{font-size:10px;color:var(--dim);font-family:monospace;text-transform:uppercase;
+letter-spacing:1px;margin-right:2px;}
+input[type=search]{background:var(--bg3);border:1px solid var(--line);color:var(--fg);
+padding:6px 10px;border-radius:6px;font-size:13px;min-width:200px;flex:0 1 300px;font-family:monospace;}
+input[type=search]:focus{outline:none;border-color:var(--amber);}
+.chip,.vchip,.toggle,.btn{background:var(--bg3);border:1px solid var(--line);color:var(--dim);
+padding:5px 10px;border-radius:13px;font-size:12px;cursor:pointer;font-family:monospace;
+transition:all .12s;white-space:nowrap;}
+.chip:hover,.vchip:hover,.toggle:hover,.btn:hover{border-color:var(--amber);color:var(--fg);}
+.chip.on{background:var(--amber);color:#1a1510;border-color:var(--amber);font-weight:600;}
+.vchip.on{background:var(--vc);color:#12100c;border-color:var(--vc);font-weight:600;}
+.chip-n{opacity:.7;font-size:10px;}
+.toggle.on{background:#4a3a1a;border-color:var(--amber2);color:var(--amber2);}
+.btn{border-radius:6px;}
+.btn.primary{color:var(--amber2);border-color:#5a4a2a;}
+main{padding:6px 18px 90px;}
+.run-sec{margin-top:16px;}
+.run-head,.cat-head{cursor:pointer;user-select:none;display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
+.run-head{font-size:15px;color:var(--amber2);border-bottom:1px solid var(--line);padding:8px 0 6px;margin-top:8px;}
+.cat-head{font-size:12px;color:var(--dim);padding:8px 0 4px;margin-left:4px;text-transform:uppercase;letter-spacing:1px;}
+.caret{display:inline-block;width:12px;color:var(--amber);transition:transform .12s;}
+.collapsed .caret{transform:rotate(-90deg);}
+.collapsed > .body{display:none;}
+.count-tag{color:var(--dim);font-size:11px;font-family:monospace;}
+.selall{font-size:10px;color:var(--dim);background:var(--bg3);border:1px solid var(--line);
+border-radius:5px;padding:2px 7px;cursor:pointer;font-family:monospace;}
+.selall:hover{border-color:var(--amber);color:var(--fg);}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(132px,1fr));gap:10px;margin:6px 0 14px;}
+.tile{background:var(--bg2);border:1px solid var(--line);border-radius:8px;padding:8px 8px 7px;
+position:relative;display:flex;flex-direction:column;transition:border-color .12s;}
+.tile:hover{border-color:#5a5040;}
+.tile.sel{border-color:var(--amber2);box-shadow:0 0 0 1px var(--amber2) inset;}
+.thumb-wrap{background:repeating-conic-gradient(#201c17 0% 25%,#2a251e 0% 50%) 50%/16px 16px;
+border-radius:5px;aspect-ratio:1;display:flex;align-items:center;justify-content:center;overflow:hidden;cursor:zoom-in;}
+.thumb-wrap img{max-width:100%;max-height:100%;image-rendering:pixelated;image-rendering:crisp-edges;}
+.selbox{position:absolute;top:6px;left:6px;width:20px;height:20px;cursor:pointer;z-index:2;
+accent-color:var(--amber);margin:0;}
+.fn{font-family:monospace;font-size:10px;color:var(--fg);margin-top:6px;word-break:break-all;line-height:1.3;}
+.meta{font-size:9px;color:var(--dim);margin-top:2px;font-family:monospace;}
+.cat-pill{display:inline-block;font-size:8px;padding:1px 5px;border-radius:6px;color:#15110b;
+font-weight:700;text-transform:uppercase;letter-spacing:.5px;}
+.vtags{display:flex;flex-wrap:wrap;gap:3px;margin-top:6px;}
+.vtag{font-size:8px;font-family:monospace;padding:2px 5px;border-radius:5px;cursor:pointer;
+border:1px solid var(--line);background:transparent;color:var(--dim);text-transform:uppercase;
+letter-spacing:.3px;line-height:1;transition:all .1s;}
+.vtag:hover{color:var(--fg);border-color:var(--vc);}
+.vtag.on{background:var(--vc);color:#12100c;border-color:var(--vc);font-weight:700;}
+.empty{color:var(--dim);font-style:italic;padding:20px;text-align:center;}
+footer{color:var(--dim);font-size:11px;padding:20px 18px;border-top:1px solid var(--line);font-family:monospace;line-height:1.6;}
+.bulkbar{position:fixed;left:0;right:0;bottom:0;z-index:30;background:linear-gradient(0deg,#221d16,#1a1611);
+border-top:1px solid #5a4a2a;padding:10px 18px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;
+box-shadow:0 -3px 14px #000a;transform:translateY(110%);transition:transform .18s;}
+.bulkbar.on{transform:translateY(0);}
+.bulkbar .selcount{color:var(--amber2);font-family:monospace;font-size:13px;font-weight:600;}
+.bulkbar .sep{color:var(--line);}
+.bulk-add,.bulk-del{border-radius:6px;font-size:11px;padding:5px 9px;border:1px solid var(--line);
+background:var(--bg3);color:var(--dim);cursor:pointer;font-family:monospace;}
+.bulk-add{--vc:#888;}
+.bulk-add:hover{background:var(--vc);color:#12100c;border-color:var(--vc);}
+.bulk-del:hover{background:#3a2020;border-color:#cc5a4a;color:#e8b0a8;}
+.lightbox{position:fixed;inset:0;background:#000d;z-index:100;display:none;align-items:center;
+justify-content:center;flex-direction:column;gap:12px;cursor:zoom-out;}
+.lightbox.on{display:flex;}
+.lightbox img{max-width:80vw;max-height:72vh;image-rendering:pixelated;
+background:repeating-conic-gradient(#201c17 0% 25%,#2a251e 0% 50%) 50%/24px 24px;border:1px solid var(--line);}
+.lightbox .lbcap{color:var(--fg);font-family:monospace;font-size:13px;text-align:center;padding:0 20px;}
+#toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#2a2419;
+border:1px solid var(--amber);color:var(--amber2);padding:8px 16px;border-radius:8px;
+font-family:monospace;font-size:12px;z-index:200;opacity:0;transition:opacity .2s;pointer-events:none;}
+#toast.on{opacity:1;}
+"""
+
+js = r"""
+const DATA=__DATA__;
+const CATCOLORS=__CATCOLORS__;
+const VERDICTS=__VERDICTS__;
+const VCOLORS=__VCOLORS__;
+const KV='pcs:verdicts';   // {rel:[tags]}
+let V={};                  // in-memory verdict map
+let storageOK=false;
+function loadV(){try{const s=localStorage.getItem(KV);V=s?JSON.parse(s):{};storageOK=true;}
+  catch(e){V={};storageOK=false;}}
+function saveV(){if(!storageOK)return;try{localStorage.setItem(KV,JSON.stringify(V));}catch(e){storageOK=false;}}
+function tagsOf(r){return V[r]||[];}
+function hasTag(r,t){return tagsOf(r).indexOf(t)>=0;}
+function setTag(r,t,on){let a=V[r]?V[r].slice():[];const i=a.indexOf(t);
+  if(on&&i<0)a.push(t);else if(!on&&i>=0)a.splice(i,1);
+  if(a.length)V[r]=a;else delete V[r];}
+
+let activeCats=new Set(), activeVerdicts=new Set(), query='';
+const selected=new Set();
+let lastClickedIdx=null;
+const tileByRel={}; let orderedRels=[];
+
+function build(){
+  const runs={};
+  for(const d of DATA){(runs[d.u]=runs[d.u]||{});(runs[d.u][d.c]=runs[d.u][d.c]||[]).push(d);}
+  const main=document.getElementById('main');
+  for(const run of Object.keys(runs).sort()){
+    const sec=document.createElement('section');sec.className='run-sec';
+    const rc=Object.values(runs[run]).reduce((a,b)=>a+b.length,0);
+    const rh=document.createElement('div');rh.className='run-head';
+    rh.innerHTML=`<span class="caret">v</span><span class="mono">${run}</span> <span class="count-tag">${rc}</span>`;
+    const selBtn=document.createElement('span');selBtn.className='selall';selBtn.textContent='select group';
+    rh.appendChild(selBtn);
+    const rbody=document.createElement('div');rbody.className='body';
+    rh.addEventListener('click',e=>{if(e.target===selBtn)return;sec.classList.toggle('collapsed');});
+    const groupRels=[];
+    sec.appendChild(rh);sec.appendChild(rbody);
+    for(const cat of Object.keys(runs[run]).sort()){
+      const cwrap=document.createElement('div');cwrap.className='cat-sec';cwrap.dataset.cat=cat;
+      const ch=document.createElement('div');ch.className='cat-head';
+      ch.innerHTML=`<span class="caret">v</span>${cat} <span class="count-tag">${runs[run][cat].length}</span>`;
+      const cSel=document.createElement('span');cSel.className='selall';cSel.textContent='select';
+      ch.appendChild(cSel);
+      const cbody=document.createElement('div');cbody.className='body grid';
+      ch.addEventListener('click',e=>{if(e.target===cSel)return;cwrap.classList.toggle('collapsed');});
+      const catRels=[];
+      for(const d of runs[run][cat]){const t=tile(d);cbody.appendChild(t);catRels.push(d.r);groupRels.push(d.r);}
+      cSel.onclick=e=>{e.stopPropagation();selectRels(catRels);};
+      cwrap.appendChild(ch);cwrap.appendChild(cbody);rbody.appendChild(cwrap);
+    }
+    selBtn.onclick=e=>{e.stopPropagation();selectRels(groupRels);};
+    main.appendChild(sec);
+  }
+}
+
+function tile(d){
+  const t=document.createElement('div');t.className='tile';t.dataset.rel=d.r;
+  t.dataset.fn=d.f.toLowerCase();t.dataset.cat=d.c;t.dataset.sub=d.s.toLowerCase();
+  const col=CATCOLORS[d.c]||'#888';
+  t.innerHTML=`
+    <input type="checkbox" class="selbox" title="select">
+    <div class="thumb-wrap"><img loading="lazy" src="${enc(d.r)}" alt="${esc(d.f)}"></div>
+    <div class="fn">${esc(d.f)}</div>
+    <div class="meta"><span class="cat-pill" style="background:${col}">${d.c}</span> ${esc(d.s)}</div>
+    <div class="vtags"></div>`;
+  const vt=t.querySelector('.vtags');
+  for(const v of VERDICTS){
+    const b=document.createElement('button');b.className='vtag';b.dataset.v=v;b.textContent=v;
+    b.style.setProperty('--vc',VCOLORS[v]);
+    if(hasTag(d.r,v))b.classList.add('on');
+    b.onclick=e=>{e.stopPropagation();const on=!hasTag(d.r,v);setTag(d.r,v,on);
+      b.classList.toggle('on',on);saveV();refreshCounts();if(activeVerdicts.size)applyFilter();};
+    vt.appendChild(b);
+  }
+  const cb=t.querySelector('.selbox');
+  cb.addEventListener('click',e=>{e.stopPropagation();onSelClick(d.r,e.shiftKey,cb.checked);});
+  t.querySelector('img').onclick=e=>{e.stopPropagation();openLB(d);};
+  tileByRel[d.r]=t;
+  return t;
+}
+
+function esc(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
+function enc(s){return s.split('/').map(encodeURIComponent).join('/');}
+
+// ---- selection ----
+function onSelClick(rel,shift,checked){
+  const idx=orderedRels.indexOf(rel);
+  if(shift&&lastClickedIdx!==null){
+    const [a,b]=[Math.min(lastClickedIdx,idx),Math.max(lastClickedIdx,idx)];
+    for(let i=a;i<=b;i++){const r=orderedRels[i];const tt=tileByRel[r];
+      if(tt.style.display==='none')continue; setSel(r,checked);}
+  }else{setSel(rel,checked);}
+  lastClickedIdx=idx;updateSelUI();
+}
+function setSel(rel,on){const t=tileByRel[rel];if(!t)return;
+  if(on){selected.add(rel);t.classList.add('sel');}else{selected.delete(rel);t.classList.remove('sel');}
+  const cb=t.querySelector('.selbox');if(cb)cb.checked=on;}
+function selectRels(rels){const vis=rels.filter(r=>tileByRel[r].style.display!=='none');
+  const allSel=vis.every(r=>selected.has(r));
+  for(const r of vis)setSel(r,!allSel);updateSelUI();}
+function selectAllVisible(){const vis=orderedRels.filter(r=>tileByRel[r].style.display!=='none');
+  const allSel=vis.length&&vis.every(r=>selected.has(r));
+  for(const r of vis)setSel(r,!allSel);updateSelUI();}
+function clearSel(){for(const r of[...selected])setSel(r,false);updateSelUI();}
+function updateSelUI(){const n=selected.size;
+  document.getElementById('selcount').textContent=n;
+  document.getElementById('bulkbar').classList.toggle('on',n>0);}
+
+// ---- bulk verdict ----
+function bulkApply(v,on){for(const r of selected){setTag(r,v,on);
+  const t=tileByRel[r];const b=t.querySelector(`.vtag[data-v="${v}"]`);if(b)b.classList.toggle('on',on);}
+  saveV();refreshCounts();if(activeVerdicts.size)applyFilter();
+  toast(`${on?'Set':'Removed'} ${v} on ${selected.size} sprite(s)`);}
+
+// ---- filtering ----
+function applyFilter(){
+  let shown=0;
+  for(const r of orderedRels){
+    const t=tileByRel[r];let ok=true;
+    if(activeCats.size&&!activeCats.has(t.dataset.cat))ok=false;
+    if(ok&&query){const hay=t.dataset.fn+' '+t.dataset.cat+' '+t.dataset.sub;if(!hay.includes(query))ok=false;}
+    if(ok&&activeVerdicts.size){const tags=tagsOf(r);
+      let m=false;for(const v of activeVerdicts)if(tags.indexOf(v)>=0){m=true;break;}if(!m)ok=false;}
+    t.style.display=ok?'':'none';if(ok)shown++;
+  }
+  for(const cs of document.querySelectorAll('.cat-sec')){
+    const any=[...cs.querySelectorAll('.tile')].some(x=>x.style.display!=='none');cs.style.display=any?'':'none';}
+  for(const rs of document.querySelectorAll('.run-sec')){
+    const any=[...rs.querySelectorAll('.cat-sec')].some(c=>c.style.display!=='none');rs.style.display=any?'':'none';}
+  document.getElementById('shown').textContent=shown;
+}
+function refreshCounts(){
+  const c={};for(const v of VERDICTS)c[v]=0;let any=0;
+  for(const r in V){for(const t of V[r])if(c[t]!==undefined)c[t]++;any++;}
+  for(const v of VERDICTS)document.getElementById('vcount-'+v).textContent=c[v];
+  document.getElementById('taggedn').textContent=any;
+}
+
+// ---- export / import ----
+function download(name,text,type){const blob=new Blob([text],{type:type||'text/plain'});
+  const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download=name;
+  document.body.appendChild(a);a.click();a.remove();setTimeout(()=>URL.revokeObjectURL(url),1000);}
+function exportJSON(){download('pixellab_verdicts.json',JSON.stringify(V,null,2),'application/json');
+  toast('Exported JSON');}
+function exportCSV(){let rows=['relative_path,tags'];
+  for(const r of orderedRels){const tg=tagsOf(r);if(tg.length)rows.push(`"${r}","${tg.join(';')}"`);}
+  download('pixellab_verdicts.csv',rows.join('\n'),'text/csv');toast('Exported CSV');}
+function copyList(v){const rels=orderedRels.filter(r=>hasTag(r,v));
+  const text=rels.join('\n');
+  if(navigator.clipboard&&navigator.clipboard.writeText){
+    navigator.clipboard.writeText(text).then(()=>toast(`Copied ${rels.length} ${v} path(s)`),
+      ()=>fallbackCopy(text,rels.length,v));
+  }else fallbackCopy(text,rels.length,v);}
+function fallbackCopy(text,n,v){const ta=document.createElement('textarea');ta.value=text;
+  ta.style.position='fixed';ta.style.opacity='0';document.body.appendChild(ta);ta.select();
+  let ok=false;try{ok=document.execCommand('copy');}catch(e){}ta.remove();
+  toast(ok?`Copied ${n} ${v} path(s)`:`Copy blocked -- see console`);if(!ok)console.log(text);}
+function importJSON(file){const rd=new FileReader();
+  rd.onload=()=>{try{const obj=JSON.parse(rd.result);
+    if(typeof obj!=='object'||Array.isArray(obj))throw 0;
+    V=obj;saveV();
+    for(const r of orderedRels){const t=tileByRel[r];
+      for(const b of t.querySelectorAll('.vtag'))b.classList.toggle('on',hasTag(r,b.dataset.v));}
+    refreshCounts();applyFilter();toast('Imported verdicts');
+  }catch(e){toast('Import failed -- not a valid verdicts JSON');}};
+  rd.readAsText(file);}
+
+// ---- misc ----
+function openLB(d){const lb=document.getElementById('lb');lb.querySelector('img').src=enc(d.r);
+  lb.querySelector('.lbcap').textContent=`${d.f}  --  ${d.u}/${d.s}`;lb.classList.add('on');}
+let toastT=null;
+function toast(msg){const el=document.getElementById('toast');el.textContent=msg;el.classList.add('on');
+  clearTimeout(toastT);toastT=setTimeout(()=>el.classList.remove('on'),1800);}
+
+window.addEventListener('DOMContentLoaded',()=>{
+  loadV();orderedRels=DATA.map(d=>d.r);build();
+  document.getElementById('total').textContent=DATA.length;
+  refreshCounts();applyFilter();
+  document.getElementById('q').addEventListener('input',e=>{query=e.target.value.trim().toLowerCase();applyFilter();});
+  for(const chip of document.querySelectorAll('.chip')){chip.onclick=()=>{const c=chip.dataset.cat;
+    if(activeCats.has(c)){activeCats.delete(c);chip.classList.remove('on');}
+    else{activeCats.add(c);chip.classList.add('on');}applyFilter();};}
+  for(const vc of document.querySelectorAll('.vchip')){vc.onclick=()=>{const v=vc.dataset.v;
+    if(activeVerdicts.has(v)){activeVerdicts.delete(v);vc.classList.remove('on');}
+    else{activeVerdicts.add(v);vc.classList.add('on');}applyFilter();};}
+  document.getElementById('selallvis').onclick=selectAllVisible;
+  // bulk bar buttons
+  const addWrap=document.getElementById('bulkadd'),delWrap=document.getElementById('bulkdel');
+  for(const v of VERDICTS){
+    const a=document.createElement('button');a.className='bulk-add';a.textContent='+'+v;
+    a.style.setProperty('--vc',VCOLORS[v]);a.onclick=()=>bulkApply(v,true);addWrap.appendChild(a);
+    const d=document.createElement('button');d.className='bulk-del';d.textContent='-'+v;
+    d.onclick=()=>bulkApply(v,false);delWrap.appendChild(d);
+  }
+  document.getElementById('clearsel').onclick=clearSel;
+  document.getElementById('expjson').onclick=exportJSON;
+  document.getElementById('expcsv').onclick=exportCSV;
+  document.getElementById('copypromote').onclick=()=>copyList('promote');
+  document.getElementById('copyfavour').onclick=()=>copyList('favour');
+  document.getElementById('impbtn').onclick=()=>document.getElementById('impfile').click();
+  document.getElementById('impfile').addEventListener('change',e=>{if(e.target.files[0])importJSON(e.target.files[0]);e.target.value='';});
+  const lb=document.getElementById('lb');lb.onclick=()=>lb.classList.remove('on');
+  document.addEventListener('keydown',e=>{if(e.key==='Escape'){lb.classList.remove('on');}});
+  if(!storageOK)document.getElementById('storewarn').style.display='inline';
+});
+"""
+
+js = (
+    js.replace("__DATA__", data_json)
+    .replace("__CATCOLORS__", json.dumps(CAT_COLORS))
+    .replace("__VERDICTS__", json.dumps(VERDICTS))
+    .replace("__VCOLORS__", json.dumps(VERDICT_COLORS))
+)
+
+doc = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>P(Doom)1 -- pixellab triage</title>
+<style>{css}</style>
+</head>
+<body>
+<header>
+  <div class="title-row">
+    <h1>P(Doom)1 pixellab library <span class="sub">// triage sheet</span></h1>
+    <span class="badge"><span id="shown">{total}</span> / <span id="total">{total}</span> shown</span>
+    <span class="badge">tagged <span id="taggedn">0</span></span>
+    <span class="badge" id="storewarn" style="display:none;color:#d88">localStorage off -- verdicts wont persist (use Export)</span>
+  </div>
+  <div class="controls">
+    <input id="q" type="search" placeholder="filter by filename / category / folder...">
+    <span class="row-label">cat</span>{chips}
+  </div>
+  <div class="controls">
+    <span class="row-label">verdict</span>{vchips}
+    <span class="sep"> </span>
+    <button class="btn" id="selallvis">select all visible</button>
+    <button class="btn" id="expjson">export JSON</button>
+    <button class="btn" id="expcsv">export CSV</button>
+    <button class="btn" id="copypromote">copy PROMOTE</button>
+    <button class="btn" id="copyfavour">copy FAVOUR</button>
+    <button class="btn primary" id="impbtn">import JSON</button>
+    <input type="file" id="impfile" accept="application/json,.json" style="display:none">
+  </div>
+</header>
+<main id="main"></main>
+<footer>
+  Local triage tool -- untracked, not committed. Thumbnail = enlarge (Esc/click closes).
+  Per-sprite verdict tags (like/dislike/favour/disfavour/promote) + batch select (checkbox,
+  shift-click ranges, select-group / select-all-visible) + bulk apply/remove bar.
+  Verdicts persist to this browser's localStorage; Export JSON/CSV to make them portable/actionable.
+  {total} sprites across {len([r for r in runs if run_counts[r]])} runs.
+</footer>
+<div class="bulkbar" id="bulkbar">
+  <span class="selcount"><span id="selcount">0</span> selected</span>
+  <span class="sep">|</span>
+  <span class="row-label">apply</span><span id="bulkadd" style="display:flex;gap:5px;flex-wrap:wrap"></span>
+  <span class="sep">|</span>
+  <span class="row-label">remove</span><span id="bulkdel" style="display:flex;gap:5px;flex-wrap:wrap"></span>
+  <span class="sep">|</span>
+  <button class="btn" id="clearsel">clear selection</button>
+</div>
+<div class="lightbox" id="lb"><img src="" alt=""><div class="lbcap"></div></div>
+<div id="toast"></div>
+<script>{js}</script>
+</body>
+</html>
+"""
+
+with open(OUT, "w", encoding="utf-8") as f:
+    f.write(doc)
+print("WROTE:", OUT, "bytes:", len(doc.encode("utf-8")))


### PR DESCRIPTION
## What

Consolidates the scattered art-review pipeline into one tracked, documented home under `tools/art_review/` so future work improves the scripts instead of re-deriving them. Doc + tooling hygiene only -- no game code, no CI paths touched.

Pipeline: generate a contact sheet of pixel-sprite art -> triage it in the browser (5 verdict tags, batch select, export) -> save the JSON export -> analyze it for imbalances + actionable promote/favour/prune lists -> feed the gaps into the next generation round.

## Changes

- **`tools/art_review/gen_contact_sheet.py`** (NEW, tracked) -- the contact-sheet / triage HTML generator. Was ephemeral in `G:/tmp` and at risk of evaporating. Hardcoded absolute `ART_DIR` replaced with a repo-relative resolve (two levels up from the script) plus an optional CLI-arg override; behaviour otherwise identical.
- **`tools/art_review/analyze_verdicts.py`** (NEW, tracked) -- the verdict analyzer. Was untracked in the working copy. Same repo-relative path treatment; `--selftest` still passes.
- **`tools/art_review/README.md`** (NEW, `Status: LIVE`) -- maps the 5-step flow end to end with exact commands, the export JSON schema (`{ "relative/path.png": ["favour","promote",...] }`), each script's inputs/outputs, the tracked-vs-regenerable split, and a note on the sibling `art_generated/hero_gallery.html` + the older co-located review app.
- **`art_source/pixellab_verdicts.json`** (NEW, tracked) -- the owner's 651 triage opinions. Valuable, non-regenerable decision data, now under version control.
- **`.gitignore`** -- ignore the regenerable artifacts (`pixellab_contact_sheet.html`, `promote_list.txt`, `favour_list.txt`, `disfavour_dislike_list.txt`, `art_generated/hero_gallery.html`) while keeping the generators + analyzer + verdicts.json tracked.

## Verification

- Both scripts `ast.parse` cleanly and run end-to-end from the new home against `art_source/` (repo-relative resolution confirmed).
- `analyze_verdicts.py --selftest` passes; a real run reports STALE verdict paths = 0 (the tracked verdicts match the on-disk inventory).
- Pre-commit hooks (black/isort/ruff/ASCII/no-emoji) all pass; artifacts confirmed gitignored (`git check-ignore`).

Do NOT merge yet -- for review.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)