### PR TITLE
feat(office): prop manifest v1 -- per-asset footprint/anchor/height metadata + loader (renderer integration follows scale lane)

### DIFF
--- a/docs/art/PROP_MANIFEST.md
+++ b/docs/art/PROP_MANIFEST.md
@@ -1,0 +1,68 @@
+# Office prop manifest
+
+Per-asset metadata for office floor props, so props stop being force-scaled
+identically. Pattern-matched on `godot/data/icon_mapping.json` (the repo's
+registry convention: `_meta` version header + one keyed entry per asset).
+
+- **Data:** `godot/data/office/props_manifest.json` (SSOT; `_schema` block inside
+  documents every field)
+- **Loader:** `godot/scripts/core/prop_catalogue.gd` (`PropCatalogue`, static/lazy
+  like `quirk_catalogue.gd`)
+- **Tests:** `godot/tests/unit/test_prop_manifest.gd`
+
+## Why
+
+The renderers (`office_floor.gd`, `office_sandbox.gd`) currently force-scale
+EVERY prop to `PROP_TARGET_H = 46` display px, feet-anchored -- a water cooler and
+a four-tile server cluster end up the same height. The manifest records what each
+asset actually is (real canvas, opaque-subject bounds, feet anchor, tile
+footprint, height) so a renderer can size and place each prop on its own terms.
+
+## Fields (summary -- `_schema` in the JSON is authoritative)
+
+| field | meaning |
+|---|---|
+| `art` | `res://` path to the PNG under `assets/office_floor/props/` |
+| `canvas_px` | full PNG size `[w, h]` (includes transparent padding) |
+| `subject_px` | opaque-subject (alpha bbox) size `[w, h]` |
+| `anchor_px` | feet anchor in canvas coords: bottom-centre of the opaque bbox (x may be `.5`; y = exclusive bbox bottom, the baseline row) |
+| `footprint_tiles` | floor tiles occupied `[w, h]` at the 32 px art-tile scale (floor art is 32 px, displayed at 64 px); depth is judgement -- front-view art has none |
+| `height_tiles` | subject height / 32, rounded to nearest 0.25 (ties up) |
+| `style_tags` | office-state families: `"scummy"` / `"decent"`; both = state-neutral art |
+| `sockets` | ALWAYS `[]` for now -- schema placeholder, see below |
+| `review` | `true` = a field needs Pip's ruling (see `notes`) |
+
+## Adding a prop
+
+1. Drop the PNG in `godot/assets/office_floor/props/` (transparent padding is
+   fine -- the subject bbox is what matters).
+2. Measure canvas + alpha bbox (python PIL: `Image.open(p).split()[3].getbbox()`
+   gives `(left, top, right_excl, bottom_excl)`; subject = right-left x
+   bottom-top; anchor = `((left+right)/2, bottom_excl)`).
+3. Add the entry to `props_manifest.json` (id = file basename). Set `review: true`
+   on anything you guessed (footprint depth, style family).
+4. Run the fast gate -- `test_prop_manifest.gd` fails loudly if a PNG lacks an
+   entry, an art path dangles, or geometry is out of bounds.
+
+## Renderer integration -- explicit follow-up, NOT in this lane
+
+`office_floor.gd` / `office_sandbox.gd` were being edited by another lane when
+this shipped, so nothing consumes `PropCatalogue` yet. The follow-up, AFTER the
+in-flight scale lane merges:
+
+- Replace the `PROP_TARGET_H / src.y` force-scale with
+  `PropCatalogue.height_px(id, tile_px) / subject_h` so each prop keeps its
+  authored proportions.
+- Anchor placement at `anchor_px` (subject feet) instead of texture
+  bottom-centre -- kills the padding-dependent drift.
+- Use `footprint_tiles` for placement/occupancy once props block walking.
+- `PropCatalogue` fallback for unmanifested ids reproduces today's 46 px
+  behaviour (and warns once), so integration cannot regress unknown assets.
+
+## Sockets are schema-only
+
+`sockets` defines the FUTURE attachment-point shape
+(`{"name", "px": [x, y], "layer": "front"|"behind"}`) for the cosmetics sprite
+category in `art_source/` (paper-doll layers, e.g. a poster taped to a server
+rack). No consumer exists; keep every `sockets` array empty until one does --
+the unit test validates the shape only if populated.

