### PR TITLE
feat(office): pass 3 -- cat-worker avoidance, organic bubbles, water-cooler approach slots

### DIFF
--- a/docs/art/PROP_MANIFEST.md
+++ b/docs/art/PROP_MANIFEST.md
@@ -27,6 +27,7 @@ footprint, height) so a renderer can size and place each prop on its own terms.
 | `subject_px` | opaque-subject (alpha bbox) size `[w, h]` |
 | `anchor_px` | feet anchor in canvas coords: bottom-centre of the opaque bbox (x may be `.5`; y = exclusive bbox bottom, the baseline row) |
 | `footprint_tiles` | floor tiles occupied `[w, h]` at the 32 px art-tile scale (floor art is 32 px, displayed at 64 px); depth is judgement -- front-view art has none |
+| `approach_px` | v1.2, OPTIONAL: list of `[x, y]` approach-slot offsets from `anchor_px`, in source px (`+x` right, `+y` down = in front). Landmark destination resolution (`office_floor.gd` `approach_point_for`) prefers the first FREE slot, so walkers queue at a prop's sides instead of stacking in front of it (`water_cooler` populates left/right). Omit it and resolution falls back to the nearest-outside-footprint point unchanged |
 | `height_tiles` | subject height / 32, rounded to nearest 0.25 (ties up) |
 | `style_tags` | office quality tiers this art serves, from the canonical ladder `"scummy"` / `"decent"` / `"premium"` (ruled 2026-07-26; `docs/game-design/SEED_ASSET_REGISTRY_AND_VERDICTS.md`). Tier-variant art uses id convention `<base_id>_<tier>`; where a variant is missing, renderers show the decent art unchanged (no tinting) |
 | `sockets` | ALWAYS `[]` for now -- schema placeholder, see below |
@@ -56,6 +57,10 @@ footprint, height) so a renderer can size and place each prop on its own terms.
   `_draw_prop`; sandbox sprites get `centered = false, offset = -anchor_px`.)
 - The sandbox uses `footprint_tiles` for placement occupancy: a manifested prop
   marks its footprint cells so populate furniture will not overlap it.
+- `approach_px` (v1.2, office pass 3) drives landmark-visit destinations:
+  `OfficeFloor.approach_point_for()` hands a walker the first free slot
+  (occupied = someone standing within 10 px of it, or navigating to it);
+  props without the field keep the plain nearest-outside-footprint fallback.
 - `style_tags` drive tier selection: `office_floor.set_office_style(tier)` picks
   a `<id>_<tier>` variant when manifested + tagged for the tier; otherwise the
   decent art draws unchanged. The sandbox prop pool filters manifested assets by

--- a/godot/data/office/props_manifest.json
+++ b/godot/data/office/props_manifest.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "version": "1.1",
+    "version": "1.2",
     "description": "Per-asset metadata for office floor props. Consumed by office_floor.gd / office_sandbox.gd (integrated 2026-07-26): manifested props render at authored proportions, feet-anchored at anchor_px, and occupy footprint_tiles. Loaded by scripts/core/prop_catalogue.gd. Measurements taken from the real PNGs (alpha bounding box) -- see docs/art/PROP_MANIFEST.md for how to add a prop.",
     "measured_with": "python PIL alpha-channel getbbox(), 2026-07-26"
   },
@@ -10,6 +10,7 @@
     "subject_px": "[w, h] opaque-subject bounding box size in pixels (alpha bbox).",
     "anchor_px": "[x, y] feet anchor in CANVAS coordinates: bottom-centre of the opaque bbox. x may be a .5 half-pixel for even-width subjects; y is the exclusive bottom of the opaque bbox (the baseline row the feet sit on).",
     "footprint_tiles": "[w, h] floor tiles occupied for placement/collision, at the 32px art-tile scale (floor tile art is 32px, displayed at 64px). h (depth) is a judgement call -- front-view art carries no depth information.",
+    "approach_px": "v1.2, OPTIONAL: list of [x, y] approach-slot offsets from anchor_px, in SOURCE px (+x right, +y down = in front). Landmark destination resolution (office_floor.gd approach_point_for) prefers the first FREE slot over the raw landmark point, so walkers stand at a prop's sides instead of stacking in front of it. Slots are tried in authored order (deterministic). Omit for props without preferred approach spots -- resolution then falls back to the nearest-outside-footprint point unchanged.",
     "height_tiles": "subject height / 32, rounded to the nearest 0.25 (ties round up).",
     "style_tags": "office quality tiers this art serves, from the canonical ladder [\"scummy\", \"decent\", \"premium\"] (ruled 2026-07-26; see docs/game-design/SEED_ASSET_REGISTRY_AND_VERDICTS.md). Tag only the tiers the art was AUTHORED for. Renderers fall back to the decent art unchanged where a tier-variant is missing (no tinting hacks). Tier-variant entries use the id convention <base_id>_<tier>, e.g. water_cooler_scummy.",
     "sockets": "SCHEMA PLACEHOLDER, always [] for now. Future attachment points for cosmetics/paper-doll layers. Each socket will be {\"name\": String, \"px\": [x, y] canvas coords, \"layer\": \"front\"|\"behind\" draw order relative to the prop}. No consumer exists yet -- do not populate until one does.",
@@ -47,11 +48,12 @@
       "subject_px": [37, 109],
       "anchor_px": [31.5, 114],
       "footprint_tiles": [1, 1],
+      "approach_px": [[-26, 2], [26, 2]],
       "height_tiles": 3.5,
       "style_tags": ["decent"],
       "sockets": [],
       "review": true,
-      "notes": "Tier inferred as decent (no tier-variant art exists); Pip to confirm in the next review sweep. Footprint confident (37px subject fits one 32px tile)."
+      "notes": "Tier inferred as decent (no tier-variant art exists); Pip to confirm in the next review sweep. Footprint confident (37px subject fits one 32px tile). approach_px: left/right side slots ~26 source px (~1.4x subject half-width) from the anchor, 2px front-biased -- walkers queue at the cooler's sides instead of standing in front (Pip, 2026-07-26)."
     }
   }
 }

--- a/godot/scripts/core/prop_catalogue.gd
+++ b/godot/scripts/core/prop_catalogue.gd
@@ -120,6 +120,22 @@ static func art_path(id: String) -> String:
 	return String(_defs[id].get("art", ""))
 
 
