### PR TITLE
chore(tools): home complete art-review pipeline v2 (2 generators + v2 analyzer + README)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,11 +132,20 @@ generated_icons/
 asset_gallery.html
 # Local art-review app state (per-reviewer verdicts/notes; written by serve_review.py)
 tools/art_review/review_state.json
-# Office-sandbox v2 dev-tool state (promote list + per-reviewer feedback; local only).
-# These live only in the owner's working copy; the sandbox loader degrades gracefully
-# when they are absent (see godot/scripts/ui/office_floor/office_sandbox.gd).
+# Art-review pipeline v2 regenerable artifacts (tools/art_review/). The verdicts
+# JSONs (pixellab_verdicts.json, hero_verdicts.json) and the generator/analyzer
+# tools ARE tracked -- only these derived outputs are ignored. hero_gallery.html
+# also falls under the art_generated/ rule above.
+art_source/pixellab_contact_sheet.html
+art_generated/hero_gallery.html
 art_source/promote_list.txt
-art_source/pixellab_verdicts.json
+art_source/favour_list.txt
+art_source/disfavour_dislike_list.txt
+art_source/hero_promote_list.txt
+art_source/hero_favour_list.txt
+art_source/hero_disfavour_dislike_list.txt
+# Office-sandbox v2 dev-tool state (per-reviewer feedback; local only). The sandbox
+# loader degrades gracefully when absent (godot/scripts/ui/office_floor/office_sandbox.gd).
 art_source/sandbox_feedback.json
 test_output.png
 test_openai_api.py

--- a/art_source/pixellab_verdicts.json
+++ b/art_source/pixellab_verdicts.json
@@ -1,0 +1,2498 @@
+{
+  "pixellab_2026-07-16/08-V8-fullcolor-chibi-hightopdown_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/08-V8-fullcolor-chibi-hightopdown_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/08-V8-fullcolor-chibi-hightopdown_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/08-V8-fullcolor-chibi-hightopdown_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/09-V9-heroic-fullcolor_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/09-V9-heroic-fullcolor_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/09-V9-heroic-fullcolor_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/09-V9-heroic-fullcolor_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/10-C1-V4-cozywarm_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/10-C1-V4-cozywarm_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/10-C1-V4-cozywarm_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/10-C1-V4-cozywarm_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/11-C2-V5-cozygrim-chibi_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/11-C2-V5-cozygrim-chibi_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/11-C2-V5-cozygrim-chibi_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/11-C2-V5-cozygrim-chibi_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/12-C3-cast-burnedout-senior_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/12-C3-cast-burnedout-senior_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/12-C3-cast-burnedout-senior_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/12-C3-cast-burnedout-senior_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/13-C4-cast-eccentric-junior_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/13-C4-cast-eccentric-junior_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/13-C4-cast-eccentric-junior_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/13-C4-cast-eccentric-junior_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/14-C5-cast-south-asian-man_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/14-C5-cast-south-asian-man_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/14-C5-cast-south-asian-man_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/14-C5-cast-south-asian-man_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/15-Cat1-singed-tabby_east.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/15-Cat1-singed-tabby_north.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/15-Cat1-singed-tabby_south.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/15-Cat1-singed-tabby_west.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/16-Cat2-spooky-doom_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/16-Cat2-spooky-doom_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/16-Cat2-spooky-doom_south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/16-Cat2-spooky-doom_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/19-Cat1-tophat_east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/19-Cat1-tophat_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/19-Cat1-tophat_south.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/19-Cat1-tophat_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/20-Cat2-spooky-tophat_east.png": [
+    "favour"
+  ],
+  "pixellab_2026-07-16/20-Cat2-spooky-tophat_north.png": [
+    "favour"
+  ],
+  "pixellab_2026-07-16/20-Cat2-spooky-tophat_south.png": [
+    "favour"
+  ],
+  "pixellab_2026-07-16/20-Cat2-spooky-tophat_west.png": [
+    "favour"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_0.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_5.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_6.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_7.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_east_8.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_0.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_5.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_6.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_7.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_north_8.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_0.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_5.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_6.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_7.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_south_8.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_0.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_5.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_6.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_7.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat1/walk_west_8.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_0.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_1.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_2.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_3.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_4.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_5.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_6.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_7.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_east_8.png": [
+    "favour",
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_0.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_1.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_2.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_3.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_4.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_5.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_6.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_7.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_north_8.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_0.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_1.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_2.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_3.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_4.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_5.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_6.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_7.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_south_8.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_0.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_1.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_2.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_3.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_4.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_5.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_6.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_7.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/cat_walk_cat2/walk_west_8.png": [
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_eldritch_1.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_eldritch_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_purple_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_eldritch_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_purple_4.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_purple_3.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/cats_body_type_quadruped_template_cat/cat_purple_2.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/cast_woman_lead_older_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/cast_woman_lead_older_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/cast_woman_lead_older_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/cast_woman_lead_older_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/founder_silhouette_1.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/founder_silhouette_2.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/founder_silhouette_3.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-16/sweep/characters_use_create_character/founder_silhouette_4.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_1.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_1_north-east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_1_north-west.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_1_north.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_south-east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_south-west.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_west.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_north-west.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_north-east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3_east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_east.png": [
+    "dislike",
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_2_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_north-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_north-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_south-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_south-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_eldritch_4_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_north-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_north-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_south-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_south-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_1_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2_east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2_north-east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2_north-west.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_2_north.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_east.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_north-east.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_north-west.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_north.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_south-east.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_south-west.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/cats/cat_purple_4_west.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/characters/cast_eccentric_genius_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/characters/cast_eccentric_genius_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/characters/cast_eccentric_genius_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/characters/cast_eccentric_genius_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/founder/founder_2.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/founder/founder_1.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/founder/founder_3.png": [
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/founder/founder_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_black/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/cat_tabby/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/eccentric_genius/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/founder/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/researcher_labcoat/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_blouse_f/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_cardigan_older/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_headphones_young/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_hoodie_m/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/south.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/characters/worker_shirt_glasses_m/rotations/west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_north-east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_north-west.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_north.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_south-east.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_south-west.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_eldritch_1_west.png": [
+    "like"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_north-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_north-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_south-east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_south-west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_1_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cats/cat_purple_2_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_black_woman_young_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_eccentric_genius_f_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_wheelchair_user_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_north-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_north-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_north.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_south-east.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_south-west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/characters/cast_woman_lead_older_1_west.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/floor_carpet.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/floor_concrete.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/floor_lino.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/wall_decent.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/tilesets/wall_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/floor_carpet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/floor_concrete_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/floor_lino_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/wall_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/tilesets/wall_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/floor_carpet.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/floor_concrete.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/floor_lino.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/wall_decent.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/tilesets/wall_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/17-Operator-silhouette_east.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/17-Operator-silhouette_north.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/17-Operator-silhouette_south.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/17-Operator-silhouette_west.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/18-Hat-tall.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_medium_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_medium_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_medium_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_medium_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_sports_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_sports_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_sports_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/hat_sports_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/headphones_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/headphones_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/headphones_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/headphones_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lab_coat_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lab_coat_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lab_coat_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lab_coat_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lanyard_badge_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lanyard_badge_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lanyard_badge_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/cosmetics_overlays/lanyard_badge_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/hat_medium_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/hat_medium_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/hat_sports_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/hat_sports_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/lab_coat_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/cosmetics/lab_coat_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/bookshelf.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/chair.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/coat_rack.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/couch.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/plant.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/server_rack.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/water_cooler.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/office_library/whiteboard.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/cat_bed_basket.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/cat_litter_box.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/coffee_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/coffee_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/desk_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/desk_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/fridge_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/fridge_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/hat_tall.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/monitor_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/monitor_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/pc_clean.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/pc_scummy.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/props/window_clean.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/props/window_scummy.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_decent_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_decent_2.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_decent_3.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_decent_4.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_scummy_1.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_scummy_2.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_scummy_3.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/door_scummy_4.png": [
+    "like"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_carpet_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_carpet_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_carpet_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_concrete_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_concrete_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_concrete_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_concrete_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_lino_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_lino_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_lino_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/floor_lino_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_decent_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_decent_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_decent_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_decent_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_scummy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_scummy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/wall_scummy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_clear_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_clear_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_clear_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_clear_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_doomy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_doomy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_doomy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_doomy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_storm_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_storm_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_storm_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/environment/window_weather_storm_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_decent_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_decent_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/chair_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/coat_rack_reroll_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/coat_rack_reroll_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/coat_rack_reroll_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/coat_rack_reroll_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/desk_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/desk_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/desk_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/desk_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/filing_cabinet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/filing_cabinet_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/filing_cabinet_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/filing_cabinet_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_decent_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_decent_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_scummy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_scummy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/kitchen_bench_scummy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/meeting_table_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/meeting_table_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/meeting_table_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/meeting_table_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/monitor_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/monitor_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/monitor_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/monitor_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/pc_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/pc_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/pc_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/pc_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/printer_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/printer_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/printer_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/printer_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/server_cluster_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/server_cluster_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/server_cluster_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/server_cluster_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/trash_can_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/trash_can_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/trash_can_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/trash_can_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/water_cooler_reroll_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/water_cooler_reroll_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/water_cooler_reroll_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/props/water_cooler_reroll_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_compute_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_compute_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_compute_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_compute_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_doom_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_doom_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_doom_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/icon_doom_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_indicator_dot_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_indicator_dot_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_indicator_dot_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_indicator_dot_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_texture_tile_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_texture_tile_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_texture_tile_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-16/sweep/ui_filler_map_object/ui_texture_tile_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_compute_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_compute_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_compute_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_compute_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_doom_1.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_doom_2.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_doom_3.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/icons/icon_doom_4.png": [
+    "disfavour",
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/chair_decent_1.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/chair_decent_2.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/chair_decent_3.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/chair_decent_4.png": [
+    "dislike"
+  ],
+  "pixellab_2026-07-17/reroll/objects/coat_rack_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/coat_rack_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/coat_rack_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/coat_rack_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/desk_mega_screen_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/desk_mega_screen_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/desk_mega_screen_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/desk_mega_screen_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/filing_cabinet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/filing_cabinet_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/filing_cabinet_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/filing_cabinet_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_decent_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_decent_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_scummy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_scummy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/kitchen_bench_scummy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/meeting_table_1.png": [
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/objects/meeting_table_2.png": [
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/objects/meeting_table_3.png": [
+    "disfavour"
+  ],
+  "pixellab_2026-07-17/reroll/objects/meeting_table_4.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/monitor_mega_startup_1.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/monitor_mega_startup_2.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/monitor_mega_startup_3.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/monitor_mega_startup_4.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/pc_mega_1.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/pc_mega_2.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/pc_mega_3.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/pc_mega_4.png": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "pixellab_2026-07-17/reroll/objects/server_cluster_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/server_cluster_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/server_cluster_mega_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/server_cluster_mega_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/trash_recycling_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/trash_recycling_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/trash_recycling_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/trash_recycling_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/water_cooler_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/water_cooler_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/water_cooler_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/objects/water_cooler_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_clear_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_clear_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_clear_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_clear_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_doomy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_doomy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_doomy_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_doomy_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_storm_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_storm_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_storm_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/sky_storm_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/window_frame_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/window_frame_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/window_frame_3.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-17/reroll/windows/window_frame_4.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/armchair_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/bookshelf_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/box_stack_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/cable_spool_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/cardboard_box_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/chair_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/chair_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/chair_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/coat_rack_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/coffee_machine_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/corkboard_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/couch_waiting_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/desk_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/desk_lamp_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/desk_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/desk_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/exit_sign_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/filing_cabinet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/filing_cabinet_tall_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/fire_extinguisher_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/floor_lamp_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/kitchen_bench_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/kitchen_bench_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/laptop_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/microwave_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/mini_fridge_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/monitor_doomcurve_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/monitor_dual_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/monitor_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/monitor_single_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/office_phone_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/pc_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/pc_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/plant_dead_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/plant_small_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/plant_tall_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/printer_mega_copier_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/printer_small_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/recycling_bin_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/server_cluster_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/server_rack_single_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/snack_table_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/standing_whiteboard_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/trash_can_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/wall_clock_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/water_cooler_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/whiteboard_blank_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-19/props/whiteboard_equations_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/chairs/chair_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/chairs/chair_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/chairs/chair_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/chairs/chair_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/kitchen/kitchen_bench_decent_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/kitchen/kitchen_bench_decent_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/coat_rack_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/coat_rack_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/desk_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/desk_mega_screen_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/door_scummy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/door_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/filing_cabinet_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/monitor_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/monitor_mega_startup_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/pc_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/pc_mega_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/printer_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/printer_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/server_cluster_mega_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/trash_recycling_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/objects/trash_recycling_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_clear_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_clear_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_doomy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_doomy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_storm_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/sky_storm_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/window_frame_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/window_frame_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-21-rerolls/windows/window_frame_3.png": [
+    "like",
+    "promote"
+  ]
+}