--- a/godot/data/office/props_manifest.json
+++ b/godot/data/office/props_manifest.json
@@ -1,0 +1,56 @@
+{
+  "_meta": {
+    "version": "1.0",
+    "description": "Per-asset metadata for office floor props. Replaces the renderer's one-size-fits-all PROP_TARGET_H force-scale (office_floor.gd / office_sandbox.gd) once the in-flight scale lane merges. Loaded by scripts/core/prop_catalogue.gd. Measurements taken from the real PNGs (alpha bounding box) -- see docs/art/PROP_MANIFEST.md for how to add a prop.",
+    "measured_with": "python PIL alpha-channel getbbox(), 2026-07-26"
+  },
+  "_schema": {
+    "art": "res:// path to the prop PNG under assets/office_floor/props/.",
+    "canvas_px": "[w, h] full PNG canvas size in pixels (includes transparent padding).",
+    "subject_px": "[w, h] opaque-subject bounding box size in pixels (alpha bbox).",
+    "anchor_px": "[x, y] feet anchor in CANVAS coordinates: bottom-centre of the opaque bbox. x may be a .5 half-pixel for even-width subjects; y is the exclusive bottom of the opaque bbox (the baseline row the feet sit on).",
+    "footprint_tiles": "[w, h] floor tiles occupied for placement/collision, at the 32px art-tile scale (floor tile art is 32px, displayed at 64px). h (depth) is a judgement call -- front-view art carries no depth information.",
+    "height_tiles": "subject height / 32, rounded to the nearest 0.25 (ties round up).",
+    "style_tags": "office-state families this prop belongs to: any of [\"scummy\", \"decent\"]. Both tags = state-neutral art shown in either state.",
+    "sockets": "SCHEMA PLACEHOLDER, always [] for now. Future attachment points for cosmetics/paper-doll layers. Each socket will be {\"name\": String, \"px\": [x, y] canvas coords, \"layer\": \"front\"|\"behind\" draw order relative to the prop}. No consumer exists yet -- do not populate until one does.",
+    "review": "optional bool: true = a field needs Pip's judgement (see notes).",
+    "notes": "optional free-text provenance / uncertainty notes."
+  },
+  "props": {
+    "filing_cabinet": {
+      "art": "res://assets/office_floor/props/filing_cabinet.png",
+      "canvas_px": [72, 112],
+      "subject_px": [52, 100],
+      "anchor_px": [37, 106],
+      "footprint_tiles": [2, 1],
+      "height_tiles": 3.25,
+      "style_tags": ["scummy", "decent"],
+      "sockets": [],
+      "review": true,
+      "notes": "Footprint: subject is 52px wide = 1.6 tiles, rounded up to 2x1, but a filing cabinet may be intended as 1x1 -- Pip to rule. Height 3.125 rounded up to 3.25 (exact tie). Style tags inferred: no scummy/decent pair file exists, art is state-neutral."
+    },
+    "server_cluster": {
+      "art": "res://assets/office_floor/props/server_cluster.png",
+      "canvas_px": [128, 120],
+      "subject_px": [118, 113],
+      "anchor_px": [64, 116],
+      "footprint_tiles": [4, 1],
+      "height_tiles": 3.5,
+      "style_tags": ["scummy", "decent"],
+      "sockets": [],
+      "review": true,
+      "notes": "Footprint: 118px wide = 3.7 tiles -> 4 wide; depth set to 1 but a server rack cluster plausibly occupies 2 tiles deep -- Pip to rule. Style tags inferred: no pair file, state-neutral art."
+    },
+    "water_cooler": {
+      "art": "res://assets/office_floor/props/water_cooler.png",
+      "canvas_px": [64, 120],
+      "subject_px": [37, 109],
+      "anchor_px": [31.5, 114],
+      "footprint_tiles": [1, 1],
+      "height_tiles": 3.5,
+      "style_tags": ["scummy", "decent"],
+      "sockets": [],
+      "notes": "Style tags inferred: no pair file, state-neutral art. Footprint confident (37px subject fits one 32px tile)."
+    }
+  }
+}