+static func approach_points(id: String) -> Array:
+	"""Approach-slot offsets from anchor_px, in SOURCE px (manifest v1.2
+	`approach_px`), as an Array of Vector2 in authored order. Empty for props
+	without slots or unmanifested ids -- callers then keep the plain
+	nearest-outside-footprint destination (pass-2 behaviour unchanged)."""
+	_ensure_loaded()
+	var out: Array = []
+	if not _defs.has(id):
+		_warn_once(id)
+		return out
+	for p in _defs[id].get("approach_px", []):
+		if p is Array and p.size() == 2:
+			out.append(Vector2(float(p[0]), float(p[1])))
+	return out
+
+
 static func style_tags(id: String) -> Array[String]:
 	"""Office quality tiers this art serves, from the canonical ladder
 	scummy/decent/premium (ruled 2026-07-26). Empty for unmanifested ids."""

--- a/godot/scripts/ui/office_floor/employee_sprite.gd
+++ b/godot/scripts/ui/office_floor/employee_sprite.gd
@@ -481,14 +481,19 @@ static func inside_any_rect(p: Vector2, rects: Array) -> bool:
 ## only, no RNG. Exactly-coincident neighbours contribute nothing (no direction
 ## is derivable from positions alone); the intentional case -- shared desk slots --
 ## is handled by the arrival damping instead. Result magnitude is capped at 1.
-static func separation_vector(pos: Vector2, neighbors: Array, radius: float = SEPARATION_RADIUS) -> Vector2:
+## Pass 3: optional per-neighbour `weights` (index-aligned with `neighbors`;
+## missing entries default to 1.0) scale each neighbour's contribution BEFORE
+## the cap -- OfficeFloor uses this for the asymmetric cat-worker avoidance
+## (a worker barely deflects for a cat; a cat yields readily to a worker).
+static func separation_vector(pos: Vector2, neighbors: Array, radius: float = SEPARATION_RADIUS, weights: Array = []) -> Vector2:
 	var out := Vector2.ZERO
-	for n in neighbors:
-		var d: Vector2 = pos - (n as Vector2)
+	for i in range(neighbors.size()):
+		var d: Vector2 = pos - (neighbors[i] as Vector2)
 		var dist := d.length()
 		if dist >= radius or dist <= 0.0001:
 			continue
-		out += (d / dist) * (1.0 - dist / radius)
+		var w := float(weights[i]) if i < weights.size() else 1.0
+		out += (d / dist) * (1.0 - dist / radius) * w
 	if out.length() > 1.0:
 		out = out.normalized()
 	return out
@@ -521,11 +526,13 @@ func current_destination() -> Variant:
 			return null           # idle / stressed hold position
 
 ## Apply one frame of separation steering away from `neighbor_positions`
-## (positions of the OTHER walkers, snapshotted by OfficeFloor so update order
-## cannot matter). Push fades to zero within SEPARATION_DAMP_RADIUS of the
-## current nav target -- separation must not fight arrival.
-func apply_separation(neighbor_positions: Array, delta: float) -> void:
-	var sep := separation_vector(position, neighbor_positions, SEPARATION_RADIUS)
+## (positions of the OTHER walkers/cats, snapshotted by OfficeFloor so update
+## order cannot matter). Push fades to zero within SEPARATION_DAMP_RADIUS of the
+## current nav target -- separation must not fight arrival. Optional `weights`
+## (pass 3) index-align with `neighbor_positions`: cats push workers at a
+## reduced weight so a worker only shoulder-turns for a cat.
+func apply_separation(neighbor_positions: Array, delta: float, weights: Array = []) -> void:
+	var sep := separation_vector(position, neighbor_positions, SEPARATION_RADIUS, weights)
 	if sep == Vector2.ZERO:
 		return
 	var damp := 1.0
@@ -616,18 +623,31 @@ func _process_working(delta: float) -> void:
 				_break_cooldown = _rng.randf_range(BREAK_COOLDOWN_RANGE.x, BREAK_COOLDOWN_RANGE.y)
 
 func _start_break() -> void:
-	# get-food -> fridge or water cooler; or pat the cat.
+	# get-food -> fridge or water cooler; or pat the cat. Landmark targets route
+	# through the floor's approach-slot resolution (pass 3): a prop declaring
+	# manifest `approach_px` slots hands out a free side slot; everything else
+	# comes back unchanged (pass-2 nearest-outside-footprint behaviour).
 	match _rng.randi() % 3:
 		0:
 			_break_kind = "fridge"
-			_break_target = fridge_pos
+			_break_target = _landmark_break_target(fridge_pos)
 		1:
 			_break_kind = "water"
-			_break_target = water_pos
+			_break_target = _landmark_break_target(water_pos)
 		_:
 			_break_kind = "cat"
-			_break_target = cat_pos
+			_break_target = _landmark_break_target(cat_pos)
 	_work_sub = "to_break"
+
+## Pass-3 approach slots: ask the owning floor (duck-typed -- sprites also run
+## detached in unit tests) to resolve a landmark point to a free approach slot.
+## Falls back to the raw landmark point when there is no floor above us or the
+## landmark's prop declares no slots -- identical to the pass-2 behaviour.
+func _landmark_break_target(landmark: Vector2) -> Vector2:
+	var par := get_parent()
+	if par != null and par.has_method("approach_point_for"):
+		return par.approach_point_for(landmark, entity_id)
+	return landmark
 
 ## True when this employee is working AND parked at its own desk (available to
 ## be pulled into a collaboration). Read-only.

--- a/godot/scripts/ui/office_floor/office_floor.gd
+++ b/godot/scripts/ui/office_floor/office_floor.gd
@@ -16,7 +16,13 @@ class_name OfficeFloor
 ##   set_sprite_frames(frames)     # optional: FALLBACK shared art for Tier 1
 ##   set_use_variant_pool(on)      # per-worker appearance variants (WorkerVariantPool); default ON
 ##   set_extra_blocked_rects(a)    # additive dev hook: extra no-stand prop footprints (sandbox)
+##   approach_point_for(landmark, requester_id) -> Vector2  # pass 3: free approach slot, or landmark unchanged
 ##   OfficeFloor.snapshot_from_state(state) -> Array   # static, read-only GameState adapter
+##
+## Cats (pass 3): any Node2D child in group CAT_GROUP ("office_floor_cats")
+## joins the separation pass -- cats and workers avoid each other with the
+## asymmetric weights below. The sandbox cats register themselves; a future
+## live cat only needs add_to_group(OfficeFloor.CAT_GROUP).
 ##
 ## Employee snapshot dict fields (ALL optional; unknown fields ignored; see
 ## EmployeeFSM for the state mapping and graceful-degrade rules):
@@ -74,11 +80,44 @@ const HAT_COLOR := Color(0.14, 0.14, 0.18)
 const COLLAB_CHECK_RANGE := Vector2(2.5, 5.0)   # seconds between collaboration attempts
 const COLLAB_START_CHANCE := 0.5                # chance to actually pair when eligible
 
