### PR TITLE
feat(dev): office sandbox v3 -- scaling, populate + placement, real cat walks, doom-glow + overlay POC

### DIFF
--- a/godot/scripts/ui/office_floor/office_sandbox.gd
+++ b/godot/scripts/ui/office_floor/office_sandbox.gd
@@ -1,32 +1,31 @@
 extends Control
-## OFFICE SANDBOX v2 -- a standalone DEV TOY for the office-floor view (Pip: open
-## this in the evening and play). Spawn walking people, cycle their skin, add/remove
-## cats, change the room's mood, AND (v2) load the PROMOTED art assets from
-## art_source, drop props onto a tile grid, flip the office STATE (scummy/decent) to
-## preview "office reflects game state", and leave IN-CONTEXT feedback that persists.
+## OFFICE SANDBOX v3 -- a standalone DEV TOY for the office-floor view (Pip: open
+## this in the evening and play). v3 adds SCALING, a POPULATE-UP sequence with simple
+## space/placement logic, REAL cat walk-cycles loaded from art_source, and two dev-only
+## prototypes: doom-glow on cats + a transparent-overlay (poster-on-wall) compositing POC.
+##
+## Everything v2 shipped still works: promoted-asset loader, prop placement, skin/mood
+## cycling, scummy/decent office STATE, and in-context feedback.
 ##
 ## This is the prototyping ground for the future runtime "office reflects game state"
 ## asset system (see docs/game-design/SEED_ASSET_REGISTRY_AND_VERDICTS.md). It is a
 ## DEV TOOL and NEVER ships to players.
 ##
 ## MECHANICS-SAFE / W3-SAFE (by construction): PURE COMPOSITION. It instantiates the
-## existing OfficeFloor view (res://scenes/ui/office_floor/office_floor.tscn) and
-## drives it through its EXISTING public API only, plus two ADDITIVE cosmetic dev
-## hooks added in this PR (OfficeFloor.set_floor_tile_texture / set_wall_strip_texture,
-## both backward-compatible no-ops for the live WATCH integration). There is NO game
-## state, no economy, no win/lose, no touching of employee_fsm/employee_sprite/
-## watch_screen/main_ui/GameState. Just a toy + an art review loop.
+## existing OfficeFloor view (res://scenes/ui/office_floor/office_floor.tscn) and drives
+## it through its EXISTING public API only, plus the two ADDITIVE cosmetic dev hooks that
+## v2 added (OfficeFloor.set_floor_tile_texture / set_wall_strip_texture -- both
+## backward-compatible no-ops for the live WATCH integration). v3 adds NO new hooks to
+## OfficeFloor or EmployeeSprite: all scaling / doom-glow / overlays are applied by the
+## sandbox onto nodes it owns or onto sprite NODE transforms (never touching the sprites'
+## internal art scale, movement, or game state). There is NO game state, no economy, no
+## win/lose, no touching of employee_fsm/employee_sprite/watch_screen/main_ui/GameState.
 ##
-## PROMOTED-ASSET LOADING (v2): the promoted assets live in art_source/ which is
-## OUTSIDE the Godot project (NOT res://). We compute the art_source dir from
-## ProjectSettings.globalize_path("res://") + "/../art_source", read the promote list
-## art_source/promote_list.txt (newline paths grouped by "# category/subtype"
-## headers, each path relative to art_source), and load each PNG by ABSOLUTE
-## filesystem path via Image.load() -> ImageTexture. If promote_list.txt is absent we
-## fall back to art_source/pixellab_verdicts.json (keys whose tag array contains
-## "promote"). BOTH files are UNTRACKED (they live only in Pip's working copy), so in
-## a fresh checkout the loader finds nothing and degrades cleanly to placeholders --
-## the toy still runs, it just has an empty prop pool until run from the working copy.
+## PROMOTED-ASSET + CAT-WALK LOADING: art_source/ lives OUTSIDE the Godot project (NOT
+## res://). Props come from art_source/promote_list.txt (v2). Cat walk-cycles are loaded
+## DIRECTLY from known art_source cat-walk dirs by ABSOLUTE path via Image.load() -- they
+## are git-tracked, so they resolve in any checkout; if art_source is absent the loader
+## degrades cleanly (empty prop pool + procedural cats) and the toy still runs.
 
 const OfficeFloorScene := preload("res://scenes/ui/office_floor/office_floor.tscn")
 # Real pixellab.ai art-loop SpriteFrames (idle/walking/working/stressed + directional walks).
@@ -47,6 +46,46 @@ const PROP_TARGET_H := 46.0
 # uses). Applied to promoted floor/wall tilesets before handing them to the dev hooks.
 const WANG_BASE_REGION := Rect2i(64, 32, 32, 32)
 const TILE_UPSCALE := 2
+
+# --- v3 tuning --------------------------------------------------------------
+# Global OCCUPANT scale default. The v2 sprites drew at EmployeeSprite.SPRITE_SCALE (2.0);
+# on a small floor that reads too big ("spawn one person, it's relatively huge"). 0.65 makes
+# a spawned worker a sane fraction of the floor. Tunable live with [-]/[=]. Applied as a NODE
+# transform scale onto occupants (people/cats/props) -- never touches the sprites' art scale.
+const OCCUPANT_SCALE_DEFAULT := 0.65
+const OCCUPANT_SCALE_MIN := 0.2
+const OCCUPANT_SCALE_MAX := 3.0
+const OCCUPANT_SCALE_STEP := 1.12       # multiplicative per keypress
+const PER_SPRITE_STEP := 1.1            # per-selected-sprite scale step
+const PER_SPRITE_MIN := 0.25
+const PER_SPRITE_MAX := 4.0
+
+# POPULATE-UP sequence: cumulative TARGET totals per press (level 1..10). Level 0 = empty.
+# Each press advances one stage (people via set_roster, cats wandering, furniture on walls).
+const _POP_STAGES := [
+	{"people": 1,  "cats": 0, "furn": 2},
+	{"people": 3,  "cats": 1, "furn": 4},
+	{"people": 5,  "cats": 1, "furn": 6},
+	{"people": 7,  "cats": 2, "furn": 8},
+	{"people": 9,  "cats": 2, "furn": 10},
+	{"people": 12, "cats": 3, "furn": 13},
+	{"people": 15, "cats": 3, "furn": 16},
+	{"people": 18, "cats": 4, "furn": 19},
+	{"people": 21, "cats": 5, "furn": 22},
+	{"people": 24, "cats": 6, "furn": 26},
+]
+
+# Cat walk-cycle source dirs (relative to art_source). Each holds walk_<dir>_<n>.png for
+# dir in {south,east,north,west}. These are git-tracked so they resolve in any checkout.
+const _CAT_WALK_DIRS: Array[String] = [
+	"pixellab_2026-07-16/cat_walk_cat1",
+	"pixellab_2026-07-16/cat_walk_cat2",
+]
+# Cat art sets that exist as rotation-only (static) frames and STILL NEED walk-cycles
+# generated (pixellab) before they can become real walkers. Reported on-screen/stdout.
+const _CAT_SETS_NEEDING_WALKS := ["cat_black", "cat_tabby", "cat_eldritch(x4)", "cat_purple(x4)"]
+
+const DOOM_STEP := 0.1
 
 # Skins the sandbox rotates through. "art" = real pixellab frames; "color" = a generated
 # animated placeholder tinted body+hat (Tier 1); "blob" = Tier 0 procedural blob+hat.