--- a/godot/scripts/core/prop_catalogue.gd
+++ b/godot/scripts/core/prop_catalogue.gd
@@ -1,0 +1,154 @@
+extends RefCounted
+class_name PropCatalogue
+## Data-driven office-prop metadata catalogue. Loads res://data/office/props_manifest.json
+## once (static/lazy, same pattern as quirk_catalogue.gd) and exposes a small read-only API:
+## per-prop footprint, feet anchor, height, and style-family tags.
+##
+## PURPOSE: replace the renderer's one-size-fits-all PROP_TARGET_H force-scale (every prop
+## squashed to 46 display px, feet-anchored) with per-asset metadata. This lane ships DATA +
+## LOADER + TESTS only; office_floor.gd / office_sandbox.gd integration is a documented
+## follow-up AFTER the in-flight scale lane merges (see docs/art/PROP_MANIFEST.md).
+##
+## DETERMINISM: ids() and style_ids() return SORTED id lists, so any seeded-rng draw over
+## them is independent of JSON key / Dictionary iteration order (same rule as ADR-0006).
+##
+## FALLBACK: every accessor answers sanely for an unmanifested id (push_warning ONCE per id)
+## so a new prop PNG dropped in without a manifest entry renders like today instead of
+## crashing: height matches the legacy PROP_TARGET_H behaviour, footprint is 1x1, anchor is
+## the ANCHOR_UNSET sentinel (caller should fall back to texture bottom-centre).
+
+const Definitions = preload("res://scripts/data/definition_loader.gd")
+const MANIFEST_PATH := "res://data/office/props_manifest.json"
+
+## Legacy renderer behaviour being replaced: office_floor.gd::PROP_TARGET_H scales every
+## prop to 46 px tall at the 64 px DISPLAY tile (floor art is 32 px drawn 2x). The fallback
+## height reproduces that: 46/64 of a tile, whatever tile_px the caller passes.
+const FALLBACK_TARGET_H := 46.0
+const DISPLAY_TILE_PX := 64.0
+
+## Sentinel returned by anchor() for unmanifested ids: "no anchor data, use the texture's
+## bottom-centre" (a real anchor always has x >= 0 and y > 0).
+const ANCHOR_UNSET := Vector2(-1, -1)
+
+static var _loaded: bool = false
+static var _defs: Dictionary = {}
+static var _ids: Array[String] = []
+static var _warned: Dictionary = {}
+
+
+static func _ensure_loaded() -> void:
+	if _loaded:
+		return
+	_loaded = true
+	var data := Definitions.load_object(MANIFEST_PATH, "PropCatalogue")
+	_defs = data.get("props", {})
+	if _defs.is_empty():
+		push_error("[PropCatalogue] No props loaded from %s" % MANIFEST_PATH)
+	_ids = []
+	for k in _defs.keys():
+		_ids.append(String(k))
+	# Sorted so index-based seeded draws are deterministic regardless of parse order.
+	_ids.sort()
+
+
+static func ids() -> Array[String]:
+	_ensure_loaded()
+	return _ids.duplicate()
+
+
+static func size() -> int:
+	_ensure_loaded()
+	return _ids.size()
+
+
+static func has(id: String) -> bool:
+	_ensure_loaded()
+	return _defs.has(id)
+
+
+static func get_entry(id: String) -> Dictionary:
+	"""Full manifest entry for `id`, or {} for unmanifested ids (warns once)."""
+	_ensure_loaded()
+	if not _defs.has(id):
+		_warn_once(id)
+		return {}
+	return _defs[id]
+
+
+static func height_px(id: String, tile_px: float = DISPLAY_TILE_PX) -> float:
+	"""Rendered subject height in px when a floor tile renders at `tile_px`.
+	Manifested: height_tiles * tile_px. Fallback: the legacy PROP_TARGET_H
+	force-scale (46 px at the 64 px display tile), scaled to `tile_px`."""
+	_ensure_loaded()
+	if not _defs.has(id):
+		_warn_once(id)
+		return FALLBACK_TARGET_H * tile_px / DISPLAY_TILE_PX
+	return float(_defs[id].get("height_tiles", FALLBACK_TARGET_H / DISPLAY_TILE_PX)) * tile_px
+
+
+static func anchor(id: String) -> Vector2:
+	"""Feet anchor in CANVAS px (bottom-centre of the opaque subject). Returns
+	ANCHOR_UNSET for unmanifested ids -- caller falls back to texture bottom-centre."""
+	_ensure_loaded()
+	if not _defs.has(id):
+		_warn_once(id)
+		return ANCHOR_UNSET
+	var a: Array = _defs[id].get("anchor_px", [])
+	if a.size() != 2:
+		return ANCHOR_UNSET
+	return Vector2(float(a[0]), float(a[1]))
+
+
+static func footprint(id: String) -> Vector2i:
+	"""Floor tiles occupied [w, h] at the 32 px art-tile scale. Fallback: 1x1."""
+	_ensure_loaded()
+	if not _defs.has(id):
+		_warn_once(id)
+		return Vector2i(1, 1)
+	var f: Array = _defs[id].get("footprint_tiles", [])
+	if f.size() != 2:
+		return Vector2i(1, 1)
+	return Vector2i(int(f[0]), int(f[1]))
+
+
+static func art_path(id: String) -> String:
+	"""res:// path of the prop texture, or "" for unmanifested ids."""
+	_ensure_loaded()
+	if not _defs.has(id):
+		_warn_once(id)
+		return ""
+	return String(_defs[id].get("art", ""))
+
+
+static func style_tags(id: String) -> Array[String]:
+	"""Office-state families ("scummy"/"decent") this prop belongs to. Empty for
+	unmanifested ids."""
+	_ensure_loaded()
+	var out: Array[String] = []
+	if not _defs.has(id):
+		_warn_once(id)
+		return out
+	for t in _defs[id].get("style_tags", []):
+		out.append(String(t))
+	return out
+
+
+static func style_ids(tag: String) -> Array[String]:
+	"""All prop ids carrying style tag `tag`, SORTED (deterministic for seeded draws)."""
+	_ensure_loaded()
+	var out: Array[String] = []
+	for id in _ids:
+		if _defs[id].get("style_tags", []).has(tag):
+			out.append(id)
+	return out  # _ids already sorted
+
+
+static func _warn_once(id: String) -> void:
+	if _warned.has(id):
+		return
+	_warned[id] = true
+	push_warning(
+		"[PropCatalogue] '%s' has no manifest entry -- using legacy PROP_TARGET_H fallback. "
+		% id
+		+ "Add it to %s (see docs/art/PROP_MANIFEST.md)." % MANIFEST_PATH
+	)