-# #913 water-cooler bubbles: tiny procedural 3-frame loop drawn over the jug
-# (no new art). ~2 fps and low alpha so it reads as ambient life, not a beacon.
+# --- Pass 3: cat-worker mutual avoidance -------------------------------------
+# Cats and workers repel each other through the SAME deterministic separation
+# pass as worker-worker (positions only, order-independent snapshot, no RNG).
+# Cats participate by group membership: any Node2D child of the floor in
+# CAT_GROUP is steered directly by the floor each frame.
+# ASYMMETRIC weights (a weight scales how hard THAT neighbour pushes THIS mover):
+#   WORKER_FOR_CAT 0.25 -- a worker barely deflects for a cat: max push
+#     0.25 * SEPARATION_STRENGTH(40) = 10 px/s vs walk speed 42 -- a visible
+#     shoulder-turn that can never stall an arrival.
+#   CAT_FOR_WORKER 1.6 -- a cat yields readily: 1.6 * 40 = 64 px/s exceeds the
+#     cat wander speed (30), so the worker's personal space wins and the cat
+#     detours around instead of clipping through.
+#   CAT_FOR_CAT 1.0 -- cats keep out of each other at the plain worker weight.
+const CAT_GROUP := "office_floor_cats"
+const SEP_WEIGHT_WORKER_FOR_CAT := 0.25
+const SEP_WEIGHT_CAT_FOR_WORKER := 1.6
+const SEP_WEIGHT_CAT_FOR_CAT := 1.0
+
+# #913 water-cooler bubbles -> pass-3 ORGANIC bursts (Pip 2026-07-26: "make
+# them way more intermittent and seemingly-random -- if you have 2 firing on
+# slightly off-kilter timers, it seems organic."). Bubble EVENTS are sparse:
+# each of TWO independent emitters fires one short BUBBLE_FRAMES-frame rise per
+# period, then stays quiet.
+# NO-COMMON-MULTIPLE PRINCIPLE (copy this pattern for future ambient juice):
+# the two base periods 7.3 s and 11.9 s are incommensurate -- they share no
+# short common multiple (the joint pattern realigns only every
+# 7.3 * 11.9 ~= 86.9 s), so the combined burst rhythm never visibly repeats
+# inside a sitting. Each emitter also gets a DETERMINISTIC per-prop phase
+# offset hashed from the prop's position (ADR-0006: cosmetic yet reproducible,
+# no RNG draws), so two coolers on screen would not fire in sync either.
 const BUBBLE_FRAMES := 3
-const BUBBLE_FRAME_TIME := 0.5                  # seconds per frame
+const BUBBLE_FRAME_TIME := 0.35                 # burst = 3 * 0.35 ~= 1 s of rise
+const BUBBLE_EMITTER_PERIODS: Array[float] = [7.3, 11.9]
 const BUBBLE_COLOR := Color(0.85, 0.95, 1.0, 0.38)
+
+# Pass 3 approach slots (prop manifest v1.2 `approach_px`): a slot is taken
+# when another sprite stands within this radius of it (or is navigating to it).
+const APPROACH_SLOT_CLAIM_RADIUS := 10.0
 
 var _sprites: Dictionary = {}   # id -> OfficeEmployeeSprite
 var _shared_frames: SpriteFrames = null   # FALLBACK art shared across sprites
@@ -93,8 +132,13 @@ var _appearance: Dictionary = {}          # sprite id -> appearance_id (for reap
 # footprints (PropCatalogue) + any extra rects a host supplies (sandbox props).
 var _blocked_rects: Array = []
 var _extra_blocked_rects: Array = []
-var _bubble_frame := 0
-var _bubble_t := 0.0
+# Landmark props on this floor: [{id, feet}] -- rebuilt with the blocked rects;
+# feeds the pass-3 approach-slot resolution (approach_point_for).
+var _landmark_props: Array = []
+# Pass-3 organic bubbles: one monotonic clock; per-emitter last-drawn frame so
+# _tick_bubbles only redraws on an actual frame transition.
+var _bubble_clock := 0.0
+var _bubble_frames_drawn: Array = [-1, -1]
 var _rng := RandomNumberGenerator.new()   # cosmetic-only (collaboration timing); NOT the game RNG
 var _collab_timer := 0.0
 var _floor_tile: Texture2D = null   # base concrete tile cropped from the Wang atlas (cosmetic)
@@ -128,30 +172,90 @@ func _process(delta: float) -> void:
 	_apply_separation(delta)
 	_tick_bubbles(delta)
 
-# Tier-1 collision: one separation pass per frame. Positions are SNAPSHOTTED
-# before any sprite moves, so the result is independent of iteration order --
-# fully deterministic from positions alone (no RNG; see EmployeeSprite).
-# O(n^2) is fine at the 1..24-walker scale this floor is scoped to.
+# Tier-1 collision: one separation pass per frame over workers AND cats
+# (pass 3). Positions are SNAPSHOTTED before anything moves, so the result is
+# independent of iteration order -- fully deterministic from positions alone
+# (no RNG; see EmployeeSprite). Workers get the full damped treatment
+# (apply_separation); cats -- plain Node2D wanderers with no floor-known nav
+# target -- are displaced directly and clamped into the bounds. O(n^2) is fine
+# at the 1..24-walker + few-cats scale this floor is scoped to.
 func _apply_separation(delta: float) -> void:
-	if _sprites.size() < 2:
-		return
 	var ids := _sprites.keys()
+	var cats := _cat_nodes()
+	var n := ids.size() + cats.size()
+	if n < 2:
+		return
+	# Snapshot: workers first (roster order), then cats (child order).
 	var pts: Array = []
+	var is_cat: Array = []
 	for id in ids:
 		pts.append((_sprites[id] as Node2D).position)
-	for i in range(ids.size()):
+		is_cat.append(false)
+	for c in cats:
+		pts.append((c as Node2D).position)
+		is_cat.append(true)
+	for i in range(n):
 		var others: Array = []
-		for j in range(ids.size()):
-			if j != i:
-				others.append(pts[j])
-		(_sprites[ids[i]] as OfficeEmployeeSprite).apply_separation(others, delta)
+		var weights: Array = []
+		for j in range(n):
+			if j == i:
+				continue
+			others.append(pts[j])
+			if is_cat[i]:
+				weights.append(SEP_WEIGHT_CAT_FOR_CAT if is_cat[j] else SEP_WEIGHT_CAT_FOR_WORKER)
+			else:
+				weights.append(SEP_WEIGHT_WORKER_FOR_CAT if is_cat[j] else 1.0)
+		if is_cat[i]:
+			var cat := cats[i - ids.size()] as Node2D
+			var sep := OfficeEmployeeSprite.separation_vector(
+				pts[i], others, OfficeEmployeeSprite.SEPARATION_RADIUS, weights)
+			if sep != Vector2.ZERO:
+				var b := _bounds()
+				cat.position = (cat.position
+					+ sep * OfficeEmployeeSprite.SEPARATION_STRENGTH * delta).clamp(b.position, b.end)
+		else:
+			(_sprites[ids[i]] as OfficeEmployeeSprite).apply_separation(others, delta, weights)
 