@@ -81,7 +120,7 @@ var _states: Array = [
 # Union of every state's bias keywords -- a prop matching none of these is "neutral".
 const _STATE_KEYWORDS := ["scummy", "decent", "clean", "mega"]
 
-# Cat coat colours cycled as cats are added.
+# Cat coat colours cycled as procedural cats are added (fallback only; real cats use art).
 var _cat_palette: Array = [
 	Color(0.16, 0.16, 0.18),   # black
 	Color(0.85, 0.55, 0.25),   # ginger tabby
@@ -94,6 +133,16 @@ const _NAME_POOL := [
 	"Rowan", "Emerson", "Devon", "Skyler", "Marlowe", "Reese", "Sasha", "Nico",
 ]
 const _SPEC_POOL := ["safety", "capabilities", "interpretability", "alignment", "manager"]
+
+# Placeholder furniture kinds (procedural; used by POPULATE so the placement logic is
+# demonstrable even in a fresh checkout with no promoted props). {id: [w,h, color]}.
+const _FURN_KINDS := {
+	"desk":    [44, 22, Color(0.42, 0.30, 0.20)],
+	"cabinet": [24, 38, Color(0.55, 0.56, 0.60)],
+	"plant":   [22, 30, Color(0.24, 0.55, 0.30)],
+	"server":  [26, 40, Color(0.18, 0.20, 0.24)],
+	"printer": [30, 24, Color(0.70, 0.70, 0.72)],
+}
 
 # Feedback tags leaveable on the focused prop (written to sandbox_feedback.json).
 const _TAG_KEYS := {
@@ -120,9 +169,23 @@ var _promoted: Dictionary = {}             # category -> Array of asset dicts
 var _load_report: String = ""              # human-readable "found N props, M tilesets"
 var _prop_pool: Array = []                 # state-filtered subset of promoted props
 var _prop_idx: int = 0
-var _placed_props: Array = []              # Sprite2D children of _floor
+var _placed_props: Array = []              # Sprite2D children of _floor (manual placement)
 var _ghost: Sprite2D = null                # translucent placement preview following the mouse
 var _feedback: Dictionary = {}             # asset_id -> {"tags":[...], "notes":[...]}
+
+# --- v3 state ---------------------------------------------------------------
+var _occupant_scale: float = OCCUPANT_SCALE_DEFAULT
+var _pop_level: int = 0
+var _furniture: Array = []                 # Sprite2D furniture placed by POPULATE (wall-affinity)
+var _occupied_cells: Dictionary = {}       # str(cell centre) -> true (furniture no-overlap)
+var _cat_frame_sets: Array = []            # [{name, frames}] real walk-cycle SpriteFrames
+var _cat_walk_report: String = ""
+var _doom_level: float = 0.0
+var _overlay_mode: bool = false            # false = prop placement, true = poster overlay
+var _overlays: Array = []                  # Sprite2D transparent wall overlays (stackable)
+var _poster_texs: Array = []               # placeholder/promoted poster textures
+var _poster_idx: int = 0
+var _marker: SandboxMarker = null          # highlights the per-sprite / overlay selection target
 
 func _ready() -> void:
 	_rng.randomize()
@@ -132,15 +195,18 @@ func _ready() -> void:
 	_floor.set_anchors_preset(Control.PRESET_FULL_RECT)
 	add_child(_floor)
 
-	# Load promoted assets + any existing feedback BEFORE the overlay so the legend/
-	# status can report counts. Both degrade to empty if the source files are absent.
+	# Load promoted assets + cat walk-cycles + any existing feedback BEFORE the overlay so
+	# the legend/status can report counts. All degrade to empty if the source files absent.
 	_art_root = _compute_art_root()
 	_load_feedback()
 	_load_promoted()
+	_load_cat_walks()
+	_build_poster_pool()
 	_rebuild_prop_pool()
 
 	_build_overlay()
 	_build_ghost()
+	_build_marker()
 
 	# Start with the real-art skin and a few people so it's alive on open.
 	_apply_skin(0)
@@ -149,6 +215,7 @@ func _ready() -> void:
 	for _i in range(5):
 		_spawn_person()
 	_add_cat()
+	_apply_occupant_scale()
 	_update_status()
 
 func _build_overlay() -> void:
@@ -164,11 +231,11 @@ func _build_overlay() -> void:
 	_legend = Label.new()
 	_legend.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_legend.add_theme_font_size_override("font_size", 13)
-	_legend.text = "OFFICE SANDBOX v2  --  dev toy (no game state)\n" \
-		+ "[1]/[2] spawn/despawn person   [S] cycle skin   [B] mood/light\n" \
-		+ "[C]/[X] add/remove cat   [R] randomize   [0] clear all   [ESC] quit\n" \
-		+ "[T] office STATE (scummy/decent -> props bias + floor/wall swap)\n" \
-		+ "[P] cycle prop   [LMB] place on grid   [RMB] remove nearest   [K] clear props\n" \
+	_legend.text = "OFFICE SANDBOX v3  --  dev toy (no game state)\n" \
+		+ "[1]/[2] spawn/despawn person   [S] skin   [B] mood   [C]/[X] add/remove cat   [R] randomize   [0] clear   [ESC] quit\n" \
+		+ "SCALE:  [-]/[=] all occupants   [,]/[.] the sprite under the cursor   |   POPULATE:  [U] up a stage   [I] down a stage\n" \
+		+ "[T] office STATE (scummy/decent)   [P] cycle prop/poster   [LMB] place   [RMB] remove nearest   [K] clear props\n" \
+		+ "DOOM-GLOW on cats:  [ [ ] decrease   [ ] ] increase   |   OVERLAY POC:  [V] toggle poster-on-wall mode   [;]/['] selected overlay opacity\n" \
 		+ "feedback on current prop:  [L]ike  [J] dislike  [F]avour  [G] disfavour  [M] promote  [N] note"
 	vb.add_child(_legend)
 
@@ -191,15 +258,39 @@ func _build_ghost() -> void:
 	_floor.add_child(_ghost)
 	_refresh_ghost_texture()
 
+func _build_marker() -> void:
+	_marker = SandboxMarker.new()
+	_marker.z_index = 6
+	_marker.visible = false
+	_floor.add_child(_marker)
+
 func _process(_delta: float) -> void:
-	# Ghost preview snaps to the tile grid under the mouse so the drop cell is obvious.
-	if _ghost == null:
-		return
-	if _prop_pool.is_empty():
-		_ghost.visible = false
-		return
-	_ghost.visible = true
-	_ghost.position = _snap_to_grid(_floor.get_local_mouse_position())
+	# Ghost preview: in prop mode it snaps to the tile grid; in overlay mode it snaps to the
+	# nearest wall so the poster drop target reads. Marker highlights the selection target for
+	# the per-sprite scale ([,]/[.]) or the overlay opacity ([;]/[']) keys.
+	var mouse := _floor.get_local_mouse_position()
+	if _ghost != null:
+		if _overlay_mode:
+			_ghost.visible = _ghost.texture != null
+			_ghost.position = _snap_to_wall(mouse)
+		elif _prop_pool.is_empty():
+			_ghost.visible = false
+		else:
+			_ghost.visible = true
+			_ghost.position = _snap_to_grid(mouse)
+	if _marker != null:
+		if _overlay_mode:
+			var ov := _nearest_overlay(mouse)
+			_marker.visible = ov != null
+			if ov != null:
+				_marker.position = ov.position
+				_marker.radius = 26.0
+		else:
+			var sp := _nearest_person(mouse)
+			_marker.visible = sp != null
+			if sp != null:
+				_marker.position = sp.position
+				_marker.radius = 18.0
 
 func _input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:
@@ -208,9 +299,15 @@ func _input(event: InputEvent) -> void:
 			return
 		match mb.button_index:
 			MOUSE_BUTTON_LEFT:
-				_place_prop()
+				if _overlay_mode:
+					_place_overlay()
+				else:
+					_place_prop()
 			MOUSE_BUTTON_RIGHT:
-				_remove_nearest_prop(_floor.get_local_mouse_position())
+				if _overlay_mode:
+					_remove_nearest_overlay(_floor.get_local_mouse_position())
+				else:
+					_remove_nearest_prop(_floor.get_local_mouse_position())
 			_:
 				return
 		_update_status()
@@ -245,6 +342,28 @@ func _input(event: InputEvent) -> void:
 			_clear_props()
 		KEY_R:
 			_randomize()
+		KEY_U:
+			_populate_up()
+		KEY_I:
+			_populate_down()
+		KEY_MINUS, KEY_KP_SUBTRACT:
+			_nudge_occupant_scale(1.0 / OCCUPANT_SCALE_STEP)
+		KEY_EQUAL, KEY_KP_ADD:
+			_nudge_occupant_scale(OCCUPANT_SCALE_STEP)
+		KEY_COMMA:
+			_scale_nearest_person(1.0 / PER_SPRITE_STEP)
+		KEY_PERIOD:
+			_scale_nearest_person(PER_SPRITE_STEP)
+		KEY_BRACKETLEFT:
+			_nudge_doom(-DOOM_STEP)
+		KEY_BRACKETRIGHT:
+			_nudge_doom(DOOM_STEP)
+		KEY_V:
+			_toggle_overlay_mode()
+		KEY_SEMICOLON:
+			_nudge_overlay_opacity(-0.1)
+		KEY_APOSTROPHE:
+			_nudge_overlay_opacity(0.1)
 		KEY_0, KEY_KP_0, KEY_BACKSPACE, KEY_DELETE:
 			_clear_all()
 		KEY_ESCAPE:
@@ -260,6 +379,7 @@ func _spawn_person() -> void:
 	_roster.append(_make_person(_next_id))
 	_next_id += 1
 	_push_roster()
+	_apply_occupant_scale()
 
 # Build one employee snapshot dict with a randomised mood so the roster shows a
 # mix of FSM states (working / walking-drift / idle-disengaged / stressed).
@@ -311,6 +431,7 @@ func _apply_skin(idx: int) -> void:
 			_floor.set_tier(1)
 		_:
 			_floor.set_tier(0)                     # "blob"
+	_apply_occupant_scale()
 
 # --- Mood / lighting --------------------------------------------------------
 func _cycle_mood() -> void:
@@ -383,6 +504,9 @@ func _rebuild_prop_pool() -> void:
 	_refresh_ghost_texture()
 
 func _cycle_prop() -> void:
+	if _overlay_mode:
+		_cycle_poster()
+		return
 	if _prop_pool.is_empty():
 		return
 	_prop_idx = (_prop_idx + 1) % _prop_pool.size()
@@ -396,10 +520,14 @@ func _current_prop() -> Dictionary:
 func _refresh_ghost_texture() -> void:
 	if _ghost == null:
 		return
+	if _overlay_mode:
+		_ghost.texture = _current_poster()
+		_ghost.scale = Vector2.ONE
+		return
 	var p := _current_prop()
 	_ghost.texture = p.get("tex", null) if not p.is_empty() else null
 	if _ghost.texture != null:
-		_ghost.scale = _prop_scale(_ghost.texture)
+		_ghost.scale = _prop_scale(_ghost.texture) * _occupant_scale
 
 func _prop_scale(tex: Texture2D) -> Vector2:
 	var h := tex.get_size().y
@@ -416,8 +544,11 @@ func _place_prop() -> void:
 	var spr := Sprite2D.new()
 	spr.texture = tex
 	spr.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	spr.scale = _prop_scale(tex)
-	spr.position = _snap_to_grid(_floor.get_local_mouse_position())
+	var base := _prop_scale(tex)
+	spr.set_meta("base_scale", base)
+	spr.scale = base * _occupant_scale
+	# Wall-affinity assist: if the drop point is near a wall, snap flush to it; else free grid.
+	spr.position = _grid_or_wall(_floor.get_local_mouse_position())
 	spr.z_index = 2
 	spr.set_meta("asset_id", String(p.get("id", "")))
 	_floor.add_child(spr)
@@ -452,6 +583,21 @@ func _snap_to_grid(pos: Vector2) -> Vector2:
 	return Vector2(
 		floor(pos.x / GRID) * GRID + GRID * 0.5,
 		floor(pos.y / GRID) * GRID + GRID * 0.5)
+
+# Grid-snap, but if the point is within one grid cell of a wall, snap flush to that wall
+# (furniture wall-affinity for manual placement; the POPULATE placer uses walls exclusively).
+func _grid_or_wall(pos: Vector2) -> Vector2:
+	var b := _floor_bounds()
+	var snapped := _snap_to_grid(pos)
+	if pos.x - b.position.x < GRID:
+		snapped.x = b.position.x + GRID * 0.5
+	elif b.end.x - pos.x < GRID:
+		snapped.x = b.end.x - GRID * 0.5
+	if pos.y - b.position.y < GRID:
+		snapped.y = b.position.y + GRID * 0.5
+	elif b.end.y - pos.y < GRID:
+		snapped.y = b.end.y - GRID * 0.5
+	return snapped
 
 # --- In-context feedback ----------------------------------------------------
 # Tag the CURRENT (focused) prop and persist to <art_source>/sandbox_feedback.json.
@@ -491,17 +637,28 @@ func _tags_for(id: String) -> String:
 	return "-" if parts.is_empty() else ", ".join(parts)
 
 # --- Cats -------------------------------------------------------------------
+# Spawn a cat. Uses a REAL loaded walk-cycle (cycling the available sets) when any exist;
+# otherwise falls back to the procedural drawn cat. Both honour doom-glow + occupant scale.
 func _add_cat() -> void:
 	if _cats.size() >= MAX_CATS:
 		return
-	var cat := SandboxCat.new()
-	cat.color = _cat_palette[_cat_color_idx % _cat_palette.size()]
+	var cat: SandboxCatBase
+	if not _cat_frame_sets.is_empty():
+		var rc := RealCat.new()
+		rc.setup(_cat_frame_sets[_cat_color_idx % _cat_frame_sets.size()]["frames"])
+		cat = rc
+	else:
+		var sc := SandboxCat.new()
+		sc.color = _cat_palette[_cat_color_idx % _cat_palette.size()]
+		cat = sc
 	_cat_color_idx += 1
 	var b := _floor_bounds()
 	cat.position = Vector2(
 		_rng.randf_range(b.position.x, b.end.x),
 		_rng.randf_range(b.position.y, b.end.y))
 	_floor.add_child(cat)
+	cat.scale = Vector2(_occupant_scale, _occupant_scale)
+	cat.set_doom(_doom_level)
 	_cats.append(cat)
 
 func _remove_cat() -> void:
@@ -517,6 +674,311 @@ func _floor_bounds() -> Rect2:
 		s = Vector2(360, 260)
 	return Rect2(Vector2(16, 16), s - Vector2(32, 32))
 
+# --- v3: SCALING ------------------------------------------------------------
+# Apply the global occupant scale (times any per-sprite multiplier held in node meta) to
+# every occupant the sandbox owns: employee sprites (NODE transform only -- never the art
+# scale the live view sets), cats, populate-furniture, and manually-placed props.
+func _apply_occupant_scale() -> void:
+	for c in _floor.get_children():
+		if c is OfficeEmployeeSprite:
+			var m := float((c as Node).get_meta("sb_scale_mult", 1.0))
+			(c as Node2D).scale = Vector2(_occupant_scale * m, _occupant_scale * m)
+	for cat in _cats:
+		if is_instance_valid(cat):
+			cat.scale = Vector2(_occupant_scale, _occupant_scale)
+	for f in _furniture:
+		if is_instance_valid(f):
+			var base: Vector2 = f.get_meta("base_scale", Vector2.ONE)
+			f.scale = base * _occupant_scale
+	for spr in _placed_props:
+		if is_instance_valid(spr):
+			var base2: Vector2 = spr.get_meta("base_scale", Vector2.ONE)
+			spr.scale = base2 * _occupant_scale
+	_refresh_ghost_texture()
+
+func _nudge_occupant_scale(mult: float) -> void:
+	_occupant_scale = clampf(_occupant_scale * mult, OCCUPANT_SCALE_MIN, OCCUPANT_SCALE_MAX)
+	_apply_occupant_scale()
+
+func _scale_nearest_person(mult: float) -> void:
+	var sp := _nearest_person(_floor.get_local_mouse_position())
+	if sp == null:
+		return
+	var m := float(sp.get_meta("sb_scale_mult", 1.0))
+	m = clampf(m * mult, PER_SPRITE_MIN, PER_SPRITE_MAX)
+	sp.set_meta("sb_scale_mult", m)
+	_apply_occupant_scale()
+
+func _nearest_person(at: Vector2) -> Node2D:
+	var best: Node2D = null
+	var best_d := INF
+	for c in _floor.get_children():
+		if c is OfficeEmployeeSprite:
+			var d: float = (c as Node2D).position.distance_to(at)
+			if d < best_d:
+				best_d = d
+				best = c
+	return best
+
+# --- v3: POPULATE-UP sequence + placement logic -----------------------------
+func _populate_up() -> void:
+	if _pop_level >= _POP_STAGES.size():
+		return
+	_pop_level += 1
+	_apply_pop_stage()
+
+func _populate_down() -> void:
+	if _pop_level <= 0:
+		return
+	_pop_level -= 1
+	_apply_pop_stage()
+
+func _apply_pop_stage() -> void:
+	var want_people := 0
+	var want_cats := 0
+	var want_furn := 0
+	if _pop_level > 0:
+		var st: Dictionary = _POP_STAGES[_pop_level - 1]
+		want_people = int(st["people"])
+		want_cats = int(st["cats"])
+		want_furn = int(st["furn"])
+	# People (spread around the desks by OfficeFloor's own layout -- sane, non-overlapping).
+	while _roster.size() < want_people and _roster.size() < MAX_PEOPLE:
+		_roster.append(_make_person(_next_id))
+		_next_id += 1
+	while _roster.size() > want_people:
+		_roster.pop_back()
+	_push_roster()
+	# Cats (wander freely).
+	while _cats.size() < want_cats and _cats.size() < MAX_CATS:
+		_add_cat()
+	while _cats.size() > want_cats:
+		_remove_cat()
+	# Furniture (wall-affinity, no-overlap).
+	while _furniture.size() < want_furn:
+		if not _spawn_furniture():
+			break
+	while _furniture.size() > want_furn:
+		_remove_furniture()
+	_apply_occupant_scale()
+
+# Place one furniture piece on a free perimeter (wall) grid cell. Returns false if the
+# floor is full. Demonstrates the first "space logic" slice: furniture hugs walls, does
+# not overlap other furniture.
+func _spawn_furniture() -> bool:
+	var cell := _pick_wall_cell()
+	if cell == Vector2.INF:
+		return false
+	var kinds := _FURN_KINDS.keys()
+	var kind := String(kinds[_rng.randi() % kinds.size()])
+	var tex := _furniture_tex(kind)
+	var spr := Sprite2D.new()
+	spr.texture = tex
+	spr.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	var base := _prop_scale(tex)
+	spr.set_meta("base_scale", base)
+	spr.scale = base * _occupant_scale
+	spr.position = cell
+	spr.z_index = 2
+	spr.set_meta("cell_key", str(cell))
+	_floor.add_child(spr)
+	_furniture.append(spr)
+	_occupied_cells[str(cell)] = true
+	return true
+
+func _remove_furniture() -> void:
+	if _furniture.is_empty():
+		return
+	var spr = _furniture.pop_back()
+	if is_instance_valid(spr):
+		_occupied_cells.erase(String(spr.get_meta("cell_key", "")))
+		spr.queue_free()
+
+# Return a random unoccupied grid cell centre on the floor PERIMETER (wall-affinity). Falls
+# back to any interior cell if the perimeter is full. Returns Vector2.INF if nothing free.
+func _pick_wall_cell() -> Vector2:
+	var b := _floor_bounds()
+	var cols := int(b.size.x / GRID)
+	var rows := int(b.size.y / GRID)
+	if cols < 2 or rows < 2:
+		return Vector2.INF
+	var edge: Array = []
+	var inner: Array = []
+	for r in range(rows):
+		for c in range(cols):
+			var centre := Vector2(
+				b.position.x + c * GRID + GRID * 0.5,
+				b.position.y + r * GRID + GRID * 0.5)
+			if _occupied_cells.has(str(centre)):
+				continue
+			if c == 0 or c == cols - 1 or r == 0 or r == rows - 1:
+				edge.append(centre)
+			else:
+				inner.append(centre)
+	var pool: Array = edge if not edge.is_empty() else inner
+	if pool.is_empty():
+		return Vector2.INF
+	var chosen: Vector2 = pool[_rng.randi() % pool.size()]
+	return chosen
+
+func _furniture_tex(kind: String) -> Texture2D:
+	var spec: Array = _FURN_KINDS[kind]
+	var w := int(spec[0])
+	var h := int(spec[1])
+	var col: Color = spec[2]
+	var img := Image.create(w, h, false, Image.FORMAT_RGBA8)
+	img.fill(col)
+	# simple top highlight + dark base so it reads as a solid object, not a flat rect
+	img.fill_rect(Rect2i(0, 0, w, max(1, int(h * 0.18))), col.lightened(0.25))
+	img.fill_rect(Rect2i(0, h - max(1, int(h * 0.14)), w, max(1, int(h * 0.14))), col.darkened(0.35))
+	# 1px border
+	for x in range(w):
+		img.set_pixel(x, 0, col.darkened(0.5))
+		img.set_pixel(x, h - 1, col.darkened(0.5))
+	for y in range(h):
+		img.set_pixel(0, y, col.darkened(0.5))
+		img.set_pixel(w - 1, y, col.darkened(0.5))
+	return ImageTexture.create_from_image(img)
+
+# --- v3: DOOM-GLOW on cats (prototype) --------------------------------------
+func _nudge_doom(d: float) -> void:
+	_doom_level = clampf(_doom_level + d, 0.0, 1.0)
+	for cat in _cats:
+		if is_instance_valid(cat):
+			cat.set_doom(_doom_level)
+
+# --- v3: transparent OVERLAY (poster-on-wall) POC ---------------------------
+# Builds the offered poster texture pool. Prefers promoted assets whose id reads like a
+# poster / wall-art / decal; otherwise generates translucent placeholder posters so the
+# compositing demo works with no art. Posters are placed with wall-affinity, stack on top of
+# each other, and each has an independently adjustable opacity -- proving transparent-layer
+# compositing (the incremental foundation a weather-through-windows feature builds on later).
+func _build_poster_pool() -> void:
+	_poster_texs.clear()
+	for a in _promoted.get("props", []):
+		var id_l := String(a.get("id", "")).to_lower()
+		if id_l.find("poster") != -1 or id_l.find("wall_art") != -1 or id_l.find("decal") != -1 or id_l.find("art") != -1:
+			var tex = a.get("tex", null)
+			if tex != null:
+				_poster_texs.append(tex)
+	if _poster_texs.is_empty():
+		var hues: Array[Color] = [Color(0.85, 0.30, 0.35), Color(0.30, 0.55, 0.85), Color(0.35, 0.75, 0.45), Color(0.80, 0.70, 0.30)]
+		for hue in hues:
+			_poster_texs.append(_make_poster_tex(hue))
+
+func _make_poster_tex(hue: Color) -> Texture2D:
+	var w := 40
+	var h := 56
+	var img := Image.create(w, h, false, Image.FORMAT_RGBA8)
+	img.fill(hue.lightened(0.1))
+	# frame border
+	var border := hue.darkened(0.5)
+	for x in range(w):
+		img.set_pixel(x, 0, border)
+		img.set_pixel(x, 1, border)
+		img.set_pixel(x, h - 1, border)
+		img.set_pixel(x, h - 2, border)
+	for y in range(h):
+		img.set_pixel(0, y, border)
+		img.set_pixel(1, y, border)
+		img.set_pixel(w - 1, y, border)
+		img.set_pixel(w - 2, y, border)
+	# a diagonal + a band so overlap/transparency is legible when stacked
+	for i in range(min(w, h)):
+		img.set_pixel(clampi(i, 0, w - 1), clampi(i, 0, h - 1), hue.darkened(0.25))
+	img.fill_rect(Rect2i(4, int(h * 0.6), w - 8, 4), hue.darkened(0.3))
+	return ImageTexture.create_from_image(img)
+
+func _current_poster() -> Texture2D:
+	if _poster_texs.is_empty():
+		return null
+	return _poster_texs[_poster_idx % _poster_texs.size()]
+
+func _cycle_poster() -> void:
+	if _poster_texs.is_empty():
+		return
+	_poster_idx = (_poster_idx + 1) % _poster_texs.size()
+	_refresh_ghost_texture()
+
+func _toggle_overlay_mode() -> void:
+	_overlay_mode = not _overlay_mode
+	_refresh_ghost_texture()
+
+func _place_overlay() -> void:
+	var tex := _current_poster()
+	if tex == null:
+		return
+	var spr := Sprite2D.new()
+	spr.texture = tex
+	spr.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	spr.position = _snap_to_wall(_floor.get_local_mouse_position())
+	# z_index 1 = on the wall, behind the people (z 0) that stand lower on the floor. Later
+	# overlays get a higher z so a stack composites front-to-back visibly.
+	spr.z_index = 1 + (_overlays.size() % 4)
+	var op := 0.7
+	spr.modulate = Color(1, 1, 1, op)
+	spr.set_meta("opacity", op)
+	_floor.add_child(spr)
+	_overlays.append(spr)
+
+func _remove_nearest_overlay(at: Vector2) -> void:
+	var ov := _nearest_overlay(at)
+	if ov == null:
+		return
+	_overlays.erase(ov)
+	ov.queue_free()
+
+func _nearest_overlay(at: Vector2) -> Sprite2D:
+	var best: Sprite2D = null
+	var best_d := INF
+	for spr in _overlays:
+		if not is_instance_valid(spr):
+			continue
+		var d: float = spr.position.distance_to(at)
+		if d < best_d:
+			best_d = d
+			best = spr
+	return best
+
+func _nudge_overlay_opacity(d: float) -> void:
+	var ov := _nearest_overlay(_floor.get_local_mouse_position())
+	if ov == null:
+		return
+	var op := clampf(float(ov.get_meta("opacity", 0.7)) + d, 0.05, 1.0)
+	ov.set_meta("opacity", op)
+	ov.modulate = Color(1, 1, 1, op)
+
+# Snap a point to the nearest wall of the floor bounds (poster wall-affinity). Posters sit
+# just inside the wall so they read as mounted on it.
+func _snap_to_wall(p: Vector2) -> Vector2:
+	var b := _floor_bounds()
+	var inset := 20.0
+	var dl := p.x - b.position.x
+	var dr := b.end.x - p.x
+	var dt := p.y - b.position.y
+	var db := b.end.y - p.y
+	var m := minf(minf(dl, dr), minf(dt, db))
+	if m == dt:
+		return Vector2(clampf(p.x, b.position.x + inset, b.end.x - inset), b.position.y + inset)
+	elif m == db:
+		return Vector2(clampf(p.x, b.position.x + inset, b.end.x - inset), b.end.y - inset)
+	elif m == dl:
+		return Vector2(b.position.x + inset, clampf(p.y, b.position.y + inset, b.end.y - inset))
+	return Vector2(b.end.x - inset, clampf(p.y, b.position.y + inset, b.end.y - inset))
+
+func _clear_overlays() -> void:
+	for spr in _overlays:
+		if is_instance_valid(spr):
+			spr.queue_free()
+	_overlays.clear()
+
+func _clear_furniture() -> void:
+	for spr in _furniture:
+		if is_instance_valid(spr):
+			spr.queue_free()
+	_furniture.clear()
+	_occupied_cells.clear()
+
 # --- Bulk toys --------------------------------------------------------------
 func _randomize() -> void:
 	_clear_all()
@@ -529,6 +991,7 @@ func _randomize() -> void:
 	var c := _rng.randi_range(1, 3)
 	for _j in range(c):
 		_add_cat()
+	_apply_occupant_scale()
 
 func _clear_all() -> void:
 	_roster.clear()
@@ -538,23 +1001,42 @@ func _clear_all() -> void:
 			cat.queue_free()
 	_cats.clear()
 	_clear_props()
+	_clear_furniture()
+	_clear_overlays()
+	_pop_level = 0
 
 func _update_status() -> void:
 	if _status == null:
 		return
-	_status.text = "skin: %s   |   people: %d   |   cats: %d   |   mood: %s" % [
-		_skins[_skin_idx]["name"], _roster.size(), _cats.size(), _moods[_mood_idx]["name"]]
+	_status.text = "skin: %s   |   people: %d   |   cats: %d   |   mood: %s   |   scale: %d%%   |   populate: %d/%d" % [
+		_skins[_skin_idx]["name"], _roster.size(), _cats.size(), _moods[_mood_idx]["name"],
+		int(round(_occupant_scale * 100.0)), _pop_level, _POP_STAGES.size()]
 	if _asset_status == null:
 		return
+	var mode_line := "MODE: %s   |   doom-glow: %d%%   |   overlays: %d" % [
+		("OVERLAY (poster on wall)" if _overlay_mode else "prop placement"),
+		int(round(_doom_level * 100.0)), _overlays.size()]
 	var cur := _current_prop()
 	var cur_line: String
-	if cur.is_empty():
+	if _overlay_mode:
+		cur_line = "current poster: %d/%d (%s)" % [
+			(_poster_idx % max(1, _poster_texs.size())) + 1, _poster_texs.size(),
+			"promoted" if _has_promoted_posters() else "placeholder"]
+	elif cur.is_empty():
 		cur_line = "current prop: (none -- %s)" % _load_report
 	else:
 		var id := String(cur.get("id", ""))
 		cur_line = "current prop: %s  [%s]" % [id.get_file(), _tags_for(id)]
-	_asset_status.text = "state: %s   |   props offered: %d   |   placed: %d\n%s\nloaded: %s" % [
-		_states[_state_idx]["name"], _prop_pool.size(), _placed_props.size(), cur_line, _load_report]
+	_asset_status.text = "state: %s   |   props offered: %d   |   placed: %d   |   furniture: %d\n%s\n%s\ncats: %s\nloaded: %s" % [
+		_states[_state_idx]["name"], _prop_pool.size(), _placed_props.size(), _furniture.size(),
+		mode_line, cur_line, _cat_walk_report, _load_report]
+
+func _has_promoted_posters() -> bool:
+	for a in _promoted.get("props", []):
+		var id_l := String(a.get("id", "")).to_lower()
+		if id_l.find("poster") != -1 or id_l.find("wall_art") != -1 or id_l.find("decal") != -1:
+			return true
+	return false
 
 # ===========================================================================
 # PROMOTED-ASSET LOADER (from art_source, OUTSIDE res://; absolute-path I/O).
@@ -572,8 +1054,9 @@ func _load_promoted() -> void:
 	_promoted = {}
 	var counts := {}          # category -> [found, loaded]
 	if not DirAccess.dir_exists_absolute(_art_root):
+		# Expected on a fresh checkout run outside Pip's working copy -- degrade cleanly.
 		_load_report = "art_source not found at %s" % _art_root
-		push_warning("[office_sandbox] " + _load_report)
+		print("[office_sandbox] " + _load_report)
 		return
 	var entries: Array = _read_promote_list()          # [{rel, category, subtype}, ...]
 	var source := "promote_list.txt"
@@ -581,8 +1064,10 @@ func _load_promoted() -> void:
 		entries = _read_verdicts_promoted()
 		source = "pixellab_verdicts.json"
 	if entries.is_empty():
+		# Expected when promote_list.txt / pixellab_verdicts.json are absent (they are
+		# untracked, so live only in Pip's working copy) -- degrade to an empty prop pool.
 		_load_report = "no promoted assets found (place promote_list.txt / pixellab_verdicts.json in art_source)"
-		push_warning("[office_sandbox] " + _load_report)
+		print("[office_sandbox] " + _load_report)
 		return
 	for e in entries:
 		var rel := String(e.get("rel", ""))
@@ -681,6 +1166,72 @@ func _infer_category(rel: String) -> String:
 	return "misc"
 
 # ===========================================================================
+# CAT WALK-CYCLE LOADER (real pixellab frames from art_source; absolute-path I/O).
+# ===========================================================================
+# For each known cat-walk dir, assemble a SpriteFrames with walk_<dir> clips (+ an idle
+# frame). Cats spawned afterwards use these; sets without walk frames stay procedural and
+# are flagged. Degrades cleanly (empty -> all procedural) when art_source is absent.
+func _load_cat_walks() -> void:
+	_cat_frame_sets.clear()
+	var loaded: Array = []
+	if DirAccess.dir_exists_absolute(_art_root):
+		for rel in _CAT_WALK_DIRS:
+			var d := (_art_root + "/" + rel).simplify_path()
+			if not DirAccess.dir_exists_absolute(d):
+				continue
+			var sf := _build_cat_frames(d)
+			if sf != null:
+				_cat_frame_sets.append({"name": rel.get_file(), "frames": sf})
+				loaded.append(rel.get_file())
+	if loaded.is_empty():
+		_cat_walk_report = "REAL cat walkers: none (art_source absent) -- using procedural cats. Generate walk frames (pixellab) for: " + ", ".join(_CAT_SETS_NEEDING_WALKS)
+	else:
+		_cat_walk_report = "REAL cat walkers: %s   |   still NEED walk-frames (pixellab): %s" % [
+			", ".join(loaded), ", ".join(_CAT_SETS_NEEDING_WALKS)]
+	print("[office_sandbox] ", _cat_walk_report)
+
+# Assemble a walk-cycle SpriteFrames from <dir>/walk_<facing>_<n>.png sequences.
+# Clips: walk_south / walk_east / walk_north / walk_west (looping) + idle (south frame 0).
+# Returns null if no frames were found.
+func _build_cat_frames(dir_abs: String) -> SpriteFrames:
+	var sf := SpriteFrames.new()
+	var first := true
+	var made_any := false
+	for facing: String in ["south", "east", "north", "west"]:
+		var clip := "walk_" + facing
+		var i := 0
+		var added := 0
+		while true:
+			var p := "%s/walk_%s_%d.png" % [dir_abs, facing, i]
+			if not FileAccess.file_exists(p):
+				break
+			var tex := _load_texture(p)
+			if tex == null:
+				break
+			if first:
+				sf.rename_animation("default", clip)
+				first = false
+			elif not sf.has_animation(clip):
+				sf.add_animation(clip)
+			sf.set_animation_loop(clip, true)
+			sf.set_animation_speed(clip, 10.0)
+			sf.add_frame(clip, tex)
+			added += 1
+			i += 1
+		if added > 0:
+			made_any = true
+	if not made_any:
+		return null
+	var south0 := _load_texture(dir_abs + "/walk_south_0.png")
+	if south0 != null:
+		if not sf.has_animation("idle"):
+			sf.add_animation("idle")
+		sf.set_animation_loop("idle", true)
+		sf.set_animation_speed("idle", 1.0)
+		sf.add_frame("idle", south0)
+	return sf
+
+# ===========================================================================
 # FEEDBACK PERSISTENCE (<art_source>/sandbox_feedback.json; merges on load).
 # ===========================================================================
 func _feedback_path() -> String:
@@ -710,54 +1261,176 @@ func _save_feedback() -> void:
 	f.store_string(JSON.stringify(_feedback, "  "))
 	f.close()
 
-# ---------------------------------------------------------------------------
-# Self-contained procedural cat. Wanders inside its parent's bounds and draws a
-# small pixel-ish cat in _draw(). Cosmetic-only, private RNG; touches no game
-# state. Kept an inner class so the toy needs no new shared files or cat art
-# import (the pixellab pixel-cats live only in art_source -- see the PR notes).
-# ---------------------------------------------------------------------------
-class SandboxCat extends Node2D:
+# ===========================================================================
+# CATS. Base wander + doom-glow shared by the procedural cat (SandboxCat, drawn) and the
+# real walk-cycle cat (RealCat, AnimatedSprite2D). Cosmetic-only, private RNG; touches no
+# game state. Inner classes so the toy needs no new shared files.
+# ===========================================================================
+class SandboxCatBase extends Node2D:
 	var color: Color = Color(0.2, 0.2, 0.2)
 	var speed: float = 30.0
 	var _target: Vector2 = Vector2.ZERO
 	var _bounds: Rect2 = Rect2(0, 0, 320, 220)
 	var _pause: float = 0.0
+	var _doom: float = 0.0
+	var _t: float = 0.0
 	var _rng := RandomNumberGenerator.new()
+	var _glow: Sprite2D = null
+	static var _glow_tex: Texture2D = null
 
 	func _ready() -> void:
 		_rng.randomize()
 		_target = position
 		z_index = 5
 		texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		_glow = Sprite2D.new()
+		_glow.texture = _get_glow_tex()
+		var mat := CanvasItemMaterial.new()
+		mat.blend_mode = CanvasItemMaterial.BLEND_MODE_ADD
+		_glow.material = mat
+		_glow.z_index = -1                # behind the cat body
+		_glow.modulate = Color(1.0, 0.25, 0.15, 0.0)
+		add_child(_glow)
+		_build_visual()
+		_update_glow()
+
+	func _get_glow_tex() -> Texture2D:
+		if _glow_tex == null:
+			_glow_tex = _make_radial()
+		return _glow_tex
+
+	static func _make_radial() -> Texture2D:
+		var s := 96
+		var img := Image.create(s, s, false, Image.FORMAT_RGBA8)
+		var c := Vector2(s / 2.0, s / 2.0)
+		for y in range(s):
+			for x in range(s):
+				var dist := Vector2(x, y).distance_to(c) / (s / 2.0)
+				var a := clampf(1.0 - dist, 0.0, 1.0)
+				a = a * a
+				img.set_pixel(x, y, Color(1, 1, 1, a))
+		return ImageTexture.create_from_image(img)
 
 	func _process(delta: float) -> void:
+		_t += delta
 		var p := get_parent()
 		if p is Control:
 			_bounds = Rect2(Vector2(16, 16), (p as Control).size - Vector2(32, 32))
+		var dirv := Vector2.ZERO
+		var moving := false
 		if _pause > 0.0:
 			_pause -= delta
 		elif position.distance_to(_target) <= 4.0:
 			_pick_target()
 			_pause = _rng.randf_range(0.5, 2.5)
 		else:
+			var before := position
 			position = position.move_toward(_target, speed * delta)
+			dirv = position - before
+			moving = dirv.length_squared() > 0.0001
 		position.x = clampf(position.x, _bounds.position.x, _bounds.end.x)
 		position.y = clampf(position.y, _bounds.position.y, _bounds.end.y)
-		queue_redraw()
+		_update_glow()
+		_on_tick(dirv, moving, delta)
+
+	func _update_glow() -> void:
+		if _glow == null:
+			return
+		var pulse := 0.75 + 0.25 * sin(_t * 4.0)
+		_glow.modulate = Color(1.0, 0.25, 0.15, _doom * pulse)
+		var sc := 0.6 + _doom * 0.9
+		_glow.scale = Vector2(sc, sc)
+
+	func set_doom(level: float) -> void:
+		_doom = clampf(level, 0.0, 1.0)
+		_update_glow()
+		_on_doom()
 
 	func _pick_target() -> void:
 		_target = Vector2(
 			_rng.randf_range(_bounds.position.x, _bounds.end.x),
 			_rng.randf_range(_bounds.position.y, _bounds.end.y))
 
+	# virtuals
+	func _build_visual() -> void:
+		pass
+	func _on_tick(_dirv: Vector2, _moving: bool, _delta: float) -> void:
+		pass
+	func _on_doom() -> void:
+		pass
+
+# Procedural drawn cat (fallback when no real walk-cycle art is available).
+class SandboxCat extends SandboxCatBase:
+	func _on_tick(_dirv: Vector2, _moving: bool, _delta: float) -> void:
+		queue_redraw()
+
+	func _on_doom() -> void:
+		queue_redraw()
+
 	func _draw() -> void:
-		var dark := color.darkened(0.35)
+		var body := color.lerp(Color(0.85, 0.12, 0.10), _doom * 0.6)
+		var dark := body.darkened(0.35)
 		draw_line(Vector2(-8, 0), Vector2(-13, -6), dark, 2.0)                       # tail
-		draw_circle(Vector2(0, 0), 7.0, color)                                       # body
-		draw_circle(Vector2(6, -4), 4.5, color)                                      # head
+		draw_circle(Vector2(0, 0), 7.0, body)                                        # body
+		draw_circle(Vector2(6, -4), 4.5, body)                                       # head
 		draw_colored_polygon(PackedVector2Array([                                     # left ear
 			Vector2(3.0, -8.0), Vector2(4.5, -11.0), Vector2(6.5, -8.0)]), dark)
 		draw_colored_polygon(PackedVector2Array([                                     # right ear
 			Vector2(7.0, -8.0), Vector2(9.0, -11.0), Vector2(10.0, -8.0)]), dark)
-		draw_circle(Vector2(5.0, -4.5), 0.9, Color(0.15, 0.9, 0.4))                   # eyes
-		draw_circle(Vector2(8.0, -4.5), 0.9, Color(0.15, 0.9, 0.4))
+		var eye := Color(0.15, 0.9, 0.4).lerp(Color(1.0, 0.85, 0.1), _doom)           # eyes redden->amber with doom
+		draw_circle(Vector2(5.0, -4.5), 0.9 + _doom * 0.6, eye)
+		draw_circle(Vector2(8.0, -4.5), 0.9 + _doom * 0.6, eye)
+
+# Real walk-cycle cat (AnimatedSprite2D playing loaded pixellab frames).
+class RealCat extends SandboxCatBase:
+	const ART_SCALE := 0.45                    # 68px source -> ~30px on floor
+	var _frames: SpriteFrames = null
+	var _anim: AnimatedSprite2D = null
+
+	func setup(frames: SpriteFrames) -> void:
+		_frames = frames
+
+	func _build_visual() -> void:
+		_anim = AnimatedSprite2D.new()
+		_anim.sprite_frames = _frames
+		_anim.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		_anim.scale = Vector2(ART_SCALE, ART_SCALE)
+		add_child(_anim)
+		if _frames != null and _frames.has_animation("idle"):
+			_anim.play("idle")
+		elif _frames != null and _frames.get_animation_names().size() > 0:
+			_anim.play(_frames.get_animation_names()[0])
+
+	func _on_tick(dirv: Vector2, moving: bool, _delta: float) -> void:
+		if _anim == null or _frames == null:
+			return
+		if not moving:
+			if _frames.has_animation("idle") and _anim.animation != "idle":
+				_anim.play("idle")
+			return
+		var clip := "walk_" + _dir_name(dirv)
+		if _frames.has_animation(clip):
+			if _anim.animation != clip:
+				_anim.play(clip)
+
+	func _on_doom() -> void:
+		if _anim != null:
+			_anim.self_modulate = Color(1, 1, 1, 1).lerp(Color(1.0, 0.35, 0.28, 1.0), _doom * 0.7)
+
+	func _dir_name(v: Vector2) -> String:
+		if absf(v.x) >= absf(v.y):
+			return "east" if v.x > 0.0 else "west"
+		return "south" if v.y > 0.0 else "north"
+
+# ===========================================================================
+# Selection highlight ring (marks the per-sprite-scale / overlay-opacity target).
+# ===========================================================================
+class SandboxMarker extends Node2D:
+	var radius: float = 18.0
+
+	func _process(_delta: float) -> void:
+		queue_redraw()
+
+	func _draw() -> void:
+		draw_arc(Vector2.ZERO, radius, 0.0, TAU, 28, Color(1.0, 0.9, 0.2, 0.85), 1.5)
+		draw_arc(Vector2.ZERO, radius + 2.0, 0.0, TAU, 28, Color(0.1, 0.1, 0.1, 0.5), 1.0)

--- a/godot/tests/unit/test_office_sandbox_v3.gd
+++ b/godot/tests/unit/test_office_sandbox_v3.gd
@@ -1,0 +1,159 @@
+extends GutTest
+## Robustness / inferential guard for the OFFICE SANDBOX v3 dev toy. The sandbox never
+## ships to players, but it is a live prototyping surface, so this locks the invariants
+## that a UI-preview tool must not violate: it INSTANTIATES clean, its state machines are
+## bounded (populate / scale / doom / overlay opacity all CLAMP, never overrun or crash),
+## destructive calls on empty collections are no-ops, the first "space logic" slice holds
+## (furniture hugs walls + never shares a cell), and the real cat WALK-CYCLE data a spawned
+## cat would preview is assembled with the expected clips (the pixels still need a human's
+## eyes -- see the PR "UX QA" note -- but the DATA behind the preview is machine-checkable).
+##
+## PURE VIEW / mechanics-safe: no GameState, no seeded RNG, no writes. Art loading degrades
+## gracefully when art_source is absent, so the cat-walk assertions are guarded.
+
+const SandboxScene := preload("res://scenes/ui/office_floor/office_sandbox.tscn")
+
+
+func _sandbox() -> Control:
+	var s: Control = SandboxScene.instantiate()
+	add_child_autofree(s)
+	return s
+
+
+func test_instantiates_clean_with_a_floor():
+	var s := _sandbox()
+	await get_tree().process_frame
+	assert_not_null(s._floor, "sandbox built its OfficeFloor child")
+	assert_true(s._roster.size() > 0, "opens alive with some people")
+
+
+func test_populate_up_is_bounded_and_sequenced():
+	var s := _sandbox()
+	await get_tree().process_frame
+	# Drive the full sequence, then push PAST the last stage -- must not overrun or crash.
+	for _i in range(20):
+		s._populate_up()
+	var last: Dictionary = s._POP_STAGES[s._POP_STAGES.size() - 1]
+	assert_eq(s._pop_level, s._POP_STAGES.size(), "populate level clamps at the last stage")
+	assert_eq(s._roster.size(), int(last["people"]), "final stage people count reached")
+	assert_eq(s._cats.size(), int(last["cats"]), "final stage cat count reached")
+	assert_eq(s._furniture.size(), int(last["furn"]), "final stage furniture count reached")
+
+
+func test_populate_down_past_zero_is_a_noop_not_a_crash():
+	var s := _sandbox()
+	await get_tree().process_frame
+	s._populate_up()
+	s._populate_up()
+	for _i in range(10):
+		s._populate_down()   # more downs than ups
+	assert_eq(s._pop_level, 0, "populate level floors at 0")
+	assert_eq(s._roster.size(), 0, "everyone gone at level 0")
+	assert_eq(s._cats.size(), 0, "no cats at level 0")
+	assert_eq(s._furniture.size(), 0, "no furniture at level 0")
+
+
+func test_furniture_hugs_walls_and_never_shares_a_cell():
+	var s := _sandbox()
+	await get_tree().process_frame
+	for _i in range(6):
+		s._populate_up()
+	assert_true(s._furniture.size() > 0, "furniture was placed")
+	# no-overlap: one occupied-cell record per furniture piece
+	assert_eq(s._occupied_cells.size(), s._furniture.size(), "no two furniture share a grid cell")
+	# wall-affinity: every piece sits within one grid cell of a wall
+	var b: Rect2 = s._floor_bounds()
+	for spr in s._furniture:
+		var p: Vector2 = spr.position
+		var cell: float = s.GRID
+		var near_wall: bool = (p.x - b.position.x <= cell) or (b.end.x - p.x <= cell) \
+			or (p.y - b.position.y <= cell) or (b.end.y - p.y <= cell)
+		assert_true(near_wall, "furniture piece hugs a wall (pos=%s bounds=%s)" % [p, b])
+
+
+func test_occupant_scale_clamps_and_applies_to_sprites():
+	var s := _sandbox()
+	await get_tree().process_frame
+	# Hammer the bounds.
+	for _i in range(40):
+		s._nudge_occupant_scale(1.0 / s.OCCUPANT_SCALE_STEP)
+	assert_almost_eq(s._occupant_scale, s.OCCUPANT_SCALE_MIN, 0.001, "scale floors at MIN")
+	for _i in range(40):
+		s._nudge_occupant_scale(s.OCCUPANT_SCALE_STEP)
+	assert_almost_eq(s._occupant_scale, s.OCCUPANT_SCALE_MAX, 0.001, "scale ceils at MAX")
+	# The scale is actually applied to the employee sprite NODE transform (the P0 fix for
+	# "spawn one person, it's relatively huge" -- occupant size is now controllable).
+	var found := false
+	for c in s._floor.get_children():
+		if c is OfficeEmployeeSprite:
+			assert_almost_eq((c as Node2D).scale.x, s._occupant_scale, 0.01, "sprite node scale follows occupant scale")
+			found = true
+			break
+	assert_true(found, "at least one employee sprite present to scale")
+
+
+func test_doom_level_clamps_zero_to_one():
+	var s := _sandbox()
+	await get_tree().process_frame
+	for _i in range(30):
+		s._nudge_doom(0.1)
+	assert_almost_eq(s._doom_level, 1.0, 0.0001, "doom ceils at 1.0")
+	for _i in range(30):
+		s._nudge_doom(-0.1)
+	assert_almost_eq(s._doom_level, 0.0, 0.0001, "doom floors at 0.0")
+
+
+func test_overlay_stack_places_and_opacity_clamps():
+	var s := _sandbox()
+	await get_tree().process_frame
+	s._toggle_overlay_mode()
+	assert_true(s._overlay_mode, "overlay mode on")
+	for _i in range(3):
+		s._place_overlay()
+	assert_eq(s._overlays.size(), 3, "three transparent overlays stacked")
+	# opacity of the selected (nearest) overlay clamps within (0, 1]
+	for _i in range(30):
+		s._nudge_overlay_opacity(0.1)
+	var top_op := float(s._overlays[0].get_meta("opacity", -1.0))
+	assert_lt(top_op, 1.0001, "opacity ceils at 1.0")
+	for _i in range(30):
+		s._nudge_overlay_opacity(-0.1)
+	var low_op := float(s._overlays[0].get_meta("opacity", -1.0))
+	assert_gt(low_op, 0.0, "opacity stays above 0 (still a visible layer)")
+
+
+func test_destructive_calls_on_empty_are_noops():
+	var s := _sandbox()
+	await get_tree().process_frame
+	s._clear_all()
+	# All of these should be safe no-ops on empty collections (no crash, no negative counts).
+	s._despawn_person()
+	s._remove_cat()
+	s._remove_furniture()
+	s._remove_nearest_prop(Vector2.ZERO)
+	s._remove_nearest_overlay(Vector2.ZERO)
+	assert_eq(s._roster.size(), 0, "roster still empty")
+	assert_eq(s._cats.size(), 0, "cats still empty")
+	assert_eq(s._furniture.size(), 0, "furniture still empty")
+	assert_eq(s._placed_props.size(), 0, "props still empty")
+	assert_eq(s._overlays.size(), 0, "overlays still empty")
+	pass_test("destructive-on-empty did not crash")
+
+
+func test_cat_walk_cycle_preview_data_is_well_formed():
+	# The walk-cycle PREVIEW pixels need a human's eyes; the DATA behind it does not.
+	# When art_source is present (git-tracked cat_walk_cat1/2), assert the SpriteFrames a
+	# spawned cat previews has the four directional walk clips + an idle, each with frames.
+	var s := _sandbox()
+	await get_tree().process_frame
+	assert_ne(s._cat_walk_report, "", "cat-walk loader produced a status line")
+	if s._cat_frame_sets.is_empty():
+		pass_test("art_source absent in this checkout -- procedural cats + generation flag (guarded)")
+		return
+	var frames: SpriteFrames = s._cat_frame_sets[0]["frames"]
+	for facing: String in ["south", "east", "north", "west"]:
+		var clip := "walk_" + facing
+		assert_true(frames.has_animation(clip), "real cat has %s clip" % clip)
+		assert_true(frames.get_frame_count(clip) > 0, "%s has frames" % clip)
+		assert_true(frames.get_animation_loop(clip), "%s loops" % clip)
+	assert_true(frames.has_animation("idle"), "real cat has an idle frame for pauses")

--- a/godot/tests/unit/test_office_sandbox_v3.gd.uid
+++ b/godot/tests/unit/test_office_sandbox_v3.gd.uid
@@ -1,0 +1,1 @@
+uid://dw7dxsksgf75c


### PR DESCRIPTION
## Office Sandbox v3 -- dev toy (never ships)

Extends the standalone office-floor **dev sandbox** (v2 -> v3). Mechanics-safe by
construction: pure composition over the existing `OfficeFloor` view, driven through its
public API + v2's already-additive cosmetic tile hooks. **No game state, no new
`OfficeFloor`/`EmployeeSprite` hooks, no touch to the live watch_screen/main_ui
integration.** All scaling / doom-glow / overlays are applied by the sandbox onto nodes
it owns or onto sprite *node transforms* -- never the sprites' internal art scale,
movement, or any game state.

### What landed, by priority

**P0 -- Scaling (the reported "spawn one person, it's relatively huge")**
- Global occupant scale `[-]` / `[=]` (default **65%**, clamped 20-300%), applied as a
  node-transform onto people + cats + props. On-screen % readout.
- Per-sprite scale `[,]` / `[.]` on the sprite **under the cursor** (yellow selection
  ring marks the target).

**P0 -- Populate + placement logic**
- `[U]` populate-up / `[I]` populate-down step a **10-stage** office build-up (1 worker +
  a couple desks ... up to a full-ish ~24-person office with cats). `[0]` resets.
- First "space logic" slice: **furniture hugs walls** (perimeter grid cells, no two share
  a cell), **people spread** via the existing desk layout, **cats wander freely**.
  Procedural placeholder furniture (desk/cabinet/plant/server/printer) so it works with
  zero promoted art. Manual placement also gains wall-snap when dropped near a wall.

**P1 -- Real cat walk-cycles**
- Loads git-tracked pixellab walk frames from `art_source` by absolute path and assembles
  `SpriteFrames` (walk_south/east/north/west + idle). Spawned cats become **real
  directional walkers**; procedural cat is the fallback.
- **Became real walkers:** `cat_walk_cat1`, `cat_walk_cat2` (4 dirs x 9 frames each).
- **Still need walk-frames generated (pixellab) -- rotation-only today:** `cat_black`,
  `cat_tabby`, `cat_eldritch` (x4), `cat_purple` (x4). Flagged on-screen + stdout.

**P2 -- doom-glow on cats** (kept)
- `[` / `]` drive a doom level 0..1 -> additive radial glow (CanvasItemMaterial ADD,
  pulsing) + body reddening on every cat (real and procedural). `office_cat.gd` has a
  `update_doom_level()` stub but no variants, so the glow is self-contained here.

**P2 -- SWAP: weather/sky -> transparency/overlay POC** (per coordinator scope change)
- Dropped the weather backdrop. Replaced with a **transparent-layer compositing** proof:
  `[V]` toggles poster-on-wall mode; `[LMB]` places posters with **wall-affinity**;
  overlays **stack**; `[;]` / `[']` set the selected overlay's **opacity** (proving the
  transparency). Uses a promoted poster/wall-art asset if present, else translucent
  placeholder posters. This is the incremental foundation a true weather-through-windows
  feature builds on later (which will additionally need window art with transparency --
  currently a gap).

v2 kept intact: promoted-asset loader, prop placement, skin/mood cycling, scummy/decent
office STATE + floor/wall tileset swap, in-context feedback.

### Additive OfficeFloor hooks
**None new.** v3 reuses only v2's `set_floor_tile_texture` / `set_wall_strip_texture`
(both backward-compatible no-ops for the live integration). One tiny non-hook tidy: two
`_load_promoted` *expected-degrade* messages downgraded `push_warning` -> `print` (a
fresh checkout with no `promote_list.txt` is the documented normal path, not a fault --
this also lets the headless test run without tripping GUT's error handler).

### On UX QA + robustness testing (answering the mid-review question)
- **Automatable now (added):** `tests/unit/test_office_sandbox_v3.gd` (9 tests, all green)
  is the destructive/inferential slice -- clean instantiate, **bounded** populate (push
  past the last stage / below zero = no overrun), **clamps** on scale/doom/opacity,
  **destructive-on-empty no-ops** (remove cat/prop/overlay/person with nothing there),
  furniture **wall-affinity + no-overlap**, and the cat **walk-cycle preview *data*** is
  well-formed (four looping directional clips + idle, each with frames).
- **Still needs human eyes (by nature):** the *look* of a walk-cycle, glow intensity,
  poster legibility, scale "feels right" -- pixels and motion. Recommend a short manual
  QA checklist per launch (walk smoothness, no popping at direction changes, glow reads
  at doom=1, overlays visibly composite). I can add that as a doc if wanted.
- **Deferred (flagged, not built):** sprite/furniture/cat **collision** -- people can
  still visually overlap at high populate levels and cats ignore each other. Fine for now
  per your note; it's the natural next "space logic" increment (occupancy grid ->
  soft-separation) once the layout model firms up.

### Verify
- `--import` clean; headless scene instantiate runs `_ready` + 14s of `_process` with **no
  script errors**; loader degrades cleanly when `art_source`/`promote_list.txt` absent.
- Fast gate green: **656 tests, 0 failures, 75/75 files**.

### Launch command
```
"C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe" --path godot res://scenes/ui/office_floor/office_sandbox.tscn
```
(or `godot --path godot res://scenes/ui/office_floor/office_sandbox.tscn`). Full control
legend is on-screen. Do **not** merge -- Pip reviews first.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
