### PR TITLE
docs(ws3): pin WS-3 to Wed 2026-07-29 0800-1800 AEST; track calendar + roadmap-recast HTML

### DIFF
--- a/docs/RELEASE_CALENDAR.html
+++ b/docs/RELEASE_CALENDAR.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>P(Doom)1 -- release calendar</title>
+<style>
+  :root{--bg:#17120e;--panel:#211a14;--panel2:#2b221a;--ink:#ece0cf;--dim:#a9977f;--faint:#6f6250;
+    --amber:#e8a33d;--amber2:#c07a1f;--win:#6fae86;--line:#3a2e22;--fork:#d8695a;--seed:#6fae86;}
+  @media (prefers-color-scheme:light){:root{--bg:#efe6d6;--panel:#f7efe0;--panel2:#fbf5e9;--ink:#2b2116;
+    --dim:#6b5b45;--faint:#9a876c;--amber:#b9741a;--amber2:#8f5710;--win:#3f8a5c;--line:#ddccb0;
+    --fork:#c14a3a;--seed:#3f8a5c;}}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);line-height:1.5;
+    font-family:ui-sans-serif,system-ui,"Segoe UI",Helvetica,Arial,sans-serif}
+  .wrap{max-width:840px;margin:0 auto;padding:2.2rem 1.4rem 5rem}
+  .eyebrow{font-family:ui-monospace,Consolas,monospace;font-size:.7rem;letter-spacing:.22em;
+    text-transform:uppercase;color:var(--amber);margin:0 0 .5rem}
+  h1{font-family:ui-monospace,"Cascadia Code",Consolas,monospace;font-weight:700;
+    font-size:clamp(1.5rem,3.4vw,2.1rem);margin:0 0 .3rem}
+  .sub{color:var(--dim);font-size:.92rem;margin:0 0 1.6rem;max-width:66ch}
+  .legend{display:flex;flex-wrap:wrap;gap:.5rem 1.1rem;font-family:ui-monospace,Consolas,monospace;
+    font-size:.72rem;color:var(--dim);margin:0 0 1.8rem;padding-bottom:1.2rem;border-bottom:1px solid var(--line)}
+  .dot{display:inline-block;width:.7em;height:.7em;border-radius:50%;margin-right:.35em;vertical-align:middle}
+  .d-epoch{background:var(--fork)}.d-seed{background:var(--seed)}.d-mile{background:var(--amber)}.d-design{background:#8a7bd8}
+  .month{font-family:ui-monospace,Consolas,monospace;font-size:.72rem;letter-spacing:.16em;text-transform:uppercase;
+    color:var(--faint);margin:1.8rem 0 .7rem;padding-top:.3rem}
+  .row{display:grid;grid-template-columns:5.2rem 1fr;gap:.9rem;padding:.5rem 0;border-bottom:1px solid var(--line);align-items:baseline}
+  .when{font-family:ui-monospace,Consolas,monospace;font-size:.78rem;color:var(--dim);white-space:nowrap}
+  .when b{color:var(--ink)}
+  .what{font-size:.92rem}
+  .what .tag{font-family:ui-monospace,Consolas,monospace;font-size:.64rem;letter-spacing:.06em;text-transform:uppercase;
+    border-radius:4px;padding:.1rem .4rem;margin-right:.5rem;white-space:nowrap}
+  .t-epoch{background:var(--fork);color:#2a1210}.t-seed{background:var(--seed);color:#12251a}
+  .t-mile{background:var(--amber);color:#20140a}.t-design{background:#8a7bd8;color:#141021}.t-patch{border:1px solid var(--line);color:var(--dim)}
+  .what .meta{color:var(--faint);font-size:.8rem;font-family:ui-monospace,Consolas,monospace}
+  .now{background:var(--panel2);border-left:3px solid var(--amber);border-radius:6px;
+    padding:.5rem .7rem;margin:.3rem 0 .3rem;font-family:ui-monospace,Consolas,monospace;font-size:.8rem;color:var(--amber)}
+  .theme{color:var(--ink)}
+  footer{margin-top:2.5rem;padding-top:1rem;border-top:1px solid var(--line);
+    color:var(--faint);font-size:.76rem;font-family:ui-monospace,Consolas,monospace}
+</style></head><body>
+<div class="wrap">
+  <p class="eyebrow">P(Doom)1 &middot; release &amp; league calendar</p>
+  <h1>The next three months</h1>
+  <p class="sub">Two clocks: a <b>forking monthly Epoch</b> on the first Friday (new minor version + ladder bump + Theme), and a <b>weekly Seed</b> every Friday (fresh board, same rules). Dates verified against the 2026 calendar.</p>
+  <div class="legend">
+    <span><span class="dot d-epoch"></span>Epoch (forks: minor + ladder)</span>
+    <span><span class="dot d-seed"></span>Weekly seed (no fork)</span>
+    <span><span class="dot d-mile"></span>Big Milestone</span>
+    <span><span class="dot d-design"></span>Design</span>
+  </div>
+
+  <div class="now">&gt;&gt; You are here: Sat 26 Jul 2026 &middot; build 0.13.1 &middot; ladder L2</div>
+
+  <div class="month">July 2026</div>
+  <div class="row"><div class="when">Mon-Tue<br>27-28</div><div class="what"><span class="tag t-patch">patch</span><span class="theme">v0.13.1 build</span> <span class="meta">-- from release/v0.13; honesty pass; ladder stays L2</span></div></div>
+  <div class="row"><div class="when"><b>Wed 29</b></div><div class="what"><span class="tag t-design">WS-3</span><span class="theme">Workshop 3 -- mechanics</span> <span class="meta">-- crisp parts, brutal decisions (#811)</span></div></div>
+  <div class="row"><div class="when">Fri 31</div><div class="what"><span class="tag t-seed">seed</span>weekly seed rotation <span class="meta">-- L2</span></div></div>
+
+  <div class="month">August 2026</div>
+  <div class="row"><div class="when"><b>Fri 7</b></div><div class="what"><span class="tag t-epoch">epoch -> L3</span><span class="theme">v0.14 "Per-tick &amp; People"</span> <span class="meta">(prov.) -- per-tick resolution + people &amp; money cohesion</span></div></div>
+  <div class="row"><div class="when">Fri 14</div><div class="what"><span class="tag t-seed">seed</span>weekly seed <span class="meta">-- L3</span></div></div>
+  <div class="row"><div class="when">Fri 21</div><div class="what"><span class="tag t-seed">seed</span>weekly seed <span class="meta">-- L3</span></div></div>
+  <div class="row"><div class="when">Fri 28</div><div class="what"><span class="tag t-seed">seed</span>weekly seed <span class="meta">-- L3</span></div></div>
+
+  <div class="month">September 2026</div>
+  <div class="row"><div class="when"><b>Fri 4</b></div><div class="what"><span class="tag t-epoch">epoch -> L4</span><span class="theme">v0.15 (unnamed)</span> <span class="meta">-- onboarding-as-mechanic + public-alpha hardening</span></div></div>
+  <div class="row"><div class="when">Fri 11 / 18 / 25</div><div class="what"><span class="tag t-seed">seed</span>weekly seeds <span class="meta">-- L4</span></div></div>
+  <div class="row"><div class="when"><b>Tue 29</b></div><div class="what"><span class="tag t-mile">milestone</span><span class="theme">First Contact target</span> <span class="meta">-- public-alpha readiness (spans v0.13-v0.15)</span></div></div>
+
+  <div class="month">October 2026</div>
+  <div class="row"><div class="when"><b>Fri 2</b></div><div class="what"><span class="tag t-epoch">epoch -> L5</span><span class="theme">v0.16 "Sightings"</span> <span class="meta">(prov.) -- rivals begin; wider event pool from pdoom-data</span></div></div>
+  <div class="row"><div class="when">Fri 9 / 16 / 23 / 30</div><div class="what"><span class="tag t-seed">seed</span>weekly seeds <span class="meta">-- L5</span></div></div>
+
+  <footer>Provisional Theme names beyond v0.13 are unblessed (no-lies standard). Source: RELEASE_NOMENCLATURE.md + ROADMAP.md &middot; rendered 2026-07-25.</footer>
+</div>
+</body></html>

--- a/docs/ROADMAP_RECAST_PROPOSAL.html
+++ b/docs/ROADMAP_RECAST_PROPOSAL.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>P(Doom)1 -- ROADMAP re-cast (proposed)</title>
+<style>
+  :root{
+    --bg:#17120e;--panel:#211a14;--panel2:#2b221a;--ink:#ece0cf;--dim:#a9977f;--faint:#6f6250;
+    --amber:#e8a33d;--amber2:#c07a1f;--win:#6fae86;--line:#3a2e22;--fork:#d8695a;
+  }
+  @media (prefers-color-scheme:light){:root{
+    --bg:#efe6d6;--panel:#f7efe0;--panel2:#fbf5e9;--ink:#2b2116;--dim:#6b5b45;--faint:#9a876c;
+    --amber:#b9741a;--amber2:#8f5710;--win:#3f8a5c;--line:#ddccb0;--fork:#c14a3a;}}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);line-height:1.55;
+    font-family:ui-sans-serif,system-ui,"Segoe UI",Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:920px;margin:0 auto;padding:2.2rem 1.4rem 5rem}
+  .eyebrow{font-family:ui-monospace,Consolas,monospace;font-size:.7rem;letter-spacing:.22em;
+    text-transform:uppercase;color:var(--amber);margin:0 0 .5rem}
+  h1{font-family:ui-monospace,"Cascadia Code",Consolas,monospace;font-weight:700;
+    font-size:clamp(1.5rem,3.4vw,2.1rem);line-height:1.1;margin:0 0 .3rem}
+  .sub{color:var(--dim);font-size:.95rem;margin:0 0 .3rem;max-width:70ch}
+  .badge{display:inline-block;font-family:ui-monospace,Consolas,monospace;font-size:.66rem;
+    letter-spacing:.1em;text-transform:uppercase;color:#20140a;background:var(--amber);
+    border-radius:5px;padding:.2rem .55rem;margin:.6rem 0 1.6rem}
+  h2{font-family:ui-monospace,Consolas,monospace;font-size:1.05rem;margin:2.4rem 0 .3rem;
+    padding-bottom:.4rem;border-bottom:1px solid var(--line)}
+  .note{color:var(--faint);font-size:.82rem;margin:.2rem 0 1rem}
+  table{width:100%;border-collapse:collapse;font-size:.9rem;margin:.6rem 0}
+  th,td{text-align:left;padding:.55rem .6rem;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:ui-monospace,Consolas,monospace;font-size:.66rem;letter-spacing:.08em;
+    text-transform:uppercase;color:var(--faint)}
+  td.v{font-family:ui-monospace,Consolas,monospace;color:var(--amber);white-space:nowrap;font-weight:600}
+  td.d{font-family:ui-monospace,Consolas,monospace;color:var(--dim);white-space:nowrap;font-size:.82rem}
+  .ladder{font-family:ui-monospace,Consolas,monospace;color:var(--fork);font-size:.8rem}
+  .prov{color:var(--faint);font-style:italic}
+  .shipped{color:var(--win);font-family:ui-monospace,Consolas,monospace;font-size:.72rem}
+  .arc{background:var(--panel);border:1px solid var(--line);border-left:4px solid var(--amber);
+    border-radius:9px;padding:.9rem 1.1rem;margin:.8rem 0}
+  .arc h3{margin:0 0 .25rem;font-family:ui-monospace,Consolas,monospace;font-size:1rem}
+  .arc .span{font-family:ui-monospace,Consolas,monospace;font-size:.72rem;color:var(--faint)}
+  .arc p{margin:.4rem 0 0;color:var(--dim);font-size:.88rem}
+  .retired{opacity:.55}
+  .retired table td,.retired table th{text-decoration:line-through}
+  .retired .why{text-decoration:none;color:var(--fork);font-size:.82rem;margin:.3rem 0 0;font-family:ui-monospace,Consolas,monospace}
+  .callout{background:var(--panel2);border:1px solid var(--line);border-radius:9px;padding:.9rem 1.1rem;margin:1.4rem 0;font-size:.9rem}
+  .callout b{color:var(--amber)}
+  code{font-family:ui-monospace,Consolas,monospace;font-size:.85em;background:var(--panel2);padding:.05rem .3rem;border-radius:4px}
+  footer{margin-top:2.5rem;padding-top:1rem;border-top:1px solid var(--line);
+    color:var(--faint);font-size:.78rem;font-family:ui-monospace,Consolas,monospace}
+</style></head><body>
+<div class="wrap">
+  <p class="eyebrow">P(Doom)1 &middot; roadmap &middot; nomenclature v2</p>
+  <h1>ROADMAP re-cast -- monthly Themes</h1>
+  <p class="sub">Replaces the old "one minor version per quarter" table with the canonical model
+  (<code>RELEASE_NOMENCLATURE.md</code>): each month is a named Theme = a minor bump = a forking epoch;
+  two Big Milestones are the only multi-month groupings.</p>
+  <span class="badge">Proposed -- for your blessing (nothing written to ROADMAP.md yet)</span>
+
+  <h2>Monthly Themes</h2>
+  <p class="note">Epoch = first Friday of the month. Theme names beyond v0.13 are PROVISIONAL -- yours to name.</p>
+  <table>
+    <tr><th>Version</th><th>Ships</th><th>Ladder</th><th>Theme</th><th>Headline</th></tr>
+    <tr><td class="v">v0.13</td><td class="d">Jul 24</td><td class="ladder">L2</td>
+        <td>Launch epoch <span class="shipped">SHIPPED</span></td>
+        <td>Hiring pipeline, onboarding cold-open, office visuals, league live, legibility + stability, v0.13.1 honesty pass</td></tr>
+    <tr><td class="v">v0.14</td><td class="d">Aug 7</td><td class="ladder">L3</td>
+        <td>"Per-tick &amp; People" <span class="prov">(prov.)</span></td>
+        <td>Per-tick resolution + people &amp; money cohesion (roles / salary / manager / payroll)</td></tr>
+    <tr><td class="v">v0.15</td><td class="d">Sep 4</td><td class="ladder">L4</td>
+        <td><span class="prov">(unnamed)</span></td>
+        <td>Onboarding-as-mechanic + public-alpha hardening (leaderboard, install ping, bug reporter, test builds)</td></tr>
+    <tr><td class="v">v0.16</td><td class="d">Oct 2</td><td class="ladder">L5</td>
+        <td>"Sightings" <span class="prov">(prov.)</span></td>
+        <td>Rivals begin -- Developments / procedural presence; wider event pool from pdoom-data</td></tr>
+    <tr><td class="v">v0.17</td><td class="d">Nov 6</td><td class="ladder">L6</td>
+        <td>"The World Shoots Back" <span class="prov">(prov.)</span></td>
+        <td>News feedline + rival midgame pressure (poaching, litigation, funding attacks)</td></tr>
+    <tr><td class="v">v0.18</td><td class="d">Dec 4</td><td class="ladder">L7</td>
+        <td><span class="prov">(unnamed)</span></td>
+        <td>Rival direct confrontation + News v1 + voice re-skin of event content</td></tr>
+  </table>
+  <p class="note">Confidence decays with distance: v0.14-v0.15 grounded in existing design; v0.16+ is direction to steer, not commitment. WS-3 (Wed Jul 29) will reshape.</p>
+
+  <h2>Big Milestones (the only multi-month objects)</h2>
+  <div class="arc">
+    <h3>First Contact <span class="span">&middot; target Sep 29 &middot; spans v0.13-v0.15</span></h3>
+    <p>Public-alpha readiness: onboarding, the share loop, leaderboard hardened, monthly league v0, first-contact UX.</p>
+  </div>
+  <div class="arc">
+    <h3>Rivals &amp; News <span class="span">&middot; target Dec 30 &middot; spans v0.16-v0.18</span></h3>
+    <p>Rivals become a strategic surface: intel/capability-race, poaching rework, News channel v1, the DQ-22 aggro-midgame, voice content pass.</p>
+  </div>
+
+  <h2>Retired: the old quarterly table</h2>
+  <div class="retired">
+    <table>
+      <tr><th>Quarter</th><th>Version</th><th>Theme</th></tr>
+      <tr><td>Q3 2026</td><td>v0.12</td><td>First Contact</td></tr>
+      <tr><td>Q4 2026</td><td>v0.13</td><td>Rivals and News</td></tr>
+      <tr><td>Q1 2027</td><td>v0.14</td><td>The World Shoots Back</td></tr>
+      <tr><td>Q2 2027</td><td>v0.15</td><td>Beta / Steam Coming Soon</td></tr>
+    </table>
+    <p class="why">Doubly stale: v0.13.1 already shipped (versions move monthly, not quarterly), and First Contact / Rivals &amp; News are Big Milestones spanning several Themes, not single versions.</p>
+  </div>
+
+  <div class="callout">
+    <b>Two decisions for you:</b> (1) name the upcoming Themes (v0.14+ shown provisional) -- or leave them unnamed until closer; (2) "The World Shoots Back" has no home in the new model -- I've provisionally parked it as v0.17's Theme name; keep it there, promote it, or retire it. On your nod I'll write the blessed version into <code>ROADMAP.md</code> and sweep the two downstream docs that still say <code>v0.12 "First Contact"</code>.
+  </div>
+
+  <footer>Proposed 2026-07-25 &middot; source: RELEASE_NOMENCLATURE.md + coherence sweep (#860) &middot; not yet in ROADMAP.md</footer>
+</div>
+</body></html>

--- a/docs/game-design/WORKSHOP_3_PREP.md
+++ b/docs/game-design/WORKSHOP_3_PREP.md
@@ -1,6 +1,8 @@
-# Workshop 3 -- Running Order (2026-07-30) + Prep Pack
+# Workshop 3 -- Running Order (2026-07-29) + Prep Pack
 
-> Status: RUNNING ORDER for WS-3 (Wed 2026-07-30, issue #811), written 2026-07-25.
+> Status: RUNNING ORDER for WS-3 (Wed 2026-07-29, 0800-1800 AEST, issue #811),
+> written 2026-07-25. Date pinned 2026-07-26 (earlier copies said "Wed 07-30",
+> but 07-30 is a Thursday; may move EARLIER at Pip's call, not later).
 > Sections R0-R6 are the day-of agenda. Sections 0-6 further down are the original
 > prep pack (2026-07-23) that fed this agenda -- BACKGROUND, partially superseded;
 > read the reconciliation note at the head of the appendix before trusting a detail
@@ -128,7 +130,7 @@ now RESOLVED -- do not treat them as live:
   WS-3 is a deep-mechanics workshop feeding the v0.14+ Epochs, not a milestone-anchor
   choice. See ROADMAP.md + RELEASE_NOMENCLATURE.md.
 - **"No WS-3 mechanics session is scheduled" / "the Friday unknown" (Section 5):
-  RESOLVED.** WS-3 is scheduled Wed 2026-07-30 (issue #811), separate from the old
+  RESOLVED.** WS-3 is scheduled Wed 2026-07-29 (issue #811), separate from the old
   Friday #758 slot.
 - **"Office economy proposal does not exist" (Theme B gate, Sections 3b/5/6):
   RESOLVED.** `OFFICE_ECONOMY_PROPOSAL.md` now exists -- it is R3's input.


### PR DESCRIPTION
Pins the WS-3 date everywhere after the contradiction was found INSIDE issue #811 (title said Wed 07-29, body said Wed 2026-07-30 -- a Thursday). Pip ruled 2026-07-26: **Wed 07-29, 0800-1800 AEST**, may move earlier but not later. #811 body already edited to match.

Also starts tracking docs/RELEASE_CALENDAR.html (already showed Wed 29) and docs/ROADMAP_RECAST_PROPOSAL.html per Pip's call to keep both at least through WS-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)