### PR TITLE
chore(release): v0.13.1 CHANGELOG entry + complete release zip packaging (#917 increment 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Feeds the hidden Risk Pool system (research integrity, capability overhang, financial exposure)
   - New `research_quality_selector.gd` UI; defaults to Standard and remembers last selection
   - Unit tests: `test_research_quality.gd`, `test_risk_system.gd`
-- **Game-design documentation** (#500): `godot/docs/design/` — `TWO_ACT_STRUCTURE.md`, `INTRO_CINEMATIC.md`, `TONE_AND_ART.md`
+- **Game-design documentation** (#500): `godot/docs/design/` -- `TWO_ACT_STRUCTURE.md`, `INTRO_CINEMATIC.md`, `TONE_AND_ART.md`
 - **Scenario/Mod Hook System** (#483): Custom scenarios without code changes
   - Drop JSON files into `godot/data/scenarios/` to add new scenarios
   - Scenario selection dropdown in Custom Game setup screen
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CI/CD pipeline restored** (#527, #530, #535): the daily Enhanced CI/CD pipeline had been failing for 10+ days and two workflows (`data-validation`, `dev-blog-automation`) failed at startup for months
   - Repaired PEP 701 nested-quote f-strings that broke on the Python 3.11 runner (valid only on 3.12+)
   - Added missing `pyyaml` dependency to the sync/cleanup stages
-  - Fixed invalid workflow YAML (column-0 lines terminating `run:` block scalars → 0s startup failures)
+  - Fixed invalid workflow YAML (column-0 lines terminating `run:` block scalars -> 0s startup failures)
   - Fixed schema-validation check failing under AJV strict mode on `format: "uri"` (added `ajv-formats`)
 
 ### Technical
@@ -40,6 +40,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Repo cleanup**: archived ~35 pygame-era debris files to `archive/legacy-pygame/`; removed duplicates; pruned 9 stale remote branches and 6 orphaned worktrees
 - New files: `scenario_loader.gd`, `docs/SCENARIOS.md`, `godot/data/scenarios/*.json`
 - Modified: `game_config.gd`, `game_manager.gd`, `pregame_setup.gd`, `pregame_setup.tscn`, `events.gd`
+
+---
+
+## [v0.13.1] - 2026-07-25 - 'Soft-Lock Hotfixes'
+
+### Fixed
+- **Ledger event-orphan dialog soft-lock** (#883): an event opening over the ledger
+  orphaned the ledger dialog, leaving it un-closeable and the session stuck
+- **Staff-card ESC dead-mouse soft-lock** (#887): closing a staff card with ESC could
+  leave the input blocker alive, deadening the mouse for the rest of the session
+
+Both bugs could strand a session; no other gameplay changes in this release.
 
 ---
 

--- a/scripts/build_all_platforms.py
+++ b/scripts/build_all_platforms.py
@@ -23,6 +23,20 @@ from typing import Optional
 class MultiPlatformBuilder:
     """Builds game for Windows, Linux, and macOS using Godot."""
 
+    # GDExtension libraries the Godot export lays down beside the executable
+    # (from godot/addons/godotsteam/godotsteam.gdextension: the [libraries]
+    # release entry plus the [dependencies] steam_api library). Shipping a zip
+    # without them causes GDExtension load errors and dead Steam integration
+    # (v0.13.1 forensics, issue #917), so packaging fails loudly if absent.
+    EXPECTED_WINDOWS_LIBS = [
+        "libgodotsteam.windows.template_release.x86_64.dll",
+        "steam_api64.dll",
+    ]
+    EXPECTED_LINUX_LIBS = [
+        "libgodotsteam.linux.template_release.x86_64.so",
+        "libsteam_api.so",
+    ]
+
     def __init__(
         self, version: str, godot_path: Optional[str] = None, project_path: Optional[Path] = None
     ):
@@ -183,13 +197,67 @@ class MultiPlatformBuilder:
             # Create distribution ZIPs
             zip_success = self.zip_builds()
             if not zip_success:
-                print("\n[WARNING] Some ZIP packaging failed")
+                print("\n[ERROR] ZIP packaging failed -- refusing to ship incomplete zips")
+                all_success = False
 
             print(f"\nBuilds location: {self.repo_root / 'builds'}")
         else:
             print("\n[WARNING] Some builds failed. Check errors above.")
 
         return all_success
+
+    def _release_note(self, platform_key: str) -> Optional[Path]:
+        """Per-platform HOW-TO-RUN template shipped inside each zip."""
+        note = self.repo_root / "tools" / "release_notes" / f"HOW-TO-RUN-{platform_key}.txt"
+        if not note.exists():
+            print(f"[ERROR] Missing release note template: {note}")
+            return None
+        return note
+
+    def _zip_native_build(
+        self,
+        build_dir: Path,
+        zip_path: Path,
+        exe_name: str,
+        lib_glob: str,
+        expected_libs: list,
+        platform_key: str,
+    ) -> bool:
+        """Zip a Windows/Linux build dir: exe + pck + GDExtension libs + HOW-TO-RUN.
+
+        Includes every lib matching lib_glob that the export laid down beside the
+        executable, and fails if any expected GodotSteam library is absent.
+        """
+        ok = True
+        files = [build_dir / exe_name, build_dir / "PDoom.pck"]
+        files.extend(sorted(build_dir.glob(lib_glob)))
+
+        missing = [n for n in expected_libs if not (build_dir / n).exists()]
+        if missing:
+            print(f"[ERROR] {build_dir} is missing expected GDExtension libraries: {missing}")
+            print("        The shipped game would fail to load GodotSteam. Aborting package.")
+            ok = False
+
+        note = self._release_note(platform_key)
+        if note is None:
+            ok = False
+
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in files:
+                if f.exists():
+                    zf.write(f, f.name)
+                    print(f"    + {f.name}")
+                else:
+                    print(f"[ERROR] Expected build output missing: {f}")
+                    ok = False
+            if note is not None:
+                zf.write(note, "HOW-TO-RUN.txt")
+                print("    + HOW-TO-RUN.txt")
+
+        size_mb = zip_path.stat().st_size / (1024 * 1024)
+        status = "[SUCCESS]" if ok else "[ERROR]"
+        print(f"{status} Created {zip_path.name} ({size_mb:.1f} MB)")
+        return ok
 
     def zip_builds(self) -> bool:
         """Create distribution ZIPs for each platform."""
@@ -199,24 +267,21 @@ class MultiPlatformBuilder:
 
         success = True
 
-        # Windows: ZIP the .exe and .pck together
+        # Windows: ZIP exe + pck + GodotSteam DLLs + HOW-TO-RUN
         windows_dir = self.repo_root / "builds" / "windows" / self.version
         if windows_dir.exists():
             zip_path_versioned = windows_dir / f"PDoom-Windows-{self.version}.zip"
             zip_path_simple = windows_dir / "PDoom-Windows.zip"
             try:
-                # Create versioned zip
-                with zipfile.ZipFile(zip_path_versioned, "w", zipfile.ZIP_DEFLATED) as zf:
-                    exe_file = windows_dir / "PDoom.exe"
-                    pck_file = windows_dir / "PDoom.pck"
-
-                    if exe_file.exists():
-                        zf.write(exe_file, "PDoom.exe")
-                    if pck_file.exists():
-                        zf.write(pck_file, "PDoom.pck")
-
-                size_mb = zip_path_versioned.stat().st_size / (1024 * 1024)
-                print(f"[SUCCESS] Created {zip_path_versioned.name} ({size_mb:.1f} MB)")
+                if not self._zip_native_build(
+                    windows_dir,
+                    zip_path_versioned,
+                    "PDoom.exe",
+                    "*.dll",
+                    self.EXPECTED_WINDOWS_LIBS,
+                    "windows",
+                ):
+                    success = False
 
                 # Also create simple-named zip for website compatibility
                 shutil.copy2(zip_path_versioned, zip_path_simple)
@@ -225,41 +290,59 @@ class MultiPlatformBuilder:
                 print(f"[ERROR] Failed to create Windows ZIP: {e}")
                 success = False
 
-        # Linux: ZIP the executable and .pck
+        # Linux: ZIP executable + pck + GodotSteam .so libs + HOW-TO-RUN
         linux_dir = self.repo_root / "builds" / "linux" / self.version
         if linux_dir.exists():
             zip_path = linux_dir / f"PDoom-Linux-{self.version}.zip"
             try:
-                with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-                    exe_file = linux_dir / "PDoom.x86_64"
-                    pck_file = linux_dir / "PDoom.pck"
-
-                    if exe_file.exists():
-                        zf.write(exe_file, "PDoom.x86_64")
-                    if pck_file.exists():
-                        zf.write(pck_file, "PDoom.pck")
-
-                size_mb = zip_path.stat().st_size / (1024 * 1024)
-                print(f"[SUCCESS] Created {zip_path.name} ({size_mb:.1f} MB)")
+                if not self._zip_native_build(
+                    linux_dir,
+                    zip_path,
+                    "PDoom.x86_64",
+                    "*.so",
+                    self.EXPECTED_LINUX_LIBS,
+                    "linux",
+                ):
+                    success = False
             except Exception as e:
                 print(f"[ERROR] Failed to create Linux ZIP: {e}")
                 success = False
 
-        # macOS: Rename existing .zip for consistency
+        # macOS: the export emits PDoom.app.zip directly, with the GodotSteam
+        # framework + libsteam_api.dylib already embedded in Contents/Frameworks/
+        # (verified against the CI-built v0.13.1 asset). Verify that, add
+        # HOW-TO-RUN.txt beside the .app inside the zip, then copy to the
+        # versioned name.
         mac_dir = self.repo_root / "builds" / "mac" / self.version
         old_mac_zip = mac_dir / "PDoom.app.zip"
         new_mac_zip = mac_dir / f"PDoom-macOS-{self.version}.zip"
-        if old_mac_zip.exists() and not new_mac_zip.exists():
+        if old_mac_zip.exists():
             try:
+                with zipfile.ZipFile(old_mac_zip, "a", zipfile.ZIP_DEFLATED) as zf:
+                    names = zf.namelist()
+                    frameworks = [n for n in names if "/Contents/Frameworks/" in n]
+                    if not frameworks:
+                        print(
+                            "[ERROR] macOS .app bundle has no Contents/Frameworks/ -- "
+                            "GodotSteam GDExtension was not embedded by the export"
+                        )
+                        success = False
+                    else:
+                        print(f"[INFO] macOS bundle embeds {len(frameworks)} Frameworks/ entries")
+                    note = self._release_note("macos")
+                    if note is None:
+                        success = False
+                    elif "HOW-TO-RUN.txt" not in names:
+                        zf.write(note, "HOW-TO-RUN.txt")
+                        print("    + HOW-TO-RUN.txt (added beside the .app inside the zip)")
+
+                # Copy (overwrite) so the versioned zip matches the updated one
                 shutil.copy2(old_mac_zip, new_mac_zip)
                 size_mb = new_mac_zip.stat().st_size / (1024 * 1024)
                 print(f"[SUCCESS] Created {new_mac_zip.name} ({size_mb:.1f} MB)")
             except Exception as e:
-                print(f"[ERROR] Failed to rename macOS ZIP: {e}")
+                print(f"[ERROR] Failed to package macOS ZIP: {e}")
                 success = False
-        elif new_mac_zip.exists():
-            size_mb = new_mac_zip.stat().st_size / (1024 * 1024)
-            print(f"[INFO] macOS package ready: {new_mac_zip.name} ({size_mb:.1f} MB)")
 
         return success
 

--- a/tools/release_notes/HOW-TO-RUN-linux.txt
+++ b/tools/release_notes/HOW-TO-RUN-linux.txt
@@ -1,0 +1,27 @@
+P(Doom) -- Linux
+
+HOW TO RUN
+1. EXTRACT this whole zip to a folder first. Do NOT run the game from
+   inside an archive viewer -- it needs PDoom.pck and the .so libraries
+   sitting next to it.
+2. Make the game executable if needed, then run it:
+      chmod +x PDoom.x86_64
+      ./PDoom.x86_64
+3. If nothing happens when launching from a file manager, run it from a
+   terminal instead so you can see any error output.
+
+WHATS IN HERE
+   PDoom.x86_64   the game
+   PDoom.pck      the game data (must stay next to the executable)
+   *.so           Steam integration libraries (keep them here)
+
+HEADS UP
+   The Linux build is not extensively tested yet -- expect rough edges.
+   Reports are very welcome.
+
+FEEDBACK
+   In-game F8 saves a bug report to your disk and shows you the file path --
+   please email that file to pip@beacongcr.org (the in-game reporter does not
+   send anything itself yet).
+
+Thanks for playing -- Pip

--- a/tools/release_notes/HOW-TO-RUN-macos.txt
+++ b/tools/release_notes/HOW-TO-RUN-macos.txt
@@ -1,0 +1,26 @@
+P(Doom) -- macOS
+
+HOW TO RUN
+1. EXTRACT this zip first (double-click it in Finder), then move the
+   extracted P(Doom).app wherever you like (e.g. Applications).
+2. First launch: right-click (or Control-click) P(Doom).app -> Open ->
+   Open. A plain double-click may be blocked by Gatekeeper because the
+   build is unsigned / not notarized (alpha).
+3. If macOS still refuses ("cannot be opened" / "damaged"), clear the
+   quarantine flag from a terminal:
+      xattr -dr com.apple.quarantine "P(Doom).app"
+
+WHATS IN HERE
+   P(Doom).app    the game -- game data and Steam libraries live inside
+                  the app bundle, so there is nothing else to keep together
+
+HEADS UP
+   The macOS build is not extensively tested yet -- expect rough edges.
+   Reports are very welcome.
+
+FEEDBACK
+   In-game F8 saves a bug report to your disk and shows you the file path --
+   please email that file to pip@beacongcr.org (the in-game reporter does not
+   send anything itself yet).
+
+Thanks for playing -- Pip

--- a/tools/release_notes/HOW-TO-RUN-windows.txt
+++ b/tools/release_notes/HOW-TO-RUN-windows.txt
@@ -1,0 +1,22 @@
+P(Doom) -- Windows
+
+HOW TO RUN
+1. EXTRACT this whole zip to a folder first (right-click -> Extract All).
+   Do NOT run PDoom.exe from inside the zip viewer -- the game needs the
+   other files sitting next to it, and the zip viewer hides them. This is
+   the #1 thing that trips people up.
+2. Open the extracted folder and double-click PDoom.exe.
+3. If Windows SmartScreen says "Windows protected your PC":
+   click "More info" -> "Run anyway". The build is unsigned (alpha).
+
+WHATS IN HERE
+   PDoom.exe    the game
+   PDoom.pck    the game data (must stay next to the exe)
+   *.dll        Steam integration libraries (keep them here)
+
+FEEDBACK
+   In-game F8 saves a bug report to your disk and shows you the file path --
+   please email that file to pip@beacongcr.org (the in-game reporter does not
+   send anything itself yet).
+
+Thanks for playing -- Pip


### PR DESCRIPTION
Two drive-by fixes from the v0.13.1 release forensics. First increment of the cross-OS robustness epic #917.

## 1. CHANGELOG entry for v0.13.1

Pre-Release Checks (`.github/workflows/pre-release-checks.yml`) does a plain `grep -q "$TAG_VERSION" CHANGELOG.md` (plus a `config/version` check in `godot/project.godot` and a clean-tree check). The v0.13.1 tag failed because CHANGELOG.md had no 0.13.1 anywhere. Added a `## [v0.13.1] - 2026-07-25 - 'Soft-Lock Hotfixes'` entry in the file's existing format (Keep-a-Changelog headings, bold-bullet + issue refs), describing #883 (event opening over the ledger orphaned an un-closeable ledger dialog) and #887 (staff-card ESC left the input blocker alive, dead mouse). Wording checked against the actual fix commits (900d96d2, 409535dc).

Note: the grep only satisfies FUTURE tags -- the failed check on the already-pushed v0.13.1 tag stays failed unless re-tagged. Also note CHANGELOG.md still has no v0.12.x / v0.13.0 entries (pre-existing gap, out of scope for this drive-by).

Drive-by within the drive-by: the ASCII gate (incremental, whole-file once the file is touched) flagged three pre-existing non-ASCII chars in CHANGELOG.md (em-dash, arrow); converted to `--` / `->`.

## 2. Release zips now include GodotSteam binaries + HOW-TO-RUN.txt

The Enhanced Release workflow's packaging lives in `scripts/build_all_platforms.py::zip_builds()` (called by the "Build all platforms" step) -- so the fix is in that script, and **zero YAML was changed** (no job restructuring, zip names byte-identical: `PDoom-Windows-v{V}.zip`, `PDoom-Windows.zip`, `PDoom-Linux-v{V}.zip`, `PDoom-macOS-v{V}.zip`, `PDoom.app.zip`).

What the export actually lays down (desk-checked):
- **Windows**: export dir gets `PDoom.exe`, `PDoom.pck`, `libgodotsteam.windows.template_release.x86_64.dll` + `steam_api64.dll` (per `godot/addons/godotsteam/godotsteam.gdextension` `[libraries]`/`[dependencies]`; confirmed on a local Windows export at `builds/windows/alpha/`). Old zip step packed only exe+pck -> the shipped build hit GDExtension load errors.
- **Linux**: same mechanism -> `libgodotsteam.linux.template_release.x86_64.so` + `libsteam_api.so` beside `PDoom.x86_64`.
- **macOS**: **verified, not assumed** -- I downloaded the actual CI-built `PDoom-macOS-v0.13.1.zip` release asset and listed it: the `.app` bundle ALREADY embeds `Contents/Frameworks/libgodotsteam.macos.template_release.framework/` and `Contents/Frameworks/libsteam_api.dylib`. So macOS needed no binary fix; it only lacked a run note.

New packaging (per-platform):
- Windows/Linux zips: exe + pck + **all** `*.dll` / `*.so` the export laid down + `HOW-TO-RUN.txt`; **fails loudly** if either expected GodotSteam lib is absent.
- macOS: verifies `Contents/Frameworks/` exists inside the export-produced `PDoom.app.zip`, appends `HOW-TO-RUN.txt` at zip root beside the `.app` (idempotent -- skipped if already present; the file sits outside the bundle so the ad-hoc code signature is untouched), then copies to the versioned name (now always refreshed so both stay in sync).
- **Deliberate behavior change**: incomplete packaging now fails the build job (previously a non-fatal `[WARNING]`), so a broken zip can never reach the release again.

New templates `tools/release_notes/HOW-TO-RUN-{windows,linux,macos}.txt`: extract-first warning (the #1 tripwire), SmartScreen / Gatekeeper right-click-Open + `xattr -dr com.apple.quarantine` / `chmod +x` guidance, F8-feedback-to-email line, not-extensively-tested caveat on linux/macos. Based on the hand-written v0.13.0 `HOW-TO-RUN.txt` (`builds/PDoom-v0.13.0-windows/`); I could not find the v0.13.1 hand-written copies in the repo, worktrees, or `G:/tmp`. Templates are version-agnostic (no per-version stamping -- the zip filename carries the version).

## Desk-check (workflow cannot be run pre-tag)

Ran `zip_builds()` against a fabricated build tree mimicking the export layout: (1) complete tree -> all five zips contain exactly the intended file lists (asserted); (2) re-run -> idempotent, no duplicate zip entries; (3) deleted `steam_api64.dll` -> packaging fails as designed. All passed.

## Not verifiable until the next tag
- That the CI (Linux-hosted) Windows/Linux exports lay the GDExtension libs beside the executable exactly as the local Windows export does (Godot-documented behavior + local evidence; if it ever differs, the new hard-fail catches it instead of shipping a broken zip).
- The end-to-end workflow run itself (artifact upload globs and release-attach globs are untouched, so only the zip contents change).
- Observation from forensics: the v0.13.1 release has **no Windows/Linux zip assets at all** (only macOS + feeds) -- whatever dropped them is upstream of packaging and not addressed here; worth watching on the next tag.

Refs #917 (first increment), #883, #887.

🤖 Generated with [Claude Code](https://claude.com/claude-code)