### PR TITLE
feat(office): pass 2 -- tier-1 collision, #913 juice, worker variant-pool mechanism

### DIFF
--- a/godot/data/office/worker_variants.json
+++ b/godot/data/office/worker_variants.json
@@ -1,0 +1,19 @@
+{
+  "_meta": {
+    "purpose": "Worker appearance variant registry (#793 mechanism half). Maps appearance_id -> SpriteFrames via WorkerVariantPool (stable posmod over list order). Add triaged round-2 worker sheets HERE as new entries -- no code changes needed.",
+    "updated": "2026-07-26",
+    "rules": [
+      "List order is the assignment order: appearance_id maps to posmod(id_or_hash, count).",
+      "Adding/removing a variant REMAPS assignments (cosmetic-only, ADR-0006 pure view).",
+      "frames must be a res:// SpriteFrames with the employee_sprite clip contract (idle/walking/working/stressed + optional walking_<facing> and *_alt clips).",
+      "A missing/unloadable frames path degrades to the floor's shared fallback frames."
+    ]
+  },
+  "variants": [
+    {
+      "id": "worker_v0",
+      "frames": "res://assets/office_floor/artloop_char/office_worker.tres",
+      "notes": "The current shared pixellab worker. Variant 0 == the shared asset keeps behaviour unchanged until round-2 workers are triaged in (do NOT wire raw art_source files)."
+    }
+  ]
+}

--- a/godot/scripts/ui/office_floor/employee_sprite.gd
+++ b/godot/scripts/ui/office_floor/employee_sprite.gd
@@ -34,6 +34,11 @@ const ARRIVE_EPS := 4.0
 # at 2.0 the 140px subject drew ~280px tall in a ~260px room.)
 const TILE_PX := 64.0                        # one floor tile on screen
 const CHAR_TARGET_H := TILE_PX * 2.0         # 128px: target on-screen worker height
+# Cat height as a fraction of one tile. Shared scale-ruling home: cat renderers
+# (sandbox RealCat today, any future live cat) derive their target height from
+# TILE_PX * CAT_TILE_RATIO so one constant moves every cat. #913 "sneaky 1.1x":
+# 0.5 -> 0.55 tile (Pip-approved 2026-07-26).
+const CAT_TILE_RATIO := 0.55
 const ART_CANVAS_H := 180.0                  # artloop_char frame canvas
 const ART_SUBJECT_H := 140.0                 # opaque subject height in that canvas
 const ART_FEET_Y := 158.0                    # bottom of the opaque bbox (the feet)