--- a/godot/scripts/core/prop_catalogue.gd.uid
+++ b/godot/scripts/core/prop_catalogue.gd.uid
@@ -1,0 +1,1 @@
+uid://22gkl8c1n4ue

--- a/godot/tests/unit/test_prop_manifest.gd
+++ b/godot/tests/unit/test_prop_manifest.gd
@@ -1,0 +1,159 @@
+extends GutTest
+## Guards the office prop manifest (data/office/props_manifest.json) and its loader
+## (scripts/core/prop_catalogue.gd):
+##   - manifest parses, carries a version, and every entry's art path resolves;
+##   - every PNG under assets/office_floor/props/ HAS an entry (a new prop dropped in
+##     without metadata fails here loudly instead of silently force-scaling forever);
+##   - geometry is sane (anchor inside canvas, positive footprint/height);
+##   - sockets are schema-only (shape validated IF ever populated);
+##   - PropCatalogue fallback for unmanifested ids matches the legacy PROP_TARGET_H
+##     behaviour (46 px at the 64 px display tile) so renderers degrade gracefully.
+
+const MANIFEST_PATH := "res://data/office/props_manifest.json"
+const PROPS_DIR := "res://assets/office_floor/props"
+const MIN_PROPS := 3  # floor: the three props shipping today; raise as the set grows
+
+
+func _load_manifest() -> Dictionary:
+	var file := FileAccess.open(MANIFEST_PATH, FileAccess.READ)
+	assert_not_null(file, "props_manifest.json must be readable")
+	if file == null:
+		return {}
+	var json := JSON.new()
+	assert_eq(json.parse(file.get_as_text()), OK, "props_manifest.json must be valid JSON")
+	file.close()
+	var data = json.data
+	assert_true(data is Dictionary, "manifest root must be a JSON object")
+	return data if data is Dictionary else {}
+
+
+func test_manifest_parses_with_version_and_schema():
+	var data := _load_manifest()
+	assert_ne(String(data.get("_meta", {}).get("version", "")), "", "manifest carries _meta.version")
+	assert_true(data.has("_schema"), "manifest documents its fields in a _schema block")
+	var props: Dictionary = data.get("props", {})
+	assert_true(
+		props.size() >= MIN_PROPS,
+		"expected at least %d prop entries, found %d" % [MIN_PROPS, props.size()]
+	)
+
+
+func test_every_entry_art_path_exists():
+	var props: Dictionary = _load_manifest().get("props", {})
+	for id in props:
+		var path := String(props[id].get("art", ""))
+		assert_ne(path, "", "prop '%s' has an art path" % id)
+		assert_true(ResourceLoader.exists(path), "art for '%s' does not exist: %s" % [id, path])
+
+
+func test_every_prop_png_has_an_entry():
+	# Enumerate the real directory so a newly added PNG cannot ship unmanifested.
+	var props: Dictionary = _load_manifest().get("props", {})
+	var files := DirAccess.get_files_at(PROPS_DIR)
+	assert_true(files.size() > 0, "props dir should enumerate (source tree): %s" % PROPS_DIR)
+	var png_count := 0
+	for f in files:
+		if not f.ends_with(".png"):
+			continue  # skip .import metadata files
+		png_count += 1
+		var id := f.get_basename()
+		assert_true(props.has(id), "PNG '%s' has no manifest entry (id '%s')" % [f, id])
+		if props.has(id):
+			assert_eq(
+				String(props[id].get("art", "")),
+				PROPS_DIR + "/" + f,
+				"entry '%s' art path should point at its own PNG" % id
+			)
+	assert_true(png_count >= MIN_PROPS, "expected at least %d PNGs in %s" % [MIN_PROPS, PROPS_DIR])
+
+
+func test_geometry_sane():
+	var props: Dictionary = _load_manifest().get("props", {})
+	for id in props:
+		var e: Dictionary = props[id]
+		var canvas: Array = e.get("canvas_px", [])
+		var subject: Array = e.get("subject_px", [])
+		var anchor: Array = e.get("anchor_px", [])
+		var foot: Array = e.get("footprint_tiles", [])
+		assert_eq(canvas.size(), 2, "'%s' canvas_px is [w, h]" % id)
+		assert_eq(subject.size(), 2, "'%s' subject_px is [w, h]" % id)
+		assert_eq(anchor.size(), 2, "'%s' anchor_px is [x, y]" % id)
+		assert_eq(foot.size(), 2, "'%s' footprint_tiles is [w, h]" % id)
+		if canvas.size() != 2 or subject.size() != 2 or anchor.size() != 2 or foot.size() != 2:
+			continue
+		# Subject fits the canvas; anchor lies inside the canvas (y is the exclusive
+		# bottom of the opaque bbox, so y == canvas h is legal for flush-bottom art).
+		assert_true(
+			float(subject[0]) <= float(canvas[0]) and float(subject[1]) <= float(canvas[1]),
+			"'%s' subject exceeds canvas" % id
+		)
+		assert_between(float(anchor[0]), 0.0, float(canvas[0]), "'%s' anchor x inside canvas" % id)
+		assert_between(float(anchor[1]), 1.0, float(canvas[1]), "'%s' anchor y inside canvas" % id)
+		assert_true(
+			int(foot[0]) > 0 and int(foot[1]) > 0, "'%s' footprint tiles positive" % id
+		)
+		assert_gt(float(e.get("height_tiles", 0.0)), 0.0, "'%s' height_tiles positive" % id)
+		# style_tags restricted to the known office-state families.
+		var tags: Array = e.get("style_tags", [])
+		assert_true(tags.size() > 0, "'%s' carries at least one style tag" % id)
+		for t in tags:
+			assert_true(
+				t in ["scummy", "decent"], "'%s' style tag '%s' not a known family" % [id, t]
+			)
+
+
+func test_sockets_schema_only():
+	# Sockets are a schema placeholder until a paper-doll/cosmetics consumer exists.
+	# Empty is expected today; if one is ever populated, its shape must match _schema.
+	var props: Dictionary = _load_manifest().get("props", {})
+	for id in props:
+		var sockets = props[id].get("sockets", null)
+		assert_true(sockets is Array, "'%s' sockets must be an array" % id)
+		for s in sockets:
+			assert_true(s is Dictionary, "'%s' socket entries are objects" % id)
+			assert_true(s.has("name") and s.has("px") and s.has("layer"),
+				"'%s' socket needs name/px/layer" % id)
+
+
+func test_loader_known_entry():
+	assert_true(PropCatalogue.has("water_cooler"), "water_cooler manifested")
+	assert_true(PropCatalogue.size() >= MIN_PROPS, "catalogue floor")
+	# height_px scales height_tiles by the tile size the caller renders at.
+	assert_almost_eq(PropCatalogue.height_px("water_cooler", 32.0), 3.5 * 32.0, 0.001)
+	assert_almost_eq(PropCatalogue.height_px("water_cooler", 64.0), 3.5 * 64.0, 0.001)
+	assert_eq(PropCatalogue.footprint("water_cooler"), Vector2i(1, 1))
+	var a := PropCatalogue.anchor("water_cooler")
+	assert_almost_eq(a.x, 31.5, 0.001, "anchor x = bottom-centre of opaque bbox")
+	assert_almost_eq(a.y, 114.0, 0.001, "anchor y = opaque bbox baseline")
+	assert_eq(PropCatalogue.art_path("water_cooler"), PROPS_DIR + "/water_cooler.png")
+
+
+func test_loader_fallback_matches_legacy_force_scale():
+	var bogus := "__no_such_prop__"
+	assert_false(PropCatalogue.has(bogus))
+	assert_eq(PropCatalogue.get_entry(bogus), {}, "unmanifested id -> empty entry")
+	# Legacy office_floor.gd behaviour: every prop force-scaled to 46 px at the 64 px
+	# display tile. The fallback must reproduce that so renderers degrade gracefully.
+	assert_almost_eq(PropCatalogue.height_px(bogus, 64.0), 46.0, 0.001)
+	assert_almost_eq(PropCatalogue.height_px(bogus, 32.0), 23.0, 0.001)
+	assert_eq(PropCatalogue.footprint(bogus), Vector2i(1, 1), "fallback footprint 1x1")
+	assert_eq(PropCatalogue.anchor(bogus), PropCatalogue.ANCHOR_UNSET,
+		"fallback anchor is the documented sentinel")
+	assert_eq(PropCatalogue.style_tags(bogus).size(), 0)
+	# The catalogue warns ONCE per unknown id (GUT tracks push_warning as an engine
+	# error). This consumes exactly one matching warning -- if _warn_once ever broke
+	# and warned per-call, the extra unhandled warnings would fail this test.
+	assert_engine_error(
+		"has no manifest entry",
+		"unmanifested id warns once via push_warning"
+	)
+
+
+func test_style_lookup_sorted_and_deterministic():
+	var decent := PropCatalogue.style_ids("decent")
+	assert_true(decent.size() > 0, "at least one decent-tagged prop")
+	assert_true(decent.has("water_cooler"), "water_cooler serves the decent state")
+	var sorted := decent.duplicate()
+	sorted.sort()
+	assert_eq(decent, sorted, "style_ids returns a sorted (deterministic) list")
+	assert_eq(PropCatalogue.style_ids("__no_such_style__").size(), 0)