+## Node2D children registered as cats (CAT_GROUP). Child order -- deterministic.
+func _cat_nodes() -> Array:
+	var out: Array = []
+	for c in get_children():
+		if c is Node2D and (c as Node).is_in_group(CAT_GROUP):
+			out.append(c)
+	return out
+
+# Pass-3 organic bubbles: advance the emitter clock; redraw only when an
+# emitter's burst frame actually changes (sparse events, not a constant loop).
 func _tick_bubbles(delta: float) -> void:
-	_bubble_t += delta
-	if _bubble_t >= BUBBLE_FRAME_TIME:
-		_bubble_t = fmod(_bubble_t, BUBBLE_FRAME_TIME)
-		_bubble_frame = (_bubble_frame + 1) % BUBBLE_FRAMES
+	_bubble_clock += delta
+	var feet: Vector2 = _zones(_bounds())["water_pos"]
+	var changed := false
+	for i in range(BUBBLE_EMITTER_PERIODS.size()):
+		var f := bubble_frame_at(_bubble_clock, BUBBLE_EMITTER_PERIODS[i],
+			bubble_phase_for(feet, BUBBLE_EMITTER_PERIODS[i], i))
+		if f != int(_bubble_frames_drawn[i]):
+			_bubble_frames_drawn[i] = f
+			changed = true
+	if changed:
 		queue_redraw()
+
+## Deterministic per-prop phase for bubble emitter `emitter_idx` at prop feet
+## `pos`: a pure hash of the (whole-pixel) position -- NO RNG draws (ADR-0006).
+## The same cooler in the same spot always fires on the same schedule; a second
+## cooler elsewhere desyncs automatically. Result is in [0, period).
+static func bubble_phase_for(pos: Vector2, period: float, emitter_idx: int = 0) -> float:
+	var h := ("bubbles|%d|%.0f,%.0f" % [emitter_idx, pos.x, pos.y]).hash()
+	return float(posmod(h, 1000)) / 1000.0 * period
+
+## Pure emitter clock -> burst frame. Returns -1 while the emitter is quiet, or
+## 0..BUBBLE_FRAMES-1 during the one short rise it fires per period. A pure
+## function of time (no state, no RNG) -- deterministic and unit-testable.
+static func bubble_frame_at(t: float, period: float, phase: float) -> int:
+	if period <= 0.0:
+		return -1
+	var local := fposmod(t + phase, period)
+	var idx := int(local / BUBBLE_FRAME_TIME)
+	return idx if idx < BUBBLE_FRAMES else -1
 
 func _maybe_start_collaboration() -> void:
 	var available: Array = []
@@ -319,16 +423,79 @@ func blocked_rects() -> Array:
 	return _blocked_rects.duplicate()
 
 # Landmark props whose PropCatalogue footprints become no-stand rects. The cat
-# corner and window strip stay procedural (no prop, nothing to block).
+# corner and window strip stay procedural (no prop, nothing to block). Also
+# records the id+feet of each landmark prop for approach-slot resolution.
 func _rebuild_blocked_rects() -> void:
 	_blocked_rects = []
+	_landmark_props = []
 	var b := _bounds()
 	var z := _zones(b)
-	_blocked_rects.append(_footprint_rect("water_cooler", z["water_pos"]))
-	_blocked_rects.append(_footprint_rect("filing_cabinet", z["fridge_pos"]))
-	_blocked_rects.append(_footprint_rect("server_cluster",
-		b.position + Vector2(b.size.x * 0.12, b.size.y * 0.18)))
+	_add_landmark_prop("water_cooler", z["water_pos"])
+	_add_landmark_prop("filing_cabinet", z["fridge_pos"])
+	_add_landmark_prop("server_cluster",
+		b.position + Vector2(b.size.x * 0.12, b.size.y * 0.18))
 	_blocked_rects.append_array(_extra_blocked_rects)
+
+func _add_landmark_prop(id: String, feet: Vector2) -> void:
+	_blocked_rects.append(_footprint_rect(id, feet))
+	_landmark_props.append({"id": id, "feet": feet})
+
+# --- Pass 3: prop approach slots ---------------------------------------------
+# Prop manifest v1.2: a prop may declare `approach_px` -- preferred standing
+# spots as offsets from its feet anchor, in SOURCE px. Landmark destinations
+# resolve to the first FREE slot, so walkers stand at the water cooler's SIDES
+# instead of stacking "slightly in front" of it (Pip, 2026-07-26). Props
+# without slots keep the pass-2 behaviour EXACTLY: the raw landmark point,
+# which the sprite's nearest-outside-footprint clamp then resolves.
+
+## Resolve a landmark feet-point into a standing spot for `requester_id`.
+## Deterministic: slots are tried in authored (manifest) order; a slot is free
+## when no OTHER sprite stands within APPROACH_SLOT_CLAIM_RADIUS of it or is
+## currently navigating to it. All busy -> the first slot (walkers share).
+## Landmarks without slot data return unchanged (fallback identical to pass 2).
+func approach_point_for(landmark: Vector2, requester_id: String = "") -> Vector2:
+	var slots := _approach_slots_at(landmark)
+	if slots.is_empty():
+		return landmark
+	for s in slots:
+		if _slot_free(s, requester_id):
+			return s
+	return slots[0]
+
+# Display-space approach slots of the landmark prop whose feet sit at
+# `landmark` (empty when no prop is there or it declares none). Offsets scale
+# by the same subject-height factor _draw_prop renders with, so the slots
+# track the drawn art.
+func _approach_slots_at(landmark: Vector2) -> Array:
+	for lp in _landmark_props:
+		if (lp["feet"] as Vector2).distance_to(landmark) > 0.5:
+			continue
+		var id := String(lp["id"])
+		var offs := PropCatalogue.approach_points(id)
+		if offs.is_empty():
+			return []
+		var subj: Array = PropCatalogue.get_entry(id).get("subject_px", [])
+		var subject_h := float(subj[1]) if subj.size() == 2 else 0.0
+		if subject_h <= 0.0:
+			return []
+		var scl := PropCatalogue.height_px(id, DISPLAY_TILE_PX) / subject_h
+		var out: Array = []
+		for o in offs:
+			out.append(landmark + (o as Vector2) * scl)
+		return out
+	return []
+
+func _slot_free(slot: Vector2, requester_id: String) -> bool:
+	for id in _sprites:
+		if str(id) == requester_id:
+			continue
+		var spr: OfficeEmployeeSprite = _sprites[id]
+		if spr.position.distance_to(slot) < APPROACH_SLOT_CLAIM_RADIUS:
+			return false
+		var dest = spr.current_destination()
+		if dest != null and (dest as Vector2).distance_to(slot) < 1.0:
+			return false
+	return true
 
 # Floor area a feet-anchored prop occupies: footprint_tiles wide, extending UP
 # from the feet point (same convention as the sandbox occupancy pass, #907).