@@ -59,6 +64,23 @@ const PLACEHOLDER_FEET_OFFSET := Vector2(0.0, PLACEHOLDER_CANVAS_H * 0.5 - PLACE
 # 24x32-blob era that let the bigger art clip through the room bounds).
 const FOOTPRINT_RATIO := 0.15
 const FEET_BOTTOM_PAD := 2.0                 # feet stay just off the bottom wall line
+
+# --- Tier-1 collision: separation steering (boids-lite) ---------------------
+# Walkers softly repel walkers so they stop rendering inside each other (the
+# obvious failure mode). DETERMINISTIC by construction: the repulsion is a pure
+# function of positions only -- no RNG anywhere in the separation path.
+# STRENGTH (40) is deliberately BELOW walk speed (42): separation can deflect
+# and slow a walker but can never stop it reaching a destination, so head-on
+# meetings pass through transiently instead of deadlocking. Near the walker's
+# CURRENT nav target the push fades to zero (SEPARATION_DAMP_RADIUS ramp), so
+# ring-slotted desk seating -- an intentional convergence point -- still works.
+const SEPARATION_RADIUS := 30.0        # px: neighbours inside this repel
+const SEPARATION_STRENGTH := 40.0      # px/sec push at full overlap (< speed 42)
+const SEPARATION_DAMP_RADIUS := 28.0   # px: push ramps 0..full over this distance from the nav target
+
+# Margin kept between feet and a blocked prop-footprint rect after a push-out.
+const BLOCKED_RECT_MARGIN := 2.0
+const WANDER_TARGET_RETRIES := 8       # attempts to roll a wander target outside blocked rects
 
 # Micro-behavior tuning (seconds / per-second chances; all cosmetic).
 const BREAK_CHANCE_PER_SEC := 0.14      # once off cooldown, chance/sec to start a break
@@ -120,6 +142,13 @@ var water_pos: Vector2 = Vector2.ZERO     # water cooler
 var cat_pos: Vector2 = Vector2.ZERO       # pat the cat
 var window_pos: Vector2 = Vector2.ZERO    # window-gaze
 var speed: float = 42.0
+# Tier-1 collision: floor-local rects (prop footprints) the FEET may not stand in.
+# Assigned by OfficeFloor alongside bounds. Straight-line movement may still cross
+# one transiently (tier-1 boundary); standing/idling inside one is prevented.
+var blocked_rects: Array = []
+# Stable identity used for the deterministic alt-clip splice (hash seed). Set from
+# the roster snapshot id; falls back to the display name.
+var entity_id: String = ""
 
 var _target: Vector2 = Vector2.ZERO
 var _rng := RandomNumberGenerator.new()   # cosmetic-only; deliberately un-seeded from the game
@@ -144,6 +173,19 @@ var _facing: String = FACING_SOUTH
 var _facing_active: bool = false          # true while translating or spinning-in-place
 var _facing_textures: Dictionary = DEFAULT_FACING_TEXTURES
 
+# --- #913 alt-clip splice ("butt-flash" hook) --------------------------------
+# When the SpriteFrames carries "<clip>_alt" (e.g. "walking_north_alt"), the
+# walker occasionally plays that alt loop ONCE mid-cycle, then returns to the
+# base clip. DETERMINISTIC: which loops splice is a pure hash of entity_id +
+# loop count (should_play_alt), roughly 1-in-ALT_CLIP_PERIOD loops. The art
+# itself handles the visual blend (cat_b2 MANIFEST: alt loops are authored as
+# splice-window frames ~2-8); we just play the alt clip from its start.
+const ALT_CLIP_SUFFIX := "_alt"
+const ALT_CLIP_PERIOD := 6                # ~1-in-6 loops plays the alt clip
+var _anim_loop_count := 0
+var _alt_active := false
+var _alt_base_clip := ""
+
 func _ready() -> void:
 	_rng.randomize()
 	_target = position
@@ -151,6 +193,9 @@ func _ready() -> void:
 	_anim.visible = false
 	# Crisp pixel art, no blur, regardless of per-file .import filter settings.
 	_anim.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	# #913 alt-clip splice: count base-clip loops; end a spliced alt loop after one pass.
+	_anim.animation_looped.connect(_on_animation_looped)
+	_anim.animation_finished.connect(_on_animation_finished)
 	add_child(_anim)
 	_facing_sprite = Sprite2D.new()
 	_facing_sprite.visible = false
@@ -169,6 +214,7 @@ func configure(data: Dictionary) -> void:
 	var prev_state := sprite_state
 	sprite_state = data.get("state", EmployeeFSM.STATE_IDLE)
 	emp_name = data.get("name", "")
+	entity_id = String(data.get("entity_id", emp_name if entity_id == "" else entity_id))
 	body_color = data.get("body_color", body_color)
 	hat_color = data.get("hat_color", hat_color)
 	desk_pos = data.get("desk_pos", desk_pos)
@@ -295,8 +341,58 @@ func _show_animated_clip(clip_name: String) -> void:
 	if _facing_sprite:
 		_facing_sprite.visible = false
 	_anim.visible = true
+	if _alt_active:
+		if clip_name == _alt_base_clip:
+			return   # let the spliced alt loop finish one pass; _end_alt_clip restores base
+		_alt_active = false   # wanted clip changed mid-splice -> cancel the alt
+		_alt_base_clip = ""
 	if _anim.sprite_frames and _anim.sprite_frames.has_animation(clip_name):
 		_anim.play(clip_name)
+
+# --- #913 alt-clip splice ----------------------------------------------------
+
+## Pure decision: does loop `loop_index` of entity `id` splice in the alt clip?
+## Deterministic (stable string hash + posmod) -- exactly one splice per `period`
+## consecutive loops, phase-offset per entity so a floor full of walkers doesn't
+## flash in sync. No RNG (ADR-0006-adjacent: cosmetic but reproducible).
+static func should_play_alt(id: String, loop_index: int, period: int = ALT_CLIP_PERIOD) -> bool:
+	if period <= 0:
+		return false
+	return posmod(id.hash() + loop_index, period) == 0
+
+func _on_animation_looped() -> void:
+	if _alt_active:
+		_end_alt_clip()
+		return
+	_anim_loop_count += 1
+	_maybe_start_alt_clip()
+
+func _on_animation_finished() -> void:
+	# A non-looping alt clip ends here instead of animation_looped.
+	if _alt_active:
+		_end_alt_clip()
+
+func _maybe_start_alt_clip() -> void:
+	if _anim == null or _anim.sprite_frames == null:
+		return
+	var base := String(_anim.animation)
+	if base.ends_with(ALT_CLIP_SUFFIX):
+		return
+	var alt := base + ALT_CLIP_SUFFIX
+	if not _anim.sprite_frames.has_animation(alt):
+		return
+	if not should_play_alt(entity_id, _anim_loop_count):
+		return
+	_alt_active = true
+	_alt_base_clip = base
+	_anim.play(alt)
+
+func _end_alt_clip() -> void:
+	_alt_active = false
+	var back := _alt_base_clip
+	_alt_base_clip = ""
+	if _anim and _anim.sprite_frames and _anim.sprite_frames.has_animation(back):
+		_anim.play(back)
 
 func _show_static_facing(facing: String) -> void:
 	if _facing_sprite == null:
@@ -322,14 +418,124 @@ static func facing_from_vector(v: Vector2) -> String:
 func _set_facing(f: String) -> void:
 	_facing = f
 
-## Clamp a movement target into the walkable feet rect (#899 feet-anchor pass).
-## Landmarks/desks laid out near the top wall stay valid destinations -- feet
-## stop at the closest legal point (head overlapping the wall art reads as
-## standing AT it) -- and arrival checks agree with the clamped point instead
-## of never triggering.
+## Clamp a movement target into the walkable feet rect (#899 feet-anchor pass)
+## AND out of any blocked prop-footprint rect (tier-1 collision). Landmarks/desks
+## laid out near the top wall stay valid destinations -- feet stop at the closest
+## legal point (head overlapping the wall art reads as standing AT it) -- and a
+## destination INSIDE a prop (e.g. the water-cooler landmark is the prop's feet)
+## resolves to the nearest point just outside it, so arrival checks agree with
+## the standing spot instead of never triggering.
 func _clamp_target(p: Vector2) -> Vector2:
 	var walk := _feet_rect()
-	return p.clamp(walk.position, walk.end)
+	var c := p.clamp(walk.position, walk.end)
+	return push_out_of_rects(c, blocked_rects, walk)
+
+# --- Tier-1 collision helpers (pure/static, unit-testable) -------------------
+
+## Nearest point just OUTSIDE rect `r` for an inside point `p`. Exits through the
+## nearest edge, preferring exits that stay inside the walkable rect `walk` (so a
+## prop against a wall pushes feet back onto the floor, not into the wall).
+static func exit_point_from_rect(p: Vector2, r: Rect2, walk: Rect2, margin: float = BLOCKED_RECT_MARGIN) -> Vector2:
+	var candidates := [
+		Vector2(r.position.x - margin, p.y),   # out the left edge
+		Vector2(r.end.x + margin, p.y),        # right
+		Vector2(p.x, r.position.y - margin),   # top
+		Vector2(p.x, r.end.y + margin),        # bottom
+	]
+	var best := Vector2.INF
+	var best_d := INF
+	var best_in_walk := Vector2.INF
+	var best_in_walk_d := INF
+	for c in candidates:
+		var d: float = p.distance_to(c)
+		if d < best_d:
+			best_d = d
+			best = c
+		if walk.has_point(c) and d < best_in_walk_d:
+			best_in_walk_d = d
+			best_in_walk = c
+	return best_in_walk if best_in_walk != Vector2.INF else best
+
+## Push `p` out of every rect in `rects` (two settling passes cover overlapping
+## rects). Points already outside all rects pass through unchanged.
+static func push_out_of_rects(p: Vector2, rects: Array, walk: Rect2, margin: float = BLOCKED_RECT_MARGIN) -> Vector2:
+	for _pass in range(2):
+		var moved := false
+		for r in rects:
+			if (r as Rect2).has_point(p):
+				p = exit_point_from_rect(p, r, walk, margin)
+				moved = true
+		if not moved:
+			break
+	return p
+
+## True when `p` is inside any blocked rect (used by wander retries + tests).
+static func inside_any_rect(p: Vector2, rects: Array) -> bool:
+	for r in rects:
+		if (r as Rect2).has_point(p):
+			return true
+	return false
+
+## Pure separation steering (boids-lite): summed, distance-weighted repulsion
+## from every neighbour position closer than `radius`. Deterministic -- positions
+## only, no RNG. Exactly-coincident neighbours contribute nothing (no direction
+## is derivable from positions alone); the intentional case -- shared desk slots --
+## is handled by the arrival damping instead. Result magnitude is capped at 1.
+static func separation_vector(pos: Vector2, neighbors: Array, radius: float = SEPARATION_RADIUS) -> Vector2:
+	var out := Vector2.ZERO
+	for n in neighbors:
+		var d: Vector2 = pos - (n as Vector2)
+		var dist := d.length()
+		if dist >= radius or dist <= 0.0001:
+			continue
+		out += (d / dist) * (1.0 - dist / radius)
+	if out.length() > 1.0:
+		out = out.normalized()
+	return out
+
+## The point this walker is CURRENTLY navigating toward, or null while it is
+## deliberately holding position (idle/stressed, dwelling on a break/collab,
+## spinning). Used to damp separation near arrival so convergence points
+## (desk ring slots, the water cooler) still work.
+func current_destination() -> Variant:
+	match sprite_state:
+		EmployeeFSM.STATE_WORKING:
+			match _work_sub:
+				"desk", "returning":
+					return desk_pos
+				"to_break":
+					return _break_target
+				"to_collab":
+					return _collab_target + Vector2(BODY_RADIUS * 1.6, 0.0)
+				_:
+					return null   # on_break / collaborating: dwelling in place
+		EmployeeFSM.STATE_WALKING:
+			match _aimless:
+				"drift":
+					return _target
+				"window":
+					return window_pos
+				_:
+					return null   # spin: turning on the spot
+		_:
+			return null           # idle / stressed hold position
+
+## Apply one frame of separation steering away from `neighbor_positions`
+## (positions of the OTHER walkers, snapshotted by OfficeFloor so update order
+## cannot matter). Push fades to zero within SEPARATION_DAMP_RADIUS of the
+## current nav target -- separation must not fight arrival.
+func apply_separation(neighbor_positions: Array, delta: float) -> void:
+	var sep := separation_vector(position, neighbor_positions, SEPARATION_RADIUS)
+	if sep == Vector2.ZERO:
+		return
+	var damp := 1.0
+	var dest = current_destination()
+	if dest != null:
+		damp = clampf(position.distance_to(_clamp_target(dest)) / SEPARATION_DAMP_RADIUS, 0.0, 1.0)
+	if damp <= 0.0:
+		return
+	position += sep * SEPARATION_STRENGTH * damp * delta
+	_clamp_to_bounds()
 
 ## True when the feet are at (the walkable projection of) `target`.
 func _arrived(target: Vector2) -> bool:
@@ -490,15 +696,29 @@ func _pick_aimless() -> void:
 
 func _pick_wander_target() -> void:
 	var walk := _feet_rect()
-	_target = Vector2(
-		_rng.randf_range(walk.position.x, walk.end.x),
-		_rng.randf_range(walk.position.y, walk.end.y)
-	)
+	# Tier-1 collision: reroll targets that land inside a prop footprint (cosmetic
+	# RNG, so retries are fine); final fallback projects the target out instead.
+	for _i in range(WANDER_TARGET_RETRIES):
+		_target = Vector2(
+			_rng.randf_range(walk.position.x, walk.end.x),
+			_rng.randf_range(walk.position.y, walk.end.y)
+		)
+		if not inside_any_rect(_target, blocked_rects):
+			return
+	_target = push_out_of_rects(_target, blocked_rects, walk)
 
 func _clamp_to_bounds() -> void:
 	var walk := _feet_rect()
 	position.x = clampf(position.x, walk.position.x, walk.end.x)
 	position.y = clampf(position.y, walk.position.y, walk.end.y)
+	# Tier-1 collision: never STAND inside a prop footprint. Gated on "not actively
+	# translating": a walker mid-walk may cross a prop transiently (accepted tier-1
+	# boundary -- real pathing is tier 2, awaiting the tile-grid ruling / WS-3; an
+	# ungated per-frame push-out would instead pin walkers against a prop sitting on
+	# their straight-line path). Every stationary pose (idle/stressed, break/collab
+	# dwell, spin, post-arrival) gets pushed out, so nobody idles inside furniture.
+	if not _facing_active:
+		position = push_out_of_rects(position, blocked_rects, walk)
 
 # --- Tier 0 rendering: blob + hat ------------------------------------------
 func _draw() -> void:

--- a/godot/scripts/ui/office_floor/office_floor.gd
+++ b/godot/scripts/ui/office_floor/office_floor.gd
@@ -13,7 +13,9 @@ class_name OfficeFloor
 ##   set_roster(snapshot: Array)   # array of employee dicts; adds/updates/removes sprites
 ##   set_tier(t: int)              # 0 = placeholder blobs+hats, 1 = AnimatedSprite2D FSM
 ##   tier                          # property (get/set)
-##   set_sprite_frames(frames)     # optional: real pixellab.ai art for Tier 1
+##   set_sprite_frames(frames)     # optional: FALLBACK shared art for Tier 1
+##   set_use_variant_pool(on)      # per-worker appearance variants (WorkerVariantPool); default ON
+##   set_extra_blocked_rects(a)    # additive dev hook: extra no-stand prop footprints (sandbox)
 ##   OfficeFloor.snapshot_from_state(state) -> Array   # static, read-only GameState adapter
 ##
 ## Employee snapshot dict fields (ALL optional; unknown fields ignored; see
@@ -72,8 +74,27 @@ const HAT_COLOR := Color(0.14, 0.14, 0.18)
 const COLLAB_CHECK_RANGE := Vector2(2.5, 5.0)   # seconds between collaboration attempts
 const COLLAB_START_CHANCE := 0.5                # chance to actually pair when eligible
 
+# #913 water-cooler bubbles: tiny procedural 3-frame loop drawn over the jug
+# (no new art). ~2 fps and low alpha so it reads as ambient life, not a beacon.
+const BUBBLE_FRAMES := 3
+const BUBBLE_FRAME_TIME := 0.5                  # seconds per frame
+const BUBBLE_COLOR := Color(0.85, 0.95, 1.0, 0.38)
+
 var _sprites: Dictionary = {}   # id -> OfficeEmployeeSprite
-var _shared_frames: SpriteFrames = null   # optional real art shared across sprites
+var _shared_frames: SpriteFrames = null   # FALLBACK art shared across sprites
+# Worker appearance variants (#793 mechanism half): when ON (default), each
+# sprite's SpriteFrames comes from WorkerVariantPool keyed by the snapshot's
+# appearance_id; any unresolved variant falls back to _shared_frames. Variant 0
+# is wired to the current shared asset, so behaviour is unchanged until new
+# worker art is triaged in. The sandbox turns this OFF for colour-skin previews.
+var _use_variant_pool := true
+var _appearance: Dictionary = {}          # sprite id -> appearance_id (for reapplies)
+# Tier-1 collision: floor-local no-stand rects built from landmark-prop
+# footprints (PropCatalogue) + any extra rects a host supplies (sandbox props).
+var _blocked_rects: Array = []
+var _extra_blocked_rects: Array = []
+var _bubble_frame := 0
+var _bubble_t := 0.0
 var _rng := RandomNumberGenerator.new()   # cosmetic-only (collaboration timing); NOT the game RNG
 var _collab_timer := 0.0
 var _floor_tile: Texture2D = null   # base concrete tile cropped from the Wang atlas (cosmetic)
@@ -94,6 +115,7 @@ func _ready() -> void:
 	_rng.randomize()
 	_collab_timer = _rng.randf_range(COLLAB_CHECK_RANGE.x, COLLAB_CHECK_RANGE.y)
 	resized.connect(_on_resized)
+	_rebuild_blocked_rects()
 	queue_redraw()
 
 # Collaboration is orchestrated HERE because the floor knows who else is working.
@@ -103,6 +125,33 @@ func _process(delta: float) -> void:
 	if _collab_timer <= 0.0:
 		_collab_timer = _rng.randf_range(COLLAB_CHECK_RANGE.x, COLLAB_CHECK_RANGE.y)
 		_maybe_start_collaboration()
+	_apply_separation(delta)
+	_tick_bubbles(delta)
+
+# Tier-1 collision: one separation pass per frame. Positions are SNAPSHOTTED
+# before any sprite moves, so the result is independent of iteration order --
+# fully deterministic from positions alone (no RNG; see EmployeeSprite).
+# O(n^2) is fine at the 1..24-walker scale this floor is scoped to.
+func _apply_separation(delta: float) -> void:
+	if _sprites.size() < 2:
+		return
+	var ids := _sprites.keys()
+	var pts: Array = []
+	for id in ids:
+		pts.append((_sprites[id] as Node2D).position)
+	for i in range(ids.size()):
+		var others: Array = []
+		for j in range(ids.size()):
+			if j != i:
+				others.append(pts[j])
+		(_sprites[ids[i]] as OfficeEmployeeSprite).apply_separation(others, delta)
+
+func _tick_bubbles(delta: float) -> void:
+	_bubble_t += delta
+	if _bubble_t >= BUBBLE_FRAME_TIME:
+		_bubble_t = fmod(_bubble_t, BUBBLE_FRAME_TIME)
+		_bubble_frame = (_bubble_frame + 1) % BUBBLE_FRAMES
+		queue_redraw()
 
 func _maybe_start_collaboration() -> void:
 	var available: Array = []
@@ -118,11 +167,13 @@ func _maybe_start_collaboration() -> void:
 		a.try_start_collaboration(b.desk_pos)
 
 func _on_resized() -> void:
-	# Keep everyone inside the new bounds.
+	# Keep everyone inside the new bounds; landmark footprints move with them.
 	var b := _bounds()
+	_rebuild_blocked_rects()
 	for id in _sprites:
 		var spr: OfficeEmployeeSprite = _sprites[id]
 		spr.bounds = b
+		spr.blocked_rects = _blocked_rects
 	_relayout_desks()
 	queue_redraw()
 
@@ -144,12 +195,16 @@ func set_roster(snapshot: Array) -> void:
 			continue
 		var id = emp.get("id", emp.get("name", str(i)))
 		seen[id] = true
+		# Appearance seam (#758/#793): appearance_id keys the worker's variant art;
+		# absent -> the roster id (stable), so assignment never shuffles on re-set.
+		_appearance[id] = emp.get("appearance_id", id)
 		var state := EmployeeFSM.map_state(emp)
 		var spec := String(emp.get("specialization", ""))
 		var body: Color = SPEC_COLORS.get(spec, DEFAULT_BODY_COLOR)
 		var desk := _desk_for_index(i, total, b)
 		var cfg := {
 			"state": state, "name": String(emp.get("name", str(id))),
+			"entity_id": str(id),
 			"body_color": body, "hat_color": HAT_COLOR, "desk_pos": desk,
 			"fridge_pos": z["fridge_pos"], "water_pos": z["water_pos"],
 			"cat_pos": z["cat_pos"], "window_pos": z["window_pos"],
@@ -157,22 +212,26 @@ func set_roster(snapshot: Array) -> void:
 		if _sprites.has(id):
 			var spr: OfficeEmployeeSprite = _sprites[id]
 			spr.bounds = b
+			spr.blocked_rects = _blocked_rects
 			spr.configure(cfg)
 		else:
 			var spr2: OfficeEmployeeSprite = EmployeeSpriteScript.new()
 			spr2.tier = tier
 			spr2.bounds = b
+			spr2.blocked_rects = _blocked_rects
 			spr2.position = desk
 			add_child(spr2)
 			spr2.configure(cfg)
-			if _shared_frames != null:
-				spr2.set_sprite_frames(_shared_frames)
+			var fr := _resolved_frames(_appearance[id])
+			if fr != null:
+				spr2.set_sprite_frames(fr)
 			_sprites[id] = spr2
 	# Remove sprites for employees no longer present.
 	for id in _sprites.keys():
 		if not seen.has(id):
 			_sprites[id].queue_free()
 			_sprites.erase(id)
+			_appearance.erase(id)
 	queue_redraw()
 
 ## Number of employee sprites currently on the floor (the walker count). Read-only;
@@ -186,11 +245,37 @@ func set_tier(t: int) -> void:
 		_sprites[id].set_tier(t)
 	queue_redraw()
 
-## Supply a real Tier-1 SpriteFrames (animations: idle/walking/working/stressed).
+## Supply the FALLBACK Tier-1 SpriteFrames (animations: idle/walking/working/
+## stressed). With the variant pool ON (default) each sprite still prefers its
+## appearance-mapped variant; today variant 0 IS this same shared asset, so the
+## two paths render identically until new worker art is triaged in.
 func set_sprite_frames(frames: SpriteFrames) -> void:
 	_shared_frames = frames
+	_reapply_frames()
+
+## Toggle per-worker appearance variants (WorkerVariantPool). The sandbox turns
+## this OFF so its colour-skin preview frames apply uniformly; the live WATCH
+## integration leaves it ON.
+func set_use_variant_pool(enabled: bool) -> void:
+	if _use_variant_pool == enabled:
+		return
+	_use_variant_pool = enabled
+	_reapply_frames()
+
+## Frames for one worker: appearance-mapped variant when the pool is on and the
+## variant's art resolves; otherwise the shared fallback (graceful degrade).
+func _resolved_frames(appearance_id) -> SpriteFrames:
+	if _use_variant_pool:
+		var f := WorkerVariantPool.frames_for(appearance_id)
+		if f != null:
+			return f
+	return _shared_frames
+
+func _reapply_frames() -> void:
 	for id in _sprites:
-		_sprites[id].set_sprite_frames(frames)
+		var f := _resolved_frames(_appearance.get(id, id))
+		if f != null:
+			_sprites[id].set_sprite_frames(f)
 
 # ---------------------------------------------------------------------------
 # ADDITIVE DEV HOOKS (office sandbox v2). PURELY COSMETIC + backward-compatible:
@@ -220,6 +305,39 @@ func set_office_style(style: String) -> void:
 	_office_style = style
 	queue_redraw()
 
+## ADDITIVE dev hook (tier-1 collision): extra no-stand rects in floor-local
+## coords -- the sandbox feeds its placed-prop/furniture footprints through here.
+## The live WATCH integration never calls this (backward-compatible no-op).
+func set_extra_blocked_rects(rects: Array) -> void:
+	_extra_blocked_rects = rects.duplicate()
+	_rebuild_blocked_rects()
+	for id in _sprites:
+		_sprites[id].blocked_rects = _blocked_rects
+
+## Read-only: the current no-stand rects (own landmarks + extras). For tests.
+func blocked_rects() -> Array:
+	return _blocked_rects.duplicate()
+
+# Landmark props whose PropCatalogue footprints become no-stand rects. The cat
+# corner and window strip stay procedural (no prop, nothing to block).
+func _rebuild_blocked_rects() -> void:
+	_blocked_rects = []
+	var b := _bounds()
+	var z := _zones(b)
+	_blocked_rects.append(_footprint_rect("water_cooler", z["water_pos"]))
+	_blocked_rects.append(_footprint_rect("filing_cabinet", z["fridge_pos"]))
+	_blocked_rects.append(_footprint_rect("server_cluster",
+		b.position + Vector2(b.size.x * 0.12, b.size.y * 0.18)))
+	_blocked_rects.append_array(_extra_blocked_rects)
+
+# Floor area a feet-anchored prop occupies: footprint_tiles wide, extending UP
+# from the feet point (same convention as the sandbox occupancy pass, #907).
+func _footprint_rect(id: String, feet: Vector2) -> Rect2:
+	var fp := PropCatalogue.footprint(id)
+	var w := fp.x * DISPLAY_TILE_PX
+	var d := fp.y * DISPLAY_TILE_PX
+	return Rect2(feet - Vector2(w * 0.5, d), Vector2(w, d))
+
 func _relayout_desks() -> void:
 	var b := _bounds()
 	var z := _zones(b)
@@ -232,6 +350,7 @@ func _relayout_desks() -> void:
 		spr.water_pos = z["water_pos"]
 		spr.cat_pos = z["cat_pos"]
 		spr.window_pos = z["window_pos"]
+		spr.blocked_rects = _blocked_rects
 
 # Cosmetic destination LANDMARKS derived from the floor bounds -- placed at distinct
 # spots so a walking employee's destination reads at a glance (Tier-1 named points,
@@ -364,9 +483,24 @@ func _draw() -> void:
 	draw_circle(z["cat_pos"], 9.0, Color(0.9, 0.5, 0.7, 0.4))            # cat corner (pink)
 	# #907: landmark props render manifest-scaled/anchored, style-variant-aware.
 	_draw_landmark_prop("water_cooler", PROP_WATER_COOLER, z["water_pos"])          # top-right
+	_draw_water_bubbles(z["water_pos"])                                             # #913 juice
 	_draw_landmark_prop("filing_cabinet", PROP_FILING_CABINET, z["fridge_pos"])     # bottom-right
 	_draw_landmark_prop("server_cluster", PROP_SERVER,
 		b.position + Vector2(b.size.x * 0.12, b.size.y * 0.18))                     # top-left decor
+
+# #913: subtle 3-frame procedural bubble loop over the water-cooler jug (drawn,
+# no art). Two bubbles rise a step per frame inside the jug (the top ~third of
+# the manifest-scaled prop); the second lags a frame so the loop reads organic.
+func _draw_water_bubbles(feet: Vector2) -> void:
+	var h := PropCatalogue.height_px("water_cooler", DISPLAY_TILE_PX)
+	if h <= 0.0:
+		return
+	var rise := h * 0.05                                   # px climbed per frame
+	var base_y := feet.y - h * 0.72                        # bottom of the jug water line
+	var y_a := base_y - float(_bubble_frame) * rise
+	var y_b := base_y - float((_bubble_frame + BUBBLE_FRAMES - 1) % BUBBLE_FRAMES) * rise
+	draw_circle(Vector2(feet.x - h * 0.02, y_a), 1.6, BUBBLE_COLOR)
+	draw_circle(Vector2(feet.x + h * 0.025, y_b + h * 0.03), 1.1, BUBBLE_COLOR)
 
 # ---------------------------------------------------------------------------
 # READ-ONLY GameState adapter. Static so callers can build a snapshot without

--- a/godot/scripts/ui/office_floor/office_sandbox.gd
+++ b/godot/scripts/ui/office_floor/office_sandbox.gd
@@ -530,9 +530,14 @@ func _apply_skin_to_floor(f: OfficeFloor) -> void:
 	var s: Dictionary = _skins[_skin_idx]
 	match String(s.get("kind", "")):
 		"art":
+			# Real art goes through the variant pool (variant 0 == this same asset,
+			# so the render is unchanged until new worker variants are triaged in).
+			f.set_use_variant_pool(true)
 			f.set_sprite_frames(RealSpriteFrames)
 			f.set_tier(1)
 		"color":
+			# Colour-skin preview must apply UNIFORMLY -> bypass the variant pool.
+			f.set_use_variant_pool(false)
 			var frames: SpriteFrames = EmployeeSpriteScript._build_placeholder_frames(s["body"], HAT)
 			f.set_sprite_frames(frames)
 			f.set_tier(1)
@@ -744,6 +749,7 @@ func _place_prop() -> void:
 	af.add_child(spr)
 	_placed_props.append(spr)
 	_occupy_prop_footprint(spr, af, id)
+	_sync_blocked_rects()
 
 # #907: a manifested prop OCCUPIES its footprint_tiles cells (display tiles are 64px =
 # 2x2 sandbox grid cells each) so POPULATE furniture will not overlap it. Unmanifested
@@ -774,6 +780,40 @@ func _release_prop_footprint(spr: Sprite2D) -> void:
 	for key in spr.get_meta("occupied_keys", []):
 		_occupied_cells.erase(String(key))
 
+# --- Tier-1 collision: feed prop/furniture footprints to the floors ----------
+# Walkers must never STAND inside furniture. Each floor gets the no-stand rects
+# of the props parented to it via OfficeFloor.set_extra_blocked_rects (additive
+# dev hook; the floor adds its own landmark-prop footprints itself).
+func _blocked_rect_for(spr: Sprite2D) -> Rect2:
+	var mid := _manifest_id_for(spr.texture, String(spr.get_meta("asset_id", "")))
+	if mid != "":
+		# Manifested: authored footprint, feet-anchored (extends up from the feet).
+		var fp := PropCatalogue.footprint(mid)
+		var w := fp.x * DISPLAY_TILE_PX
+		var d := fp.y * DISPLAY_TILE_PX
+		return Rect2(spr.position - Vector2(w * 0.5, d), Vector2(w, d))
+	# Unmanifested (placeholder furniture / legacy props): the drawn sprite rect.
+	var base: Vector2 = spr.get_meta("base_scale", Vector2.ONE)
+	var sz: Vector2 = spr.texture.get_size() * base if spr.texture != null else Vector2(GRID, GRID)
+	if spr.centered:
+		return Rect2(spr.position - sz * 0.5, sz)
+	return Rect2(spr.position + spr.offset * base, sz)
+
+func _sync_blocked_rects() -> void:
+	var rects_a: Array = []
+	var rects_b: Array = []
+	for spr in _placed_props + _furniture + _furniture_b:
+		if not is_instance_valid(spr):
+			continue
+		var r: Rect2 = _blocked_rect_for(spr)
+		if _floor_b != null and is_instance_valid(_floor_b) and spr.get_parent() == _floor_b:
+			rects_b.append(r)
+		elif spr.get_parent() == _floor:
+			rects_a.append(r)
+	_floor.set_extra_blocked_rects(rects_a)
+	if _floor_b != null and is_instance_valid(_floor_b):
+		_floor_b.set_extra_blocked_rects(rects_b)
+
 func _remove_nearest_prop(at: Vector2) -> void:
 	if _placed_props.is_empty():
 		return
@@ -794,6 +834,7 @@ func _remove_nearest_prop(at: Vector2) -> void:
 			_release_prop_footprint(spr)
 			spr.queue_free()
 		_placed_props.remove_at(best)
+		_sync_blocked_rects()
 
 func _clear_props() -> void:
 	for spr in _placed_props:
@@ -801,6 +842,7 @@ func _clear_props() -> void:
 			_release_prop_footprint(spr)
 			spr.queue_free()
 	_placed_props.clear()
+	_sync_blocked_rects()
 
 func _snap_to_grid(pos: Vector2) -> Vector2:
 	return Vector2(
@@ -885,7 +927,9 @@ func _add_cat(target: OfficeFloor = null) -> void:
 	var cat: SandboxCatBase
 	if not _cat_frame_sets.is_empty():
 		var rc := RealCat.new()
-		rc.setup(_cat_frame_sets[_cat_color_idx % _cat_frame_sets.size()]["frames"])
+		# Stable per-cat id phase-offsets the deterministic alt-clip splice (#913).
+		rc.setup(_cat_frame_sets[_cat_color_idx % _cat_frame_sets.size()]["frames"],
+			"cat_%d" % _cat_color_idx)
 		cat = rc
 	else:
 		var sc := SandboxCat.new()
@@ -1062,6 +1106,7 @@ func _apply_pop_stage(f: OfficeFloor = null) -> void:
 	while furn.size() > want_furn:
 		_remove_furniture(af)
 	_apply_occupant_scale()
+	_sync_blocked_rects()
 
 # Place one furniture piece on a free perimeter (wall) grid cell of floor `f`. Returns
 # false if the floor is full. Demonstrates the first "space logic" slice: furniture hugs
@@ -1230,6 +1275,7 @@ func _exit_compare() -> void:
 	_apply_floor_styles()   # restore the single-view tier
 	_rebuild_prop_pool()
 	_layout_floors()
+	_sync_blocked_rects()
 	_last_msg = "compare OFF (single floor; [V] to bring it back)"
 
 func _layout_floors() -> void:
@@ -1271,6 +1317,7 @@ func _spawn_compare_furniture() -> void:
 		if not _spawn_furniture(_floor):
 			break
 	_apply_occupant_scale()
+	_sync_blocked_rects()
 
 # Sparse starter furnishing: a desk / plant / cabinet against the left floor's
 # walls, via the same placeholder _furniture_tex path POPULATE uses. Registers each
@@ -1300,6 +1347,7 @@ func _spawn_starter_props() -> void:
 		_occupied_cells[key] = true
 		_floor_b.add_child(spr)
 		_furniture_b.append(spr)
+	_sync_blocked_rects()
 
 # --- v3: DOOM-GLOW on cats (prototype) --------------------------------------
 func _nudge_doom(d: float) -> void:
@@ -1447,6 +1495,7 @@ func _clear_furniture() -> void:
 			spr.queue_free()
 	_furniture_b.clear()
 	_occupied_cells.clear()
+	_sync_blocked_rects()
 
 # --- Bulk toys --------------------------------------------------------------
 func _randomize() -> void:
@@ -1713,6 +1762,24 @@ func _build_cat_frames(dir_abs: String) -> SpriteFrames:
 			i += 1
 		if added > 0:
 			made_any = true
+		# #913 splice seam: optional alternate loop frames (walk_<facing>_alt_<n>.png,
+		# e.g. the butt-flash strut) load into "walk_<facing>_alt"; RealCat splices
+		# them in deterministically when present. No files -> no clip -> hook dormant.
+		var alt_clip := clip + "_alt"
+		var ai := 0
+		while true:
+			var ap := "%s/walk_%s_alt_%d.png" % [dir_abs, facing, ai]
+			if not FileAccess.file_exists(ap):
+				break
+			var atex := _load_texture(ap)
+			if atex == null:
+				break
+			if not sf.has_animation(alt_clip):
+				sf.add_animation(alt_clip)
+				sf.set_animation_loop(alt_clip, true)
+				sf.set_animation_speed(alt_clip, 10.0)
+			sf.add_frame(alt_clip, atex)
+			ai += 1
 	if not made_any:
 		return null
 	var south0 := _load_texture(dir_abs + "/walk_south_0.png")
@@ -1879,22 +1946,32 @@ class RealCat extends SandboxCatBase:
 	# #899 scale unification: cat and human sizes derive from the SAME on-screen
 	# tile unit (OfficeEmployeeSprite.TILE_PX = 64px; humans target CHAR_TARGET_H
 	# = 2 tiles = 128px). Cat art: 68x68 canvas, opaque subject ~34px tall.
-	# Target: a cat reads ~0.5 tile (32px) beside a 2-tile human.
-	# ART_SCALE = 32 / 34 ~= 0.94 (was a magic 0.45 -> ~15px, a quarter-tile cat).
+	# Target height comes from the SHARED cat ratio (#913 sneaky 1.1x: 0.5 ->
+	# 0.55 tile via OfficeEmployeeSprite.CAT_TILE_RATIO -- one constant, all cats).
 	const CAT_SUBJECT_H := 34.0
-	const CAT_TARGET_H := OfficeEmployeeSprite.TILE_PX * 0.5   # 32px on screen
-	const ART_SCALE := CAT_TARGET_H / CAT_SUBJECT_H            # ~0.94
+	const CAT_TARGET_H := OfficeEmployeeSprite.TILE_PX * OfficeEmployeeSprite.CAT_TILE_RATIO
+	const ART_SCALE := CAT_TARGET_H / CAT_SUBJECT_H
+	var cat_id: String = "cat"           # stable id seeding the alt-clip splice hash
 	var _frames: SpriteFrames = null
 	var _anim: AnimatedSprite2D = null
+	# #913 alt-clip splice (cat contract: "walk_<dir>_alt", e.g. walk_north_alt --
+	# the butt-flash loop). Same deterministic 1-in-N mechanism as the workers
+	# (OfficeEmployeeSprite.should_play_alt); art arrives from the cat sweep later.
+	var _loops := 0
+	var _alt_active := false
+	var _alt_base := ""
 
-	func setup(frames: SpriteFrames) -> void:
+	func setup(frames: SpriteFrames, id: String = "cat") -> void:
 		_frames = frames
+		cat_id = id
 
 	func _build_visual() -> void:
 		_anim = AnimatedSprite2D.new()
 		_anim.sprite_frames = _frames
 		_anim.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 		_anim.scale = Vector2(ART_SCALE, ART_SCALE)
+		_anim.animation_looped.connect(_on_anim_looped)
+		_anim.animation_finished.connect(_on_anim_finished)
 		add_child(_anim)
 		if _frames != null and _frames.has_animation("idle"):
 			_anim.play("idle")
@@ -1904,14 +1981,51 @@ class RealCat extends SandboxCatBase:
 	func _on_tick(dirv: Vector2, moving: bool, _delta: float) -> void:
 		if _anim == null or _frames == null:
 			return
+		var wanted := ""
 		if not moving:
-			if _frames.has_animation("idle") and _anim.animation != "idle":
-				_anim.play("idle")
+			if _frames.has_animation("idle"):
+				wanted = "idle"
+		else:
+			var clip := "walk_" + _dir_name(dirv)
+			if _frames.has_animation(clip):
+				wanted = clip
+		if wanted == "":
 			return
-		var clip := "walk_" + _dir_name(dirv)
-		if _frames.has_animation(clip):
-			if _anim.animation != clip:
-				_anim.play(clip)
+		if _alt_active:
+			if wanted == _alt_base:
+				return               # let the spliced alt play its one pass
+			_alt_active = false      # direction/idle change cancels the splice
+			_alt_base = ""
+		if _anim.animation != wanted:
+			_anim.play(wanted)
+
+	# #913 splice: on each completed base loop, deterministically (hash of cat id
+	# + loop count, ~1-in-6) play "<clip>_alt" once, then return to the base clip.
+	func _on_anim_looped() -> void:
+		if _alt_active:
+			_end_alt()
+			return
+		_loops += 1
+		var base := String(_anim.animation)
+		if base.ends_with(OfficeEmployeeSprite.ALT_CLIP_SUFFIX):
+			return
+		var alt := base + OfficeEmployeeSprite.ALT_CLIP_SUFFIX
+		if _frames != null and _frames.has_animation(alt) \
+				and OfficeEmployeeSprite.should_play_alt(cat_id, _loops):
+			_alt_active = true
+			_alt_base = base
+			_anim.play(alt)
+
+	func _on_anim_finished() -> void:
+		if _alt_active:
+			_end_alt()
+
+	func _end_alt() -> void:
+		_alt_active = false
+		var back := _alt_base
+		_alt_base = ""
+		if _frames != null and _frames.has_animation(back):
+			_anim.play(back)
 
 	func _on_doom() -> void:
 		if _anim != null:

--- a/godot/scripts/ui/office_floor/worker_variant_pool.gd
+++ b/godot/scripts/ui/office_floor/worker_variant_pool.gd
@@ -1,0 +1,114 @@
+extends RefCounted
+class_name WorkerVariantPool
+## Data-driven worker APPEARANCE variant registry (#793 mechanism half).
+##
+## Loads res://data/office/worker_variants.json once (static/lazy, same pattern
+## as PropCatalogue) and maps an employee's appearance_id to a SpriteFrames
+## resource. ART-AGNOSTIC: today the manifest lists ONE variant -- the current
+## shared office_worker.tres -- so every worker resolves to the same art and
+## behaviour is byte-for-byte unchanged. When the round-2 worker sheets are
+## triaged in (Pip), new variants are ADDED to the JSON list; no code changes.
+##
+## DETERMINISM / STABILITY: variant_index_for() is a pure function of the
+## appearance_id and the variant count (posmod of an int id, or of the stable
+## String hash) -- the same appearance_id always lands on the same variant for a
+## fixed variant list, independent of roster order or size. Note the boundary:
+## CHANGING the variant count remaps assignments (documented tradeoff; the
+## per-run mapping is what matters for a cosmetic pure view, ADR-0006).
+##
+## FALLBACK: a variant whose frames path is missing/unloadable resolves to null
+## (warn once); the caller (OfficeFloor) then falls back to its shared frames.
+
+const Definitions = preload("res://scripts/data/definition_loader.gd")
+const MANIFEST_PATH := "res://data/office/worker_variants.json"
+
+static var _loaded: bool = false
+static var _variants: Array = []           # [{id, frames, ...}] in manifest order
+static var _frames_cache: Dictionary = {}  # frames path -> SpriteFrames or null
+static var _warned: Dictionary = {}
+
+
+static func _ensure_loaded() -> void:
+	if _loaded:
+		return
+	_loaded = true
+	var data := Definitions.load_object(MANIFEST_PATH, "WorkerVariantPool")
+	_variants = []
+	for v in data.get("variants", []):
+		if v is Dictionary:
+			_variants.append(v)
+	if _variants.is_empty():
+		push_warning("[WorkerVariantPool] no variants in %s -- floors fall back to shared frames" % MANIFEST_PATH)
+
+
+static func count() -> int:
+	_ensure_loaded()
+	return _variants.size()
+
+
+static func variant_id_at(index: int) -> String:
+	_ensure_loaded()
+	if index < 0 or index >= _variants.size():
+		return ""
+	return String(_variants[index].get("id", ""))
+
+
+## Pure, stable appearance -> variant-index mapping. Accepts an int (used
+## directly) or anything else (stable String hash). Returns -1 when the pool is
+## empty (caller falls back). Exposed with an explicit `cnt` so tests can pin it.
+static func variant_index_for(appearance_id, cnt: int) -> int:
+	if cnt <= 0:
+		return -1
+	var n: int
+	match typeof(appearance_id):
+		TYPE_INT:
+			n = appearance_id
+		TYPE_FLOAT:
+			n = int(appearance_id)
+		_:
+			n = String(appearance_id).hash()
+	return posmod(n, cnt)
+
+
+## SpriteFrames for this appearance, or null when the pool is empty or the
+## mapped variant's art fails to load (graceful fallback path).
+static func frames_for(appearance_id) -> SpriteFrames:
+	_ensure_loaded()
+	var idx := variant_index_for(appearance_id, _variants.size())
+	if idx < 0:
+		return null
+	return _load_frames(String(_variants[idx].get("frames", "")))
+
+
+static func _load_frames(path: String) -> SpriteFrames:
+	if path == "":
+		return null
+	if not _frames_cache.has(path):
+		var res: Resource = null
+		if ResourceLoader.exists(path):
+			res = load(path)
+		if res is SpriteFrames:
+			_frames_cache[path] = res
+		else:
+			_frames_cache[path] = null
+			if not _warned.has(path):
+				_warned[path] = true
+				# print, not push_warning: this is the DESIGNED degrade path (missing
+				# variant art -> shared frames) and unit tests exercise it on purpose.
+				print("[WorkerVariantPool] variant frames missing/invalid: %s -- falling back to shared frames" % path)
+	return _frames_cache[path]
+
+
+# --- test seams (unit tests only; static state persists across a GUT run) ----
+static func _override_variants_for_test(variants: Array) -> void:
+	_loaded = true
+	_variants = variants.duplicate(true)
+	_frames_cache.clear()
+	_warned.clear()
+
+
+static func _reset_for_test() -> void:
+	_loaded = false
+	_variants = []
+	_frames_cache.clear()
+	_warned.clear()

--- a/godot/scripts/ui/office_floor/worker_variant_pool.gd.uid
+++ b/godot/scripts/ui/office_floor/worker_variant_pool.gd.uid
@@ -1,0 +1,1 @@
+uid://cwhl7qf0jdrg2

--- a/godot/tests/unit/test_office_alt_clip_splice.gd
+++ b/godot/tests/unit/test_office_alt_clip_splice.gd
@@ -1,0 +1,165 @@
+extends GutTest
+## #913 alt-clip splice hook ("butt-flash"): when a SpriteFrames carries
+## "<clip>_alt" (workers: "walking_north_alt"; cats: "walk_north_alt"), the
+## walker occasionally plays the alt loop ONCE, then returns to the base clip.
+## DETERMINISTIC: the splice decision is a pure hash of entity id + loop count
+## (should_play_alt, ~1-in-6 loops) -- no RNG, reproducible, phase-offset per
+## entity. Art arrives later from the cat sweep; these tests use synthetic
+## frames, proving the hook is art-agnostic.
+
+const EmployeeSpriteScript := preload("res://scripts/ui/office_floor/employee_sprite.gd")
+
+const PERIOD := OfficeEmployeeSprite.ALT_CLIP_PERIOD
+
+
+func _make_frames(clips: Array) -> SpriteFrames:
+	var sf := SpriteFrames.new()
+	var img := Image.create(8, 8, false, Image.FORMAT_RGBA8)
+	img.fill(Color.WHITE)
+	var tex := ImageTexture.create_from_image(img)
+	var first := true
+	for c in clips:
+		var clip := String(c)
+		if first:
+			sf.rename_animation("default", clip)
+			first = false
+		elif not sf.has_animation(clip):
+			sf.add_animation(clip)
+		sf.set_animation_loop(clip, true)
+		sf.set_animation_speed(clip, 6.0)
+		sf.add_frame(clip, tex)
+		sf.add_frame(clip, tex)
+	return sf
+
+
+func _make_sprite(clips: Array, id: String) -> OfficeEmployeeSprite:
+	var spr: OfficeEmployeeSprite = EmployeeSpriteScript.new()
+	add_child_autofree(spr)
+	spr.bounds = Rect2(0, 0, 400, 300)
+	spr.tier = 1
+	spr.entity_id = id
+	spr.set_sprite_frames(_make_frames(clips))
+	return spr
+
+
+func _first_trigger_loop(id: String) -> int:
+	for l in range(1, PERIOD + 1):
+		if OfficeEmployeeSprite.should_play_alt(id, l):
+			return l
+	return -1
+
+
+# --- should_play_alt: pure + deterministic -----------------------------------
+
+func test_exactly_one_splice_per_period_window():
+	for id in ["worker_0", "worker_1", "cat_2", "zz"]:
+		var triggers := 0
+		for l in range(1, PERIOD + 1):
+			if OfficeEmployeeSprite.should_play_alt(String(id), l):
+				triggers += 1
+		assert_eq(triggers, 1, "%s: exactly 1 splice in any %d consecutive loops" % [id, PERIOD])
+
+
+func test_should_play_alt_is_deterministic():
+	for l in range(0, 24):
+		assert_eq(
+			OfficeEmployeeSprite.should_play_alt("stable_id", l),
+			OfficeEmployeeSprite.should_play_alt("stable_id", l),
+			"same id + loop -> same decision, every time (loop %d)" % l)
+
+
+func test_trigger_loops_are_periodic_per_entity():
+	var first := _first_trigger_loop("periodic_id")
+	assert_gt(first, 0, "a trigger exists inside the first window")
+	assert_true(OfficeEmployeeSprite.should_play_alt("periodic_id", first + PERIOD),
+		"triggers repeat every ALT_CLIP_PERIOD loops")
+	assert_false(OfficeEmployeeSprite.should_play_alt("periodic_id", first + 1),
+		"the loop right after a trigger does not re-trigger")
+
+
+func test_non_positive_period_never_triggers():
+	assert_false(OfficeEmployeeSprite.should_play_alt("x", 3, 0))
+	assert_false(OfficeEmployeeSprite.should_play_alt("x", 3, -2))
+
+
+# --- worker sprite: splice in, one pass, splice out --------------------------
+
+func test_worker_splices_alt_once_then_returns_to_base():
+	var id := "splicer"
+	var spr := _make_sprite(["walking", "walking_alt"], id)
+	spr.sprite_state = EmployeeFSM.STATE_WALKING
+	spr._refresh_visual()
+	assert_eq(String(spr._anim.animation), "walking", "base clip playing")
+	var trigger := _first_trigger_loop(id)
+	assert_gt(trigger, 0)
+	for l in range(1, trigger):
+		spr._on_animation_looped()
+		assert_eq(String(spr._anim.animation), "walking", "no splice before the trigger loop (loop %d)" % l)
+	spr._on_animation_looped()   # the trigger loop
+	assert_eq(String(spr._anim.animation), "walking_alt", "alt clip spliced in on the deterministic loop")
+	assert_true(spr._alt_active)
+	spr._on_animation_looped()   # the alt loop completes its single pass
+	assert_eq(String(spr._anim.animation), "walking", "back to the base clip after ONE alt pass")
+	assert_false(spr._alt_active)
+
+
+func test_directional_alt_clip_contract():
+	# The documented contract name: "walking_north_alt" splices over "walking_north".
+	var id := "north_walker"
+	var spr := _make_sprite(["walking", "walking_north", "walking_north_alt"], id)
+	spr.sprite_state = EmployeeFSM.STATE_WALKING
+	spr._facing = OfficeEmployeeSprite.FACING_NORTH
+	spr._facing_active = true
+	spr._update_facing_visual()
+	assert_eq(String(spr._anim.animation), "walking_north", "directional base clip playing")
+	var trigger := _first_trigger_loop(id)
+	for _l in range(1, trigger):
+		spr._on_animation_looped()
+	spr._on_animation_looped()
+	assert_eq(String(spr._anim.animation), "walking_north_alt", "walking_north_alt spliced in")
+
+
+func test_no_alt_clip_means_hook_stays_dormant():
+	var spr := _make_sprite(["walking"], "dormant")
+	spr.sprite_state = EmployeeFSM.STATE_WALKING
+	spr._refresh_visual()
+	for _l in range(PERIOD * 3):
+		spr._on_animation_looped()
+		assert_eq(String(spr._anim.animation), "walking", "no *_alt clip -> nothing ever splices")
+	assert_false(spr._alt_active)
+
+
+func test_state_change_cancels_an_active_splice():
+	var id := "cancelled"
+	var spr := _make_sprite(["walking", "walking_alt", "working"], id)
+	spr.sprite_state = EmployeeFSM.STATE_WALKING
+	spr._refresh_visual()
+	var trigger := _first_trigger_loop(id)
+	for _l in range(trigger):
+		spr._on_animation_looped()
+	assert_true(spr._alt_active, "alt is mid-splice")
+	spr._show_animated_clip("working")
+	assert_false(spr._alt_active, "wanting a different clip cancels the splice")
+	assert_eq(String(spr._anim.animation), "working")
+
+
+func test_non_looping_alt_ends_via_animation_finished():
+	var id := "oneshot"
+	var spr := _make_sprite(["walking", "walking_alt"], id)
+	spr._anim.sprite_frames.set_animation_loop("walking_alt", false)
+	spr.sprite_state = EmployeeFSM.STATE_WALKING
+	spr._refresh_visual()
+	var trigger := _first_trigger_loop(id)
+	for _l in range(trigger):
+		spr._on_animation_looped()
+	assert_true(spr._alt_active)
+	spr._on_animation_finished()
+	assert_false(spr._alt_active)
+	assert_eq(String(spr._anim.animation), "walking", "non-looping alt returns to base on finish")
+
+
+# --- shared cat scale ruling (#913 sneaky 1.1x) ------------------------------
+
+func test_cat_tile_ratio_is_the_1_1x_bump():
+	assert_almost_eq(OfficeEmployeeSprite.CAT_TILE_RATIO, 0.55, 0.0001,
+		"cats read 0.55 tile (0.5 * 1.1 sneaky bump, Pip-approved 2026-07-26)")

--- a/godot/tests/unit/test_office_alt_clip_splice.gd.uid
+++ b/godot/tests/unit/test_office_alt_clip_splice.gd.uid
@@ -1,0 +1,1 @@
+uid://dbvuuosqlf0hg

--- a/godot/tests/unit/test_office_no_stand_in_footprint.gd
+++ b/godot/tests/unit/test_office_no_stand_in_footprint.gd
@@ -1,0 +1,129 @@
+extends GutTest
+## Tier-1 collision, part 2: no-walk zones from prop footprints. Walkers may
+## still CROSS a prop transiently mid-walk (accepted tier-1 boundary; real
+## pathing is tier 2, awaiting the tile-grid ruling / WS-3) but must never
+## STAND/IDLE inside one: stationary poses are pushed out, wander targets
+## re-roll, and destinations inside a prop resolve to the nearest point just
+## outside it (so the water-cooler landmark stays reachable). Pure view.
+
+const EmployeeSpriteScript := preload("res://scripts/ui/office_floor/employee_sprite.gd")
+const OfficeFloorScene := preload("res://scenes/ui/office_floor/office_floor.tscn")
+
+const WALK := Rect2(11, 11, 378, 278)   # tier-0 feet rect of Rect2(0,0,400,300) bounds
+const PROP := Rect2(150, 150, 64, 64)   # a 1x1-display-tile footprint mid-floor
+
+
+func _make_sprite() -> OfficeEmployeeSprite:
+	var spr: OfficeEmployeeSprite = EmployeeSpriteScript.new()
+	add_child_autofree(spr)
+	spr.bounds = Rect2(0, 0, 400, 300)
+	spr.blocked_rects = [PROP]
+	return spr
+
+
+# --- pure helpers ------------------------------------------------------------
+
+func test_point_outside_passes_through_unchanged():
+	var p := Vector2(50, 50)
+	assert_eq(OfficeEmployeeSprite.push_out_of_rects(p, [PROP], WALK), p)
+
+
+func test_point_inside_is_pushed_just_outside():
+	var out := OfficeEmployeeSprite.push_out_of_rects(Vector2(160, 180), [PROP], WALK)
+	assert_false(PROP.has_point(out), "pushed point is outside the footprint")
+
+
+func test_push_exits_through_the_nearest_edge():
+	# 5px from the left edge, far from the others -> exits left.
+	var out := OfficeEmployeeSprite.push_out_of_rects(Vector2(155, 180), [PROP], WALK)
+	assert_lt(out.x, PROP.position.x, "exited through the near (left) edge")
+	assert_eq(out.y, 180.0, "push is a straight slide, no drift")
+
+
+func test_push_prefers_an_exit_inside_the_walkable_rect():
+	# Prop flush against the bottom of the walkable rect: a point near its bottom
+	# edge must NOT be pushed below the floor -- it takes an in-bounds exit instead.
+	var wall_prop := Rect2(200, WALK.end.y - 64.0, 64, 64)
+	var inside := Vector2(232, WALK.end.y - 4.0)
+	var out := OfficeEmployeeSprite.push_out_of_rects(inside, [wall_prop], WALK)
+	assert_false(wall_prop.has_point(out), "outside the prop")
+	assert_true(WALK.has_point(out), "exit stays on the walkable floor, not inside the wall")
+
+
+func test_inside_any_rect():
+	assert_true(OfficeEmployeeSprite.inside_any_rect(Vector2(160, 160), [PROP]))
+	assert_false(OfficeEmployeeSprite.inside_any_rect(Vector2(10, 10), [PROP]))
+
+
+# --- sprite behaviour --------------------------------------------------------
+
+func test_idle_walker_inside_a_footprint_is_pushed_out():
+	var spr := _make_sprite()
+	spr.sprite_state = EmployeeFSM.STATE_IDLE
+	spr.position = Vector2(170, 170)          # standing inside the prop
+	spr._process(0.05)
+	assert_false(PROP.has_point(spr.position), "idle pose never renders inside furniture")
+
+
+func test_stressed_walker_inside_a_footprint_is_pushed_out():
+	var spr := _make_sprite()
+	spr.sprite_state = EmployeeFSM.STATE_STRESSED
+	spr.position = Vector2(180, 200)
+	spr._process(0.05)
+	assert_false(PROP.has_point(spr.position), "stressed pose never renders inside furniture")
+
+
+func test_destination_inside_a_prop_resolves_to_its_edge():
+	# The water-cooler landmark IS the prop's feet point: the clamped target must
+	# sit just outside the footprint so arrival triggers at the standing spot.
+	var spr := _make_sprite()
+	var target := Vector2(180, 180)           # inside PROP
+	var clamped := spr._clamp_target(target)
+	assert_false(PROP.has_point(clamped), "nav targets resolve outside footprints")
+	assert_true(spr._feet_rect().has_point(clamped), "resolved target stays walkable")
+
+
+func test_wander_targets_avoid_footprints():
+	var spr := _make_sprite()
+	spr._rng.seed = 12345                     # cosmetic RNG; seeded for a stable sweep
+	for _i in range(40):
+		spr._pick_wander_target()
+		assert_false(PROP.has_point(spr._target), "wander target rerolled out of the footprint")
+
+
+func test_worker_idling_on_break_never_parks_inside_prop():
+	# A break dwell at a target inside the prop: the walker walks to the clamped
+	# edge point, dwells there, and is never left standing inside the footprint.
+	var spr := _make_sprite()
+	spr.sprite_state = EmployeeFSM.STATE_WORKING
+	spr._work_sub = "to_break"
+	spr._break_target = Vector2(182, 182)     # inside PROP
+	spr.position = Vector2(60, 180)
+	for _i in range(400):
+		spr._process(0.05)
+		if spr._work_sub == "on_break":
+			break
+	assert_eq(spr._work_sub, "on_break", "break dwell reached (arrival check agrees with the clamp)")
+	assert_false(PROP.has_point(spr.position), "dwelling happens at the prop's edge, not inside it")
+
+
+# --- OfficeFloor wiring ------------------------------------------------------
+
+func test_floor_builds_landmark_footprint_rects():
+	var f: OfficeFloor = OfficeFloorScene.instantiate()
+	add_child_autofree(f)
+	await get_tree().process_frame
+	assert_eq(f.blocked_rects().size(), 3,
+		"water cooler + filing cabinet + server cluster footprints are no-stand rects")
+
+
+func test_floor_hands_blocked_rects_to_sprites_and_extras_propagate():
+	var f: OfficeFloor = OfficeFloorScene.instantiate()
+	add_child_autofree(f)
+	await get_tree().process_frame
+	f.set_roster([{"id": 0, "name": "A", "assigned": true}])
+	var spr: OfficeEmployeeSprite = f._sprites[0]
+	assert_eq(spr.blocked_rects.size(), 3, "sprites receive the floor's no-stand rects")
+	f.set_extra_blocked_rects([Rect2(10, 10, 20, 20)])
+	assert_eq(f.blocked_rects().size(), 4, "sandbox extras are additive")
+	assert_eq(spr.blocked_rects.size(), 4, "existing sprites are re-armed with the extras")

--- a/godot/tests/unit/test_office_no_stand_in_footprint.gd.uid
+++ b/godot/tests/unit/test_office_no_stand_in_footprint.gd.uid
@@ -1,0 +1,1 @@
+uid://dpvf0nun7ui7a

--- a/godot/tests/unit/test_office_walker_separation.gd
+++ b/godot/tests/unit/test_office_walker_separation.gd
@@ -1,0 +1,152 @@
+extends GutTest
+## Tier-1 collision, part 1: separation steering (boids-lite). Walkers softly
+## repel walkers so they stop rendering inside each other -- DETERMINISTIC (a
+## pure function of positions; no RNG in the separation path) -- while desk ring
+## slots stay intentional convergence points (the push fades to zero inside
+## SEPARATION_DAMP_RADIUS of the walker's current nav target, and STRENGTH is
+## deliberately below walk speed so separation can never block an arrival).
+## Pure view (ADR-0006): no game state anywhere.
+
+const EmployeeSpriteScript := preload("res://scripts/ui/office_floor/employee_sprite.gd")
+
+const DT := 0.05
+const OPEN_FLOOR_MIN_DIST := 20.0   # "not inside each other" floor for the open-floor case
+
+
+func _make_sprite() -> OfficeEmployeeSprite:
+	var spr: OfficeEmployeeSprite = EmployeeSpriteScript.new()
+	add_child_autofree(spr)
+	spr.bounds = Rect2(0, 0, 400, 300)
+	return spr
+
+
+# --- separation_vector: pure, deterministic ---------------------------------
+
+func test_no_neighbours_no_push():
+	assert_eq(OfficeEmployeeSprite.separation_vector(Vector2(50, 50), [], 30.0), Vector2.ZERO)
+
+
+func test_far_neighbour_no_push():
+	var v := OfficeEmployeeSprite.separation_vector(Vector2(50, 50), [Vector2(200, 50)], 30.0)
+	assert_eq(v, Vector2.ZERO, "neighbour outside the radius must not repel")
+
+
+func test_near_neighbour_pushes_away():
+	# Neighbour to the east -> push west (negative x), no vertical component.
+	var v := OfficeEmployeeSprite.separation_vector(Vector2(50, 50), [Vector2(60, 50)], 30.0)
+	assert_lt(v.x, 0.0, "push points away from the neighbour")
+	assert_almost_eq(v.y, 0.0, 0.0001)
+
+
+func test_closer_neighbour_pushes_harder():
+	var near := OfficeEmployeeSprite.separation_vector(Vector2(50, 50), [Vector2(55, 50)], 30.0)
+	var far := OfficeEmployeeSprite.separation_vector(Vector2(50, 50), [Vector2(75, 50)], 30.0)
+	assert_gt(near.length(), far.length(), "repulsion weight grows as distance shrinks")
+
+
+func test_magnitude_capped_at_one():
+	var crowd := [Vector2(51, 50), Vector2(52, 50), Vector2(50, 51), Vector2(50, 52), Vector2(49, 50)]
+	var v := OfficeEmployeeSprite.separation_vector(Vector2(50, 50), crowd, 30.0)
+	assert_true(v.length() <= 1.0001, "summed push is normalised, never explosive")
+
+
+func test_exactly_coincident_neighbour_contributes_nothing():
+	# No direction is derivable from positions alone; the intentional case
+	# (shared desk slots) is handled by arrival damping instead.
+	var v := OfficeEmployeeSprite.separation_vector(Vector2(50, 50), [Vector2(50, 50)], 30.0)
+	assert_eq(v, Vector2.ZERO)
+
+
+func test_separation_vector_is_deterministic():
+	var neighbors := [Vector2(60, 55), Vector2(45, 40)]
+	var a := OfficeEmployeeSprite.separation_vector(Vector2(50, 50), neighbors, 30.0)
+	var b := OfficeEmployeeSprite.separation_vector(Vector2(50, 50), neighbors, 30.0)
+	assert_eq(a, b, "pure function of positions -- same inputs, same push")
+
+
+# --- open floor: overlapping walkers separate to a minimum distance ----------
+
+func test_open_floor_overlapping_idlers_separate():
+	var a := _make_sprite()
+	var b := _make_sprite()
+	a.sprite_state = EmployeeFSM.STATE_IDLE   # holding position: full separation applies
+	b.sprite_state = EmployeeFSM.STATE_IDLE
+	a.position = Vector2(200, 150)
+	b.position = Vector2(206, 150)            # rendering inside each other
+	for _i in range(200):
+		# Mirror OfficeFloor._apply_separation: snapshot positions FIRST so the
+		# result is independent of update order.
+		var pa := a.position
+		var pb := b.position
+		a.apply_separation([pb], DT)
+		b.apply_separation([pa], DT)
+	assert_gt(a.position.distance_to(b.position), OPEN_FLOOR_MIN_DIST,
+		"idle walkers pushed apart to a readable min distance")
+
+
+func test_open_floor_separation_is_deterministic():
+	var results: Array = []
+	for _run in range(2):
+		var a := _make_sprite()
+		var b := _make_sprite()
+		a.sprite_state = EmployeeFSM.STATE_IDLE
+		b.sprite_state = EmployeeFSM.STATE_IDLE
+		a.position = Vector2(200, 150)
+		b.position = Vector2(210, 152)
+		for _i in range(100):
+			var pa := a.position
+			var pb := b.position
+			a.apply_separation([pb], DT)
+			b.apply_separation([pa], DT)
+		results.append([a.position, b.position])
+	assert_eq(results[0][0], results[1][0], "same start -> same end (no RNG in separation)")
+	assert_eq(results[0][1], results[1][1], "same start -> same end (no RNG in separation)")
+
+
+# --- separation must NOT fight arrival ---------------------------------------
+
+func test_worker_still_reaches_desk_past_a_neighbour():
+	var a := _make_sprite()
+	a.sprite_state = EmployeeFSM.STATE_WORKING
+	a._work_sub = "desk"
+	a._break_cooldown = 100000.0              # keep the break RNG out of this test
+	a.position = Vector2(100, 150)
+	a.desk_pos = Vector2(260, 150)
+	var blocker := Vector2(240, 150)          # parked walker near the approach
+	for _i in range(600):
+		a._process(DT)
+		a.apply_separation([blocker], DT)
+		a._break_cooldown = 100000.0
+	assert_true(a.is_at_desk(), "separation (strength < speed, damped near target) never blocks desk arrival")
+
+
+func test_ring_slot_neighbours_both_hold_their_desks():
+	# Two desks closer together than SEPARATION_RADIUS: the damp ramp (zero at
+	# the walker's own nav target) must let BOTH sit their slots without jitter.
+	var a := _make_sprite()
+	var b := _make_sprite()
+	a.sprite_state = EmployeeFSM.STATE_WORKING
+	b.sprite_state = EmployeeFSM.STATE_WORKING
+	a._work_sub = "desk"
+	b._work_sub = "desk"
+	a._break_cooldown = 100000.0
+	b._break_cooldown = 100000.0
+	a.desk_pos = Vector2(200, 150)
+	b.desk_pos = Vector2(212, 150)            # 12px apart < SEPARATION_RADIUS 30
+	a.position = Vector2(120, 140)
+	b.position = Vector2(300, 160)
+	for _i in range(600):
+		var pa := a.position
+		var pb := b.position
+		a._process(DT)
+		b._process(DT)
+		a.apply_separation([pb], DT)
+		b.apply_separation([pa], DT)
+		a._break_cooldown = 100000.0
+		b._break_cooldown = 100000.0
+	assert_true(a.is_at_desk(), "walker A seated at its ring slot")
+	assert_true(b.is_at_desk(), "walker B seated at the adjacent ring slot")
+	assert_true(a.position.distance_to(a.desk_pos) <= a.ARRIVE_EPS + 0.001,
+		"A parked ON its desk slot -- separation damped to zero at the target")
+	assert_true(b.position.distance_to(b.desk_pos) <= b.ARRIVE_EPS + 0.001,
+		"B parked ON its desk slot -- separation damped to zero at the target")

--- a/godot/tests/unit/test_office_walker_separation.gd.uid
+++ b/godot/tests/unit/test_office_walker_separation.gd.uid
@@ -1,0 +1,1 @@
+uid://dyqxouh0re3nr

--- a/godot/tests/unit/test_worker_variant_pool.gd
+++ b/godot/tests/unit/test_worker_variant_pool.gd
@@ -1,0 +1,113 @@
+extends GutTest
+## Worker appearance variant pool (#793 mechanism half). Art-agnostic registry:
+## data/office/worker_variants.json lists variant id -> SpriteFrames path;
+## appearance_id maps to a variant via a pure, stable function (posmod of int
+## id / stable String hash); a missing variant degrades to the floor's shared
+## fallback frames. Variant 0 is wired to the CURRENT shared asset, so today's
+## render is unchanged -- these tests lock the mechanism, not the art.
+
+const OfficeFloorScene := preload("res://scenes/ui/office_floor/office_floor.tscn")
+const SharedWorkerFrames := preload("res://assets/office_floor/artloop_char/office_worker.tres")
+
+
+func after_each():
+	WorkerVariantPool._reset_for_test()
+
+
+# --- the shipped manifest ----------------------------------------------------
+
+func test_manifest_loads_with_variant_zero_as_the_shared_asset():
+	assert_gt(WorkerVariantPool.count(), 0, "worker_variants.json lists at least one variant")
+	var f := WorkerVariantPool.frames_for(0)
+	assert_not_null(f, "variant 0 resolves")
+	assert_eq(f, SharedWorkerFrames,
+		"variant 0 IS the current shared office_worker.tres -- behaviour unchanged until new art is triaged in")
+	assert_true(f.has_animation("walking"), "resolved frames honour the clip contract")
+
+
+# --- pure, stable assignment -------------------------------------------------
+
+func test_int_appearance_ids_map_by_posmod():
+	assert_eq(WorkerVariantPool.variant_index_for(0, 3), 0)
+	assert_eq(WorkerVariantPool.variant_index_for(7, 3), 1)
+	assert_eq(WorkerVariantPool.variant_index_for(-1, 3), 2, "negative ids still land in range")
+
+
+func test_string_appearance_ids_are_stable_and_in_range():
+	for id in ["alice", "bob", "r_129", ""]:
+		var a := WorkerVariantPool.variant_index_for(String(id), 5)
+		var b := WorkerVariantPool.variant_index_for(String(id), 5)
+		assert_eq(a, b, "'%s': same appearance -> same variant, every call" % id)
+		assert_between(a, 0, 4, "'%s': index in range" % id)
+
+
+func test_empty_pool_returns_sentinel():
+	assert_eq(WorkerVariantPool.variant_index_for(3, 0), -1)
+
+
+func test_assignment_ignores_roster_order_and_size():
+	# The mapping depends ONLY on appearance_id + variant count -- re-querying in
+	# any order, interleaved with other ids, never changes an answer.
+	var expected := WorkerVariantPool.variant_index_for(11, 4)
+	for other in [99, 2, 57, 11, 0]:
+		WorkerVariantPool.variant_index_for(int(other), 4)
+	assert_eq(WorkerVariantPool.variant_index_for(11, 4), expected)
+
+
+# --- graceful fallback -------------------------------------------------------
+
+func test_missing_variant_art_resolves_null():
+	WorkerVariantPool._override_variants_for_test([
+		{"id": "ghost", "frames": "res://assets/does_not_exist.tres"},
+	])
+	assert_null(WorkerVariantPool.frames_for(0), "unloadable variant art -> null (caller falls back)")
+
+
+func test_floor_falls_back_to_shared_frames_when_variant_missing():
+	WorkerVariantPool._override_variants_for_test([
+		{"id": "ghost", "frames": "res://assets/does_not_exist.tres"},
+	])
+	var f: OfficeFloor = OfficeFloorScene.instantiate()
+	add_child_autofree(f)
+	await get_tree().process_frame
+	f.set_tier(1)
+	f.set_sprite_frames(SharedWorkerFrames)
+	f.set_roster([{"id": 0, "name": "A", "assigned": true, "appearance_id": 0}])
+	var spr: OfficeEmployeeSprite = f._sprites[0]
+	assert_eq(spr._anim.sprite_frames, SharedWorkerFrames,
+		"variant unresolved -> the shared fallback frames render")
+
+
+# --- OfficeFloor wiring ------------------------------------------------------
+
+func test_floor_applies_variant_frames_by_appearance_id():
+	var f: OfficeFloor = OfficeFloorScene.instantiate()
+	add_child_autofree(f)
+	await get_tree().process_frame
+	f.set_tier(1)
+	f.set_roster([{"id": 0, "name": "A", "assigned": true, "appearance_id": 3}])
+	var spr: OfficeEmployeeSprite = f._sprites[0]
+	assert_eq(spr._anim.sprite_frames, SharedWorkerFrames,
+		"pool ON by default: appearance maps to variant 0 == the shared asset (unchanged render)")
+
+
+func test_pool_off_applies_shared_frames_uniformly():
+	# The sandbox colour-skin path: bypassing the pool must let an explicit
+	# set_sprite_frames() win for every sprite, new and existing.
+	var f: OfficeFloor = OfficeFloorScene.instantiate()
+	add_child_autofree(f)
+	await get_tree().process_frame
+	f.set_tier(1)
+	f.set_roster([{"id": 0, "name": "A", "assigned": true, "appearance_id": 1}])
+	f.set_use_variant_pool(false)
+	var custom := SpriteFrames.new()
+	custom.add_animation("walking")
+	f.set_sprite_frames(custom)
+	var spr: OfficeEmployeeSprite = f._sprites[0]
+	assert_eq(spr._anim.sprite_frames, custom, "pool OFF -> the explicit shared frames apply")
+	f.set_roster([
+		{"id": 0, "name": "A", "assigned": true, "appearance_id": 1},
+		{"id": 1, "name": "B", "assigned": true, "appearance_id": 2},
+	])
+	var spr_b: OfficeEmployeeSprite = f._sprites[1]
+	assert_eq(spr_b._anim.sprite_frames, custom, "new sprites also get the shared frames while the pool is OFF")

--- a/godot/tests/unit/test_worker_variant_pool.gd.uid
+++ b/godot/tests/unit/test_worker_variant_pool.gd.uid
@@ -1,0 +1,1 @@
+uid://dtch3kj81oicf


### PR DESCRIPTION
## What

Office pass 2, all Pip-approved (2026-07-26). Three chunks on `godot/scripts/ui/office_floor/*`:

### 1. Tier-1 collision (so obvious failure modes stop rendering)
- **Separation steering (boids-lite):** walkers softly repel walkers within 30px. Deterministic by construction -- a pure function of positions (no RNG), applied over an order-independent position snapshot in `OfficeFloor._process`. Tuning: strength 40 px/s deliberately BELOW walk speed 42 (separation can deflect, never block an arrival); push ramps to zero within 28px of the walker's current nav target, so ring-slotted desk seating (intentional convergence) still works.
- **No-stand zones from prop footprints:** landmark-prop footprints (`PropCatalogue.footprint_tiles`, feet-anchored) + sandbox-placed props (via new additive hook `set_extra_blocked_rects`) become blocked rects. Stationary poses are pushed out, wander targets reroll, and destinations inside a prop (the water-cooler landmark IS the prop's feet) resolve to the nearest outside point so arrivals still trigger.
- **Tier-1 / tier-2 boundary (documented in-code):** mid-walk straight lines may still CROSS a prop transiently -- accepted for tier 1 (an ungated per-frame push-out would pin walkers against props on their path). Real path-around navigation is tier 2 and awaits the tile-grid ruling (WS-3).

### 2. #913 juice
- **Water-cooler bubbles:** subtle 3-frame procedural loop drawn over the jug (~2 fps, low alpha, no new art).
- **Sneaky 1.1x cats:** new shared `OfficeEmployeeSprite.CAT_TILE_RATIO = 0.55` (was inline 0.5); RealCat derives from it -- one constant moves every cat.
- **Butt-flash splice HOOK (art arrives later from the cat sweep):** when a SpriteFrames carries `<clip>_alt` (workers `walking_north_alt`, cats `walk_north_alt`), the walker plays the alt loop ONCE ~1-in-6 loops, deterministically (stable hash of entity id + loop count; phase-offset per entity, no RNG), then returns to the base clip. Alt plays from its start; the art carries the blend (cat_b2 MANIFEST: splice-window frames ~2-8). Sandbox cat loader also picks up optional `walk_<dir>_alt_<n>.png`.

### 3. Worker variant-pool mechanism (#793 mechanism half)
- `WorkerVariantPool` + `data/office/worker_variants.json`: variant id -> SpriteFrames path; `appearance_id` (finally read) maps via a pure stable posmod/hash; missing variant art degrades to the floor's shared fallback frames. **Variant 0 == the current shared `office_worker.tres`, so rendering is byte-for-byte unchanged** until round-2 workers are triaged in (no raw art_source wiring). Sandbox colour-skin previews bypass the pool (`set_use_variant_pool(false)`) so they stay uniform.

### Also
- Merged `origin/main` (#918/#920/#921 round-2 art + window promote verdicts); regenerated promote lists locally -- the sandbox offers the 5 promoted round-2 windows with no loader change (scummy windows on the SMALL/scummy floor, clean on LARGE/decent, per the existing tier bias).

## Tests

Fast gate green: **729 tests, 0 failures, 81/81 files** (`run_godot_tests.py --quick --ci-mode --min-tests 300`). 27 new tests across 4 files: separation min-distance + determinism + desk-arrival-not-prevented; no-idle-inside-footprint (+ floor wiring); alt-clip splice determinism with synthetic frames; variant assignment stability + fallback.

Refs #913, #793 (mechanism half). Collision framing: tier 1 of the plan discussed for #915/WS-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)