--- a/godot/tests/unit/test_prop_manifest.gd.uid
+++ b/godot/tests/unit/test_prop_manifest.gd.uid
@@ -1,0 +1,1 @@
+uid://dfoqgixfjmpqk


### PR DESCRIPTION
## What

Creates the prop MANIFEST system so office props stop being force-scaled identically (`PROP_TARGET_H = 46` squashes a water cooler and a four-tile server cluster to the same height). This lane delivers **DATA + LOADER + TESTS only** -- `office_floor.gd` / `office_sandbox.gd` / `employee_sprite.gd` are deliberately untouched (another lane is editing them); renderer integration is a documented follow-up.

- **`godot/data/office/props_manifest.json`** -- versioned registry on the `icon_mapping.json` v2.0 pattern. One entry per PNG under `assets/office_floor/props/`, measured from the real art (python PIL alpha bbox). Includes a `_schema` block documenting every field and the future socket shape `{name, px:[x,y], layer}`.
- **`godot/scripts/core/prop_catalogue.gd`** -- `PropCatalogue`, static/lazy loader on the `quirk_catalogue.gd` determinism pattern (sorted id lists). `get_entry / height_px / anchor / footprint / art_path / style_tags / style_ids`. Unmanifested ids fall back to the legacy `PROP_TARGET_H` behaviour (46 px at the 64 px display tile) with a once-per-id `push_warning`.
- **`godot/tests/unit/test_prop_manifest.gd`** -- manifest parses + versioned; every art path resolves; every PNG has an entry (new art cannot ship unmanifested); anchors inside canvas; footprints/heights positive; sockets schema-only; fallback matches legacy force-scale; style lookup sorted/deterministic.
- **`docs/art/PROP_MANIFEST.md`** -- field meanings, add-a-prop recipe, integration plan.