@@ -488,19 +655,26 @@ func _draw() -> void:
 	_draw_landmark_prop("server_cluster", PROP_SERVER,
 		b.position + Vector2(b.size.x * 0.12, b.size.y * 0.18))                     # top-left decor
 
-# #913: subtle 3-frame procedural bubble loop over the water-cooler jug (drawn,
-# no art). Two bubbles rise a step per frame inside the jug (the top ~third of
-# the manifest-scaled prop); the second lags a frame so the loop reads organic.
+# Pass-3 organic bubbles (#913 evolved): draw whichever emitters are mid-burst
+# right now. Two emitters on incommensurate timers (constants above) each rise
+# one bubble through the jug (the top ~third of the manifest-scaled prop) over
+# a short 3-frame burst; between bursts the jug is still. Pure function of the
+# emitter clock -- sparse, never visibly repeating, no RNG.
 func _draw_water_bubbles(feet: Vector2) -> void:
 	var h := PropCatalogue.height_px("water_cooler", DISPLAY_TILE_PX)
 	if h <= 0.0:
 		return
 	var rise := h * 0.05                                   # px climbed per frame
 	var base_y := feet.y - h * 0.72                        # bottom of the jug water line
-	var y_a := base_y - float(_bubble_frame) * rise
-	var y_b := base_y - float((_bubble_frame + BUBBLE_FRAMES - 1) % BUBBLE_FRAMES) * rise
-	draw_circle(Vector2(feet.x - h * 0.02, y_a), 1.6, BUBBLE_COLOR)
-	draw_circle(Vector2(feet.x + h * 0.025, y_b + h * 0.03), 1.1, BUBBLE_COLOR)
+	# Emitter 0 sits slightly left and larger; emitter 1 right and smaller.
+	var xs: Array = [feet.x - h * 0.02, feet.x + h * 0.025]
+	var radii: Array = [1.6, 1.1]
+	for i in range(BUBBLE_EMITTER_PERIODS.size()):
+		var f := bubble_frame_at(_bubble_clock, BUBBLE_EMITTER_PERIODS[i],
+			bubble_phase_for(feet, BUBBLE_EMITTER_PERIODS[i], i))
+		if f < 0:
+			continue
+		draw_circle(Vector2(float(xs[i]), base_y - float(f) * rise), float(radii[i]), BUBBLE_COLOR)
 
 # ---------------------------------------------------------------------------
 # READ-ONLY GameState adapter. Static so callers can build a snapshot without

--- a/godot/scripts/ui/office_floor/office_sandbox.gd
+++ b/godot/scripts/ui/office_floor/office_sandbox.gd
@@ -1842,6 +1842,10 @@ class SandboxCatBase extends Node2D:
 		_rng.randomize()
 		_target = position
 		z_index = 5
+		# Pass 3 cat-worker avoidance: registering in the floor's cat group opts
+		# this cat into OfficeFloor's deterministic separation pass (workers
+		# barely deflect for cats; cats yield more -- see office_floor.gd).
+		add_to_group(OfficeFloor.CAT_GROUP)
 		texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 		_glow = Sprite2D.new()
 		_glow.texture = _get_glow_tex()