--- a/tools/art_review/README.md
+++ b/tools/art_review/README.md
@@ -1,0 +1,144 @@
+# art_review -- art triage pipeline (v2)
+
+Status: LIVE
+
+Local-first, browser-based triage for the game's two art libraries, plus a
+stdlib analyzer that turns triage decisions into actionable promote / favour /
+prune lists and an "untriaged" oversight-gap report. Pure Python 3.11 + self-
+contained HTML; ASCII only; no external services at review time.
+
+Two libraries, one workflow:
+
+  * sprites -- the pixellab pixel-art library under `art_source/pixellab_*`
+    (characters, cats, props, tilesets, cosmetics).
+  * hero    -- the gpt-image-1 hero / banner / icon library under
+    `art_generated/` (game_icons, ui_icons, hero_banners, ...).
+
+Each library: a generator builds a self-contained review HTML, you triage in
+the browser (tag + bulk-select), you "export JSON" to a tracked verdicts file,
+then the analyzer reads the verdicts against the on-disk inventory.
+
+
+## Pipeline -- sprites
+
+    python tools/art_review/gen_contact_sheet.py
+        -> writes art_source/pixellab_contact_sheet.html   (regenerable artifact)
+
+    open art_source/pixellab_contact_sheet.html in a browser
+        - filter by category / folder / filename; per-sprite verdict tags;
+          checkbox + shift-click range select; bulk apply/remove bar;
+          thumbnail = lightbox. Verdicts persist to that browser's
+          localStorage.
+        - click "export JSON" and SAVE the download over:
+              art_source/pixellab_verdicts.json                (TRACKED source)
+
+    python tools/art_review/analyze_verdicts.py --library sprites
+        -> report to stdout + writes:
+              art_source/promote_list.txt                      (regenerable)
+              art_source/favour_list.txt                       (regenerable)
+              art_source/disfavour_dislike_list.txt            (regenerable)
+
+
+## Pipeline -- hero
+
+    python tools/art_review/gen_hero_gallery.py
+        -> writes art_generated/hero_gallery.html          (regenerable artifact)
+        (pulls prompt/provenance from art_prompts/*.yaml|json + art_generated/logs;
+         needs PyYAML. multi-size exports of one asset -- foo_v2_64/128/.../1024.png
+         -- are deduped to one entry per (run-subdir, id, version).)
+
+    open art_generated/hero_gallery.html in a browser
+        - full-size lightbox + per-asset provenance (prompt, model, cost, hash);
+          same tag + bulk-select controls as the contact sheet.
+        - click "export JSON" and SAVE the download over:
+              art_source/hero_verdicts.json                    (TRACKED source)
+
+    python tools/art_review/analyze_verdicts.py --library hero
+        -> report to stdout + writes:
+              art_source/hero_promote_list.txt                 (regenerable)
+              art_source/hero_favour_list.txt                  (regenerable)
+              art_source/hero_disfavour_dislike_list.txt       (regenerable)
+
+
+## analyze_verdicts.py
+
+    python tools/art_review/analyze_verdicts.py                # both libraries (default)
+    python tools/art_review/analyze_verdicts.py --library hero
+    python tools/art_review/analyze_verdicts.py --library sprites
+    python tools/art_review/analyze_verdicts.py --selftest     # synthetic checks
+
+For each library it prints:
+
+  1. Verdict summary   -- inventory total, tagged count, per-tag counts;
+     PROMOTE + FAVOUR broken down by category and finer subtype.
+  2. Imbalance + gaps  -- over-represented promoted subtypes vs zero/under-
+     promoted subtypes that DO exist in inventory.
+  3. UNTRIAGED report (the headline) -- inventory assets with NO verdict at
+     all, by category/subtype and as a % of that category, most-first: the
+     oversight gap, i.e. where judgment has not yet reached.
+  4. Stale verdict paths -- tagged but no longer on disk.
+
+and writes the per-library promote / favour / disfavour+dislike list files
+(grouped by `# category/subtype`) named above. A missing verdicts JSON is
+handled gracefully: it prints where to paste the export and skips that library;
+the other still runs. stdlib only.
+
+Paths are repo-relative (derived from the script's own location), so the tools
+run from any working directory. `gen_contact_sheet.py` also accepts an
+alternate art_source dir as `argv[1]`.
+
+
+## Verdict JSON schema
+
+Both `pixellab_verdicts.json` and `hero_verdicts.json` are a flat object
+mapping a POSIX-style relative path to a list of verdict tags:
+
+    {
+      "pixellab_2026-07-19/objects/desk_decent_1.png": ["like", "promote"],
+      "pixellab_2026-07-17/reroll/cats/cat_black_1_east.png": ["favour"],
+      "game_icons/grant_proposal_v2_1024.png": ["promote"]
+    }
+
+  * sprite paths are relative to `art_source/`.
+  * hero paths are relative to `art_generated/`; a verdict on ANY size variant
+    of a deduped asset resolves to that asset's single entry.
+  * a bare string value ("promote") is accepted and treated as ["promote"].
+  * unknown tags are ignored; empty tag lists drop the key.
+
+### the 5 verdict tags
+
+    like        general approval / keep
+    dislike     general rejection
+    favour      shortlist -- a preferred candidate within its group
+    disfavour   deprioritize (soft prune)
+    promote     graduate into the game -- office sandbox + generation queue
+
+`analyze_verdicts.py` acts on `promote` (promote list), `favour` (favour list),
+and merges `disfavour` + `dislike` into the prune list. `like` is informational.
+
+
+## Tracked source vs regenerable artifact
+
+TRACKED (the durable human decisions + the tools):
+
+    tools/art_review/gen_contact_sheet.py
+    tools/art_review/gen_hero_gallery.py
+    tools/art_review/hero_gallery_template.html
+    tools/art_review/analyze_verdicts.py
+    tools/art_review/README.md
+    art_source/pixellab_verdicts.json      (sprite triage decisions)
+    art_source/hero_verdicts.json          (hero triage decisions)
+
+REGENERABLE, so gitignored (rebuilt any time from source + inventory):
+
+    art_source/pixellab_contact_sheet.html
+    art_generated/hero_gallery.html
+    art_source/promote_list.txt
+    art_source/favour_list.txt
+    art_source/disfavour_dislike_list.txt
+    art_source/hero_promote_list.txt
+    art_source/hero_favour_list.txt
+    art_source/hero_disfavour_dislike_list.txt
+
+The rule: verdicts JSONs and the tooling are versioned; every HTML sheet and
+every `*_list.txt` is a derived output and stays out of git.

--- a/tools/art_review/analyze_verdicts.py
+++ b/tools/art_review/analyze_verdicts.py
@@ -1,0 +1,838 @@
+#!/usr/bin/env python3
+"""Analyze art triage exports (verdict JSONs) for BOTH art libraries.
+
+Two libraries, one tool:
+
+  * sprites -- the pixellab pixel-art library under art_source/pixellab_* ,
+    triaged via art_source/pixellab_contact_sheet.html -> "export JSON" saved
+    to art_source/pixellab_verdicts.json .
+  * hero    -- the gpt-image-1 hero/banner/icon library under art_generated/ ,
+    triaged via art_generated/hero_gallery.html -> "export JSON" saved to
+    art_source/hero_verdicts.json . Multi-size exports of one asset
+    (foo_v2_64/128/256/512/1024.png) are DEDUPED to a single entry per
+    (run-subdir, id, version) -- the same identity the gallery shows -- so a
+    verdict on any size resolves to that one entry. Category = the run subdir
+    (game_icons, ui_icons, hero_banners, ...). This mirrors the dedup + category
+    logic in G:/tmp/gen_hero_gallery.py (re-implemented here, stdlib only).
+
+For EACH library the report prints:
+  1. Verdict summary  -- inventory total, tagged, per-tag counts; PROMOTE +
+     FAVOUR broken down by category and finer subtype.
+  2. Imbalance + gaps  -- over-represented promoted subtypes; zero/under-promoted
+     subtypes that DO exist in inventory.
+  3. UNTRIAGED report (the headline)  -- inventory assets with NO verdict at all,
+     counted by category/subtype and as a % of that category, sorted most-first,
+     so the owner can SEE where his judgment has not reached.
+  4. Stale verdict paths  -- tagged but no longer on disk.
+
+Per-library actionable path lists are written (grouped by "# category/subtype"):
+  sprites -> art_source/{promote,favour,disfavour_dislike}_list.txt
+  hero    -> art_source/hero_{promote,favour,disfavour_dislike}_list.txt
+
+A missing verdicts JSON is handled gracefully (prints where to paste the export
+and skips that library; the other still runs). stdlib only, Python 3.11, ASCII.
+
+Usage:
+  python tools/art_review/analyze_verdicts.py                 # both libraries
+  python tools/art_review/analyze_verdicts.py --library hero  # just hero
+  python tools/art_review/analyze_verdicts.py --library sprites
+  python tools/art_review/analyze_verdicts.py --selftest      # synthetic checks
+"""
+import collections
+import json
+import os
+import re
+import sys
+
+# --- paths -----------------------------------------------------------------
+# Repo-relative: this script lives at <repo>/tools/art_review/ , so the repo
+# root is three levels up. Works from any cwd.
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+ART_DIR = os.path.join(ROOT, "art_source")
+GEN_DIR = os.path.join(ROOT, "art_generated")
+
+# sprites (pixellab)
+VERDICTS_PATH = os.path.join(ART_DIR, "pixellab_verdicts.json")
+PROMOTE_OUT = os.path.join(ART_DIR, "promote_list.txt")
+FAVOUR_OUT = os.path.join(ART_DIR, "favour_list.txt")
+PRUNE_OUT = os.path.join(ART_DIR, "disfavour_dislike_list.txt")
+
+# hero (gpt-image-1)
+HERO_VERDICTS_PATH = os.path.join(ART_DIR, "hero_verdicts.json")
+HERO_PROMOTE_OUT = os.path.join(ART_DIR, "hero_promote_list.txt")
+HERO_FAVOUR_OUT = os.path.join(ART_DIR, "hero_favour_list.txt")
+HERO_PRUNE_OUT = os.path.join(ART_DIR, "hero_disfavour_dislike_list.txt")
+
+EXTS = (".png", ".jpg", ".jpeg", ".gif", ".webp")
+VERDICTS = ["like", "dislike", "favour", "disfavour", "promote"]
+CATS = ["characters", "cats", "props", "tilesets", "cosmetics", "other"]
+TOP_N = 8  # over-represented subtypes to list per category
+TOP_N_UNTRIAGED = 15  # untriaged subtypes to list per category before overflow
+
+# tokens stripped from the tail of a filename stem to reach the "item" identity
+_DIRS = {
+    "east",
+    "west",
+    "north",
+    "south",
+    "up",
+    "down",
+    "north-east",
+    "north-west",
+    "south-east",
+    "south-west",
+    "ne",
+    "nw",
+    "se",
+    "sw",
+}
+_UNWRAP = {"reroll", "sweep"}  # container run-subfolders to skip
+_STRIP_LEAF = {"rotations"}  # trailing folder segs that aren't identity
+
+
+# --- sprite classification (copied from gen_contact_sheet.py) --------------
+def categorize(rel_parts):
+    """Category from the folder segments (all segments below the run root)."""
+    segs = [s.lower() for s in rel_parts]
+
+    def has(*names):
+        return any(any(n in s for n in names) for s in segs)
+
+    if has("tileset"):
+        return "tilesets"
+    if has("cat"):
+        return "cats"
+    if has("cosmetic", "overlay"):
+        return "cosmetics"
+    if has(
+        "window",
+        "prop",
+        "object",
+        "kitchen",
+        "chair",
+        "library",
+        "environment",
+        "ui_filler",
+        "ui-filler",
+        "icon",
+    ):
+        return "props"
+    if has(
+        "character",
+        "founder",
+        "era_ladder",
+        "era-ladder",
+        "style_matrix",
+        "style-matrix",
+        "researcher",
+        "worker",
+        "genius",
+    ):
+        return "characters"
+    return None
+
+
+def categorize_by_name(fname):
+    """Fallback category for loose root sprites, from the filename."""
+    n = fname.lower()
+    if "cat" in n:
+        return "cats"
+    if "tileset" in n or "floor_" in n or "wall_" in n:
+        return "tilesets"
+    if "hat" in n or "silhouette" in n:
+        return "cosmetics"
+    return "characters"
+
+
+# --- sprite subtype derivation ---------------------------------------------
+def file_item(fname):
+    """Object identity from a filename: strip extension, then strip trailing
+    direction tokens (east/north-west/...) and pure-number variant tokens
+    (_1, _2). 'chair_decent_1_east.png' -> 'chair_decent';
+    'east.png' -> '' (rotation frame, identity lives in the folder)."""
+    stem = os.path.splitext(fname)[0].lower()
+    toks = stem.split("_")
+    while toks and (toks[-1] in _DIRS or toks[-1].isdigit()):
+        toks.pop()
+    return "_".join(toks)
+
+
+def unwrap_segs(dir_segs):
+    """Drop reroll/sweep container prefixes and a trailing 'rotations' seg."""
+    segs = [s for s in dir_segs if s.lower() not in _UNWRAP]
+    while segs and segs[-1].lower() in _STRIP_LEAF:
+        segs.pop()
+    return segs
+
+
+def subtype_of(cat, dir_segs, fname):
+    """Finer subtype label 'category/<item>'. Prefer the filename-derived item
+    (so props/objects splits into desk_decent, coat_rack, bin, ...); fall back
+    to the immediate folder leaf when the filename is direction-only (character
+    and cat rotation frames, whose identity is the folder name)."""
+    item = file_item(fname)
+    if not item:
+        segs = unwrap_segs(dir_segs)
+        item = segs[-1].lower() if segs else "misc"
+    return "{}/{}".format(cat, item)
+
+
+def classify_record(dir_segs, fname):
+    """Return (category, subtype) for one sprite. dir_segs are the folder
+    segments below the run root ([] for a loose root sprite)."""
+    cat = categorize(dir_segs) if dir_segs else None
+    if cat is None:
+        cat = categorize_by_name(fname)
+    if cat not in CATS:
+        cat = "other"
+    return cat, subtype_of(cat, dir_segs, fname)
+
+
+# --- sprite inventory scan -------------------------------------------------
+def build_sprite_inventory(art_dir=ART_DIR):
+    """Scan art_source/pixellab_* for images. Returns (records, alias).
+
+    records: list of {rel, run, cat, subtype, fn}; rel is POSIX-style relative
+    to art_dir (matching the verdict-JSON key form).
+    alias: {} -- sprites have no multi-file dedup, so verdict keys map to
+    themselves (identity)."""
+    records = []
+    if not os.path.isdir(art_dir):
+        return records, {}
+    runs = sorted(
+        d
+        for d in os.listdir(art_dir)
+        if d.startswith("pixellab_") and os.path.isdir(os.path.join(art_dir, d))
+    )
+    for run in runs:
+        run_root = os.path.join(art_dir, run)
+        for dirpath, dirnames, filenames in os.walk(run_root):
+            dirnames.sort()
+            for fn in sorted(filenames):
+                if not fn.lower().endswith(EXTS):
+                    continue
+                abs_path = os.path.join(dirpath, fn)
+                rel = os.path.relpath(abs_path, art_dir).replace("\\", "/")
+                sub = os.path.relpath(dirpath, run_root).replace("\\", "/")
+                dir_segs = [] if sub == "." else sub.split("/")
+                cat, subtype = classify_record(dir_segs, fn)
+                records.append(
+                    {
+                        "rel": rel,
+                        "run": run,
+                        "cat": cat,
+                        "subtype": subtype,
+                        "fn": fn,
+                    }
+                )
+    return records, {}
+
+
+# --- hero inventory scan (mirrors gen_hero_gallery.py dedup/category) -------
+# filename stem -> (id, version, size); version + trailing size are optional.
+_HERO_FN_RE = re.compile(r"^(?P<id>.+?)(?:_v(?P<ver>\d+))?(?:_(?P<size>\d+))?$")
+
+
+def parse_hero_name(stem):
+    """Split a hero filename stem into (id, version_label, size).
+    'grant_proposal_v2_1024' -> ('grant_proposal', 'v2', 1024).
+    'crt_overlay'            -> ('crt_overlay', '', None)."""
+    m = _HERO_FN_RE.match(stem)
+    if not m:
+        return stem, "", None
+    gid = m.group("id")
+    ver = m.group("ver")
+    size = m.group("size")
+    return gid, ("v" + ver if ver else ""), (int(size) if size else None)
+
+
+def build_hero_inventory(gen_dir=GEN_DIR):
+    """Walk art_generated/ and dedup multi-size exports to one entry per
+    (run-subdir, id, version), exactly as the hero gallery does. Returns
+    (records, alias).
+
+    records: list of {rel, run, cat, subtype, fn, members}. rel is the
+    REPRESENTATIVE (largest-size) file, POSIX-relative to gen_dir; cat is the
+    run subdir; subtype is 'cat/id'; members is every size-variant rel.
+    alias: {member_rel: representative_rel} for every file, so a verdict on any
+    size (or on the representative) resolves to the one deduped entry."""
+    records, alias = [], {}
+    if not os.path.isdir(gen_dir):
+        return records, alias
+    # (subdir, id, ver) -> [(size, rel), ...]
+    groups = {}
+    for dirpath, dirnames, filenames in os.walk(gen_dir):
+        dirnames.sort()
+        for fn in sorted(filenames):
+            if not fn.lower().endswith(EXTS):
+                continue
+            rel = os.path.relpath(os.path.join(dirpath, fn), gen_dir).replace("\\", "/")
+            subdir = rel.split("/")[0]
+            gid, ver, size = parse_hero_name(os.path.splitext(fn)[0])
+            key = (subdir, gid, ver)
+            groups.setdefault(key, []).append((size if size is not None else 0, rel))
+
+    for (subdir, gid, ver), files in groups.items():
+        # representative = largest size (ties broken by path for determinism)
+        files_sorted = sorted(files, key=lambda t: (-t[0], t[1]))
+        rep = files_sorted[0][1]
+        members = [r for _s, r in files_sorted]
+        cat = subdir
+        subtype = "{}/{}".format(cat, gid.lower())
+        records.append(
+            {
+                "rel": rep,
+                "run": subdir,
+                "cat": cat,
+                "subtype": subtype,
+                "fn": os.path.basename(rep),
+                "members": members,
+            }
+        )
+        for r in members:
+            alias[r] = rep
+    records.sort(key=lambda r: (r["cat"], r["subtype"], r["rel"]))
+    return records, alias
+
+
+def load_verdicts(path):
+    """Return {rel: [tags]} with POSIX keys and known tags only, or None if the
+    file is missing. Raises ValueError on a malformed (non-object) file."""
+    if not os.path.isfile(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        obj = json.load(f)
+    if not isinstance(obj, dict):
+        raise ValueError("verdicts JSON must be an object {path: [tags]}")
+    out = {}
+    for k, v in obj.items():
+        key = str(k).replace("\\", "/")
+        if isinstance(v, str):
+            v = [v]
+        tags = [t for t in (v or []) if t in VERDICTS]
+        if tags:
+            out[key] = tags
+    return out
+
+
+def canonicalize_verdicts(verdicts, alias):
+    """Remap verdict keys through alias (member -> representative) so a verdict
+    on any size variant lands on the one deduped inventory entry. Keys not in
+    alias pass through unchanged (identity for sprites; stale for hero). Tags
+    from paths that collapse onto the same entry are merged (order-preserving,
+    de-duplicated)."""
+    if not alias:
+        return dict(verdicts)
+    out = {}
+    for rel, tags in verdicts.items():
+        canon = alias.get(rel, rel)
+        acc = out.setdefault(canon, [])
+        for t in tags:
+            if t not in acc:
+                acc.append(t)
+    return out
+
+
+# --- aggregation (pure; unit-tested by --selftest) -------------------------
+def summarize(verdicts, records):
+    """Cross-reference verdicts against the inventory.
+
+    verdicts: {rel: [tags]} (already canonicalized to representative rels)
+    records:  list of inventory record dicts
+    Returns a dict of aggregates (see keys assembled at the end)."""
+    inv_by_rel = {r["rel"]: r for r in records}
+
+    verdict_counts = collections.Counter()
+    # per-verdict breakdowns, only for on-disk assets
+    by_cat = {v: collections.Counter() for v in VERDICTS}
+    by_sub = {v: collections.Counter() for v in VERDICTS}
+    # actionable path lists keyed (cat, subtype) -> [rel...]
+    lists = {v: collections.defaultdict(list) for v in VERDICTS}
+    stale = collections.Counter()  # tag -> count on paths not on disk
+    stale_paths = {}
+
+    tagged_rels = set()
+    for rel, tags in verdicts.items():
+        tagged_rels.add(rel)
+        rec = inv_by_rel.get(rel)
+        for t in tags:
+            verdict_counts[t] += 1
+        if rec is None:
+            stale_paths[rel] = tags
+            for t in tags:
+                stale[t] += 1
+            continue
+        for t in tags:
+            by_cat[t][rec["cat"]] += 1
+            by_sub[t][rec["subtype"]] += 1
+            lists[t][(rec["cat"], rec["subtype"])].append(rel)
+
+    # inventory-side coverage: subtypes per category + inventory sizes.
+    inv_subtypes = collections.defaultdict(set)  # cat -> {subtype}
+    inv_sub_count = collections.Counter()  # subtype -> inventory size
+    inv_by_cat = collections.Counter()  # cat -> inventory size
+    sub_to_cat = {}  # subtype -> cat
+    for r in records:
+        inv_subtypes[r["cat"]].add(r["subtype"])
+        inv_sub_count[r["subtype"]] += 1
+        inv_by_cat[r["cat"]] += 1
+        sub_to_cat[r["subtype"]] = r["cat"]
+
+    promote_by_sub = by_sub["promote"]
+    # per category: over-represented (top promoted) and under/zero-promote
+    over = {}  # cat -> [(subtype, promote_count)] desc
+    under = {}  # cat -> [(subtype, promote_count, inv_count)] promote<=1
+    for cat in sorted(inv_subtypes):
+        subs = inv_subtypes[cat]
+        ranked = sorted(
+            ((s, promote_by_sub.get(s, 0)) for s in subs),
+            key=lambda x: (-x[1], x[0]),
+        )
+        over[cat] = [t for t in ranked if t[1] > 0][:TOP_N]
+        under[cat] = sorted(
+            (
+                (s, promote_by_sub.get(s, 0), inv_sub_count[s])
+                for s in subs
+                if promote_by_sub.get(s, 0) <= 1
+            ),
+            key=lambda x: (x[1], -x[2], x[0]),
+        )
+
+    # UNTRIAGED: assets on disk with NO verdict at all, by category and subtype.
+    untriaged_by_cat = collections.Counter()
+    untriaged_by_sub = collections.Counter()
+    untriaged_total = 0
+    for r in records:
+        if r["rel"] not in tagged_rels:
+            untriaged_by_cat[r["cat"]] += 1
+            untriaged_by_sub[r["subtype"]] += 1
+            untriaged_total += 1
+
+    return {
+        "total_tagged": len(tagged_rels),
+        "verdict_counts": verdict_counts,
+        "by_cat": by_cat,
+        "by_sub": by_sub,
+        "lists": lists,
+        "stale": stale,
+        "stale_paths": stale_paths,
+        "over": over,
+        "under": under,
+        # untriaged aggregation (headline)
+        "untriaged_by_cat": untriaged_by_cat,
+        "untriaged_by_sub": untriaged_by_sub,
+        "untriaged_total": untriaged_total,
+        # inventory sizing (for % denominators)
+        "inv_by_cat": inv_by_cat,
+        "inv_sub_count": inv_sub_count,
+        "sub_to_cat": sub_to_cat,
+        "inv_total": len(records),
+        # legacy aliases kept for backward-compat with earlier callers/tests
+        "untouched_by_cat": untriaged_by_cat,
+        "untouched_total": untriaged_total,
+    }
+
+
+# --- reporting -------------------------------------------------------------
+def _pct(num, den):
+    return (100.0 * num / den) if den else 0.0
+
+
+def _fmt_counter(counter, indent="    "):
+    lines = []
+    for name, n in sorted(counter.items(), key=lambda x: (-x[1], x[0])):
+        lines.append("{}{:5d}  {}".format(indent, n, name))
+    return lines or ["{}(none)".format(indent)]
+
+
+def render_report(agg, inv_total, title="ART"):
+    L = []
+    p = L.append
+    p("=" * 70)
+    p("{} VERDICT ANALYSIS".format(title))
+    p("=" * 70)
+    p("inventory on disk : {} assets".format(inv_total))
+    p("tagged (triaged)  : {}".format(agg["total_tagged"]))
+    p(
+        "never triaged     : {}  ({:.1f}% of inventory)".format(
+            agg["untriaged_total"], _pct(agg["untriaged_total"], inv_total)
+        )
+    )
+    p("")
+
+    # 1. VERDICT SUMMARY -----------------------------------------------------
+    p("-- 1. VERDICT SUMMARY " + "-" * 48)
+    p("verdict tag counts:")
+    vc = agg["verdict_counts"]
+    for v in VERDICTS:
+        p("    {:5d}  {}".format(vc.get(v, 0), v))
+    stale = agg["stale"]
+    if sum(stale.values()):
+        p("  (of which STALE -- tag on a path not on disk:)")
+        for v in VERDICTS:
+            if stale.get(v):
+                p("    {:5d}  {} (stale)".format(stale[v], v))
+    for v in ("promote", "favour"):
+        p("")
+        p("  {} by CATEGORY:".format(v.upper()))
+        L.extend(_fmt_counter(agg["by_cat"][v], "      "))
+        p("  {} by SUBTYPE (desc):".format(v.upper()))
+        L.extend(_fmt_counter(agg["by_sub"][v], "      "))
+
+    # 2. IMBALANCE + GAPS ----------------------------------------------------
+    p("")
+    p("-- 2. IMBALANCE + COVERAGE GAPS " + "-" * 38)
+    any_imbalance = False
+    for cat in sorted(agg["over"]):
+        over = agg["over"][cat]
+        under = agg["under"][cat]
+        if not over and not under:
+            continue
+        any_imbalance = True
+        p("  [{}]".format(cat))
+        p("    over-represented promoted subtypes (top {}):".format(TOP_N))
+        if over:
+            for s, n in over:
+                p("      {:5d}  {}".format(n, s))
+        else:
+            p("      (nothing promoted in this category)")
+        p("    under-/zero-promote subtypes present in inventory:")
+        zero = [(s, n, inv) for (s, n, inv) in under if n == 0]
+        one = [(s, n, inv) for (s, n, inv) in under if n == 1]
+        if zero:
+            p("      ZERO promotes ({} asset types):".format(len(zero)))
+            for s, n, inv in zero:
+                p("        {}  (inventory x{})".format(s, inv))
+        if one:
+            p("      only 1 promote:")
+            for s, n, inv in one:
+                p("        {}  (inventory x{})".format(s, inv))
+        if not zero and not one:
+            p("      (every subtype here has >=2 promotes)")
+    if not any_imbalance:
+        p("  (no verdicts to weigh yet)")
+
+    # 3. UNTRIAGED (headline) -----------------------------------------------
+    p("")
+    p("-- 3. UNTRIAGED -- WHERE JUDGMENT HAS NOT REACHED " + "-" * 20)
+    p(
+        "  total untriaged: {} / {} inventory ({:.1f}%)".format(
+            agg["untriaged_total"], inv_total, _pct(agg["untriaged_total"], inv_total)
+        )
+    )
+    p("  by category (most untriaged first):")
+    ubc = agg["untriaged_by_cat"]
+    ibc = agg["inv_by_cat"]
+    ubs = agg["untriaged_by_sub"]
+    isc = agg["inv_sub_count"]
+    sub_to_cat = agg["sub_to_cat"]
+    # subtypes grouped under their category
+    subs_of_cat = collections.defaultdict(list)
+    for sub, n in ubs.items():
+        subs_of_cat[sub_to_cat.get(sub, "?")].append((sub, n))
+    if not ubc:
+        p("      (nothing untriaged -- full coverage)")
+    for cat, n in sorted(ubc.items(), key=lambda x: (-x[1], x[0])):
+        cat_inv = ibc.get(cat, 0)
+        p(
+            "    {}  ({} / {} untriaged, {:.1f}% of category)".format(
+                cat, n, cat_inv, _pct(n, cat_inv)
+            )
+        )
+        rows = sorted(subs_of_cat.get(cat, []), key=lambda x: (-x[1], x[0]))
+        for sub, sn in rows[:TOP_N_UNTRIAGED]:
+            sub_inv = isc.get(sub, 0)
+            p(
+                "        {:4d} / {:<4d}  {}  ({:.0f}% of subtype)".format(
+                    sn, sub_inv, sub, _pct(sn, sub_inv)
+                )
+            )
+        if len(rows) > TOP_N_UNTRIAGED:
+            hidden = sum(sn for _s, sn in rows[TOP_N_UNTRIAGED:])
+            p(
+                "        ... and {} more subtypes ({} untriaged assets)".format(
+                    len(rows) - TOP_N_UNTRIAGED, hidden
+                )
+            )
+
+    # 4. STALE ---------------------------------------------------------------
+    stale_paths = agg["stale_paths"]
+    p("")
+    p("-- 4. STALE VERDICT PATHS (tagged but not on disk): {} ".format(len(stale_paths)) + "-" * 12)
+    for rel in sorted(stale_paths)[:40]:
+        p("      {}  {}".format(",".join(stale_paths[rel]), rel))
+    if len(stale_paths) > 40:
+        p("      ... and {} more".format(len(stale_paths) - 40))
+    if not stale_paths:
+        p("      (none -- every verdict path is on disk)")
+    return "\n".join(L)
+
+
+def write_list_file(path, list_map, header):
+    """list_map: {(cat, subtype): [rel...]}. Writes paths grouped under a
+    '# category/subtype' header per group (subtype already contains category)."""
+    groups = sorted(list_map.items(), key=lambda kv: (kv[0][0], kv[0][1]))
+    total = 0
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write("# {}\n".format(header))
+        f.write("# generated by tools/art_review/analyze_verdicts.py\n\n")
+        for (cat, subtype), rels in groups:
+            f.write("# {}\n".format(subtype))
+            for rel in sorted(rels):
+                f.write(rel + "\n")
+                total += 1
+            f.write("\n")
+    return total
+
+
+def write_outputs(agg, promote_out, favour_out, prune_out, label):
+    lists = agg["lists"]
+    n_prom = write_list_file(
+        promote_out,
+        lists["promote"],
+        "{} PROMOTE -- office sandbox + generation queue".format(label),
+    )
+    n_fav = write_list_file(favour_out, lists["favour"], "{} FAVOUR -- shortlist".format(label))
+    # prune list: disfavour + dislike merged, keyed the same way
+    prune_map = collections.defaultdict(list)
+    for v in ("disfavour", "dislike"):
+        for key, rels in lists[v].items():
+            prune_map[key].extend(rels)
+    for key in prune_map:
+        prune_map[key] = sorted(set(prune_map[key]))
+    n_prune = write_list_file(
+        prune_out, prune_map, "{} DISFAVOUR + DISLIKE -- prune / ignore".format(label)
+    )
+    return {promote_out: n_prom, favour_out: n_fav, prune_out: n_prune}
+
+
+# --- library configuration + driver ----------------------------------------
+LIBRARIES = {
+    "sprites": {
+        "title": "PIXELLAB SPRITE",
+        "label": "SPRITES",
+        "verdicts": VERDICTS_PATH,
+        "builder": build_sprite_inventory,
+        "outputs": (PROMOTE_OUT, FAVOUR_OUT, PRUNE_OUT),
+        "empty_warn": "no sprites found under art_source/pixellab_*",
+        "paste_hint": [
+            "Open the contact sheet (art_source/pixellab_contact_sheet.html),",
+            "tag sprites, click 'export JSON', and SAVE the download to:",
+            "  {}".format(VERDICTS_PATH),
+        ],
+    },
+    "hero": {
+        "title": "HERO / BANNER / ICON",
+        "label": "HERO",
+        "verdicts": HERO_VERDICTS_PATH,
+        "builder": build_hero_inventory,
+        "outputs": (HERO_PROMOTE_OUT, HERO_FAVOUR_OUT, HERO_PRUNE_OUT),
+        "empty_warn": "no images found under art_generated/",
+        "paste_hint": [
+            "Open the hero gallery (art_generated/hero_gallery.html),",
+            "tag assets, click 'export JSON', and SAVE the download to:",
+            "  {}".format(HERO_VERDICTS_PATH),
+        ],
+    },
+}
+
+
+def run_library(key):
+    """Analyze one library. Returns True if it ran, False if skipped/missing."""
+    cfg = LIBRARIES[key]
+    print("")
+    print("#" * 70)
+    print("# LIBRARY: {}  ({})".format(key, cfg["title"]))
+    print("#" * 70)
+
+    try:
+        raw = load_verdicts(cfg["verdicts"])
+    except (ValueError, json.JSONDecodeError) as e:
+        print("ERROR: could not parse {}\n  {}".format(cfg["verdicts"], e))
+        print('Expected a flat object: { "relative/path.png": ["promote", ...] }')
+        return False
+
+    if raw is None:
+        print("No verdicts file found. paste the export to {}".format(cfg["verdicts"]))
+        print("")
+        for line in cfg["paste_hint"]:
+            print("  " + line)
+        print("  then re-run: python tools/art_review/analyze_verdicts.py --library {}".format(key))
+        return False
+
+    records, alias = cfg["builder"]()
+    if not records:
+        print("WARNING: {} -- report will be empty.".format(cfg["empty_warn"]))
+    verdicts = canonicalize_verdicts(raw, alias)
+    agg = summarize(verdicts, records)
+
+    print(render_report(agg, len(records), title=cfg["title"]))
+
+    print("")
+    print("-- 5. ACTIONABLE FILES " + "-" * 46)
+    promote_out, favour_out, prune_out = cfg["outputs"]
+    written = write_outputs(agg, promote_out, favour_out, prune_out, cfg["label"])
+    for path, n in written.items():
+        print("    wrote {:4d} paths -> {}".format(n, path))
+    return True
+
+
+# --- selftest --------------------------------------------------------------
+def selftest():
+    # -- sprite classification against real folder shapes -------------------
+    assert classify_record(["reroll", "objects"], "chair_decent_1.png") == (
+        "props",
+        "props/chair_decent",
+    ), classify_record(["reroll", "objects"], "chair_decent_1.png")
+    assert classify_record(["characters", "worker_hoodie_m", "rotations"], "east.png") == (
+        "characters",
+        "characters/worker_hoodie_m",
+    )
+    assert classify_record(["characters", "cat_black", "rotations"], "north-east.png") == (
+        "cats",
+        "cats/cat_black",
+    )
+    assert classify_record(["reroll", "cats"], "cat_eldritch_1_south-west.png") == (
+        "cats",
+        "cats/cat_eldritch",
+    )
+    assert classify_record(["tilesets"], "floor_carpet_1.png") == (
+        "tilesets",
+        "tilesets/floor_carpet",
+    )
+    assert classify_record(["cosmetics"], "hat_medium_1.png") == (
+        "cosmetics",
+        "cosmetics/hat_medium",
+    )
+    assert classify_record([], "cat_ginger_east.png") == ("cats", "cats/cat_ginger")
+
+    # -- hero filename parsing + dedup alias --------------------------------
+    assert parse_hero_name("grant_proposal_v2_1024") == ("grant_proposal", "v2", 1024)
+    assert parse_hero_name("crt_overlay") == ("crt_overlay", "", None)
+    assert parse_hero_name("compute_v1") == ("compute", "v1", None)
+    # a fake group of two sizes for one (subdir,id,ver) collapses to one entry;
+    # the smaller-size verdict must resolve to the representative.
+    alias = {
+        "game_icons/foo_v1_512.png": "game_icons/foo_v1_1024.png",
+        "game_icons/foo_v1_1024.png": "game_icons/foo_v1_1024.png",
+    }
+    canon = canonicalize_verdicts(
+        {"game_icons/foo_v1_512.png": ["promote"], "game_icons/foo_v1_1024.png": ["like"]}, alias
+    )
+    assert canon == {"game_icons/foo_v1_1024.png": ["promote", "like"]}, canon
+
+    # -- synthetic inventory + verdicts exercising every aggregate ----------
+    records = []
+
+    def add(rel, cat, subtype, fn):
+        records.append({"rel": rel, "run": "pixellab_x", "cat": cat, "subtype": subtype, "fn": fn})
+
+    # props: coat_rack promoted 3x (over), bin exists but never promoted (zero gap),
+    #        desk 1 promote (under), lamp UNTRIAGED x2 (fully untriaged subtype)
+    add("pixellab_x/objects/coat_rack_1.png", "props", "props/coat_rack", "coat_rack_1.png")
+    add("pixellab_x/objects/coat_rack_2.png", "props", "props/coat_rack", "coat_rack_2.png")
+    add("pixellab_x/objects/coat_rack_3.png", "props", "props/coat_rack", "coat_rack_3.png")
+    add(
+        "pixellab_x/objects/bin_1.png", "props", "props/bin", "bin_1.png"
+    )  # untriaged + zero-promote
+    add("pixellab_x/objects/desk_1.png", "props", "props/desk", "desk_1.png")  # 1 promote (under)
+    add("pixellab_x/objects/lamp_1.png", "props", "props/lamp", "lamp_1.png")  # untriaged
+    add("pixellab_x/objects/lamp_2.png", "props", "props/lamp", "lamp_2.png")  # untriaged
+    add("pixellab_x/cats/cat_black_1.png", "cats", "cats/cat_black", "cat_black_1.png")
+    verdicts = {
+        "pixellab_x/objects/coat_rack_1.png": ["promote", "favour"],
+        "pixellab_x/objects/coat_rack_2.png": ["promote"],
+        "pixellab_x/objects/coat_rack_3.png": ["promote", "like"],
+        "pixellab_x/objects/desk_1.png": ["promote"],
+        "pixellab_x/cats/cat_black_1.png": ["favour", "like"],
+        "pixellab_x/GONE/ghost_1.png": ["promote", "favour"],  # stale (not on disk)
+        "pixellab_x/objects/bad_1.png": ["dislike"],  # stale dislike
+    }
+    agg = summarize(verdicts, records)
+
+    assert agg["total_tagged"] == 7, agg["total_tagged"]
+    assert agg["verdict_counts"]["promote"] == 5, agg["verdict_counts"]
+    assert agg["verdict_counts"]["favour"] == 3, agg["verdict_counts"]
+    assert agg["by_sub"]["promote"]["props/coat_rack"] == 3, agg["by_sub"]["promote"]
+    assert agg["by_sub"]["promote"]["props/desk"] == 1
+    assert agg["by_cat"]["promote"]["props"] == 4, agg["by_cat"]["promote"]
+    # stale: ghost has promote+favour, bad has dislike
+    assert (
+        agg["stale"]["promote"] == 1
+        and agg["stale"]["favour"] == 1
+        and agg["stale"]["dislike"] == 1
+    )
+    assert len(agg["stale_paths"]) == 2
+    # over-represented props: coat_rack first
+    over_props = agg["over"]["props"]
+    assert over_props and over_props[0] == ("props/coat_rack", 3), over_props
+    # zero-promote gap: bin present with 0 promotes; lamp also 0 (untriaged too)
+    under_props = dict((s, n) for (s, n, inv) in agg["under"]["props"])
+    assert under_props.get("props/bin") == 0, under_props
+    assert under_props.get("props/desk") == 1
+    assert "props/coat_rack" not in under_props  # 3 promotes -> not under
+
+    # -- UNTRIAGED aggregation (the new headline) ---------------------------
+    # untriaged assets: bin_1, lamp_1, lamp_2  (cat_black tagged; coat_racks/desk tagged)
+    assert agg["untriaged_total"] == 3, agg["untriaged_total"]
+    assert agg["untriaged_by_cat"]["props"] == 3, agg["untriaged_by_cat"]
+    assert "cats" not in agg["untriaged_by_cat"], agg["untriaged_by_cat"]
+    # by subtype
+    assert agg["untriaged_by_sub"]["props/lamp"] == 2, agg["untriaged_by_sub"]
+    assert agg["untriaged_by_sub"]["props/bin"] == 1, agg["untriaged_by_sub"]
+    assert "props/coat_rack" not in agg["untriaged_by_sub"]  # fully triaged
+    # denominators for %: category inventory + subtype inventory
+    assert agg["inv_by_cat"]["props"] == 7, agg["inv_by_cat"]
+    assert agg["inv_by_cat"]["cats"] == 1
+    assert agg["inv_sub_count"]["props/lamp"] == 2
+    assert agg["sub_to_cat"]["props/lamp"] == "props"
+    # props untriaged % of category = 3/7; lamp = 2/2 = 100% of subtype
+    assert (
+        abs(_pct(agg["untriaged_by_cat"]["props"], agg["inv_by_cat"]["props"]) - (300.0 / 7)) < 1e-9
+    )
+    assert (
+        abs(_pct(agg["untriaged_by_sub"]["props/lamp"], agg["inv_sub_count"]["props/lamp"]) - 100.0)
+        < 1e-9
+    )
+    # legacy aliases still populated
+    assert agg["untouched_total"] == 3 and agg["untouched_by_cat"]["props"] == 3
+
+    # -- grouping/list assembly ---------------------------------------------
+    lists = agg["lists"]
+    assert set(lists["promote"].keys()) == {("props", "props/coat_rack"), ("props", "props/desk")}
+    assert sorted(lists["promote"][("props", "props/coat_rack")]) == [
+        "pixellab_x/objects/coat_rack_1.png",
+        "pixellab_x/objects/coat_rack_2.png",
+        "pixellab_x/objects/coat_rack_3.png",
+    ]
+    # -- render must not throw and must surface imbalance + untriaged --------
+    rep = render_report(agg, len(records), title="SELFTEST")
+    assert "props/coat_rack" in rep and "STALE" in rep and "ZERO promotes" in rep
+    assert "UNTRIAGED" in rep and "props/lamp" in rep and "% of category" in rep
+    print("selftest OK: classification, hero-dedup alias, aggregation, gaps,")
+    print("             untriaged (cat+subtype+%), stale, grouping all pass")
+    return 0
+
+
+# --- main ------------------------------------------------------------------
+def main(argv):
+    if "--selftest" in argv:
+        return selftest()
+
+    which = "both"
+    if "--library" in argv:
+        i = argv.index("--library")
+        if i + 1 < len(argv):
+            which = argv[i + 1].lower()
+    if which not in ("sprites", "hero", "both"):
+        print("ERROR: --library must be one of: sprites, hero, both")
+        return 2
+
+    keys = ["sprites", "hero"] if which == "both" else [which]
+    for k in keys:
+        run_library(k)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/art_review/gen_contact_sheet.py
+++ b/tools/art_review/gen_contact_sheet.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Generate a self-contained pixellab contact-sheet / triage HTML. Local review tool."""
+import collections
+import json
+import os
+import sys
+
+# Repo-relative: this script lives at <repo>/tools/art_review/ , so the repo
+# root is three levels up. Override art_source with argv[1] if given.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(_HERE))
+
+ART_DIR = sys.argv[1] if len(sys.argv) > 1 else os.path.join(ROOT, "art_source")
+OUT = os.path.join(ART_DIR, "pixellab_contact_sheet.html")
+EXTS = (".png", ".jpg", ".jpeg", ".gif", ".webp")
+
+
+def categorize(rel_parts):
+    segs = [s.lower() for s in rel_parts]
+
+    def has(*names):
+        return any(any(n in s for n in names) for s in segs)
+
+    if has("tileset"):
+        return "tilesets"
+    if has("cat"):
+        return "cats"
+    if has("cosmetic", "overlay"):
+        return "cosmetics"
+    if has(
+        "window",
+        "prop",
+        "object",
+        "kitchen",
+        "chair",
+        "library",
+        "environment",
+        "ui_filler",
+        "ui-filler",
+        "icon",
+    ):
+        return "props"
+    if has(
+        "character",
+        "founder",
+        "era_ladder",
+        "era-ladder",
+        "style_matrix",
+        "style-matrix",
+        "researcher",
+        "worker",
+        "genius",
+    ):
+        return "characters"
+    return None
+
+
+def categorize_by_name(fname):
+    n = fname.lower()
+    if "cat" in n:
+        return "cats"
+    if "tileset" in n or "floor_" in n or "wall_" in n:
+        return "tilesets"
+    if "hat" in n or "silhouette" in n:
+        return "cosmetics"
+    return "characters"
+
+
+CATS = ["characters", "cats", "props", "tilesets", "cosmetics", "other"]
+
+records = []
+cat_counts = collections.Counter()
+run_counts = collections.Counter()
+run_cat_counts = collections.defaultdict(collections.Counter)
+
+runs = sorted(
+    d
+    for d in os.listdir(ART_DIR)
+    if d.startswith("pixellab_") and os.path.isdir(os.path.join(ART_DIR, d))
+)
+
+for run in runs:
+    run_root = os.path.join(ART_DIR, run)
+    for dirpath, dirnames, filenames in os.walk(run_root):
+        dirnames.sort()
+        for fn in sorted(filenames):
+            if not fn.lower().endswith(EXTS):
+                continue
+            abs_path = os.path.join(dirpath, fn)
+            rel = os.path.relpath(abs_path, ART_DIR).replace("\\", "/")
+            sub = os.path.relpath(dirpath, run_root).replace("\\", "/")
+            dir_segs = [] if sub == "." else sub.split("/")
+            cat = categorize(dir_segs) if dir_segs else None
+            if cat is None:
+                cat = categorize_by_name(fn)
+            if cat not in CATS:
+                cat = "other"
+            subfolder = "/".join(dir_segs) if dir_segs else "(root)"
+            records.append({"rel": rel, "run": run, "cat": cat, "sub": subfolder, "fn": fn})
+            cat_counts[cat] += 1
+            run_counts[run] += 1
+            run_cat_counts[run][cat] += 1
+
+total = len(records)
+
+print("TOTAL:", total)
+print("BY CATEGORY:")
+for c in CATS:
+    if cat_counts[c]:
+        print(f"  {cat_counts[c]:5d}  {c}")
+print("BY RUN:")
+for r in runs:
+    print(f"  {run_counts[r]:5d}  {r}")
+    for c in CATS:
+        if run_cat_counts[r][c]:
+            print(f"          {run_cat_counts[r][c]:4d}  {c}")
+
+CAT_COLORS = {
+    "characters": "#e0a34a",
+    "cats": "#c98b3f",
+    "props": "#8fae6b",
+    "tilesets": "#6ba3b0",
+    "cosmetics": "#b57fb0",
+    "other": "#8a8375",
+}
+VERDICTS = ["like", "dislike", "favour", "disfavour", "promote"]
+VERDICT_COLORS = {
+    "like": "#6fae5a",
+    "dislike": "#cc5a4a",
+    "favour": "#e0a34a",
+    "disfavour": "#7a7268",
+    "promote": "#5a8fc0",
+}
+
+data = [
+    {"r": rec["rel"], "u": rec["run"], "c": rec["cat"], "s": rec["sub"], "f": rec["fn"]}
+    for rec in records
+]
+data_json = json.dumps(data, separators=(",", ":"))
+
+chips = "".join(
+    f'<button class="chip" data-cat="{c}">{c} <span class="chip-n">{cat_counts[c]}</span></button>'
+    for c in CATS
+    if cat_counts[c]
+)
+vchips = "".join(
+    f'<button class="vchip" data-v="{v}" style="--vc:{VERDICT_COLORS[v]}">{v} '
+    f'<span class="chip-n" id="vcount-{v}">0</span></button>'
+    for v in VERDICTS
+)
+
+css = """
+:root{--bg:#141210;--bg2:#1c1916;--bg3:#252019;--fg:#e8e0d2;--dim:#9a9081;
+--amber:#e0a34a;--amber2:#ffcf7a;--line:#3a332a;
+--like:#6fae5a;--dislike:#cc5a4a;--favour:#e0a34a;--disfavour:#7a7268;--promote:#5a8fc0;}
+*{box-sizing:border-box;}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);
+font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;overflow-x:hidden;}
+.mono,h1,h2{font-family:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;}
+header{position:sticky;top:0;z-index:20;background:linear-gradient(180deg,#1c1916,#141210);
+border-bottom:1px solid var(--line);padding:12px 18px 10px;box-shadow:0 2px 12px #0008;}
+.title-row{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;}
+h1{font-size:17px;margin:0;color:var(--amber);letter-spacing:.5px;}
+h1 .sub{color:var(--dim);font-weight:normal;font-size:12px;}
+.badge{background:var(--bg3);border:1px solid var(--line);color:var(--amber2);
+padding:3px 9px;border-radius:12px;font-size:12px;font-family:monospace;}
+.controls{display:flex;gap:8px;align-items:center;margin-top:9px;flex-wrap:wrap;}
+.row-label{font-size:10px;color:var(--dim);font-family:monospace;text-transform:uppercase;
+letter-spacing:1px;margin-right:2px;}
+input[type=search]{background:var(--bg3);border:1px solid var(--line);color:var(--fg);
+padding:6px 10px;border-radius:6px;font-size:13px;min-width:200px;flex:0 1 300px;font-family:monospace;}
+input[type=search]:focus{outline:none;border-color:var(--amber);}
+.chip,.vchip,.toggle,.btn{background:var(--bg3);border:1px solid var(--line);color:var(--dim);
+padding:5px 10px;border-radius:13px;font-size:12px;cursor:pointer;font-family:monospace;
+transition:all .12s;white-space:nowrap;}
+.chip:hover,.vchip:hover,.toggle:hover,.btn:hover{border-color:var(--amber);color:var(--fg);}
+.chip.on{background:var(--amber);color:#1a1510;border-color:var(--amber);font-weight:600;}
+.vchip.on{background:var(--vc);color:#12100c;border-color:var(--vc);font-weight:600;}
+.chip-n{opacity:.7;font-size:10px;}
+.toggle.on{background:#4a3a1a;border-color:var(--amber2);color:var(--amber2);}
+.btn{border-radius:6px;}
+.btn.primary{color:var(--amber2);border-color:#5a4a2a;}
+main{padding:6px 18px 90px;}
+.run-sec{margin-top:16px;}
+.run-head,.cat-head{cursor:pointer;user-select:none;display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
+.run-head{font-size:15px;color:var(--amber2);border-bottom:1px solid var(--line);padding:8px 0 6px;margin-top:8px;}
+.cat-head{font-size:12px;color:var(--dim);padding:8px 0 4px;margin-left:4px;text-transform:uppercase;letter-spacing:1px;}
+.caret{display:inline-block;width:12px;color:var(--amber);transition:transform .12s;}
+.collapsed .caret{transform:rotate(-90deg);}
+.collapsed > .body{display:none;}
+.count-tag{color:var(--dim);font-size:11px;font-family:monospace;}
+.selall{font-size:10px;color:var(--dim);background:var(--bg3);border:1px solid var(--line);
+border-radius:5px;padding:2px 7px;cursor:pointer;font-family:monospace;}
+.selall:hover{border-color:var(--amber);color:var(--fg);}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(132px,1fr));gap:10px;margin:6px 0 14px;}
+.tile{background:var(--bg2);border:1px solid var(--line);border-radius:8px;padding:8px 8px 7px;
+position:relative;display:flex;flex-direction:column;transition:border-color .12s;}
+.tile:hover{border-color:#5a5040;}
+.tile.sel{border-color:var(--amber2);box-shadow:0 0 0 1px var(--amber2) inset;}
+.thumb-wrap{background:repeating-conic-gradient(#201c17 0% 25%,#2a251e 0% 50%) 50%/16px 16px;
+border-radius:5px;aspect-ratio:1;display:flex;align-items:center;justify-content:center;overflow:hidden;cursor:zoom-in;}
+.thumb-wrap img{max-width:100%;max-height:100%;image-rendering:pixelated;image-rendering:crisp-edges;}
+.selbox{position:absolute;top:6px;left:6px;width:20px;height:20px;cursor:pointer;z-index:2;
+accent-color:var(--amber);margin:0;}
+.fn{font-family:monospace;font-size:10px;color:var(--fg);margin-top:6px;word-break:break-all;line-height:1.3;}
+.meta{font-size:9px;color:var(--dim);margin-top:2px;font-family:monospace;}
+.cat-pill{display:inline-block;font-size:8px;padding:1px 5px;border-radius:6px;color:#15110b;
+font-weight:700;text-transform:uppercase;letter-spacing:.5px;}
+.vtags{display:flex;flex-wrap:wrap;gap:3px;margin-top:6px;}
+.vtag{font-size:8px;font-family:monospace;padding:2px 5px;border-radius:5px;cursor:pointer;
+border:1px solid var(--line);background:transparent;color:var(--dim);text-transform:uppercase;
+letter-spacing:.3px;line-height:1;transition:all .1s;}
+.vtag:hover{color:var(--fg);border-color:var(--vc);}
+.vtag.on{background:var(--vc);color:#12100c;border-color:var(--vc);font-weight:700;}
+.empty{color:var(--dim);font-style:italic;padding:20px;text-align:center;}
+footer{color:var(--dim);font-size:11px;padding:20px 18px;border-top:1px solid var(--line);font-family:monospace;line-height:1.6;}
+.bulkbar{position:fixed;left:0;right:0;bottom:0;z-index:30;background:linear-gradient(0deg,#221d16,#1a1611);
+border-top:1px solid #5a4a2a;padding:10px 18px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;
+box-shadow:0 -3px 14px #000a;transform:translateY(110%);transition:transform .18s;}
+.bulkbar.on{transform:translateY(0);}
+.bulkbar .selcount{color:var(--amber2);font-family:monospace;font-size:13px;font-weight:600;}
+.bulkbar .sep{color:var(--line);}
+.bulk-add,.bulk-del{border-radius:6px;font-size:11px;padding:5px 9px;border:1px solid var(--line);
+background:var(--bg3);color:var(--dim);cursor:pointer;font-family:monospace;}
+.bulk-add{--vc:#888;}
+.bulk-add:hover{background:var(--vc);color:#12100c;border-color:var(--vc);}
+.bulk-del:hover{background:#3a2020;border-color:#cc5a4a;color:#e8b0a8;}
+.lightbox{position:fixed;inset:0;background:#000d;z-index:100;display:none;align-items:center;
+justify-content:center;flex-direction:column;gap:12px;cursor:zoom-out;}
+.lightbox.on{display:flex;}
+.lightbox img{max-width:80vw;max-height:72vh;image-rendering:pixelated;
+background:repeating-conic-gradient(#201c17 0% 25%,#2a251e 0% 50%) 50%/24px 24px;border:1px solid var(--line);}
+.lightbox .lbcap{color:var(--fg);font-family:monospace;font-size:13px;text-align:center;padding:0 20px;}
+#toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#2a2419;
+border:1px solid var(--amber);color:var(--amber2);padding:8px 16px;border-radius:8px;
+font-family:monospace;font-size:12px;z-index:200;opacity:0;transition:opacity .2s;pointer-events:none;}
+#toast.on{opacity:1;}
+"""
+
+js = r"""
+const DATA=__DATA__;
+const CATCOLORS=__CATCOLORS__;
+const VERDICTS=__VERDICTS__;
+const VCOLORS=__VCOLORS__;
+const KV='pcs:verdicts';   // {rel:[tags]}
+let V={};                  // in-memory verdict map
+let storageOK=false;
+function loadV(){try{const s=localStorage.getItem(KV);V=s?JSON.parse(s):{};storageOK=true;}
+  catch(e){V={};storageOK=false;}}
+function saveV(){if(!storageOK)return;try{localStorage.setItem(KV,JSON.stringify(V));}catch(e){storageOK=false;}}
+function tagsOf(r){return V[r]||[];}
+function hasTag(r,t){return tagsOf(r).indexOf(t)>=0;}
+function setTag(r,t,on){let a=V[r]?V[r].slice():[];const i=a.indexOf(t);
+  if(on&&i<0)a.push(t);else if(!on&&i>=0)a.splice(i,1);
+  if(a.length)V[r]=a;else delete V[r];}
+
+let activeCats=new Set(), activeVerdicts=new Set(), query='';
+const selected=new Set();
+let lastClickedIdx=null;
+const tileByRel={}; let orderedRels=[];
+
+function build(){
+  const runs={};
+  for(const d of DATA){(runs[d.u]=runs[d.u]||{});(runs[d.u][d.c]=runs[d.u][d.c]||[]).push(d);}
+  const main=document.getElementById('main');
+  for(const run of Object.keys(runs).sort()){
+    const sec=document.createElement('section');sec.className='run-sec';
+    const rc=Object.values(runs[run]).reduce((a,b)=>a+b.length,0);
+    const rh=document.createElement('div');rh.className='run-head';
+    rh.innerHTML=`<span class="caret">v</span><span class="mono">${run}</span> <span class="count-tag">${rc}</span>`;
+    const selBtn=document.createElement('span');selBtn.className='selall';selBtn.textContent='select group';
+    rh.appendChild(selBtn);
+    const rbody=document.createElement('div');rbody.className='body';
+    rh.addEventListener('click',e=>{if(e.target===selBtn)return;sec.classList.toggle('collapsed');});
+    const groupRels=[];
+    sec.appendChild(rh);sec.appendChild(rbody);
+    for(const cat of Object.keys(runs[run]).sort()){
+      const cwrap=document.createElement('div');cwrap.className='cat-sec';cwrap.dataset.cat=cat;
+      const ch=document.createElement('div');ch.className='cat-head';
+      ch.innerHTML=`<span class="caret">v</span>${cat} <span class="count-tag">${runs[run][cat].length}</span>`;
+      const cSel=document.createElement('span');cSel.className='selall';cSel.textContent='select';
+      ch.appendChild(cSel);
+      const cbody=document.createElement('div');cbody.className='body grid';
+      ch.addEventListener('click',e=>{if(e.target===cSel)return;cwrap.classList.toggle('collapsed');});
+      const catRels=[];
+      for(const d of runs[run][cat]){const t=tile(d);cbody.appendChild(t);catRels.push(d.r);groupRels.push(d.r);}
+      cSel.onclick=e=>{e.stopPropagation();selectRels(catRels);};
+      cwrap.appendChild(ch);cwrap.appendChild(cbody);rbody.appendChild(cwrap);
+    }
+    selBtn.onclick=e=>{e.stopPropagation();selectRels(groupRels);};
+    main.appendChild(sec);
+  }
+}
+
+function tile(d){
+  const t=document.createElement('div');t.className='tile';t.dataset.rel=d.r;
+  t.dataset.fn=d.f.toLowerCase();t.dataset.cat=d.c;t.dataset.sub=d.s.toLowerCase();
+  const col=CATCOLORS[d.c]||'#888';
+  t.innerHTML=`
+    <input type="checkbox" class="selbox" title="select">
+    <div class="thumb-wrap"><img loading="lazy" src="${enc(d.r)}" alt="${esc(d.f)}"></div>
+    <div class="fn">${esc(d.f)}</div>
+    <div class="meta"><span class="cat-pill" style="background:${col}">${d.c}</span> ${esc(d.s)}</div>
+    <div class="vtags"></div>`;
+  const vt=t.querySelector('.vtags');
+  for(const v of VERDICTS){
+    const b=document.createElement('button');b.className='vtag';b.dataset.v=v;b.textContent=v;
+    b.style.setProperty('--vc',VCOLORS[v]);
+    if(hasTag(d.r,v))b.classList.add('on');
+    b.onclick=e=>{e.stopPropagation();const on=!hasTag(d.r,v);setTag(d.r,v,on);
+      b.classList.toggle('on',on);saveV();refreshCounts();if(activeVerdicts.size)applyFilter();};
+    vt.appendChild(b);
+  }
+  const cb=t.querySelector('.selbox');
+  cb.addEventListener('click',e=>{e.stopPropagation();onSelClick(d.r,e.shiftKey,cb.checked);});
+  t.querySelector('img').onclick=e=>{e.stopPropagation();openLB(d);};
+  tileByRel[d.r]=t;
+  return t;
+}
+
+function esc(s){return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
+function enc(s){return s.split('/').map(encodeURIComponent).join('/');}
+
+// ---- selection ----
+function onSelClick(rel,shift,checked){
+  const idx=orderedRels.indexOf(rel);
+  if(shift&&lastClickedIdx!==null){
+    const [a,b]=[Math.min(lastClickedIdx,idx),Math.max(lastClickedIdx,idx)];
+    for(let i=a;i<=b;i++){const r=orderedRels[i];const tt=tileByRel[r];
+      if(tt.style.display==='none')continue; setSel(r,checked);}
+  }else{setSel(rel,checked);}
+  lastClickedIdx=idx;updateSelUI();
+}
+function setSel(rel,on){const t=tileByRel[rel];if(!t)return;
+  if(on){selected.add(rel);t.classList.add('sel');}else{selected.delete(rel);t.classList.remove('sel');}
+  const cb=t.querySelector('.selbox');if(cb)cb.checked=on;}
+function selectRels(rels){const vis=rels.filter(r=>tileByRel[r].style.display!=='none');
+  const allSel=vis.every(r=>selected.has(r));
+  for(const r of vis)setSel(r,!allSel);updateSelUI();}
+function selectAllVisible(){const vis=orderedRels.filter(r=>tileByRel[r].style.display!=='none');
+  const allSel=vis.length&&vis.every(r=>selected.has(r));
+  for(const r of vis)setSel(r,!allSel);updateSelUI();}
+function clearSel(){for(const r of[...selected])setSel(r,false);updateSelUI();}
+function updateSelUI(){const n=selected.size;
+  document.getElementById('selcount').textContent=n;
+  document.getElementById('bulkbar').classList.toggle('on',n>0);}
+
+// ---- bulk verdict ----
+function bulkApply(v,on){for(const r of selected){setTag(r,v,on);
+  const t=tileByRel[r];const b=t.querySelector(`.vtag[data-v="${v}"]`);if(b)b.classList.toggle('on',on);}
+  saveV();refreshCounts();if(activeVerdicts.size)applyFilter();
+  toast(`${on?'Set':'Removed'} ${v} on ${selected.size} sprite(s)`);}
+
+// ---- filtering ----
+function applyFilter(){
+  let shown=0;
+  for(const r of orderedRels){
+    const t=tileByRel[r];let ok=true;
+    if(activeCats.size&&!activeCats.has(t.dataset.cat))ok=false;
+    if(ok&&query){const hay=t.dataset.fn+' '+t.dataset.cat+' '+t.dataset.sub;if(!hay.includes(query))ok=false;}
+    if(ok&&activeVerdicts.size){const tags=tagsOf(r);
+      let m=false;for(const v of activeVerdicts)if(tags.indexOf(v)>=0){m=true;break;}if(!m)ok=false;}
+    t.style.display=ok?'':'none';if(ok)shown++;
+  }
+  for(const cs of document.querySelectorAll('.cat-sec')){
+    const any=[...cs.querySelectorAll('.tile')].some(x=>x.style.display!=='none');cs.style.display=any?'':'none';}
+  for(const rs of document.querySelectorAll('.run-sec')){
+    const any=[...rs.querySelectorAll('.cat-sec')].some(c=>c.style.display!=='none');rs.style.display=any?'':'none';}
+  document.getElementById('shown').textContent=shown;
+}
+function refreshCounts(){
+  const c={};for(const v of VERDICTS)c[v]=0;let any=0;
+  for(const r in V){for(const t of V[r])if(c[t]!==undefined)c[t]++;any++;}
+  for(const v of VERDICTS)document.getElementById('vcount-'+v).textContent=c[v];
+  document.getElementById('taggedn').textContent=any;
+}
+
+// ---- export / import ----
+function download(name,text,type){const blob=new Blob([text],{type:type||'text/plain'});
+  const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download=name;
+  document.body.appendChild(a);a.click();a.remove();setTimeout(()=>URL.revokeObjectURL(url),1000);}
+function exportJSON(){download('pixellab_verdicts.json',JSON.stringify(V,null,2),'application/json');
+  toast('Exported JSON');}
+function exportCSV(){let rows=['relative_path,tags'];
+  for(const r of orderedRels){const tg=tagsOf(r);if(tg.length)rows.push(`"${r}","${tg.join(';')}"`);}
+  download('pixellab_verdicts.csv',rows.join('\n'),'text/csv');toast('Exported CSV');}
+function copyList(v){const rels=orderedRels.filter(r=>hasTag(r,v));
+  const text=rels.join('\n');
+  if(navigator.clipboard&&navigator.clipboard.writeText){
+    navigator.clipboard.writeText(text).then(()=>toast(`Copied ${rels.length} ${v} path(s)`),
+      ()=>fallbackCopy(text,rels.length,v));
+  }else fallbackCopy(text,rels.length,v);}
+function fallbackCopy(text,n,v){const ta=document.createElement('textarea');ta.value=text;
+  ta.style.position='fixed';ta.style.opacity='0';document.body.appendChild(ta);ta.select();
+  let ok=false;try{ok=document.execCommand('copy');}catch(e){}ta.remove();
+  toast(ok?`Copied ${n} ${v} path(s)`:`Copy blocked -- see console`);if(!ok)console.log(text);}
+function importJSON(file){const rd=new FileReader();
+  rd.onload=()=>{try{const obj=JSON.parse(rd.result);
+    if(typeof obj!=='object'||Array.isArray(obj))throw 0;
+    V=obj;saveV();
+    for(const r of orderedRels){const t=tileByRel[r];
+      for(const b of t.querySelectorAll('.vtag'))b.classList.toggle('on',hasTag(r,b.dataset.v));}
+    refreshCounts();applyFilter();toast('Imported verdicts');
+  }catch(e){toast('Import failed -- not a valid verdicts JSON');}};
+  rd.readAsText(file);}
+
+// ---- misc ----
+function openLB(d){const lb=document.getElementById('lb');lb.querySelector('img').src=enc(d.r);
+  lb.querySelector('.lbcap').textContent=`${d.f}  --  ${d.u}/${d.s}`;lb.classList.add('on');}
+let toastT=null;
+function toast(msg){const el=document.getElementById('toast');el.textContent=msg;el.classList.add('on');
+  clearTimeout(toastT);toastT=setTimeout(()=>el.classList.remove('on'),1800);}
+
+window.addEventListener('DOMContentLoaded',()=>{
+  loadV();orderedRels=DATA.map(d=>d.r);build();
+  document.getElementById('total').textContent=DATA.length;
+  refreshCounts();applyFilter();
+  document.getElementById('q').addEventListener('input',e=>{query=e.target.value.trim().toLowerCase();applyFilter();});
+  for(const chip of document.querySelectorAll('.chip')){chip.onclick=()=>{const c=chip.dataset.cat;
+    if(activeCats.has(c)){activeCats.delete(c);chip.classList.remove('on');}
+    else{activeCats.add(c);chip.classList.add('on');}applyFilter();};}
+  for(const vc of document.querySelectorAll('.vchip')){vc.onclick=()=>{const v=vc.dataset.v;
+    if(activeVerdicts.has(v)){activeVerdicts.delete(v);vc.classList.remove('on');}
+    else{activeVerdicts.add(v);vc.classList.add('on');}applyFilter();};}
+  document.getElementById('selallvis').onclick=selectAllVisible;
+  // bulk bar buttons
+  const addWrap=document.getElementById('bulkadd'),delWrap=document.getElementById('bulkdel');
+  for(const v of VERDICTS){
+    const a=document.createElement('button');a.className='bulk-add';a.textContent='+'+v;
+    a.style.setProperty('--vc',VCOLORS[v]);a.onclick=()=>bulkApply(v,true);addWrap.appendChild(a);
+    const d=document.createElement('button');d.className='bulk-del';d.textContent='-'+v;
+    d.onclick=()=>bulkApply(v,false);delWrap.appendChild(d);
+  }
+  document.getElementById('clearsel').onclick=clearSel;
+  document.getElementById('expjson').onclick=exportJSON;
+  document.getElementById('expcsv').onclick=exportCSV;
+  document.getElementById('copypromote').onclick=()=>copyList('promote');
+  document.getElementById('copyfavour').onclick=()=>copyList('favour');
+  document.getElementById('impbtn').onclick=()=>document.getElementById('impfile').click();
+  document.getElementById('impfile').addEventListener('change',e=>{if(e.target.files[0])importJSON(e.target.files[0]);e.target.value='';});
+  const lb=document.getElementById('lb');lb.onclick=()=>lb.classList.remove('on');
+  document.addEventListener('keydown',e=>{if(e.key==='Escape'){lb.classList.remove('on');}});
+  if(!storageOK)document.getElementById('storewarn').style.display='inline';
+});
+"""
+
+js = (
+    js.replace("__DATA__", data_json)
+    .replace("__CATCOLORS__", json.dumps(CAT_COLORS))
+    .replace("__VERDICTS__", json.dumps(VERDICTS))
+    .replace("__VCOLORS__", json.dumps(VERDICT_COLORS))
+)
+
+doc = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>P(Doom)1 -- pixellab triage</title>
+<style>{css}</style>
+</head>
+<body>
+<header>
+  <div class="title-row">
+    <h1>P(Doom)1 pixellab library <span class="sub">// triage sheet</span></h1>
+    <span class="badge"><span id="shown">{total}</span> / <span id="total">{total}</span> shown</span>
+    <span class="badge">tagged <span id="taggedn">0</span></span>
+    <span class="badge" id="storewarn" style="display:none;color:#d88">localStorage off -- verdicts wont persist (use Export)</span>
+  </div>
+  <div class="controls">
+    <input id="q" type="search" placeholder="filter by filename / category / folder...">
+    <span class="row-label">cat</span>{chips}
+  </div>
+  <div class="controls">
+    <span class="row-label">verdict</span>{vchips}
+    <span class="sep"> </span>
+    <button class="btn" id="selallvis">select all visible</button>
+    <button class="btn" id="expjson">export JSON</button>
+    <button class="btn" id="expcsv">export CSV</button>
+    <button class="btn" id="copypromote">copy PROMOTE</button>
+    <button class="btn" id="copyfavour">copy FAVOUR</button>
+    <button class="btn primary" id="impbtn">import JSON</button>
+    <input type="file" id="impfile" accept="application/json,.json" style="display:none">
+  </div>
+</header>
+<main id="main"></main>
+<footer>
+  Local triage tool -- untracked, not committed. Thumbnail = enlarge (Esc/click closes).
+  Per-sprite verdict tags (like/dislike/favour/disfavour/promote) + batch select (checkbox,
+  shift-click ranges, select-group / select-all-visible) + bulk apply/remove bar.
+  Verdicts persist to this browser's localStorage; Export JSON/CSV to make them portable/actionable.
+  {total} sprites across {len([r for r in runs if run_counts[r]])} runs.
+</footer>
+<div class="bulkbar" id="bulkbar">
+  <span class="selcount"><span id="selcount">0</span> selected</span>
+  <span class="sep">|</span>
+  <span class="row-label">apply</span><span id="bulkadd" style="display:flex;gap:5px;flex-wrap:wrap"></span>
+  <span class="sep">|</span>
+  <span class="row-label">remove</span><span id="bulkdel" style="display:flex;gap:5px;flex-wrap:wrap"></span>
+  <span class="sep">|</span>
+  <button class="btn" id="clearsel">clear selection</button>
+</div>
+<div class="lightbox" id="lb"><img src="" alt=""><div class="lbcap"></div></div>
+<div id="toast"></div>
+<script>{js}</script>
+</body>
+</html>
+"""
+
+with open(OUT, "w", encoding="utf-8") as f:
+    f.write(doc)
+print("WROTE:", OUT, "bytes:", len(doc.encode("utf-8")))

--- a/tools/art_review/gen_hero_gallery.py
+++ b/tools/art_review/gen_hero_gallery.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Generate art_generated/hero_gallery.html -- triage gallery for gpt-image-1 hero/banner/icon outputs."""
+import glob
+import json
+import os
+import re
+
+import yaml
+
+# Repo-relative: this script lives at <repo>/tools/art_review/ , so the repo
+# root is three levels up. The HTML template sits next to this script.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(_HERE))
+GEN = os.path.join(ROOT, "art_generated")
+PROMPTS = os.path.join(ROOT, "art_prompts")
+OUT = os.path.join(GEN, "hero_gallery.html")
+TEMPLATE = os.path.join(_HERE, "hero_gallery_template.html")
+
+IMG_EXT = (".png", ".jpg", ".jpeg", ".webp")
+
+# ---- transliterate common non-ascii so displayed text is clean ASCII ----
+TRANS = {
+    "\u2014": "--",
+    "\u2013": "-",
+    "\u2018": "'",
+    "\u2019": "'",
+    "\u201c": '"',
+    "\u201d": '"',
+    "\u2026": "...",
+    "\u2192": "->",
+    "\u00a0": " ",
+    "\u00b0": "deg",
+    "\u00d7": "x",
+    "\u2212": "-",
+    "\u2011": "-",
+    "\u00ad": "",
+    "\u2022": "*",
+}
+
+
+def ascii_clean(s):
+    if s is None:
+        return ""
+    if not isinstance(s, str):
+        s = str(s)
+    for k, v in TRANS.items():
+        s = s.replace(k, v)
+    # drop anything still non-ascii
+    return s.encode("ascii", "ignore").decode("ascii")
+
+
+# ---------------------------------------------------------------- prompts
+def resolve_style(data, theme_name):
+    """Return resolved style-context string for a theme (style_overrides + color_bias)."""
+    parts = []
+    styles = data.get("styles") or {}
+    themes = data.get("themes") or {}
+    th = themes.get(theme_name) or {}
+    for ov in th.get("style_overrides") or []:
+        txt = styles.get(ov)
+        if txt:
+            parts.append(ascii_clean(txt))
+    cb = th.get("color_bias")
+    if cb:
+        parts.append(ascii_clean(cb))
+    return "  ".join(parts)
+
+
+# by_asset[(subdir, id)] = dict(prompt_tail, full_prompt, display_name, category, versions{ver:params})
+by_asset = {}
+prompt_yaml_files = []
+
+for path in sorted(glob.glob(os.path.join(PROMPTS, "*.yaml"))) + sorted(
+    glob.glob(os.path.join(PROMPTS, "*.json"))
+):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    except Exception as e:
+        print("SKIP (parse fail):", path, e)
+        continue
+    if not isinstance(data, dict):
+        continue
+    subdir = data.get("asset_type")
+    items = data.get("assets") or data.get("icons") or []
+    if not subdir:
+        # ui_icons.json has no asset_type -> icons list, subdir = ui_icons
+        subdir = "ui_icons"
+    global_icon = ascii_clean(data.get("global_style_icon") or "")
+    prompt_yaml_files.append((os.path.basename(path), subdir, len(items)))
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        aid = it.get("id")
+        if not aid:
+            continue
+        pt = ascii_clean(it.get("prompt_tail") or it.get("prompt") or "")
+        theme = it.get("theme")
+        style_ctx = resolve_style(data, theme) if theme else global_icon
+        full = ("  ".join([p for p in [style_ctx, pt] if p])).strip()
+        versions = {}
+        for gh in it.get("generation_history") or []:
+            ver = str(gh.get("version") or "")
+            versions[ver] = {
+                "md": ascii_clean(gh.get("model") or ""),
+                "cs": gh.get("cost_usd"),
+                "hs": ascii_clean(gh.get("full_prompt_hash") or ""),
+                "ga": ascii_clean(gh.get("generated_at") or ""),
+            }
+        key = (subdir, aid.lower())
+        # prefer entry that actually carries prompt text / history
+        prev = by_asset.get(key)
+        rec = {
+            "pt": pt,
+            "fp": full,
+            "dn": ascii_clean(it.get("display_name") or aid),
+            "cat": ascii_clean(it.get("category") or subdir),
+            "versions": versions,
+            "reroll_of": ascii_clean(it.get("reroll_of") or ""),
+            "reroll_note": ascii_clean(it.get("reroll_note") or ""),
+        }
+        if prev is None or (not prev["pt"] and pt):
+            by_asset[key] = rec
+
+# ---------------------------------------------------------------- generation logs (ground-truth prompts)
+# log lines: "... DEBUG | GENERATE: <id>_v<n>" then "... DEBUG | PROMPT: <full prompt>"
+log_prompt = {}  # (id_lower, ver) -> {"fp":prompt, "md":model}
+log_prompt_any = {}  # id_lower -> {"fp":prompt,"md":model}  (first seen)
+gen_re = re.compile(r"GENERATE:\s*(?P<vid>\S+)")
+info_gen_re = re.compile(r"Generating\s+(?P<vid>\S+)\s*\((?P<size>[0-9x]+),\s*(?P<model>[^)]+)\)")
+ver_strip = re.compile(r"_v(\d+)$")
+LOGDIR = os.path.join(GEN, "logs")
+for lp in sorted(glob.glob(os.path.join(LOGDIR, "*.log"))):
+    cur_vid = None
+    cur_model = ""
+    try:
+        with open(lp, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                mi = info_gen_re.search(line)
+                if mi:
+                    cur_model = ascii_clean(mi.group("model").strip())
+                mg = gen_re.search(line)
+                if mg:
+                    cur_vid = mg.group("vid")
+                    continue
+                idx = line.find("PROMPT:")
+                if idx >= 0 and cur_vid:
+                    prompt = ascii_clean(line[idx + 7 :].strip())
+                    m = ver_strip.search(cur_vid)
+                    if m:
+                        vid_id = cur_vid[: m.start()].lower()
+                        ver = "v" + m.group(1)
+                    else:
+                        vid_id = cur_vid.lower()
+                        ver = ""
+                    rec = {"fp": prompt, "md": cur_model or "openai gpt-image"}
+                    log_prompt[(vid_id, ver)] = rec
+                    log_prompt_any.setdefault(vid_id, rec)
+                    cur_vid = None
+    except Exception as e:
+        print("log skip", lp, e)
+print("log prompt entries:", len(log_prompt))
+
+# global id fallback index (yaml) -- catches cross-subdir dupes (e.g. ui_* icons copied into game_icons/)
+by_id_global = {}
+for (sd, aid), rec in by_asset.items():
+    by_id_global.setdefault(aid, rec)
+
+# ---------------------------------------------------------------- images
+fn_re = re.compile(r"^(?P<id>.+?)(?:_v(?P<ver>\d+))?(?:_(?P<size>\d+))?$")
+
+
+def parse_name(stem):
+    m = fn_re.match(stem)
+    if not m:
+        return stem, "", None
+    gid = m.group("id")
+    ver = m.group("ver")
+    size = m.group("size")
+    return gid, ("v" + ver if ver else ""), (int(size) if size else None)
+
+
+# collect all image files
+groups = {}  # (subdir, id, ver) -> {files:[(size,rel)], subdir,id,ver}
+subdir_asset_ids = {}  # subdir -> sorted list of asset ids (for prefix fallback)
+for sd, aid in by_asset:
+    subdir_asset_ids.setdefault(sd, []).append(aid)
+for sd in subdir_asset_ids:
+    subdir_asset_ids[sd].sort(key=len, reverse=True)  # longest first
+
+n_files = 0
+for dirpath, _dirs, files in os.walk(GEN):
+    for fn in files:
+        if not fn.lower().endswith(IMG_EXT):
+            continue
+        n_files += 1
+        rel = os.path.relpath(os.path.join(dirpath, fn), GEN).replace("\\", "/")
+        subdir = rel.split("/")[0]
+        stem = os.path.splitext(fn)[0]
+        gid, ver, size = parse_name(stem)
+        key = (subdir, gid, ver)
+        g = groups.setdefault(key, {"subdir": subdir, "id": gid, "ver": ver, "files": []})
+        g["files"].append((size if size is not None else 0, rel))
+
+
+# ---------------------------------------------------------------- build entries
+def match_prompt(subdir, gid):
+    """Return (asset_id, pinfo) from yaml. pinfo carries prompt_tail + metadata."""
+    gl = gid.lower()
+    key = (subdir, gl)
+    if key in by_asset:
+        return gl, by_asset[key]
+    # prefix fallback within same subdir
+    for aid in subdir_asset_ids.get(subdir, []):
+        if gl == aid or gl.startswith(aid + "_"):
+            return aid, by_asset[(subdir, aid)]
+    # global-id fallback (cross-subdir dupes)
+    if gl in by_id_global:
+        return gl, by_id_global[gl]
+    return None, None
+
+
+CAT_PALETTE = [
+    "#e0a34a",
+    "#8fae6b",
+    "#6ba3b0",
+    "#b57fb0",
+    "#c98b3f",
+    "#7f9fb5",
+    "#b0906b",
+    "#9a8fb0",
+    "#6fae5a",
+    "#c07f7f",
+]
+
+entries = []
+matched = 0
+cat_seen = {}
+for key, g in groups.items():
+    files = sorted(g["files"], key=lambda t: -t[0])  # largest first
+    rep = files[0][1]
+    aid, pinfo = match_prompt(g["subdir"], g["id"])
+    gl = g["id"].lower()
+    # log-based ground-truth prompt (per version, else any version of this id)
+    log_rec = log_prompt.get((gl, g["ver"])) or log_prompt_any.get(gl)
+
+    pt = pinfo["pt"] if pinfo else ""
+    fp = pinfo["fp"] if pinfo else ""
+    dn = pinfo["dn"] if pinfo else g["id"]
+    rr = pinfo["reroll_note"] if pinfo else ""
+    params = {}
+    if pinfo and pinfo.get("versions"):
+        params = pinfo["versions"].get(g["ver"], {}) or next(iter(pinfo["versions"].values()))
+    md = ascii_clean(params.get("md") or "")
+    cs = params.get("cs")
+    hs = ascii_clean(params.get("hs") or "")
+    ga = ascii_clean(params.get("ga") or "")
+
+    # fill from log when yaml gave no prompt text
+    if not fp and log_rec:
+        fp = log_rec["fp"]
+        if not pt:
+            pt = log_rec["fp"]
+        if not md:
+            md = log_rec["md"] + " (from gen log)"
+
+    has_prompt = bool(fp or pt)
+    if has_prompt:
+        matched += 1
+    cat = (pinfo["cat"] if pinfo else g["subdir"]) or g["subdir"]
+    cat_seen[cat] = cat_seen.get(cat, 0) + 1
+    entries.append(
+        {
+            "r": rep,
+            "u": g["subdir"],
+            "c": cat,
+            "f": os.path.basename(rep),
+            "id": g["id"],
+            "v": g["ver"],
+            "dn": dn,
+            "pt": pt,
+            "fp": fp,
+            "rr": rr,
+            "md": md,
+            "cs": cs,
+            "hs": hs,
+            "ga": ga,
+            "w": has_prompt,
+            "sz": [[s, r] for (s, r) in files],
+        }
+    )
+
+# order: by run then category then id then version
+entries.sort(key=lambda e: (e["u"], e["c"], e["id"], e["v"]))
+
+cat_colors = {c: CAT_PALETTE[i % len(CAT_PALETTE)] for i, c in enumerate(sorted(cat_seen))}
+
+total_imgs = n_files
+n_entries = len(entries)
+match_rate = f"{matched}/{n_entries}"
+print(f"image files walked: {total_imgs}")
+print(f"deduped entries (subdir,id,version @maxsize): {n_entries}")
+print(f"matched to prompt: {matched} ({100*matched/max(1,n_entries):.1f}%)")
+print("runs:", sorted(set(e["u"] for e in entries)))
+
+DATA_JSON = json.dumps(entries, ensure_ascii=True, separators=(",", ":"))
+CATCOL_JSON = json.dumps(cat_colors, ensure_ascii=True)
+
+with open(TEMPLATE, encoding="utf-8") as fh:
+    HTML_TEMPLATE = fh.read()
+
+HTML = (
+    HTML_TEMPLATE.replace("__DATA__", DATA_JSON)
+    .replace("__CATCOLORS__", CATCOL_JSON)
+    .replace("__NENTRIES__", str(n_entries))
+    .replace("__NIMGS__", str(total_imgs))
+    .replace("__MATCHED__", str(matched))
+    .replace("__NRUNS__", str(len(set(e["u"] for e in entries))))
+)
+
+# guard: ensure ASCII only
+bad = [c for c in HTML if ord(c) > 127]
+if bad:
+    print("WARNING non-ascii remaining:", set(bad))
+with open(OUT, "w", encoding="ascii", newline="\n") as fh:
+    fh.write(HTML)
+print("wrote:", OUT, "bytes:", os.path.getsize(OUT))

--- a/tools/art_review/hero_gallery_template.html
+++ b/tools/art_review/hero_gallery_template.html
@@ -1,0 +1,510 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>P(Doom)1 -- hero/banner/icon triage</title>
+<style>
+:root{--bg:#141210;--bg2:#1c1916;--bg3:#252019;--fg:#e8e0d2;--dim:#9a9081;
+--amber:#e0a34a;--amber2:#ffcf7a;--line:#3a332a;
+--like:#6fae5a;--dislike:#cc5a4a;--favour:#e0a34a;--disfavour:#7a7268;--promote:#5a8fc0;}
+*{box-sizing:border-box;}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);
+font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;overflow-x:hidden;}
+.mono,h1,h2{font-family:"SFMono-Regular",Consolas,"Liberation Mono",Menlo,monospace;}
+header{position:sticky;top:0;z-index:20;background:linear-gradient(180deg,#1c1916,#141210);
+border-bottom:1px solid var(--line);padding:12px 18px 10px;box-shadow:0 2px 12px #0008;}
+.title-row{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;}
+h1{font-size:17px;margin:0;color:var(--amber);letter-spacing:.5px;}
+h1 .sub{color:var(--dim);font-weight:normal;font-size:12px;}
+.badge{background:var(--bg3);border:1px solid var(--line);color:var(--amber2);
+padding:3px 9px;border-radius:12px;font-size:12px;font-family:monospace;}
+.controls{display:flex;gap:8px;align-items:center;margin-top:9px;flex-wrap:wrap;}
+.row-label{font-size:10px;color:var(--dim);font-family:monospace;text-transform:uppercase;
+letter-spacing:1px;margin-right:2px;}
+input[type=search]{background:var(--bg3);border:1px solid var(--line);color:var(--fg);
+padding:6px 10px;border-radius:6px;font-size:13px;min-width:200px;flex:0 1 320px;font-family:monospace;}
+input[type=search]:focus{outline:none;border-color:var(--amber);}
+.chip,.vchip,.toggle,.btn{background:var(--bg3);border:1px solid var(--line);color:var(--dim);
+padding:5px 10px;border-radius:13px;font-size:12px;cursor:pointer;font-family:monospace;
+transition:all .12s;white-space:nowrap;}
+.chip:hover,.vchip:hover,.toggle:hover,.btn:hover{border-color:var(--amber);color:var(--fg);}
+.chip.on{background:var(--amber);color:#1a1510;border-color:var(--amber);font-weight:600;}
+.vchip.on{background:var(--vc);color:#12100c;border-color:var(--vc);font-weight:600;}
+.chip-n{opacity:.7;font-size:10px;}
+.toggle.on{background:#4a3a1a;border-color:var(--amber2);color:var(--amber2);}
+.btn{border-radius:6px;}
+.btn.primary{color:var(--amber2);border-color:#5a4a2a;}
+main{padding:6px 18px 96px;}
+.run-sec{margin-top:16px;}
+.run-head,.cat-head{cursor:pointer;user-select:none;display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
+.run-head{font-size:15px;color:var(--amber2);border-bottom:1px solid var(--line);padding:8px 0 6px;margin-top:8px;}
+.cat-head{font-size:12px;color:var(--dim);padding:8px 0 4px;margin-left:4px;text-transform:uppercase;letter-spacing:1px;}
+.caret{display:inline-block;width:12px;color:var(--amber);transition:transform .12s;}
+.collapsed .caret{transform:rotate(-90deg);}
+.collapsed > .body{display:none;}
+.count-tag{color:var(--dim);font-size:11px;font-family:monospace;}
+.selall{font-size:10px;color:var(--dim);background:var(--bg3);border:1px solid var(--line);
+border-radius:5px;padding:2px 7px;cursor:pointer;font-family:monospace;}
+.selall:hover{border-color:var(--amber);color:var(--fg);}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));gap:12px;margin:6px 0 14px;}
+.tile{background:var(--bg2);border:1px solid var(--line);border-radius:8px;padding:8px 8px 7px;
+position:relative;display:flex;flex-direction:column;transition:border-color .12s;}
+.tile:hover{border-color:#5a5040;}
+.tile.sel{border-color:var(--amber2);box-shadow:0 0 0 1px var(--amber2) inset;}
+.thumb-wrap{background:repeating-conic-gradient(#201c17 0% 25%,#2a251e 0% 50%) 50%/18px 18px;
+border-radius:5px;aspect-ratio:16/10;display:flex;align-items:center;justify-content:center;overflow:hidden;cursor:zoom-in;}
+.thumb-wrap img{max-width:100%;max-height:100%;object-fit:contain;}
+.thumb-wrap .zhint{position:absolute;bottom:6px;right:6px;background:#000a;color:var(--amber2);
+font-family:monospace;font-size:9px;padding:2px 6px;border-radius:5px;opacity:0;transition:opacity .12s;pointer-events:none;}
+.tile:hover .zhint{opacity:1;}
+.thumb-wrap{position:relative;}
+.selbox{position:absolute;top:6px;left:6px;width:20px;height:20px;cursor:pointer;z-index:2;
+accent-color:var(--amber);margin:0;}
+.fn{font-family:monospace;font-size:10px;color:var(--fg);margin-top:6px;word-break:break-all;line-height:1.3;}
+.meta{font-size:9px;color:var(--dim);margin-top:2px;font-family:monospace;display:flex;gap:5px;align-items:center;flex-wrap:wrap;}
+.cat-pill{display:inline-block;font-size:8px;padding:1px 5px;border-radius:6px;color:#15110b;
+font-weight:700;text-transform:uppercase;letter-spacing:.5px;}
+.ver-pill{font-size:8px;padding:1px 5px;border-radius:6px;background:var(--bg3);border:1px solid var(--line);color:var(--amber2);}
+.nomatch{font-size:8px;padding:1px 5px;border-radius:6px;background:#3a2020;border:1px solid #6a3030;color:#e0a0a0;}
+.prompt-toggle{font-family:monospace;font-size:9px;color:var(--amber);cursor:pointer;margin-top:5px;user-select:none;}
+.prompt-toggle:hover{color:var(--amber2);}
+.prompt-body{display:none;font-family:monospace;font-size:9px;color:var(--dim);line-height:1.45;
+margin-top:4px;max-height:150px;overflow:auto;border-top:1px dashed var(--line);padding-top:4px;white-space:pre-wrap;}
+.prompt-body.on{display:block;}
+.vtags{display:flex;flex-wrap:wrap;gap:3px;margin-top:6px;}
+.vtag{font-size:8px;font-family:monospace;padding:2px 5px;border-radius:5px;cursor:pointer;
+border:1px solid var(--line);background:transparent;color:var(--dim);text-transform:uppercase;
+letter-spacing:.3px;line-height:1;transition:all .1s;}
+.vtag:hover{color:var(--fg);border-color:var(--vc);}
+.vtag.on{background:var(--vc);color:#12100c;border-color:var(--vc);font-weight:700;}
+.empty{color:var(--dim);font-style:italic;padding:20px;text-align:center;}
+footer{color:var(--dim);font-size:11px;padding:20px 18px;border-top:1px solid var(--line);font-family:monospace;line-height:1.6;}
+.bulkbar{position:fixed;left:0;right:0;bottom:0;z-index:30;background:linear-gradient(0deg,#221d16,#1a1611);
+border-top:1px solid #5a4a2a;padding:10px 18px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;
+box-shadow:0 -3px 14px #000a;transform:translateY(110%);transition:transform .18s;}
+.bulkbar.on{transform:translateY(0);}
+.bulkbar .selcount{color:var(--amber2);font-family:monospace;font-size:13px;font-weight:600;}
+.bulkbar .sep{color:var(--line);}
+.bulk-add,.bulk-del{border-radius:6px;font-size:11px;padding:5px 9px;border:1px solid var(--line);
+background:var(--bg3);color:var(--dim);cursor:pointer;font-family:monospace;}
+.bulk-add{--vc:#888;}
+.bulk-add:hover{background:var(--vc);color:#12100c;border-color:var(--vc);}
+.bulk-del:hover{background:#3a2020;border-color:#cc5a4a;color:#e8b0a8;}
+/* ---- lightbox ---- */
+.lightbox{position:fixed;inset:0;background:#000e;z-index:100;display:none;flex-direction:column;}
+.lightbox.on{display:flex;}
+.lb-top{display:flex;align-items:center;gap:10px;padding:8px 14px;border-bottom:1px solid var(--line);
+background:#181410;flex-wrap:wrap;flex:0 0 auto;}
+.lb-top .lb-fn{font-family:monospace;font-size:12px;color:var(--amber2);word-break:break-all;}
+.lb-top .lb-path{font-family:monospace;font-size:10px;color:var(--dim);}
+.lb-spacer{flex:1;}
+.lb-btn{background:var(--bg3);border:1px solid var(--line);color:var(--dim);font-family:monospace;
+font-size:11px;padding:5px 10px;border-radius:6px;cursor:pointer;white-space:nowrap;}
+.lb-btn:hover{border-color:var(--amber);color:var(--fg);}
+.lb-btn.on{background:#4a3a1a;border-color:var(--amber2);color:var(--amber2);}
+.lb-main{flex:1;display:flex;min-height:0;}
+.lb-stage{flex:1;overflow:auto;display:flex;align-items:center;justify-content:center;
+background:repeating-conic-gradient(#181510 0% 25%,#201c15 0% 50%) 50%/26px 26px;position:relative;}
+.lb-stage.actual{align-items:flex-start;justify-content:flex-start;cursor:grab;}
+.lb-stage.actual.drag{cursor:grabbing;}
+.lb-stage img{display:block;}
+.lb-stage.fit img{max-width:96%;max-height:96%;object-fit:contain;margin:auto;}
+.lb-stage.actual img{max-width:none;max-height:none;}
+.lb-panel{flex:0 0 340px;max-width:44vw;background:#17130f;border-left:1px solid var(--line);
+overflow:auto;padding:12px 14px;font-family:monospace;font-size:11px;color:var(--fg);}
+.lb-panel h3{margin:0 0 6px;font-size:11px;color:var(--amber);text-transform:uppercase;letter-spacing:1px;}
+.lb-panel .kv{color:var(--dim);margin:2px 0;word-break:break-word;}
+.lb-panel .kv b{color:var(--fg);font-weight:600;}
+.lb-prompt{white-space:pre-wrap;line-height:1.5;color:var(--fg);background:#0f0c09;
+border:1px solid var(--line);border-radius:6px;padding:8px;margin:6px 0;max-height:38vh;overflow:auto;}
+.lb-tail{white-space:pre-wrap;line-height:1.5;color:var(--amber2);margin:4px 0 8px;}
+.lb-sizes{display:flex;gap:5px;flex-wrap:wrap;margin:4px 0 10px;}
+.lb-size{background:var(--bg3);border:1px solid var(--line);color:var(--dim);font-size:10px;
+padding:3px 7px;border-radius:5px;cursor:pointer;}
+.lb-size:hover{border-color:var(--amber);color:var(--fg);}
+.lb-size.on{background:var(--amber);color:#1a1510;border-color:var(--amber);font-weight:600;}
+.lb-vtags{display:flex;gap:4px;flex-wrap:wrap;margin-top:6px;}
+.lb-vtag{font-size:10px;font-family:monospace;padding:3px 8px;border-radius:6px;cursor:pointer;
+border:1px solid var(--line);background:transparent;color:var(--dim);text-transform:uppercase;}
+.lb-vtag.on{color:#12100c;font-weight:700;}
+.unmatched-note{color:#e0a0a0;}
+@media(max-width:760px){.lb-main{flex-direction:column;}.lb-panel{flex:0 0 auto;max-width:none;border-left:none;border-top:1px solid var(--line);max-height:45vh;}}
+#toast{position:fixed;bottom:70px;left:50%;transform:translateX(-50%);background:#2a2419;
+border:1px solid var(--amber);color:var(--amber2);padding:8px 16px;border-radius:8px;
+font-family:monospace;font-size:12px;z-index:200;opacity:0;transition:opacity .2s;pointer-events:none;}
+#toast.on{opacity:1;}
+</style>
+</head>
+<body>
+<header>
+  <div class="title-row">
+    <h1>P(Doom)1 hero / banner / icon library <span class="sub">// gpt-image triage + provenance</span></h1>
+    <span class="badge"><span id="shown">0</span> / <span id="total">0</span> shown</span>
+    <span class="badge">tagged <span id="taggedn">0</span></span>
+    <span class="badge">prompt <span id="matchn">0</span></span>
+    <span class="badge" id="storewarn" style="display:none;color:#d88">localStorage off -- verdicts wont persist (use Export)</span>
+  </div>
+  <div class="controls">
+    <input id="q" type="search" placeholder="filter by filename / prompt / category / run...">
+    <span class="row-label">cat</span><span id="catchips" style="display:flex;gap:6px;flex-wrap:wrap"></span>
+  </div>
+  <div class="controls">
+    <span class="row-label">verdict</span>
+    <button class="vchip" data-v="like" style="--vc:#6fae5a">like <span class="chip-n" id="vcount-like">0</span></button>
+    <button class="vchip" data-v="dislike" style="--vc:#cc5a4a">dislike <span class="chip-n" id="vcount-dislike">0</span></button>
+    <button class="vchip" data-v="favour" style="--vc:#e0a34a">favour <span class="chip-n" id="vcount-favour">0</span></button>
+    <button class="vchip" data-v="disfavour" style="--vc:#7a7268">disfavour <span class="chip-n" id="vcount-disfavour">0</span></button>
+    <button class="vchip" data-v="promote" style="--vc:#5a8fc0">promote <span class="chip-n" id="vcount-promote">0</span></button>
+    <span class="sep"> </span>
+    <button class="toggle" id="onlyunmatched">only unmatched</button>
+    <button class="btn" id="selallvis">select all visible</button>
+    <button class="btn" id="expjson">export JSON</button>
+    <button class="btn" id="expcsv">export CSV</button>
+    <button class="btn" id="copypromote">copy PROMOTE</button>
+    <button class="btn" id="copyfavour">copy FAVOUR</button>
+    <button class="btn primary" id="impbtn">import JSON</button>
+    <input type="file" id="impfile" accept="application/json,.json" style="display:none">
+  </div>
+</header>
+<main id="main"></main>
+<footer>
+  Local triage tool -- untracked, not committed. Thumbnail = open FULL-SIZE lightbox (fit-to-screen; toggle "actual size" to pan/zoom at native resolution; Esc or click backdrop closes).
+  Each tile has an expandable prompt caption; the lightbox shows the full generating prompt + params (model / cost / hash / date).
+  Per-image verdict tags (like/dislike/favour/disfavour/promote) + batch select (checkbox, shift-click ranges, select-group / select-all-visible) + bulk apply/remove bar.
+  Verdicts persist to this browser's localStorage under key "hero:verdicts"; Export JSON/CSV or copy PROMOTE/FAVOUR lists to make them actionable.
+  <span id="footstat"></span>
+</footer>
+<div class="bulkbar" id="bulkbar">
+  <span class="selcount"><span id="selcount">0</span> selected</span>
+  <span class="sep">|</span>
+  <span class="row-label">apply</span><span id="bulkadd" style="display:flex;gap:5px;flex-wrap:wrap"></span>
+  <span class="sep">|</span>
+  <span class="row-label">remove</span><span id="bulkdel" style="display:flex;gap:5px;flex-wrap:wrap"></span>
+  <span class="sep">|</span>
+  <button class="btn" id="clearsel">clear selection</button>
+</div>
+<div class="lightbox" id="lb">
+  <div class="lb-top">
+    <span class="lb-fn" id="lbfn"></span>
+    <span class="lb-path" id="lbpath"></span>
+    <span class="lb-spacer"></span>
+    <button class="lb-btn on" id="lbfit">fit</button>
+    <button class="lb-btn" id="lbactual">actual size</button>
+    <button class="lb-btn" id="lbclose">[ESC] close</button>
+  </div>
+  <div class="lb-main">
+    <div class="lb-stage fit" id="lbstage"><img id="lbimg" src="" alt=""></div>
+    <div class="lb-panel" id="lbpanel"></div>
+  </div>
+</div>
+<div id="toast"></div>
+<script>
+const DATA=__DATA__;
+const CATCOLORS=__CATCOLORS__;
+const VERDICTS=["like","dislike","favour","disfavour","promote"];
+const VCOLORS={"like":"#6fae5a","dislike":"#cc5a4a","favour":"#e0a34a","disfavour":"#7a7268","promote":"#5a8fc0"};
+const KV='hero:verdicts';   // {rel:[tags]}  -- distinct key from sprite sheet (pcs:verdicts)
+let V={};
+let storageOK=false;
+function loadV(){try{const s=localStorage.getItem(KV);V=s?JSON.parse(s):{};storageOK=true;}
+  catch(e){V={};storageOK=false;}}
+function saveV(){if(!storageOK)return;try{localStorage.setItem(KV,JSON.stringify(V));}catch(e){storageOK=false;}}
+function tagsOf(r){return V[r]||[];}
+function hasTag(r,t){return tagsOf(r).indexOf(t)>=0;}
+function setTag(r,t,on){let a=V[r]?V[r].slice():[];const i=a.indexOf(t);
+  if(on&&i<0)a.push(t);else if(!on&&i>=0)a.splice(i,1);
+  if(a.length)V[r]=a;else delete V[r];}
+
+let activeCats=new Set(), activeVerdicts=new Set(), query='', onlyUnmatched=false;
+const selected=new Set();
+let lastClickedIdx=null;
+const tileByRel={}; let orderedRels=[]; const dataByRel={};
+
+function esc(s){return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');}
+function enc(s){return s.split('/').map(encodeURIComponent).join('/');}
+
+function build(){
+  const runs={};
+  for(const d of DATA){dataByRel[d.r]=d;(runs[d.u]=runs[d.u]||{});(runs[d.u][d.c]=runs[d.u][d.c]||[]).push(d);}
+  const main=document.getElementById('main');
+  for(const run of Object.keys(runs).sort()){
+    const sec=document.createElement('section');sec.className='run-sec';
+    const rc=Object.values(runs[run]).reduce((a,b)=>a+b.length,0);
+    const rh=document.createElement('div');rh.className='run-head';
+    rh.innerHTML=`<span class="caret">v</span><span class="mono">${esc(run)}</span> <span class="count-tag">${rc}</span>`;
+    const selBtn=document.createElement('span');selBtn.className='selall';selBtn.textContent='select group';
+    rh.appendChild(selBtn);
+    const rbody=document.createElement('div');rbody.className='body';
+    rh.addEventListener('click',e=>{if(e.target===selBtn)return;sec.classList.toggle('collapsed');});
+    const groupRels=[];
+    sec.appendChild(rh);sec.appendChild(rbody);
+    for(const cat of Object.keys(runs[run]).sort()){
+      const cwrap=document.createElement('div');cwrap.className='cat-sec';cwrap.dataset.cat=cat;
+      const ch=document.createElement('div');ch.className='cat-head';
+      ch.innerHTML=`<span class="caret">v</span>${esc(cat)} <span class="count-tag">${runs[run][cat].length}</span>`;
+      const cSel=document.createElement('span');cSel.className='selall';cSel.textContent='select';
+      ch.appendChild(cSel);
+      const cbody=document.createElement('div');cbody.className='body grid';
+      ch.addEventListener('click',e=>{if(e.target===cSel)return;cwrap.classList.toggle('collapsed');});
+      const catRels=[];
+      for(const d of runs[run][cat]){const t=tile(d);cbody.appendChild(t);catRels.push(d.r);groupRels.push(d.r);}
+      cSel.onclick=e=>{e.stopPropagation();selectRels(catRels);};
+      cwrap.appendChild(ch);cwrap.appendChild(cbody);rbody.appendChild(cwrap);
+    }
+    selBtn.onclick=e=>{e.stopPropagation();selectRels(groupRels);};
+    main.appendChild(sec);
+  }
+}
+
+function tile(d){
+  const t=document.createElement('div');t.className='tile';t.dataset.rel=d.r;
+  const hay=(d.f+' '+d.c+' '+d.u+' '+d.id+' '+(d.pt||'')+' '+(d.fp||'')+' '+(d.dn||'')).toLowerCase();
+  t.dataset.fn=hay;t.dataset.cat=d.c;t.dataset.w=d.w?'1':'0';
+  const col=CATCOLORS[d.c]||'#888';
+  const verPill=d.v?`<span class="ver-pill">${esc(d.v)}</span>`:'';
+  const nm=d.w?'':'<span class="nomatch">no prompt</span>';
+  const promptLine=d.pt?`<div class="prompt-toggle" data-role="pt">prompt [+]</div><div class="prompt-body">${esc(d.pt)}</div>`
+                       :'<div class="prompt-toggle unmatched-note">prompt: (unmatched)</div>';
+  t.innerHTML=`
+    <input type="checkbox" class="selbox" title="select">
+    <div class="thumb-wrap"><img loading="lazy" src="${enc(d.r)}" alt="${esc(d.f)}"><span class="zhint">open full size</span></div>
+    <div class="fn">${esc(d.dn||d.f)}</div>
+    <div class="meta"><span class="cat-pill" style="background:${col}">${esc(d.c)}</span>${verPill}${nm}</div>
+    ${promptLine}
+    <div class="vtags"></div>`;
+  const ptog=t.querySelector('.prompt-toggle[data-role="pt"]');
+  if(ptog_ok(ptog)){const body=t.querySelector('.prompt-body');
+    ptog.onclick=e=>{e.stopPropagation();const on=body.classList.toggle('on');ptog.textContent=on?'prompt [-]':'prompt [+]';};}
+  const vt=t.querySelector('.vtags');
+  for(const v of VERDICTS){
+    const b=document.createElement('button');b.className='vtag';b.dataset.v=v;b.textContent=v;
+    b.style.setProperty('--vc',VCOLORS[v]);
+    if(hasTag(d.r,v))b.classList.add('on');
+    b.onclick=e=>{e.stopPropagation();const on=!hasTag(d.r,v);setTag(d.r,v,on);
+      b.classList.toggle('on',on);saveV();refreshCounts();syncLBTags(d.r);if(activeVerdicts.size)applyFilter();};
+    vt.appendChild(b);
+  }
+  const cb=t.querySelector('.selbox');
+  cb.addEventListener('click',e=>{e.stopPropagation();onSelClick(d.r,e.shiftKey,cb.checked);});
+  t.querySelector('.thumb-wrap').onclick=e=>{e.stopPropagation();openLB(d);};
+  tileByRel[d.r]=t;
+  return t;
+}
+function ptog_ok(x){return !!x;}
+
+// ---- selection ----
+function onSelClick(rel,shift,checked){
+  const idx=orderedRels.indexOf(rel);
+  if(shift&&lastClickedIdx!==null){
+    const [a,b]=[Math.min(lastClickedIdx,idx),Math.max(lastClickedIdx,idx)];
+    for(let i=a;i<=b;i++){const r=orderedRels[i];const tt=tileByRel[r];
+      if(tt.style.display==='none')continue; setSel(r,checked);}
+  }else{setSel(rel,checked);}
+  lastClickedIdx=idx;updateSelUI();
+}
+function setSel(rel,on){const t=tileByRel[rel];if(!t)return;
+  if(on){selected.add(rel);t.classList.add('sel');}else{selected.delete(rel);t.classList.remove('sel');}
+  const cb=t.querySelector('.selbox');if(cb)cb.checked=on;}
+function selectRels(rels){const vis=rels.filter(r=>tileByRel[r].style.display!=='none');
+  const allSel=vis.every(r=>selected.has(r));
+  for(const r of vis)setSel(r,!allSel);updateSelUI();}
+function selectAllVisible(){const vis=orderedRels.filter(r=>tileByRel[r].style.display!=='none');
+  const allSel=vis.length&&vis.every(r=>selected.has(r));
+  for(const r of vis)setSel(r,!allSel);updateSelUI();}
+function clearSel(){for(const r of[...selected])setSel(r,false);updateSelUI();}
+function updateSelUI(){const n=selected.size;
+  document.getElementById('selcount').textContent=n;
+  document.getElementById('bulkbar').classList.toggle('on',n>0);}
+
+// ---- bulk verdict ----
+function bulkApply(v,on){const n=selected.size;for(const r of selected){setTag(r,v,on);
+  const t=tileByRel[r];const b=t.querySelector(`.vtag[data-v="${v}"]`);if(b)b.classList.toggle('on',on);syncLBTags(r);}
+  saveV();refreshCounts();if(activeVerdicts.size)applyFilter();
+  toast(`${on?'Set':'Removed'} ${v} on ${n} image(s)`);}
+
+// ---- filtering ----
+function applyFilter(){
+  let shown=0;
+  for(const r of orderedRels){
+    const t=tileByRel[r];let ok=true;
+    if(activeCats.size&&!activeCats.has(t.dataset.cat))ok=false;
+    if(ok&&onlyUnmatched&&t.dataset.w!=='0')ok=false;
+    if(ok&&query){if(!t.dataset.fn.includes(query))ok=false;}
+    if(ok&&activeVerdicts.size){const tags=tagsOf(r);
+      let m=false;for(const v of activeVerdicts)if(tags.indexOf(v)>=0){m=true;break;}if(!m)ok=false;}
+    t.style.display=ok?'':'none';if(ok)shown++;
+  }
+  for(const cs of document.querySelectorAll('.cat-sec')){
+    const any=[...cs.querySelectorAll('.tile')].some(x=>x.style.display!=='none');cs.style.display=any?'':'none';}
+  for(const rs of document.querySelectorAll('.run-sec')){
+    const any=[...rs.querySelectorAll('.cat-sec')].some(c=>c.style.display!=='none');rs.style.display=any?'':'none';}
+  document.getElementById('shown').textContent=shown;
+}
+function refreshCounts(){
+  const c={};for(const v of VERDICTS)c[v]=0;let any=0;
+  for(const r in V){for(const t of V[r])if(c[t]!==undefined)c[t]++;any++;}
+  for(const v of VERDICTS)document.getElementById('vcount-'+v).textContent=c[v];
+  document.getElementById('taggedn').textContent=any;
+}
+
+// ---- export / import ----
+function download(name,text,type){const blob=new Blob([text],{type:type||'text/plain'});
+  const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download=name;
+  document.body.appendChild(a);a.click();a.remove();setTimeout(()=>URL.revokeObjectURL(url),1000);}
+function exportJSON(){download('hero_verdicts.json',JSON.stringify(V,null,2),'application/json');toast('Exported JSON');}
+function exportCSV(){let rows=['relative_path,tags,prompt'];
+  for(const r of orderedRels){const tg=tagsOf(r);if(tg.length){const d=dataByRel[r];
+    const p=(d&&d.pt?d.pt:'').replace(/"/g,'""');
+    rows.push(`"${r}","${tg.join(';')}","${p}"`);}}
+  download('hero_verdicts.csv',rows.join('\n'),'text/csv');toast('Exported CSV');}
+function copyList(v){const rels=orderedRels.filter(r=>hasTag(r,v));
+  const text=rels.join('\n');
+  if(navigator.clipboard&&navigator.clipboard.writeText){
+    navigator.clipboard.writeText(text).then(()=>toast(`Copied ${rels.length} ${v} path(s)`),
+      ()=>fallbackCopy(text,rels.length,v));
+  }else fallbackCopy(text,rels.length,v);}
+function fallbackCopy(text,n,v){const ta=document.createElement('textarea');ta.value=text;
+  ta.style.position='fixed';ta.style.opacity='0';document.body.appendChild(ta);ta.select();
+  let ok=false;try{ok=document.execCommand('copy');}catch(e){}ta.remove();
+  toast(ok?`Copied ${n} ${v} path(s)`:`Copy blocked -- see console`);if(!ok)console.log(text);}
+function importJSON(file){const rd=new FileReader();
+  rd.onload=()=>{try{const obj=JSON.parse(rd.result);
+    if(typeof obj!=='object'||Array.isArray(obj))throw 0;
+    V=obj;saveV();
+    for(const r of orderedRels){const t=tileByRel[r];
+      for(const b of t.querySelectorAll('.vtag'))b.classList.toggle('on',hasTag(r,b.dataset.v));}
+    refreshCounts();applyFilter();toast('Imported verdicts');
+  }catch(e){toast('Import failed -- not a valid verdicts JSON');}};
+  rd.readAsText(file);}
+
+// ---- lightbox ----
+let lbRel=null;
+function openLB(d){
+  lbRel=d.r;
+  const img=document.getElementById('lbimg');
+  img.src=enc(d.r);
+  document.getElementById('lbfn').textContent=d.dn||d.f;
+  document.getElementById('lbpath').textContent=d.r;
+  setLBMode('fit');
+  buildPanel(d);
+  document.getElementById('lb').classList.add('on');
+}
+function buildPanel(d){
+  const p=document.getElementById('lbpanel');
+  const sizes=(d.sz||[]).map(s=>`<button class="lb-size" data-r="${esc(s[1])}">${s[0]?s[0]+'px':'orig'}</button>`).join('');
+  const params=[];
+  if(d.md)params.push(`<div class="kv"><b>model</b> ${esc(d.md)}</div>`);
+  if(d.cs!=null)params.push(`<div class="kv"><b>cost</b> $${esc(d.cs)}</div>`);
+  if(d.ga)params.push(`<div class="kv"><b>generated</b> ${esc(d.ga)}</div>`);
+  if(d.hs)params.push(`<div class="kv"><b>prompt_hash</b> ${esc(d.hs)}</div>`);
+  if(d.rr)params.push(`<div class="kv"><b>reroll note</b> ${esc(d.rr)}</div>`);
+  const prov = d.fp
+      ? `<div class="lb-prompt">${esc(d.fp)}</div>`
+      : `<div class="lb-prompt unmatched-note">prompt: (unmatched -- no generating prompt found for ${esc(d.f)})</div>`;
+  const tail = d.pt ? `<h3>prompt tail (subject)</h3><div class="lb-tail">${esc(d.pt)}</div>` : '';
+  p.innerHTML=`
+    <div class="kv"><b>id</b> ${esc(d.id)} &nbsp; <b>ver</b> ${esc(d.v||'-')} &nbsp; <b>run</b> ${esc(d.u)}</div>
+    <div class="kv"><b>file</b> ${esc(d.f)}</div>
+    ${params.join('')}
+    <h3 style="margin-top:12px">available sizes</h3>
+    <div class="lb-sizes">${sizes}</div>
+    <h3>full generating prompt</h3>
+    ${prov}
+    ${tail}
+    <h3 style="margin-top:10px">verdict</h3>
+    <div class="lb-vtags" id="lbvtags"></div>`;
+  // size buttons
+  for(const b of p.querySelectorAll('.lb-size')){
+    b.onclick=()=>{document.getElementById('lbimg').src=enc(b.dataset.r);
+      document.getElementById('lbpath').textContent=b.dataset.r;
+      for(const x of p.querySelectorAll('.lb-size'))x.classList.remove('on');b.classList.add('on');};}
+  const first=p.querySelector('.lb-size');if(first)first.classList.add('on');
+  // verdict buttons
+  const vt=document.getElementById('lbvtags');
+  for(const v of VERDICTS){const b=document.createElement('button');b.className='lb-vtag';b.dataset.v=v;
+    b.textContent=v;b.style.setProperty('--vc',VCOLORS[v]);b.style.borderColor=VCOLORS[v];
+    if(hasTag(d.r,v)){b.classList.add('on');b.style.background=VCOLORS[v];}
+    b.onclick=()=>{const on=!hasTag(d.r,v);setTag(d.r,v,on);
+      b.classList.toggle('on',on);b.style.background=on?VCOLORS[v]:'transparent';
+      const tl=tileByRel[d.r];if(tl){const tb=tl.querySelector(`.vtag[data-v="${v}"]`);if(tb)tb.classList.toggle('on',on);}
+      saveV();refreshCounts();if(activeVerdicts.size)applyFilter();};
+    vt.appendChild(b);}
+}
+function syncLBTags(r){if(lbRel!==r)return;const vt=document.getElementById('lbvtags');if(!vt)return;
+  for(const b of vt.querySelectorAll('.lb-vtag')){const on=hasTag(r,b.dataset.v);
+    b.classList.toggle('on',on);b.style.background=on?VCOLORS[b.dataset.v]:'transparent';}}
+function setLBMode(mode){const st=document.getElementById('lbstage');
+  st.classList.toggle('fit',mode==='fit');st.classList.toggle('actual',mode==='actual');
+  document.getElementById('lbfit').classList.toggle('on',mode==='fit');
+  document.getElementById('lbactual').classList.toggle('on',mode==='actual');
+  if(mode==='fit'){st.scrollTop=0;st.scrollLeft=0;}}
+function closeLB(){document.getElementById('lb').classList.remove('on');lbRel=null;}
+
+let toastT=null;
+function toast(msg){const el=document.getElementById('toast');el.textContent=msg;el.classList.add('on');
+  clearTimeout(toastT);toastT=setTimeout(()=>el.classList.remove('on'),1800);}
+
+function buildCatChips(){
+  const counts={};for(const d of DATA)counts[d.c]=(counts[d.c]||0)+1;
+  const wrap=document.getElementById('catchips');
+  for(const c of Object.keys(counts).sort()){
+    const b=document.createElement('button');b.className='chip';b.dataset.cat=c;
+    b.innerHTML=`${esc(c)} <span class="chip-n">${counts[c]}</span>`;
+    b.onclick=()=>{if(activeCats.has(c)){activeCats.delete(c);b.classList.remove('on');}
+      else{activeCats.add(c);b.classList.add('on');}applyFilter();};
+    wrap.appendChild(b);
+  }
+}
+
+window.addEventListener('DOMContentLoaded',()=>{
+  loadV();orderedRels=DATA.map(d=>d.r);
+  buildCatChips();build();
+  document.getElementById('total').textContent=DATA.length;
+  document.getElementById('matchn').textContent=DATA.filter(d=>d.w).length+' / '+DATA.length;
+  document.getElementById('footstat').textContent=`${DATA.length} images across ${__NRUNS__} runs (${__NIMGS__} raw files deduped to one representative per id/version); ${__MATCHED__} matched to a prompt.`;
+  refreshCounts();applyFilter();
+  document.getElementById('q').addEventListener('input',e=>{query=e.target.value.trim().toLowerCase();applyFilter();});
+  for(const vc of document.querySelectorAll('.vchip')){vc.onclick=()=>{const v=vc.dataset.v;
+    if(activeVerdicts.has(v)){activeVerdicts.delete(v);vc.classList.remove('on');}
+    else{activeVerdicts.add(v);vc.classList.add('on');}applyFilter();};}
+  const ou=document.getElementById('onlyunmatched');
+  ou.onclick=()=>{onlyUnmatched=!onlyUnmatched;ou.classList.toggle('on',onlyUnmatched);applyFilter();};
+  document.getElementById('selallvis').onclick=selectAllVisible;
+  const addWrap=document.getElementById('bulkadd'),delWrap=document.getElementById('bulkdel');
+  for(const v of VERDICTS){
+    const a=document.createElement('button');a.className='bulk-add';a.textContent='+'+v;
+    a.style.setProperty('--vc',VCOLORS[v]);a.onclick=()=>bulkApply(v,true);addWrap.appendChild(a);
+    const d=document.createElement('button');d.className='bulk-del';d.textContent='-'+v;
+    d.onclick=()=>bulkApply(v,false);delWrap.appendChild(d);
+  }
+  document.getElementById('clearsel').onclick=clearSel;
+  document.getElementById('expjson').onclick=exportJSON;
+  document.getElementById('expcsv').onclick=exportCSV;
+  document.getElementById('copypromote').onclick=()=>copyList('promote');
+  document.getElementById('copyfavour').onclick=()=>copyList('favour');
+  document.getElementById('impbtn').onclick=()=>document.getElementById('impfile').click();
+  document.getElementById('impfile').addEventListener('change',e=>{if(e.target.files[0])importJSON(e.target.files[0]);e.target.value='';});
+  // lightbox controls
+  document.getElementById('lbfit').onclick=()=>setLBMode('fit');
+  document.getElementById('lbactual').onclick=()=>setLBMode('actual');
+  document.getElementById('lbclose').onclick=closeLB;
+  const lb=document.getElementById('lb');
+  lb.addEventListener('click',e=>{if(e.target===lb)closeLB();});
+  const stage=document.getElementById('lbstage');
+  stage.addEventListener('click',e=>{if(e.target.id==='lbimg')return;if(e.target===stage)closeLB();});
+  document.getElementById('lbimg').addEventListener('click',e=>{e.stopPropagation();
+    setLBMode(stage.classList.contains('fit')?'actual':'fit');});
+  // drag-to-pan in actual mode
+  let dragging=false,sx=0,sy=0,sl=0,st0=0;
+  stage.addEventListener('mousedown',e=>{if(!stage.classList.contains('actual'))return;
+    dragging=true;stage.classList.add('drag');sx=e.clientX;sy=e.clientY;sl=stage.scrollLeft;st0=stage.scrollTop;e.preventDefault();});
+  window.addEventListener('mousemove',e=>{if(!dragging)return;
+    stage.scrollLeft=sl-(e.clientX-sx);stage.scrollTop=st0-(e.clientY-sy);});
+  window.addEventListener('mouseup',()=>{dragging=false;stage.classList.remove('drag');});
+  document.addEventListener('keydown',e=>{if(e.key==='Escape'){if(lb.classList.contains('on'))closeLB();}});
+  if(!storageOK)document.getElementById('storewarn').style.display='inline';
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Homes the COMPLETE current art-review pipeline into a tracked `tools/art_review/`. **Supersedes closed PR #888**, which went stale before the analyzer reached v2.

## What is homed
- `tools/art_review/gen_contact_sheet.py` -- pixellab sprite contact-sheet generator
- `tools/art_review/gen_hero_gallery.py` + `hero_gallery_template.html` -- hero/banner gallery (full-size lightbox + provenance)
- `tools/art_review/analyze_verdicts.py` -- **v2** analyzer: `--library sprites|hero|both`, per-library promote/favour/disfavour lists + an UNTRIAGED (oversight-gap) report
- `tools/art_review/README.md` (`Status: LIVE`) documenting the full v2 pipeline, verdict JSON schema, the 5 verdict tags, and the tracked-source vs regenerable-artifact split
- `art_source/pixellab_verdicts.json` -- sprite triage decisions (now tracked; `hero_verdicts.json` was already tracked via #893, not re-added)

## Robustness
- Hardcoded absolute paths in both generators and the analyzer are now **repo-relative** (derived from `__file__`) so they run from any cwd; `gen_contact_sheet.py` also accepts an alternate `art_source` dir as `argv[1]`.
- `ast.parse` clean on all three `.py`; `analyze_verdicts.py --selftest` passes; a real `--library sprites` run cross-references 651 verdicts against 786 on-disk sprites.
- ASCII-only; black/isort/ruff clean (reformatted on first commit).

## .gitignore
One clean art-review block. Ignored (regenerable): `pixellab_contact_sheet.html`, `hero_gallery.html`, and all six `*_list.txt` outputs. NOT ignored: the verdicts JSONs and the tools. Removed the stale `art_source/pixellab_verdicts.json` ignore so the sprite decisions can be tracked.

Do NOT merge -- for Pip review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)