### PR TITLE
data(art): promote 5 round-2 window variants (Pip ruling)

### DIFF
--- a/art_source/pixellab_verdicts.json
+++ b/art_source/pixellab_verdicts.json
@@ -2494,5 +2494,25 @@
   "pixellab_2026-07-21-rerolls/windows/window_frame_3.png": [
     "like",
     "promote"
+  ],
+  "pixellab_2026-07-26_round2/props/window_clean_6.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-26_round2/props/window_scummy_1.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-26_round2/props/window_scummy_2.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-26_round2/props/window_scummy_5.png": [
+    "like",
+    "promote"
+  ],
+  "pixellab_2026-07-26_round2/props/window_scummy_6.png": [
+    "like",
+    "promote"
   ]
 }


### PR DESCRIPTION
Records Pip's explicit sheet verdict ('I like the window set variants, promote them') in the standard verdict flow -- 5 entries in pixellab_verdicts.json (window clean_6, scummy_1/2/5/6), analyzer verified. Data-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)