--- a/godot/tests/unit/test_office_bubble_emitters.gd
+++ b/godot/tests/unit/test_office_bubble_emitters.gd
@@ -1,0 +1,116 @@
+extends GutTest
+## Pass-3 organic water-cooler bubbles (Pip 2026-07-26: "make them way more
+## intermittent and seemingly-random -- if you have 2 firing on slightly
+## off-kilter timers, it seems organic."). Two independent emitters with
+## INCOMMENSURATE base periods (7.3 s / 11.9 s: no short common multiple) each
+## fire one short 3-frame rise per period; a deterministic per-prop phase
+## (hash of the prop position -- ADR-0006, no RNG draws) offsets each emitter.
+## These tests pin: purity/determinism of the emitter math, sparseness (events,
+## not a constant loop), and NO-SHORT-PERIOD REPETITION -- the combined burst
+## signal must not repeat with any period <= the longest single period.
+
+const FEET := Vector2(317, 37)   # a representative water-cooler feet point
+
+
+func _phases() -> Array:
+	var out: Array = []
+	for i in range(OfficeFloor.BUBBLE_EMITTER_PERIODS.size()):
+		out.append(OfficeFloor.bubble_phase_for(FEET, OfficeFloor.BUBBLE_EMITTER_PERIODS[i], i))
+	return out
+
+
+# Combined signal: is ANY emitter mid-burst at time t?
+func _active(t: float, phases: Array) -> bool:
+	for i in range(OfficeFloor.BUBBLE_EMITTER_PERIODS.size()):
+		if OfficeFloor.bubble_frame_at(t, OfficeFloor.BUBBLE_EMITTER_PERIODS[i], phases[i]) >= 0:
+			return true
+	return false
+
+
+func test_two_emitters_with_incommensurate_periods():
+	var p: Array = OfficeFloor.BUBBLE_EMITTER_PERIODS
+	assert_eq(p.size(), 2, "the desync trick needs exactly two off-kilter timers")
+	assert_ne(p[0], p[1])
+	# Tripwire for future edits: neither period may (near-)divide the other --
+	# a clean ratio would give the combined pattern a short visible loop.
+	var remainder := fposmod(maxf(p[0], p[1]), minf(p[0], p[1]))
+	assert_gt(remainder, 0.5, "long period is not a near-multiple of the short one")
+	assert_lt(remainder, minf(p[0], p[1]) - 0.5,
+		"nor one step short of the next multiple (which would also near-align)")
+
+
+func test_phase_is_deterministic_and_in_range():
+	for i in range(2):
+		var period: float = OfficeFloor.BUBBLE_EMITTER_PERIODS[i]
+		var a := OfficeFloor.bubble_phase_for(FEET, period, i)
+		var b := OfficeFloor.bubble_phase_for(FEET, period, i)
+		assert_eq(a, b, "same prop position + emitter -> same phase (pure hash, no RNG)")
+		assert_between(a, 0.0, period, "phase lies inside one period")
+	assert_ne(
+		OfficeFloor.bubble_phase_for(FEET, 7.3, 0),
+		OfficeFloor.bubble_phase_for(FEET + Vector2(50, 10), 7.3, 0),
+		"a cooler in a different spot fires on a different schedule")
+
+
+func test_frame_at_is_pure_and_walks_the_short_rise():
+	var period := 7.3
+	var phase := 0.0
+	assert_eq(OfficeFloor.bubble_frame_at(1.0, period, phase),
+		OfficeFloor.bubble_frame_at(1.0, period, phase), "pure function of time")
+	# From the burst start the frames rise 0 -> 1 -> 2, then the emitter is quiet
+	# for the rest of the period (an EVENT, not a loop).
+	var ft := OfficeFloor.BUBBLE_FRAME_TIME
+	assert_eq(OfficeFloor.bubble_frame_at(0.5 * ft, period, phase), 0)
+	assert_eq(OfficeFloor.bubble_frame_at(1.5 * ft, period, phase), 1)
+	assert_eq(OfficeFloor.bubble_frame_at(2.5 * ft, period, phase), 2)
+	assert_eq(OfficeFloor.bubble_frame_at(3.5 * ft, period, phase), -1, "burst over -> quiet")
+	assert_eq(OfficeFloor.bubble_frame_at(period * 0.6, period, phase), -1, "mid-period silence")
+	assert_eq(OfficeFloor.bubble_frame_at(period + 0.5 * ft, period, phase), 0,
+		"next period fires the next burst")
+
+
+func test_bursts_are_sparse_events():
+	# Over 60 s the combined signal is mostly OFF (sparse events), yet both
+	# emitters actually fire: expect ~8 bursts from the 7.3 s emitter and ~5
+	# from the 11.9 s one, each ~1 s long -> active fraction well under 0.4.
+	var phases := _phases()
+	var dt := 0.05
+	var steps := int(60.0 / dt)
+	var active_n := 0
+	var rising_edges := 0
+	var prev := false
+	for n in range(steps):
+		var a := _active(n * dt, phases)
+		if a:
+			active_n += 1
+		if a and not prev:
+			rising_edges += 1
+		prev = a
+	var frac := float(active_n) / float(steps)
+	assert_between(frac, 0.05, 0.4, "sparse: quiet most of the time, but alive")
+	assert_between(rising_edges, 7, 15, "roughly 60/7.3 + 60/11.9 ~= 13 bursts (+/- overlap merges)")
+
+
+func test_combined_sequence_has_no_short_period():
+	# THE organic guarantee: sample the combined burst signal on a 0.1 s grid
+	# over 60 s and assert NO shift <= max(single periods) reproduces it. The
+	# 7.3 s emitter alone repeats at 7.3 s and the 11.9 s emitter at 11.9 s, but
+	# their SUM only realigns at 7.3 * 11.9 ~= 86.9 s -- so every candidate
+	# period up to 11.9 s must mismatch somewhere in the window.
+	var phases := _phases()
+	var dt := 0.1
+	var steps := int(60.0 / dt)
+	var sig: Array = []
+	for n in range(steps):
+		sig.append(_active(n * dt, phases))
+	var max_period: float = maxf(
+		OfficeFloor.BUBBLE_EMITTER_PERIODS[0], OfficeFloor.BUBBLE_EMITTER_PERIODS[1])
+	var max_shift := int(max_period / dt)
+	for shift in range(1, max_shift + 1):
+		var mismatch := false
+		for n in range(steps - shift):
+			if sig[n] != sig[n + shift]:
+				mismatch = true
+				break
+		assert_true(mismatch,
+			"combined burst signal must not repeat with period %.1f s" % (shift * dt))

--- a/godot/tests/unit/test_office_bubble_emitters.gd.uid
+++ b/godot/tests/unit/test_office_bubble_emitters.gd.uid
@@ -1,0 +1,1 @@
+uid://bfmggnoefi4bk

--- a/godot/tests/unit/test_office_no_stand_in_footprint.gd
+++ b/godot/tests/unit/test_office_no_stand_in_footprint.gd
@@ -127,3 +127,78 @@ func test_floor_hands_blocked_rects_to_sprites_and_extras_propagate():
 	f.set_extra_blocked_rects([Rect2(10, 10, 20, 20)])
 	assert_eq(f.blocked_rects().size(), 4, "sandbox extras are additive")
 	assert_eq(spr.blocked_rects.size(), 4, "existing sprites are re-armed with the extras")
+
+
+# --- Pass 3: approach slots (prop manifest v1.2 approach_px) ------------------
+
+func _make_floor() -> OfficeFloor:
+	var f: OfficeFloor = OfficeFloorScene.instantiate()
+	add_child_autofree(f)
+	return f
+
+
+func test_water_cooler_landmark_resolves_to_a_side_slot():
+	var f := _make_floor()
+	var z: Dictionary = f._zones(f._bounds())
+	var water: Vector2 = z["water_pos"]
+	var p: Vector2 = f.approach_point_for(water, "w1")
+	assert_ne(p, water, "water cooler declares approach_px -> not the raw landmark point")
+	assert_gt(absf(p.x - water.x), 30.0, "slot stands to the SIDE of the cooler, not in front")
+	assert_false(OfficeEmployeeSprite.inside_any_rect(p, f.blocked_rects()),
+		"slot is a legal standing spot, outside every footprint")
+
+
+func test_second_walker_gets_the_other_free_slot():
+	var f := _make_floor()
+	var z: Dictionary = f._zones(f._bounds())
+	var water: Vector2 = z["water_pos"]
+	var slot1: Vector2 = f.approach_point_for(water, "nobody")
+	# Park a walker ON the first slot; the next requester must get the other one.
+	f.set_roster([{"id": 0, "name": "A", "loyalty": 8}])   # loyalty 8 -> idle, holds position
+	var spr: OfficeEmployeeSprite = f._sprites[0]
+	spr.position = slot1
+	var slot2: Vector2 = f.approach_point_for(water, "someone_else")
+	assert_ne(slot2, slot1, "occupied slot skipped -> the free side slot is handed out")
+	assert_ne(slot2, water, "still a slot, not the raw landmark")
+	# The occupant itself keeps its own slot (requester is never its own blocker).
+	assert_eq(f.approach_point_for(water, "0"), slot1, "occupant re-resolves to its own slot")
+
+
+func test_all_slots_busy_falls_back_to_first_slot():
+	var f := _make_floor()
+	var z: Dictionary = f._zones(f._bounds())
+	var water: Vector2 = z["water_pos"]
+	var slot1: Vector2 = f.approach_point_for(water, "nobody")
+	f.set_roster([
+		{"id": 0, "name": "A", "loyalty": 8},
+		{"id": 1, "name": "B", "loyalty": 8},
+	])
+	f._sprites[0].position = slot1
+	f._sprites[1].position = f.approach_point_for(water, "y")   # the remaining free slot
+	var occupied: Vector2 = f.approach_point_for(water, "late_arrival")
+	assert_eq(occupied, slot1, "all slots taken -> deterministic first slot (walkers share)")
+
+
+func test_props_without_slots_fall_back_unchanged():
+	var f := _make_floor()
+	var z: Dictionary = f._zones(f._bounds())
+	assert_eq(f.approach_point_for(z["fridge_pos"], "x"), Vector2(z["fridge_pos"]),
+		"filing cabinet declares no approach_px -> landmark unchanged (pass-2 path)")
+	assert_eq(f.approach_point_for(Vector2(50, 50), "x"), Vector2(50, 50),
+		"a non-landmark point passes through untouched")
+
+
+func test_sprite_break_target_routes_through_floor_slots():
+	var f := _make_floor()
+	var z: Dictionary = f._zones(f._bounds())
+	f.set_roster([{"id": 0, "name": "A", "assigned": true}])
+	var spr: OfficeEmployeeSprite = f._sprites[0]
+	var t: Vector2 = spr._landmark_break_target(z["water_pos"])
+	assert_ne(t, Vector2(z["water_pos"]), "sprite's water-break target is an approach slot")
+	assert_eq(t, f.approach_point_for(z["water_pos"], "0"),
+		"sprite resolves via its owning floor with its own entity id")
+	# Detached sprite (no floor parent): raw landmark, exactly the pass-2 path.
+	var lone: OfficeEmployeeSprite = EmployeeSpriteScript.new()
+	add_child_autofree(lone)
+	assert_eq(lone._landmark_break_target(Vector2(70, 80)), Vector2(70, 80),
+		"no floor above the sprite -> landmark unchanged")

