### PR TITLE
fix(office): correct character/cat base scale, feet-anchor sprites, sandbox compare view (#899, #793 partial)

### DIFF
--- a/godot/scripts/ui/office_floor/employee_sprite.gd
+++ b/godot/scripts/ui/office_floor/employee_sprite.gd
@@ -19,12 +19,46 @@ class_name OfficeEmployeeSprite
 ##   walking  -> "aimless" isn't just drift: picks drift / window-gaze (a long
 ##               stare out the window) / spin-on-the-spot, so disengagement reads.
 
+# Tier-0 blob DRAW radius only (the drawn circle really is 11px). The movement/
+# bounds footprint no longer uses this for tier 1 -- see FOOTPRINT_RATIO below.
 const BODY_RADIUS := 11.0
 const ARRIVE_EPS := 4.0
-# #770: integer nearest-neighbor upscale of the tier-1 character art so employees
-# read at a sensible size in the WATCH office strip (the pixellab frames are ~24x32,
-# which drew tiny). Movement/bounds are unchanged -- this only scales the drawn art.
-const SPRITE_SCALE := Vector2(2.0, 2.0)
+
+# --- Character scale derivation (#899 scale pass) ---------------------------
+# Floor tiles are 32px art drawn at FLOOR_TILE_SCALE 2 (office_floor.gd), so one
+# tile is 64px on screen. A worker should read ~2 tiles tall = 128px.
+# The real artloop_char frames are 180x180 canvas with an opaque subject of
+# ~52w x 140h px (alpha bbox (65,18)-(117,158) on walking_0). 128 / 140 = 0.914;
+# 0.9 is the clean value -> drawn subject ~126px.
+# (The old 2.0 was tuned against a WRONG comment claiming the frames were ~24x32;
+# at 2.0 the 140px subject drew ~280px tall in a ~260px room.)
+const TILE_PX := 64.0                        # one floor tile on screen
+const CHAR_TARGET_H := TILE_PX * 2.0         # 128px: target on-screen worker height
+const ART_CANVAS_H := 180.0                  # artloop_char frame canvas
+const ART_SUBJECT_H := 140.0                 # opaque subject height in that canvas
+const ART_FEET_Y := 158.0                    # bottom of the opaque bbox (the feet)
+const SPRITE_SCALE := Vector2(0.9, 0.9)      # ~= CHAR_TARGET_H / ART_SUBJECT_H
+
+# Feet anchor: AnimatedSprite2D / Sprite2D are centre-anchored by default, while
+# props are feet-anchored (office_floor.gd _draw_prop), so characters floated.
+# Shift the texture up so the subject's feet sit on the node origin:
+# canvas centre y = 90, feet y = 158 -> offset (0, 90 - 158) = (0, -68) art px
+# (offset is texture-space, applied before the node scale).
+const SPRITE_FEET_OFFSET := Vector2(0.0, ART_CANVAS_H * 0.5 - ART_FEET_Y)
+
+# The GENERATED placeholder frames (_make_char_texture) are 24x32 with the
+# subject filling the canvas: scale 128 / 32 = 4.0; feet at the canvas bottom
+# -> offset 32/2 - 32 = -16. Which family is in use is detected per-frames by
+# canvas height in _apply_art_transform().
+const PLACEHOLDER_CANVAS_H := 32.0
+const PLACEHOLDER_SCALE := Vector2(4.0, 4.0)
+const PLACEHOLDER_FEET_OFFSET := Vector2(0.0, PLACEHOLDER_CANVAS_H * 0.5 - PLACEHOLDER_CANVAS_H)
+
+# Movement/bounds footprint radius derives from the DRAWN character height
+# (~0.15 * 128 ~= 19px) instead of the old hardcoded 11.0 (a leftover from the
+# 24x32-blob era that let the bigger art clip through the room bounds).
+const FOOTPRINT_RATIO := 0.15
+const FEET_BOTTOM_PAD := 2.0                 # feet stay just off the bottom wall line
 
 # Micro-behavior tuning (seconds / per-second chances; all cosmetic).
 const BREAK_CHANCE_PER_SEC := 0.14      # once off cooldown, chance/sec to start a break
@@ -117,13 +151,12 @@ func _ready() -> void:
 	_anim.visible = false
 	# Crisp pixel art, no blur, regardless of per-file .import filter settings.
 	_anim.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	_anim.scale = SPRITE_SCALE   # #770: draw the character art larger in the WATCH strip
 	add_child(_anim)
 	_facing_sprite = Sprite2D.new()
 	_facing_sprite.visible = false
 	_facing_sprite.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	_facing_sprite.scale = SPRITE_SCALE   # #770: match the animated-clip scale
 	add_child(_facing_sprite)
+	_apply_art_transform()   # scale + feet-anchor for both art nodes (#899)
 	_label = Label.new()
 	_label.add_theme_font_size_override("font_size", 10)
 	_label.position = Vector2(-BODY_RADIUS - 2.0, BODY_RADIUS + 2.0)
@@ -167,6 +200,7 @@ func set_tier(t: int) -> void:
 func set_sprite_frames(frames: SpriteFrames) -> void:
 	if _anim:
 		_anim.sprite_frames = frames
+		_apply_art_transform()
 		_refresh_visual()
 
 func _apply_tier() -> void:
@@ -179,8 +213,54 @@ func _apply_tier() -> void:
 		_anim.visible = false
 		if _facing_sprite:
 			_facing_sprite.visible = false
+	_apply_art_transform()
 	_refresh_visual()
 	queue_redraw()
+
+## Set scale + feet-anchor offset on both tier-1 art nodes (#899 scale pass).
+## Which art family the animated frames belong to is detected by canvas height
+## (real artloop frames are 180px tall; generated placeholders 32px) so real art
+## and colour-skin placeholders BOTH land at ~CHAR_TARGET_H on screen with their
+## feet on the node origin. The static _facing_sprite always uses the real-art
+## constants: its default textures are the 180x180 rotation_*.png frames.
+func _apply_art_transform() -> void:
+	var use_placeholder := false
+	if _anim and _anim.sprite_frames:
+		var names := _anim.sprite_frames.get_animation_names()
+		if names.size() > 0 and _anim.sprite_frames.get_frame_count(names[0]) > 0:
+			var tex := _anim.sprite_frames.get_frame_texture(names[0], 0)
+			if tex != null and tex.get_height() < 100:
+				use_placeholder = true
+	if _anim:
+		_anim.scale = PLACEHOLDER_SCALE if use_placeholder else SPRITE_SCALE
+		_anim.offset = PLACEHOLDER_FEET_OFFSET if use_placeholder else SPRITE_FEET_OFFSET
+	if _facing_sprite:
+		_facing_sprite.scale = SPRITE_SCALE
+		_facing_sprite.offset = SPRITE_FEET_OFFSET
+
+## Radius of the walkable footprint around the feet (bounds clamping + wander
+## targets). Tier 1: derived from the drawn height; tier 0: the blob radius.
+func _footprint_radius() -> float:
+	if tier == 1:
+		return FOOTPRINT_RATIO * CHAR_TARGET_H   # ~19px
+	return BODY_RADIUS
+
+## Rect the FEET may occupy inside `bounds`. Feet-anchored art extends UP from
+## the origin, so the top inset is the full drawn height (keeps heads inside the
+## room) and the bottom inset is just a small pad. Degenerate (too-small) bounds
+## collapse to the vertical centre instead of inverting the clamp.
+func _feet_rect() -> Rect2:
+	var r := _footprint_radius()
+	var top_pad := CHAR_TARGET_H if tier == 1 else BODY_RADIUS
+	var bottom_pad := FEET_BOTTOM_PAD if tier == 1 else BODY_RADIUS
+	var y_min := bounds.position.y + top_pad
+	var y_max := bounds.end.y - bottom_pad
+	if y_min > y_max:
+		y_min = bounds.position.y + bounds.size.y * 0.5
+		y_max = y_min
+	var x_min := bounds.position.x + r
+	var x_max := maxf(x_min, bounds.end.x - r)
+	return Rect2(Vector2(x_min, y_min), Vector2(x_max - x_min, y_max - y_min))
 
 ## Optional: override the static per-direction reference art (default: the
 ## committed rotation_{south,east,north,west}.png). Same seam shape as
@@ -242,13 +322,26 @@ static func facing_from_vector(v: Vector2) -> String:
 func _set_facing(f: String) -> void:
 	_facing = f
 
-## Move toward target and face the direction actually travelled this frame.
-## Marks _facing_active so the directional art (rather than the south-only
-## animated clip) is shown while translating.
+## Clamp a movement target into the walkable feet rect (#899 feet-anchor pass).
+## Landmarks/desks laid out near the top wall stay valid destinations -- feet
+## stop at the closest legal point (head overlapping the wall art reads as
+## standing AT it) -- and arrival checks agree with the clamped point instead
+## of never triggering.
+func _clamp_target(p: Vector2) -> Vector2:
+	var walk := _feet_rect()
+	return p.clamp(walk.position, walk.end)
+
+## True when the feet are at (the walkable projection of) `target`.
+func _arrived(target: Vector2) -> bool:
+	return position.distance_to(_clamp_target(target)) <= ARRIVE_EPS
+
+## Move toward target (clamped into the walkable rect) and face the direction
+## actually travelled this frame. Marks _facing_active so the directional art
+## (rather than the south-only animated clip) is shown while translating.
 func _move_toward_and_face(target: Vector2, delta: float) -> void:
 	_facing_active = true
 	var before := position
-	position = position.move_toward(target, speed * delta)
+	position = position.move_toward(_clamp_target(target), speed * delta)
 	var moved := position - before
 	if moved.length_squared() > 0.0001:
 		_set_facing(facing_from_vector(moved))
@@ -285,13 +378,13 @@ func _process_working(delta: float) -> void:
 	match _work_sub:
 		"desk":
 			_move_toward_and_face(desk_pos, delta)
-			if position.distance_to(desk_pos) <= ARRIVE_EPS:
+			if _arrived(desk_pos):
 				_break_cooldown -= delta
 				if _break_cooldown <= 0.0 and _rng.randf() < BREAK_CHANCE_PER_SEC * delta:
 					_start_break()
 		"to_break":
 			_move_toward_and_face(_break_target, delta)
-			if position.distance_to(_break_target) <= ARRIVE_EPS:
+			if _arrived(_break_target):
 				_work_sub = "on_break"
 				_aimless_timer = _rng.randf_range(BREAK_DWELL_RANGE.x, BREAK_DWELL_RANGE.y)
 		"on_break":
@@ -302,7 +395,7 @@ func _process_working(delta: float) -> void:
 			# stand just beside the peer's desk, not on top of it
 			var beside := _collab_target + Vector2(BODY_RADIUS * 1.6, 0.0)
 			_move_toward_and_face(beside, delta)
-			if position.distance_to(beside) <= ARRIVE_EPS:
+			if _arrived(beside):
 				_work_sub = "collaborating"
 				_aimless_timer = _rng.randf_range(BREAK_DWELL_RANGE.x, BREAK_DWELL_RANGE.y)
 		"collaborating":
@@ -311,7 +404,7 @@ func _process_working(delta: float) -> void:
 				_work_sub = "returning"
 		"returning":
 			_move_toward_and_face(desk_pos, delta)
-			if position.distance_to(desk_pos) <= ARRIVE_EPS:
+			if _arrived(desk_pos):
 				_work_sub = "desk"
 				_break_kind = ""
 				_break_cooldown = _rng.randf_range(BREAK_COOLDOWN_RANGE.x, BREAK_COOLDOWN_RANGE.y)
@@ -350,13 +443,13 @@ func _process_aimless(delta: float) -> void:
 	_aimless_timer -= delta
 	match _aimless:
 		"drift":
-			if position.distance_to(_target) <= ARRIVE_EPS:
+			if _arrived(_target):
 				_pick_wander_target()
 			_move_toward_and_face(_target, delta)
 			if _aimless_timer <= 0.0:
 				_pick_aimless()
 		"window":
-			if position.distance_to(window_pos) > ARRIVE_EPS:
+			if not _arrived(window_pos):
 				_move_toward_and_face(window_pos, delta)
 				_aimless_timer += delta   # don't burn gaze time until we've arrived
 			elif _aimless_timer <= 0.0:
@@ -396,14 +489,16 @@ func _pick_aimless() -> void:
 			_spin_step_timer = 0.0   # turn immediately on entering spin
 
 func _pick_wander_target() -> void:
+	var walk := _feet_rect()
 	_target = Vector2(
-		_rng.randf_range(bounds.position.x + BODY_RADIUS, bounds.end.x - BODY_RADIUS),
-		_rng.randf_range(bounds.position.y + BODY_RADIUS, bounds.end.y - BODY_RADIUS)
+		_rng.randf_range(walk.position.x, walk.end.x),
+		_rng.randf_range(walk.position.y, walk.end.y)
 	)
 
 func _clamp_to_bounds() -> void:
-	position.x = clampf(position.x, bounds.position.x + BODY_RADIUS, bounds.end.x - BODY_RADIUS)
-	position.y = clampf(position.y, bounds.position.y + BODY_RADIUS, bounds.end.y - BODY_RADIUS)
+	var walk := _feet_rect()
+	position.x = clampf(position.x, walk.position.x, walk.end.x)
+	position.y = clampf(position.y, walk.position.y, walk.end.y)
 
 # --- Tier 0 rendering: blob + hat ------------------------------------------
 func _draw() -> void:

--- a/godot/scripts/ui/office_floor/office_sandbox.gd
+++ b/godot/scripts/ui/office_floor/office_sandbox.gd
@@ -48,17 +48,24 @@ const WANG_BASE_REGION := Rect2i(64, 32, 32, 32)
 const TILE_UPSCALE := 2
 
 # --- v3 tuning --------------------------------------------------------------
-# Global OCCUPANT scale default. The v2 sprites drew at EmployeeSprite.SPRITE_SCALE (2.0);
-# on a small floor that reads too big ("spawn one person, it's relatively huge"). 0.65 makes
-# a spawned worker a sane fraction of the floor. Tunable live with [-]/[=]. Applied as a NODE
-# transform scale onto occupants (people/cats/props) -- never touches the sprites' art scale.
-const OCCUPANT_SCALE_DEFAULT := 0.65
+# Global OCCUPANT scale default. Since the #899 scale pass fixed the BASE art scale
+# (EmployeeSprite.SPRITE_SCALE now lands a worker at ~128px = 2 floor tiles), the sandbox
+# default multiplier is NEUTRAL: 1.0 shows the real in-game scale. (The old 0.65 existed
+# only to compensate for the oversized 2.0 base scale.) Tunable live with [-]/[=]. Applied
+# as a NODE transform scale onto occupants -- never touches the sprites' art scale.
+const OCCUPANT_SCALE_DEFAULT := 1.0
 const OCCUPANT_SCALE_MIN := 0.2
 const OCCUPANT_SCALE_MAX := 3.0
 const OCCUPANT_SCALE_STEP := 1.12       # multiplicative per keypress
-const PER_SPRITE_STEP := 1.1            # per-selected-sprite scale step
+# #899: per-sprite step raised 1.1 -> 1.25. A 10% step was easy to read as "the keys are
+# dead" on art that overflowed the room; 25% per press is unambiguous.
+const PER_SPRITE_STEP := 1.25           # per-selected-sprite scale step
 const PER_SPRITE_MIN := 0.25
 const PER_SPRITE_MAX := 4.0
+# #899: max cursor->sprite distance for the per-sprite pick ([,]/[.] and the marker ring).
+# Previously _nearest_person had NO pick radius, so the keys silently retargeted whichever
+# sprite happened to be nearest anywhere on the floor between presses.
+const PICK_RADIUS := 64.0
 
 # POPULATE-UP sequence: cumulative TARGET totals per press (level 1..10). Level 0 = empty.
 # Each press advances one stage (people via set_roster, cats wandering, furniture on walls).
@@ -186,6 +193,20 @@ var _overlays: Array = []                  # Sprite2D transparent wall overlays 
 var _poster_texs: Array = []               # placeholder/promoted poster textures
 var _poster_idx: int = 0
 var _marker: SandboxMarker = null          # highlights the per-sprite / overlay selection target
+var _last_msg: String = ""                 # #899: transient feedback line shown in the status
+
+# --- compare view (side-by-side scale check) ---------------------------------
+# [V] renders TWO OfficeFloor instances at once: LEFT a small starter room (2-3
+# staff, sparse props), RIGHT the main floor as a larger complex office (6+
+# staff, cats, dense props). Same rendering path + the same shared scale
+# constants on both -- the point is compare-and-contrast of one scale ruling in
+# two room sizes. Dev-only, pure composition, zero game-state writes.
+var _compare_mode := false
+var _floor_b: OfficeFloor = null           # LEFT starter office
+var _roster_b: Array = []
+var _furniture_b: Array = []               # starter-floor placeholder props
+var _caption_a: Label = null
+var _caption_b: Label = null
 
 func _ready() -> void:
 	_rng.randomize()
@@ -233,9 +254,10 @@ func _build_overlay() -> void:
 	_legend.add_theme_font_size_override("font_size", 13)
 	_legend.text = "OFFICE SANDBOX v3  --  dev toy (no game state)\n" \
 		+ "[1]/[2] spawn/despawn person   [S] skin   [B] mood   [C]/[X] add/remove cat   [R] randomize   [0] clear   [ESC] quit\n" \
-		+ "SCALE:  [-]/[=] all occupants   [,]/[.] the sprite under the cursor   |   POPULATE:  [U] up a stage   [I] down a stage\n" \
+		+ "SCALE:  [-]/[=] all occupants   [,]/[.] the sprite under the cursor (within 64px)   |   POPULATE:  [U] up a stage   [I] down a stage\n" \
+		+ "[V] COMPARE: side-by-side starter (small) vs complex (large) office\n" \
 		+ "[T] office STATE (scummy/decent)   [P] cycle prop/poster   [LMB] place   [RMB] remove nearest   [K] clear props\n" \
-		+ "DOOM-GLOW on cats:  [ [ ] decrease   [ ] ] increase   |   OVERLAY POC:  [V] toggle poster-on-wall mode   [;]/['] selected overlay opacity\n" \
+		+ "DOOM-GLOW on cats:  [ [ ] decrease   [ ] ] increase   |   OVERLAY POC:  [O] toggle poster-on-wall mode   [;]/['] selected overlay opacity\n" \
 		+ "feedback on current prop:  [L]ike  [J] dislike  [F]avour  [G] disfavour  [M] promote  [N] note"
 	vb.add_child(_legend)
 
@@ -359,7 +381,9 @@ func _input(event: InputEvent) -> void:
 		KEY_BRACKETRIGHT:
 			_nudge_doom(DOOM_STEP)
 		KEY_V:
-			_toggle_overlay_mode()
+			_toggle_compare()
+		KEY_O:
+			_toggle_overlay_mode()   # was [V]; V now toggles the compare view
 		KEY_SEMICOLON:
 			_nudge_overlay_opacity(-0.1)
 		KEY_APOSTROPHE:
@@ -420,18 +444,23 @@ func _cycle_skin() -> void:
 
 func _apply_skin(idx: int) -> void:
 	_skin_idx = idx
-	var s: Dictionary = _skins[idx]
+	_apply_skin_to_floor(_floor)
+	if _floor_b != null and is_instance_valid(_floor_b):
+		_apply_skin_to_floor(_floor_b)   # compare view mirrors the skin (same render path)
+	_apply_occupant_scale()
+
+func _apply_skin_to_floor(f: OfficeFloor) -> void:
+	var s: Dictionary = _skins[_skin_idx]
 	match String(s.get("kind", "")):
 		"art":
-			_floor.set_sprite_frames(RealSpriteFrames)
-			_floor.set_tier(1)
+			f.set_sprite_frames(RealSpriteFrames)
+			f.set_tier(1)
 		"color":
 			var frames: SpriteFrames = EmployeeSpriteScript._build_placeholder_frames(s["body"], HAT)
-			_floor.set_sprite_frames(frames)
-			_floor.set_tier(1)
+			f.set_sprite_frames(frames)
+			f.set_tier(1)
 		_:
-			_floor.set_tier(0)                     # "blob"
-	_apply_occupant_scale()
+			f.set_tier(0)                     # "blob"
 
 # --- Mood / lighting --------------------------------------------------------
 func _cycle_mood() -> void:
@@ -441,6 +470,8 @@ func _cycle_mood() -> void:
 func _apply_mood(idx: int) -> void:
 	_mood_idx = idx
 	_floor.modulate = _moods[idx]["tint"]
+	if _floor_b != null and is_instance_valid(_floor_b):
+		_floor_b.modulate = _moods[idx]["tint"]
 
 # --- Office STATE (prototype "reflects game state") -------------------------
 func _cycle_state() -> void:
@@ -457,6 +488,9 @@ func _apply_state(idx: int) -> void:
 	# Additive dev hooks (default null restores built-in look for the live integration).
 	_floor.set_floor_tile_texture(floor_tex)
 	_floor.set_wall_strip_texture(wall_tex)
+	if _floor_b != null and is_instance_valid(_floor_b):
+		_floor_b.set_floor_tile_texture(floor_tex)
+		_floor_b.set_wall_strip_texture(wall_tex)
 
 # Find a promoted tileset whose id contains `key`, crop its Wang base tile, upscale,
 # and return a tileable texture. Returns null if no promoted tileset matched.
@@ -669,7 +703,10 @@ func _remove_cat() -> void:
 		cat.queue_free()
 
 func _floor_bounds() -> Rect2:
-	var s := _floor.size
+	return _bounds_of(_floor)
+
+func _bounds_of(f: Control) -> Rect2:
+	var s := f.size
 	if s.x < 40.0 or s.y < 40.0:
 		s = Vector2(360, 260)
 	return Rect2(Vector2(16, 16), s - Vector2(32, 32))
@@ -679,10 +716,9 @@ func _floor_bounds() -> Rect2:
 # every occupant the sandbox owns: employee sprites (NODE transform only -- never the art
 # scale the live view sets), cats, populate-furniture, and manually-placed props.
 func _apply_occupant_scale() -> void:
-	for c in _floor.get_children():
-		if c is OfficeEmployeeSprite:
-			var m := float((c as Node).get_meta("sb_scale_mult", 1.0))
-			(c as Node2D).scale = Vector2(_occupant_scale * m, _occupant_scale * m)
+	_scale_people_on(_floor)
+	if _floor_b != null and is_instance_valid(_floor_b):
+		_scale_people_on(_floor_b)   # compare view: SAME scale constants both sides
 	for cat in _cats:
 		if is_instance_valid(cat):
 			cat.scale = Vector2(_occupant_scale, _occupant_scale)
@@ -690,11 +726,21 @@ func _apply_occupant_scale() -> void:
 		if is_instance_valid(f):
 			var base: Vector2 = f.get_meta("base_scale", Vector2.ONE)
 			f.scale = base * _occupant_scale
+	for f2 in _furniture_b:
+		if is_instance_valid(f2):
+			var base_b: Vector2 = f2.get_meta("base_scale", Vector2.ONE)
+			f2.scale = base_b * _occupant_scale
 	for spr in _placed_props:
 		if is_instance_valid(spr):
 			var base2: Vector2 = spr.get_meta("base_scale", Vector2.ONE)
 			spr.scale = base2 * _occupant_scale
 	_refresh_ghost_texture()
+
+func _scale_people_on(f: OfficeFloor) -> void:
+	for c in f.get_children():
+		if c is OfficeEmployeeSprite:
+			var m := float((c as Node).get_meta("sb_scale_mult", 1.0))
+			(c as Node2D).scale = Vector2(_occupant_scale * m, _occupant_scale * m)
 
 func _nudge_occupant_scale(mult: float) -> void:
 	_occupant_scale = clampf(_occupant_scale * mult, OCCUPANT_SCALE_MIN, OCCUPANT_SCALE_MAX)
@@ -703,13 +749,22 @@ func _nudge_occupant_scale(mult: float) -> void:
 func _scale_nearest_person(mult: float) -> void:
 	var sp := _nearest_person(_floor.get_local_mouse_position())
 	if sp == null:
+		# #899: previously this silently no-opped (or silently retargeted a far-away
+		# sprite) -- now the status line says why nothing visibly changed.
+		_last_msg = "per-sprite scale: no sprite within %dpx of the cursor" % int(PICK_RADIUS)
 		return
 	var m := float(sp.get_meta("sb_scale_mult", 1.0))
 	m = clampf(m * mult, PER_SPRITE_MIN, PER_SPRITE_MAX)
 	sp.set_meta("sb_scale_mult", m)
+	var nm := "sprite"
+	if sp is OfficeEmployeeSprite:
+		nm = (sp as OfficeEmployeeSprite).emp_name
+	_last_msg = "per-sprite scale: %s -> x%.2f" % [nm, m]
 	_apply_occupant_scale()
 
-func _nearest_person(at: Vector2) -> Node2D:
+# #899: picks the nearest employee sprite WITHIN max_dist of `at` (was unbounded,
+# which made [,]/[.] retarget invisibly-distant sprites between presses).
+func _nearest_person(at: Vector2, max_dist: float = PICK_RADIUS) -> Node2D:
 	var best: Node2D = null
 	var best_d := INF
 	for c in _floor.get_children():
@@ -718,7 +773,7 @@ func _nearest_person(at: Vector2) -> Node2D:
 			if d < best_d:
 				best_d = d
 				best = c
-	return best
+	return best if best_d <= max_dist else null
 
 # --- v3: POPULATE-UP sequence + placement logic -----------------------------
 func _populate_up() -> void:
@@ -839,6 +894,124 @@ func _furniture_tex(kind: String) -> Texture2D:
 		img.set_pixel(0, y, col.darkened(0.5))
 		img.set_pixel(w - 1, y, col.darkened(0.5))
 	return ImageTexture.create_from_image(img)
+
+# --- COMPARE VIEW: side-by-side starter vs complex office (#899 / #793) ------
+# [V] splits the sandbox into TWO OfficeFloor instances rendered through the
+# IDENTICAL path with the IDENTICAL scale constants:
+#   LEFT  = small starter environment: small bounds, 3 staff, sparse props.
+#   RIGHT = the main sandbox floor, topped up to a larger complex office:
+#           7+ staff, 2 cats, 8+ wall furniture (plus whatever was placed).
+# Purpose: visually judge one scale ruling (worker ~2 tiles, cat ~0.5 tile) in
+# two room sizes at once. Pure composition; no game-state writes.
+func _toggle_compare() -> void:
+	_compare_mode = not _compare_mode
+	if _compare_mode:
+		_enter_compare()
+	else:
+		_exit_compare()
+
+func _enter_compare() -> void:
+	# LEFT starter floor: same scene, same skin/mood/state, its own small roster.
+	_floor_b = OfficeFloorScene.instantiate()
+	add_child(_floor_b)
+	move_child(_floor_b, _floor.get_index() + 1)   # keep the legend/status panel on top
+	_apply_skin_to_floor(_floor_b)
+	_floor_b.modulate = _moods[_mood_idx]["tint"]
+	var st: Dictionary = _states[_state_idx]
+	_floor_b.set_floor_tile_texture(_tileset_tile_for(String(st.get("floor_key", ""))))
+	_floor_b.set_wall_strip_texture(_tileset_tile_for(String(st.get("wall_key", ""))))
+	_roster_b = []
+	for _i in range(3):
+		_roster_b.append(_make_person(_next_id))
+		_next_id += 1
+	_floor_b.set_roster(_roster_b)
+	# RIGHT complex floor: top up the EXISTING sandbox population (reuses the
+	# normal spawn machinery; never shrinks anything Pip already placed).
+	while _roster.size() < 7 and _roster.size() < MAX_PEOPLE:
+		_roster.append(_make_person(_next_id))
+		_next_id += 1
+	_push_roster()
+	while _cats.size() < 2 and _cats.size() < MAX_CATS:
+		_add_cat()
+	while _furniture.size() < 8:
+		if not _spawn_furniture():
+			break
+	_layout_floors()
+	_caption_a = _make_caption(_floor, "COMPLEX (large office)")
+	_caption_b = _make_caption(_floor_b, "STARTER (small office)")
+	# Starter props spawn deferred: the left floor's size is 0 until the first
+	# layout pass, and the wall spots derive from its real bounds.
+	call_deferred("_spawn_starter_props")
+	_apply_occupant_scale()
+	_last_msg = "compare ON: same render path + scale constants on both floors"
+
+func _exit_compare() -> void:
+	if _caption_a != null and is_instance_valid(_caption_a):
+		_caption_a.queue_free()
+	_caption_a = null
+	_caption_b = null                      # child of _floor_b; freed with it
+	if _floor_b != null and is_instance_valid(_floor_b):
+		_floor_b.queue_free()
+	_floor_b = null
+	_roster_b.clear()
+	_furniture_b.clear()
+	_layout_floors()
+	_last_msg = "compare OFF"
+
+func _layout_floors() -> void:
+	if _compare_mode:
+		# LEFT starter: deliberately small room. RIGHT complex: the wide remainder.
+		_set_floor_anchors(_floor_b, 0.02, 0.32, 0.36, 0.96)
+		_set_floor_anchors(_floor, 0.40, 0.04, 0.99, 0.98)
+	else:
+		_floor.set_anchors_preset(Control.PRESET_FULL_RECT)
+
+func _set_floor_anchors(f: Control, l: float, t: float, r: float, b: float) -> void:
+	if f == null or not is_instance_valid(f):
+		return
+	f.anchor_left = l
+	f.anchor_top = t
+	f.anchor_right = r
+	f.anchor_bottom = b
+	f.offset_left = 0.0
+	f.offset_top = 0.0
+	f.offset_right = 0.0
+	f.offset_bottom = 0.0
+
+func _make_caption(parent_floor: Control, text: String) -> Label:
+	var cap := Label.new()
+	cap.text = text
+	cap.add_theme_font_size_override("font_size", 12)
+	cap.modulate = Color(1.0, 0.9, 0.4)
+	cap.position = Vector2(12, 12)
+	cap.z_index = 4
+	parent_floor.add_child(cap)
+	return cap
+
+# Sparse starter furnishing: a desk / plant / cabinet against the left floor's
+# walls, via the same placeholder _furniture_tex path POPULATE uses.
+func _spawn_starter_props() -> void:
+	if _floor_b == null or not is_instance_valid(_floor_b):
+		return
+	var b := _bounds_of(_floor_b)
+	var spots: Array = [
+		Vector2(b.position.x + GRID * 0.5, b.position.y + GRID * 0.5),
+		Vector2(b.end.x - GRID * 0.5, b.position.y + GRID * 0.5),
+		Vector2(b.position.x + GRID * 0.5, b.end.y - GRID * 0.5),
+	]
+	var kinds: Array = ["desk", "plant", "cabinet"]
+	for i in range(spots.size()):
+		var tex := _furniture_tex(String(kinds[i]))
+		var spr := Sprite2D.new()
+		spr.texture = tex
+		spr.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		var base := _prop_scale(tex)
+		spr.set_meta("base_scale", base)
+		spr.scale = base * _occupant_scale
+		spr.position = spots[i]
+		spr.z_index = 2
+		_floor_b.add_child(spr)
+		_furniture_b.append(spr)
 
 # --- v3: DOOM-GLOW on cats (prototype) --------------------------------------
 func _nudge_doom(d: float) -> void:
@@ -994,6 +1167,9 @@ func _randomize() -> void:
 	_apply_occupant_scale()
 
 func _clear_all() -> void:
+	if _compare_mode:
+		_compare_mode = false
+		_exit_compare()
 	_roster.clear()
 	_push_roster()
 	for cat in _cats:
@@ -1008,13 +1184,22 @@ func _clear_all() -> void:
 func _update_status() -> void:
 	if _status == null:
 		return
-	_status.text = "skin: %s   |   people: %d   |   cats: %d   |   mood: %s   |   scale: %d%%   |   populate: %d/%d" % [
+	# #899: surface the SELECTED sprite's per-sprite multiplier so [,]/[.] have
+	# visible feedback (the old status only printed the GLOBAL scale, so a
+	# working per-sprite nudge looked like dead keys).
+	var sel := _nearest_person(_floor.get_local_mouse_position())
+	var sel_txt := "none in range"
+	if sel != null:
+		sel_txt = "x%.2f" % float(sel.get_meta("sb_scale_mult", 1.0))
+	_status.text = "skin: %s   |   people: %d   |   cats: %d   |   mood: %s   |   scale: %d%%   |   sel sprite: %s   |   populate: %d/%d%s" % [
 		_skins[_skin_idx]["name"], _roster.size(), _cats.size(), _moods[_mood_idx]["name"],
-		int(round(_occupant_scale * 100.0)), _pop_level, _POP_STAGES.size()]
+		int(round(_occupant_scale * 100.0)), sel_txt, _pop_level, _POP_STAGES.size(),
+		("" if _last_msg == "" else "\n>> " + _last_msg)]
 	if _asset_status == null:
 		return
-	var mode_line := "MODE: %s   |   doom-glow: %d%%   |   overlays: %d" % [
+	var mode_line := "MODE: %s   |   compare: %s   |   doom-glow: %d%%   |   overlays: %d" % [
 		("OVERLAY (poster on wall)" if _overlay_mode else "prop placement"),
+		("ON" if _compare_mode else "off"),
 		int(round(_doom_level * 100.0)), _overlays.size()]
 	var cur := _current_prop()
 	var cur_line: String
@@ -1383,7 +1568,14 @@ class SandboxCat extends SandboxCatBase:
 
 # Real walk-cycle cat (AnimatedSprite2D playing loaded pixellab frames).
 class RealCat extends SandboxCatBase:
-	const ART_SCALE := 0.45                    # 68px source -> ~30px on floor
+	# #899 scale unification: cat and human sizes derive from the SAME on-screen
+	# tile unit (OfficeEmployeeSprite.TILE_PX = 64px; humans target CHAR_TARGET_H
+	# = 2 tiles = 128px). Cat art: 68x68 canvas, opaque subject ~34px tall.
+	# Target: a cat reads ~0.5 tile (32px) beside a 2-tile human.
+	# ART_SCALE = 32 / 34 ~= 0.94 (was a magic 0.45 -> ~15px, a quarter-tile cat).
+	const CAT_SUBJECT_H := 34.0
+	const CAT_TARGET_H := OfficeEmployeeSprite.TILE_PX * 0.5   # 32px on screen
+	const ART_SCALE := CAT_TARGET_H / CAT_SUBJECT_H            # ~0.94
 	var _frames: SpriteFrames = null
 	var _anim: AnimatedSprite2D = null
 

--- a/godot/tests/unit/test_office_sandbox_v3.gd
+++ b/godot/tests/unit/test_office_sandbox_v3.gd
@@ -140,6 +140,34 @@ func test_destructive_calls_on_empty_are_noops():
 	pass_test("destructive-on-empty did not crash")
 
 
+func test_compare_view_toggles_and_builds_second_floor():
+	# #899/#793 scale-compare view: [V] builds a second starter OfficeFloor (LEFT)
+	# and tops the main floor up to a complex office (RIGHT); toggling off tears the
+	# starter floor down and restores the full-rect layout.
+	var s := _sandbox()
+	await get_tree().process_frame
+	s._toggle_compare()
+	await get_tree().process_frame
+	assert_true(s._compare_mode, "compare mode on")
+	assert_not_null(s._floor_b, "starter (left) floor exists")
+	assert_eq(s._roster_b.size(), 3, "starter floor has 3 staff")
+	assert_true(s._roster.size() >= 7, "complex floor topped up to 7+ staff")
+	assert_true(s._cats.size() >= 2, "complex floor has cats")
+	await get_tree().process_frame   # starter props spawn deferred (need a layout pass)
+	assert_true(s._furniture_b.size() > 0, "starter floor got sparse props")
+	s._toggle_compare()
+	assert_false(s._compare_mode, "compare mode off")
+	assert_null(s._floor_b, "starter floor torn down")
+
+
+func test_nearest_person_pick_radius_bounds_selection():
+	# #899: the per-sprite scale keys must NOT silently retarget a far-away sprite.
+	var s := _sandbox()
+	await get_tree().process_frame
+	assert_null(s._nearest_person(Vector2(-10000.0, -10000.0)),
+		"no sprite picked outside PICK_RADIUS")
+
+
 func test_cat_walk_cycle_preview_data_is_well_formed():
 	# The walk-cycle PREVIEW pixels need a human's eyes; the DATA behind it does not.
 	# When art_source is present (git-tracked cat_walk_cat1/2), assert the SpriteFrames a


### PR DESCRIPTION
## What this fixes

Workers on the office floor drew ~280px tall in a ~260px room. Root cause: `SPRITE_SCALE = 2.0` was tuned against a WRONG comment claiming the artloop_char frames are ~24x32. The real frames are 180x180 with a ~140px-tall opaque subject. This PR fixes the base scale from a measured derivation, feet-anchors the characters, unifies cat/human scaling, adds #899 diagnostics to the sandbox, and adds a side-by-side compare view for judging scale decisions.

## Scale derivations (verified against the shipped PNGs, commented in-code)

**Worker** (`employee_sprite.gd`):
- Floor tile: 32px art x `FLOOR_TILE_SCALE` 2 = **64px on screen** (`TILE_PX`).
- Target: a worker reads ~2 tiles tall = **128px** (`CHAR_TARGET_H`).
- Art: 180x180 canvas, opaque subject ~52w x 140h (alpha bbox (65,18)-(117,158) on `walking_0`; `rotation_south` matches at (63,17)-(118,158)).
- `SPRITE_SCALE` = 128 / 140 = 0.914 -> **0.9** (clean value; drawn subject ~126px). Before: 2.0 -> ~280px.

**Feet anchor**: AnimatedSprite2D/Sprite2D are centre-anchored while props are feet-anchored (`office_floor.gd _draw_prop`), so characters floated/clipped. Offset (0, 90 - 158) = **(0, -68)** art px puts the subject's feet on the node origin. The generated 24x32 placeholder colour-skins get their own scale (4.0) + offset (-16), detected per-frames by canvas height, so they also land at ~128px.

**Bounds**: movement footprint radius now derives from drawn height (`0.15 * 128 ~= 19px`) instead of the hardcoded `BODY_RADIUS 11.0` (a 24x32-blob leftover; kept only as the tier-0 blob draw radius). Feet-anchored art extends UP from the origin, so the walkable rect insets the top by the full drawn height -- heads stay inside the room. Movement targets + arrival checks clamp into that rect so desks/landmarks laid out near the top wall stay reachable (no forever-walking-in-place regression).

**Cat** (`office_sandbox.gd RealCat`): 68x68 canvas, ~34px opaque subject (bbox (19,14)-(45,48)). Target: ~0.5 tile = 32px beside a 2-tile human. `ART_SCALE` = 32 / 34 ~= **0.94** (was a magic 0.45 -> a ~15px quarter-tile cat). Cats and humans now share `OfficeEmployeeSprite.TILE_PX` as the single scale unit.

## #899 diagnostics (per-sprite scale keys "appear dead")

Audit found no code bug; the failure was UX feedback. Fixes:
- Status line now shows the **selected sprite's per-sprite multiplier** ("sel sprite: x1.25" / "none in range") plus a feedback message after each press.
- `_nearest_person` gets a **64px pick radius** (was unbounded -- the keys silently retargeted whichever sprite was nearest anywhere on the floor between presses). Out-of-range presses now say so in the status line. The marker ring obeys the same radius.
- `PER_SPRITE_STEP` **1.1 -> 1.25** (a 10% step was invisible on overflowing art).
- `OCCUPANT_SCALE_DEFAULT` **0.65 -> 1.0**: the 0.65 existed only to compensate for the oversized base art; the sandbox now opens at the real in-game scale.

## Compare view ([V])

Side-by-side scale check inside the sandbox: LEFT = small starter office (small bounds, 3 staff, sparse placeholder props), RIGHT = the main floor topped up to a complex office (7+ staff, 2 cats, 8+ wall furniture). Both are the SAME `OfficeFloor` scene rendered through the identical path with identical scale constants -- the point is judging one scale ruling in two room sizes at once. Skin/mood/state changes mirror to both floors. Pure composition, dev-only, zero game-state writes. The overlay POC toggle moved **[V] -> [O]** (legend updated).

## Tests
- Fast gate: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **658 tests, 0 failures, 75/75 files** (was 656; +2 new guards: compare view build/teardown, pick-radius bound).

## Scope notes
- #793 **partial: scale only** -- the portrait/variant pool is NOT addressed here.
- No tile-grid addressing refactor, no Camera2D, no art regeneration (deliberately out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)