## Measured inventory

| prop | canvas | subject (alpha bbox) | anchor (feet) | footprint | height_tiles | review |
|---|---|---|---|---|---|---|
| water_cooler | 64x120 | 37x109 | (31.5, 114) | 1x1 | 3.5 | - |
| filing_cabinet | 72x112 | 52x100 | (37, 106) | 2x1 | 3.25 | **yes** |
| server_cluster | 128x120 | 118x113 | (64, 116) | 4x1 | 3.5 | **yes** |

## For Pip's review (`review: true` in the JSON)

- **filing_cabinet footprint**: subject is 52 px = 1.6 tiles, rounded up to 2x1 -- but a filing cabinet may be intended 1x1. Height 3.125 was an exact tie, rounded up to 3.25.
- **server_cluster depth**: 4 wide is solid (118 px), but front-view art carries no depth -- 4x1 vs 4x2 is a ruling.
- **style_tags**: all three tagged `["scummy", "decent"]` -- no scummy/decent pair files exist, so the art is treated as state-neutral. Flag if any should be family-exclusive.

## Renderer integration follow-up (NOT this PR)

After the in-flight scale lane merges into `office_floor.gd` / `office_sandbox.gd`:
1. Replace `PROP_TARGET_H / src.y` with `PropCatalogue.height_px(id, tile_px) / subject_h` (per-asset proportions).
2. Anchor at `anchor_px` (subject feet) instead of texture bottom-centre (kills transparent-padding drift).
3. Use `footprint_tiles` for placement/occupancy when props block walking.
4. Fallback reproduces today's behaviour, so unknown assets cannot regress.

Sockets stay schema-only (empty arrays) until a cosmetics/paper-doll consumer exists.

## Testing

Fast gate: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -- **664 tests, 0 failures, 76/76 files collected** (8 new tests in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)