--- a/godot/tests/unit/test_office_walker_separation.gd
+++ b/godot/tests/unit/test_office_walker_separation.gd
@@ -8,6 +8,7 @@ extends GutTest
 ## Pure view (ADR-0006): no game state anywhere.
 
 const EmployeeSpriteScript := preload("res://scripts/ui/office_floor/employee_sprite.gd")
+const OfficeFloorScene := preload("res://scenes/ui/office_floor/office_floor.tscn")
 
 const DT := 0.05
 const OPEN_FLOOR_MIN_DIST := 20.0   # "not inside each other" floor for the open-floor case
@@ -150,3 +151,80 @@ func test_ring_slot_neighbours_both_hold_their_desks():
 		"A parked ON its desk slot -- separation damped to zero at the target")
 	assert_true(b.position.distance_to(b.desk_pos) <= b.ARRIVE_EPS + 0.001,
 		"B parked ON its desk slot -- separation damped to zero at the target")
+
+
+# --- Pass 3: cat-worker mutual avoidance (asymmetric weights) -----------------
+
+func test_weights_scale_the_push():
+	var full := OfficeEmployeeSprite.separation_vector(Vector2(50, 50), [Vector2(60, 50)], 30.0)
+	var quarter := OfficeEmployeeSprite.separation_vector(
+		Vector2(50, 50), [Vector2(60, 50)], 30.0, [0.25])
+	assert_almost_eq(quarter.length(), full.length() * 0.25, 0.0001,
+		"a 0.25 weight scales that neighbour's push to a quarter")
+
+
+func test_missing_weight_entries_default_to_one():
+	var plain := OfficeEmployeeSprite.separation_vector(
+		Vector2(50, 50), [Vector2(60, 50), Vector2(50, 60)], 30.0)
+	var partial := OfficeEmployeeSprite.separation_vector(
+		Vector2(50, 50), [Vector2(60, 50), Vector2(50, 60)], 30.0, [1.0])
+	assert_eq(plain, partial, "weights shorter than neighbours pad with 1.0")
+
+
+func _make_floor_with_idle_worker_and_cat() -> Array:
+	# One idle worker (loyalty 8 -> holds position) plus a bare Node2D cat
+	# registered in the floor's cat group -- the minimum mutual-avoidance pair.
+	var f: OfficeFloor = OfficeFloorScene.instantiate()
+	add_child_autofree(f)
+	f.set_roster([{"id": 0, "name": "A", "loyalty": 8}])
+	var spr: OfficeEmployeeSprite = f._sprites[0]
+	spr.position = Vector2(180, 150)
+	var cat := Node2D.new()
+	cat.add_to_group(OfficeFloor.CAT_GROUP)
+	f.add_child(cat)
+	cat.position = Vector2(186, 150)          # rendering inside the worker
+	return [f, spr, cat]
+
+
+func test_cat_and_worker_separate_and_cat_yields_more():
+	var trio := _make_floor_with_idle_worker_and_cat()
+	var f: OfficeFloor = trio[0]
+	var spr: OfficeEmployeeSprite = trio[1]
+	var cat: Node2D = trio[2]
+	var w0: Vector2 = spr.position
+	var c0: Vector2 = cat.position
+	for _i in range(200):
+		f._apply_separation(DT)
+	assert_gt(spr.position.distance_to(cat.position), OPEN_FLOOR_MIN_DIST,
+		"cat and worker separate to a readable min distance")
+	assert_gt(c0.distance_to(cat.position), w0.distance_to(spr.position) * 2.0,
+		"ASYMMETRY: the cat (weight 1.6) yields far more than the worker deflects (0.25)")
+
+
+func test_cat_worker_separation_is_deterministic():
+	var results: Array = []
+	for _run in range(2):
+		var trio := _make_floor_with_idle_worker_and_cat()
+		var f: OfficeFloor = trio[0]
+		for _i in range(100):
+			f._apply_separation(DT)
+		results.append([(trio[1] as Node2D).position, (trio[2] as Node2D).position])
+	assert_eq(results[0][0], results[1][0], "worker path identical run-to-run (no RNG)")
+	assert_eq(results[0][1], results[1][1], "cat path identical run-to-run (no RNG)")
+
+
+func test_unregistered_node_does_not_join_separation():
+	# A plain child NOT in the cat group must be ignored by the pass entirely.
+	var f: OfficeFloor = OfficeFloorScene.instantiate()
+	add_child_autofree(f)
+	f.set_roster([{"id": 0, "name": "A", "loyalty": 8}])
+	var spr: OfficeEmployeeSprite = f._sprites[0]
+	spr.position = Vector2(180, 150)
+	var bystander := Node2D.new()
+	f.add_child(bystander)
+	bystander.position = Vector2(186, 150)
+	var w0: Vector2 = spr.position
+	for _i in range(50):
+		f._apply_separation(DT)
+	assert_eq(spr.position, w0, "one worker + non-cat node -> no separation applied")
+	assert_eq(bystander.position, Vector2(186, 150), "non-cat node never displaced")

--- a/godot/tests/unit/test_prop_manifest.gd
+++ b/godot/tests/unit/test_prop_manifest.gd
@@ -150,6 +150,43 @@ func test_loader_fallback_matches_legacy_force_scale():
 	)
 
 
+func test_approach_px_schema_and_water_cooler_slots():
+	# v1.2: optional approach_px = list of [x, y] slot offsets from anchor_px
+	# (source px). water_cooler populates left/right side slots (Pip 2026-07-26:
+	# walkers were standing "slightly in front of the water cooler").
+	var data := _load_manifest()
+	assert_true(data.get("_schema", {}).has("approach_px"), "_schema documents approach_px")
+	var props: Dictionary = data.get("props", {})
+	for id in props:
+		if not props[id].has("approach_px"):
+			continue  # optional field -- absence is the documented fallback
+		var ap = props[id]["approach_px"]
+		assert_true(ap is Array, "'%s' approach_px is a list" % id)
+		for slot in ap:
+			assert_true(slot is Array and (slot as Array).size() == 2,
+				"'%s' approach slot is an [x, y] pair" % id)
+	var wc: Array = props.get("water_cooler", {}).get("approach_px", [])
+	assert_eq(wc.size(), 2, "water_cooler declares two approach slots")
+	if wc.size() == 2:
+		assert_lt(float(wc[0][0]), 0.0, "first slot on the LEFT side")
+		assert_gt(float(wc[1][0]), 0.0, "second slot on the RIGHT side")
+
+
+func test_loader_approach_points():
+	var pts := PropCatalogue.approach_points("water_cooler")
+	assert_eq(pts.size(), 2, "loader surfaces both water_cooler slots")
+	if pts.size() == 2:
+		assert_true(pts[0] is Vector2 and pts[1] is Vector2, "slots come back as Vector2")
+		assert_lt((pts[0] as Vector2).x, 0.0)
+		assert_gt((pts[1] as Vector2).x, 0.0)
+	# Manifested prop WITHOUT the optional field -> empty (fallback unchanged).
+	assert_eq(PropCatalogue.approach_points("filing_cabinet").size(), 0,
+		"props without approach_px report no slots")
+	# Unmanifested id -> empty list + the standard warn-once.
+	assert_eq(PropCatalogue.approach_points("__no_such_prop_ap__").size(), 0)
+	assert_engine_error("has no manifest entry", "unmanifested id warns once")
+
+
 func test_style_lookup_sorted_and_deterministic():
 	var decent := PropCatalogue.style_ids("decent")
 	assert_true(decent.size() > 0, "at least one decent-tagged prop")


### PR DESCRIPTION
Three Pip-approved items from the 2026-07-26 sandbox review. Pure-view lane
(ADR-0006): no game state read or written anywhere; all steering/juice stays
deterministic (positions + hashes only, no RNG in any new path).

## 1. Cat-worker mutual avoidance
- The pass-2 separation pass (OfficeFloor._apply_separation) now covers
  workers AND cats: any Node2D child of the floor in group
  `OfficeFloor.CAT_GROUP` ("office_floor_cats") joins the same
  order-independent snapshot pass. Sandbox `RealCat`/`SandboxCat` register
  themselves in `_ready`; a future live cat only needs `add_to_group`.
- **Asymmetric weights** (documented at the constants):
  - `SEP_WEIGHT_WORKER_FOR_CAT = 0.25` -- max push 0.25 * 40 = 10 px/s vs
    walk speed 42: a worker visibly shoulder-turns for a cat but can never be
    stalled off an arrival.
  - `SEP_WEIGHT_CAT_FOR_WORKER = 1.6` -- 64 px/s exceeds cat wander speed 30:
    the worker's personal space wins, the cat detours.
  - `SEP_WEIGHT_CAT_FOR_CAT = 1.0` -- cats also keep off each other.
- `separation_vector` / `apply_separation` gained an optional index-aligned
  `weights` array (default 1.0 per neighbour) -- every pass-2 call site and
  test is byte-identical in behaviour.

## 2. Organic water-cooler bubbles
- Pip's feedback verbatim: "make them way more intermittent and
  seemingly-random -- if you have 2 firing on slightly off-kilter timers, it
  seems organic."
- The constant #913 3-frame loop becomes sparse burst EVENTS: two independent
  emitters with **incommensurate base periods 7.3 s and 11.9 s** each fire
  one short 3-frame rise per period, then go quiet. The joint pattern only
  realigns every ~86.9 s, so the combined rhythm never visibly repeats.
- Deterministic per-prop phase = hash of the prop feet position (ADR-0006:
  cosmetic yet reproducible, zero RNG draws); a second cooler would desync
  automatically.
- The NO-COMMON-MULTIPLE PRINCIPLE is written up at the constants block for
  future juice to copy.

## 3. Water-cooler approach slots (prop manifest v1.2)
- Schema v1.2 adds optional `approach_px`: per-prop approach-slot offsets
  from `anchor_px` in source px. `water_cooler` populates left/right side
  slots, fixing Pip's "walkers stand slightly in front of the water cooler".
- `OfficeFloor.approach_point_for(landmark, requester_id)` hands out the
  first FREE slot (occupied = another sprite within 10 px, or navigating to
  it); all-busy falls back to the first slot; props without slots -- and
  sprites with no floor above them -- keep the pass-2
  nearest-outside-footprint behaviour EXACTLY.
- `PropCatalogue.approach_points()` + `docs/art/PROP_MANIFEST.md` updated.

## Tests
Fast gate green: **746 tests, 0 failures, 82/82 files collected** (min floor 300).
- `test_office_walker_separation.gd`: weighted push scaling, cat-worker
  min-distance, cat-yields-more asymmetry, run-to-run determinism, non-cat
  bystander ignored.
- `test_office_bubble_emitters.gd` (new): incommensurate-period tripwire,
  pure/deterministic phase + frame math, sparse-event cadence, and the
  no-short-period guarantee (combined burst signal has no period <= 11.9 s
  over a sampled 60 s span).
- `test_office_no_stand_in_footprint.gd`: slot preferred over raw landmark,
  second walker gets the free slot, occupant keeps its own slot, all-busy
  fallback, no-slot prop + non-landmark + detached-sprite fallbacks.
- `test_prop_manifest.gd`: v1.2 schema shape, water_cooler left/right slots,
  loader + warn-once fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)