### PR TITLE
feat(tools): completeness-pass UX for all art review sheets

### DIFF
--- a/tools/art_review/README.md
+++ b/tools/art_review/README.md
@@ -32,10 +32,18 @@ extracted from the contact sheet / hero gallery, and it provides:
   * `section(...)` / `image_cell(...)` -- collapsible sections and the standard
     image cell (checkerboard-under-alpha thumb, size-variant row, blurb,
     expandable prompt, verdict-chip slot);
-  * verdict machinery with HIDE-ON-VERDICT ("hide decided") as a first-class
-    behaviour -- decided cells leave the live queue so you can clear hundreds
-    without getting tired -- plus filter-by-verdict and export/import JSON in
-    the flat `{rel: [tags]}` schema `analyze_verdicts.py` reads.
+  * verdict machinery -- per-cell chips, filter-by-verdict, export/import JSON
+    in the flat `{rel: [tags]}` schema `analyze_verdicts.py` reads;
+  * the completeness pass (`COMPLETENESS_JS` / `COMPLETENESS_CSS` /
+    `completeness_controls()`), shared by ALL three sheets: sections render
+    COLLAPSED by default (expand state persists per-section in localStorage;
+    expand-all / collapse-all in the header); every section header carries a
+    live "unreviewed N / M" rollup where parent headers aggregate their
+    sub-sections; and a three-state show control -- ALL / HIDE DECIDED / ONLY
+    UNREVIEWED (any verdict tag = decided). ONLY UNREVIEWED is the completeness
+    pass: sections with 0 unreviewed disappear and the rest force-open, so the
+    queue is exactly the items judgment has not reached. The rollup logic has a
+    pure-Python mirror: `python tools/art_review/review_style.py --selftest`.
 
 Compare-mode hook (issue #745): every `image_cell` carries `data-rel`, the
 stable handle a compare-and-contrast mode needs. The planned shape: a "compare"
@@ -64,8 +72,8 @@ Sheets on the shared style:
 |---|---|---|
 | gen_quirk_icon_sheet.py | YES | born on it (replaces the #909 inline one-off) |
 | build_cat_angle_ab_sheet.py | YES | ported 2026-07-26 (layout CSS stays sheet-local) |
-| gen_contact_sheet.py | PARTIAL | imports VERDICTS/VERDICT_COLORS from review_style (verified byte-identical output); CSS still inline -- it IS the style source |
-| gen_hero_gallery.py + hero_gallery_template.html | NO (follow-up) | style/verdict colours live inside the template HTML; migrating means templating machinery, not a mechanical swap -- deferred so the live triage loop stays untouched before a sweep |
+| gen_contact_sheet.py | PARTIAL | imports VERDICTS/VERDICT_COLORS + COMPLETENESS_JS/CSS + completeness_controls() from review_style; page CSS still inline -- it IS the style source |
+| gen_hero_gallery.py + hero_gallery_template.html | PARTIAL | template keeps its own style/verdict colours, but the completeness engine is injected from review_style (`__RS_COMPLETENESS_JS__` / `__RS_COMPLETENESS_CSS__` placeholders) -- full style migration still a follow-up |
 | serve_review.py | NO (follow-up) | different verdict model (keep/iterate/discard, server-persisted); adopt BASE_CSS only |
 
 Follow-up rule: migrate a legacy tool only when its output can be verified

--- a/tools/art_review/gen_contact_sheet.py
+++ b/tools/art_review/gen_contact_sheet.py
@@ -6,9 +6,15 @@ import json
 import os
 import sys
 
-# shared verdict vocabulary -- review_style.py is the SSOT (same dir as this script,
-# which sys.path[0] covers when run as a script)
-from review_style import VERDICT_COLORS, VERDICTS
+# shared verdict vocabulary + completeness-pass engine -- review_style.py is the
+# SSOT (same dir as this script, which sys.path[0] covers when run as a script)
+from review_style import (
+    COMPLETENESS_CSS,
+    COMPLETENESS_JS,
+    VERDICT_COLORS,
+    VERDICTS,
+    completeness_controls,
+)
 
 # Repo-relative: this script lives at <repo>/tools/art_review/ , so the repo
 # root is three levels up. Override art_source with argv[1] if given.
@@ -262,24 +268,26 @@ function build(){
   for(const d of DATA){(runs[d.u]=runs[d.u]||{});(runs[d.u][d.c]=runs[d.u][d.c]||[]).push(d);}
   const main=document.getElementById('main');
   for(const run of Object.keys(runs).sort()){
-    const sec=document.createElement('section');sec.className='run-sec';
+    const sec=document.createElement('section');sec.className='run-sec collapsed';
+    sec.dataset.secid=run;
     const rc=Object.values(runs[run]).reduce((a,b)=>a+b.length,0);
     const rh=document.createElement('div');rh.className='run-head';
-    rh.innerHTML=`<span class="caret">v</span><span class="mono">${run}</span> <span class="count-tag">${rc}</span>`;
+    rh.innerHTML=`<span class="caret">v</span><span class="mono">${run}</span> <span class="count-tag">${rc}</span> <span class="rs-cc"></span>`;
     const selBtn=document.createElement('span');selBtn.className='selall';selBtn.textContent='select group';
     rh.appendChild(selBtn);
     const rbody=document.createElement('div');rbody.className='body';
-    rh.addEventListener('click',e=>{if(e.target===selBtn)return;sec.classList.toggle('collapsed');});
+    rh.addEventListener('click',e=>{if(e.target===selBtn)return;rsCompleteness.toggle(sec);});
     const groupRels=[];
     sec.appendChild(rh);sec.appendChild(rbody);
     for(const cat of Object.keys(runs[run]).sort()){
-      const cwrap=document.createElement('div');cwrap.className='cat-sec';cwrap.dataset.cat=cat;
+      const cwrap=document.createElement('div');cwrap.className='cat-sec collapsed';cwrap.dataset.cat=cat;
+      cwrap.dataset.secid=run+'/'+cat;
       const ch=document.createElement('div');ch.className='cat-head';
-      ch.innerHTML=`<span class="caret">v</span>${cat} <span class="count-tag">${runs[run][cat].length}</span>`;
+      ch.innerHTML=`<span class="caret">v</span>${cat} <span class="count-tag">${runs[run][cat].length}</span> <span class="rs-cc"></span>`;
       const cSel=document.createElement('span');cSel.className='selall';cSel.textContent='select';
       ch.appendChild(cSel);
       const cbody=document.createElement('div');cbody.className='body grid';
-      ch.addEventListener('click',e=>{if(e.target===cSel)return;cwrap.classList.toggle('collapsed');});
+      ch.addEventListener('click',e=>{if(e.target===cSel)return;rsCompleteness.toggle(cwrap);});
       const catRels=[];
       for(const d of runs[run][cat]){const t=tile(d);cbody.appendChild(t);catRels.push(d.r);groupRels.push(d.r);}
       cSel.onclick=e=>{e.stopPropagation();selectRels(catRels);};
@@ -306,7 +314,8 @@ function tile(d){
     b.style.setProperty('--vc',VCOLORS[v]);
     if(hasTag(d.r,v))b.classList.add('on');
     b.onclick=e=>{e.stopPropagation();const on=!hasTag(d.r,v);setTag(d.r,v,on);
-      b.classList.toggle('on',on);saveV();refreshCounts();if(activeVerdicts.size)applyFilter();};
+      b.classList.toggle('on',on);saveV();refreshCounts();rsCompleteness.updateCounts();
+      if(activeVerdicts.size||rsCompleteness.mode()!=='all')applyFilter();};
     vt.appendChild(b);
   }
   const cb=t.querySelector('.selbox');
@@ -346,7 +355,8 @@ function updateSelUI(){const n=selected.size;
 // ---- bulk verdict ----
 function bulkApply(v,on){for(const r of selected){setTag(r,v,on);
   const t=tileByRel[r];const b=t.querySelector(`.vtag[data-v="${v}"]`);if(b)b.classList.toggle('on',on);}
-  saveV();refreshCounts();if(activeVerdicts.size)applyFilter();
+  saveV();refreshCounts();rsCompleteness.updateCounts();
+  if(activeVerdicts.size||rsCompleteness.mode()!=='all')applyFilter();
   toast(`${on?'Set':'Removed'} ${v} on ${selected.size} sprite(s)`);}
 
 // ---- filtering ----
@@ -355,6 +365,7 @@ function applyFilter(){
   for(const r of orderedRels){
     const t=tileByRel[r];let ok=true;
     if(activeCats.size&&!activeCats.has(t.dataset.cat))ok=false;
+    if(ok&&!rsCompleteness.cellPass(tagsOf(r)))ok=false;
     if(ok&&query){const hay=t.dataset.fn+' '+t.dataset.cat+' '+t.dataset.sub;if(!hay.includes(query))ok=false;}
     if(ok&&activeVerdicts.size){const tags=tagsOf(r);
       let m=false;for(const v of activeVerdicts)if(tags.indexOf(v)>=0){m=true;break;}if(!m)ok=false;}
@@ -398,7 +409,7 @@ function importJSON(file){const rd=new FileReader();
     V=obj;saveV();
     for(const r of orderedRels){const t=tileByRel[r];
       for(const b of t.querySelectorAll('.vtag'))b.classList.toggle('on',hasTag(r,b.dataset.v));}
-    refreshCounts();applyFilter();toast('Imported verdicts');
+    refreshCounts();rsCompleteness.updateCounts();applyFilter();toast('Imported verdicts');
   }catch(e){toast('Import failed -- not a valid verdicts JSON');}};
   rd.readAsText(file);}
 
@@ -411,6 +422,8 @@ function toast(msg){const el=document.getElementById('toast');el.textContent=msg
 
 window.addEventListener('DOMContentLoaded',()=>{
   loadV();orderedRels=DATA.map(d=>d.r);build();
+  rsCompleteness.init({key:KV,sectionSel:'.run-sec,.cat-sec',cellSel:'.tile[data-rel]',
+    tagsOf:tagsOf,onFilter:applyFilter});
   document.getElementById('total').textContent=DATA.length;
   refreshCounts();applyFilter();
   document.getElementById('q').addEventListener('input',e=>{query=e.target.value.trim().toLowerCase();applyFilter();});
@@ -449,13 +462,15 @@ js = (
     .replace("__VCOLORS__", json.dumps(VERDICT_COLORS))
 )
 
+controls_row = completeness_controls()
+
 doc = f"""<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>P(Doom)1 -- pixellab triage</title>
-<style>{css}</style>
+<style>{css}{COMPLETENESS_CSS}</style>
 </head>
 <body>
 <header>
@@ -480,12 +495,19 @@ doc = f"""<!doctype html>
     <button class="btn primary" id="impbtn">import JSON</button>
     <input type="file" id="impfile" accept="application/json,.json" style="display:none">
   </div>
+  <div class="controls">
+    {controls_row}
+  </div>
 </header>
 <main id="main"></main>
 <footer>
   Local triage tool -- untracked, not committed. Thumbnail = enlarge (Esc/click closes).
   Per-sprite verdict tags (like/dislike/favour/disfavour/promote) + batch select (checkbox,
   shift-click ranges, select-group / select-all-visible) + bulk apply/remove bar.
+  Sections open COLLAPSED (expand state remembered per section); every header shows a live
+  "unreviewed N / M" rollup (run headers aggregate their category sub-sections).
+  show: all / hide decided / only unreviewed -- only-unreviewed is the completeness pass
+  (any verdict tag = decided; sections with 0 unreviewed disappear and the rest force-open).
   Verdicts persist to this browser's localStorage; Export JSON/CSV to make them portable/actionable.
   {total} sprites across {len([r for r in runs if run_counts[r]])} runs.
 </footer>
@@ -500,6 +522,7 @@ doc = f"""<!doctype html>
 </div>
 <div class="lightbox" id="lb"><img src="" alt=""><div class="lbcap"></div></div>
 <div id="toast"></div>
+<script>{COMPLETENESS_JS}</script>
 <script>{js}</script>
 </body>
 </html>

--- a/tools/art_review/gen_hero_gallery.py
+++ b/tools/art_review/gen_hero_gallery.py
@@ -7,6 +7,10 @@ import re
 
 import yaml
 
+# shared completeness-pass engine -- review_style.py is the SSOT (same dir as
+# this script, which sys.path[0] covers when run as a script)
+from review_style import COMPLETENESS_CSS, COMPLETENESS_JS
+
 # Repo-relative: this script lives at <repo>/tools/art_review/ , so the repo
 # root is three levels up. The HTML template sits next to this script.
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -316,6 +320,8 @@ HTML = (
     .replace("__NIMGS__", str(total_imgs))
     .replace("__MATCHED__", str(matched))
     .replace("__NRUNS__", str(len(set(e["u"] for e in entries))))
+    .replace("__RS_COMPLETENESS_JS__", COMPLETENESS_JS)
+    .replace("__RS_COMPLETENESS_CSS__", COMPLETENESS_CSS)
 )
 
 # guard: ensure ASCII only

--- a/tools/art_review/hero_gallery_template.html
+++ b/tools/art_review/hero_gallery_template.html
@@ -134,6 +134,8 @@ border:1px solid var(--line);background:transparent;color:var(--dim);text-transf
 border:1px solid var(--amber);color:var(--amber2);padding:8px 16px;border-radius:8px;
 font-family:monospace;font-size:12px;z-index:200;opacity:0;transition:opacity .2s;pointer-events:none;}
 #toast.on{opacity:1;}
+/* completeness-pass chrome -- injected from review_style.COMPLETENESS_CSS */
+__RS_COMPLETENESS_CSS__
 </style>
 </head>
 <body>
@@ -166,12 +168,23 @@ font-family:monospace;font-size:12px;z-index:200;opacity:0;transition:opacity .2
     <button class="btn primary" id="impbtn">import JSON</button>
     <input type="file" id="impfile" accept="application/json,.json" style="display:none">
   </div>
+  <div class="controls">
+    <span class="row-label">show</span>
+    <button class="toggle on" data-rsmode="all">all</button>
+    <button class="toggle" data-rsmode="hide">hide decided</button>
+    <button class="toggle" data-rsmode="only">only unreviewed</button>
+    <span class="row-label">sections</span>
+    <button class="btn" id="rs-expandall">expand all</button>
+    <button class="btn" id="rs-collapseall">collapse all</button>
+  </div>
 </header>
 <main id="main"></main>
 <footer>
   Local triage tool -- untracked, not committed. Thumbnail = open FULL-SIZE lightbox (fit-to-screen; toggle "actual size" to pan/zoom at native resolution; Esc or click backdrop closes).
   Each tile has an expandable prompt caption; the lightbox shows the full generating prompt + params (model / cost / hash / date).
   Per-image verdict tags (like/dislike/favour/disfavour/promote) + batch select (checkbox, shift-click ranges, select-group / select-all-visible) + bulk apply/remove bar.
+  Sections open COLLAPSED (expand state remembered per section); every header shows a live "unreviewed N / M" rollup (run headers aggregate their category sub-sections).
+  show: all / hide decided / only unreviewed -- only-unreviewed is the completeness pass (any verdict tag = decided; sections with 0 unreviewed disappear and the rest force-open).
   Verdicts persist to this browser's localStorage under key "hero:verdicts"; Export JSON/CSV or copy PROMOTE/FAVOUR lists to make them actionable.
   <span id="footstat"></span>
 </footer>
@@ -199,6 +212,10 @@ font-family:monospace;font-size:12px;z-index:200;opacity:0;transition:opacity .2
   </div>
 </div>
 <div id="toast"></div>
+<script>
+/* completeness-pass engine -- injected from review_style.COMPLETENESS_JS */
+__RS_COMPLETENESS_JS__
+</script>
 <script>
 const DATA=__DATA__;
 const CATCOLORS=__CATCOLORS__;
@@ -229,24 +246,26 @@ function build(){
   for(const d of DATA){dataByRel[d.r]=d;(runs[d.u]=runs[d.u]||{});(runs[d.u][d.c]=runs[d.u][d.c]||[]).push(d);}
   const main=document.getElementById('main');
   for(const run of Object.keys(runs).sort()){
-    const sec=document.createElement('section');sec.className='run-sec';
+    const sec=document.createElement('section');sec.className='run-sec collapsed';
+    sec.dataset.secid=run;
     const rc=Object.values(runs[run]).reduce((a,b)=>a+b.length,0);
     const rh=document.createElement('div');rh.className='run-head';
-    rh.innerHTML=`<span class="caret">v</span><span class="mono">${esc(run)}</span> <span class="count-tag">${rc}</span>`;
+    rh.innerHTML=`<span class="caret">v</span><span class="mono">${esc(run)}</span> <span class="count-tag">${rc}</span> <span class="rs-cc"></span>`;
     const selBtn=document.createElement('span');selBtn.className='selall';selBtn.textContent='select group';
     rh.appendChild(selBtn);
     const rbody=document.createElement('div');rbody.className='body';
-    rh.addEventListener('click',e=>{if(e.target===selBtn)return;sec.classList.toggle('collapsed');});
+    rh.addEventListener('click',e=>{if(e.target===selBtn)return;rsCompleteness.toggle(sec);});
     const groupRels=[];
     sec.appendChild(rh);sec.appendChild(rbody);
     for(const cat of Object.keys(runs[run]).sort()){
-      const cwrap=document.createElement('div');cwrap.className='cat-sec';cwrap.dataset.cat=cat;
+      const cwrap=document.createElement('div');cwrap.className='cat-sec collapsed';cwrap.dataset.cat=cat;
+      cwrap.dataset.secid=run+'/'+cat;
       const ch=document.createElement('div');ch.className='cat-head';
-      ch.innerHTML=`<span class="caret">v</span>${esc(cat)} <span class="count-tag">${runs[run][cat].length}</span>`;
+      ch.innerHTML=`<span class="caret">v</span>${esc(cat)} <span class="count-tag">${runs[run][cat].length}</span> <span class="rs-cc"></span>`;
       const cSel=document.createElement('span');cSel.className='selall';cSel.textContent='select';
       ch.appendChild(cSel);
       const cbody=document.createElement('div');cbody.className='body grid';
-      ch.addEventListener('click',e=>{if(e.target===cSel)return;cwrap.classList.toggle('collapsed');});
+      ch.addEventListener('click',e=>{if(e.target===cSel)return;rsCompleteness.toggle(cwrap);});
       const catRels=[];
       for(const d of runs[run][cat]){const t=tile(d);cbody.appendChild(t);catRels.push(d.r);groupRels.push(d.r);}
       cSel.onclick=e=>{e.stopPropagation();selectRels(catRels);};
@@ -282,7 +301,8 @@ function tile(d){
     b.style.setProperty('--vc',VCOLORS[v]);
     if(hasTag(d.r,v))b.classList.add('on');
     b.onclick=e=>{e.stopPropagation();const on=!hasTag(d.r,v);setTag(d.r,v,on);
-      b.classList.toggle('on',on);saveV();refreshCounts();syncLBTags(d.r);if(activeVerdicts.size)applyFilter();};
+      b.classList.toggle('on',on);saveV();refreshCounts();rsCompleteness.updateCounts();syncLBTags(d.r);
+      if(activeVerdicts.size||rsCompleteness.mode()!=='all')applyFilter();};
     vt.appendChild(b);
   }
   const cb=t.querySelector('.selbox');
@@ -320,7 +340,8 @@ function updateSelUI(){const n=selected.size;
 // ---- bulk verdict ----
 function bulkApply(v,on){const n=selected.size;for(const r of selected){setTag(r,v,on);
   const t=tileByRel[r];const b=t.querySelector(`.vtag[data-v="${v}"]`);if(b)b.classList.toggle('on',on);syncLBTags(r);}
-  saveV();refreshCounts();if(activeVerdicts.size)applyFilter();
+  saveV();refreshCounts();rsCompleteness.updateCounts();
+  if(activeVerdicts.size||rsCompleteness.mode()!=='all')applyFilter();
   toast(`${on?'Set':'Removed'} ${v} on ${n} image(s)`);}
 
 // ---- filtering ----
@@ -329,6 +350,7 @@ function applyFilter(){
   for(const r of orderedRels){
     const t=tileByRel[r];let ok=true;
     if(activeCats.size&&!activeCats.has(t.dataset.cat))ok=false;
+    if(ok&&!rsCompleteness.cellPass(tagsOf(r)))ok=false;
     if(ok&&onlyUnmatched&&t.dataset.w!=='0')ok=false;
     if(ok&&query){if(!t.dataset.fn.includes(query))ok=false;}
     if(ok&&activeVerdicts.size){const tags=tagsOf(r);
@@ -374,7 +396,7 @@ function importJSON(file){const rd=new FileReader();
     V=obj;saveV();
     for(const r of orderedRels){const t=tileByRel[r];
       for(const b of t.querySelectorAll('.vtag'))b.classList.toggle('on',hasTag(r,b.dataset.v));}
-    refreshCounts();applyFilter();toast('Imported verdicts');
+    refreshCounts();rsCompleteness.updateCounts();applyFilter();toast('Imported verdicts');
   }catch(e){toast('Import failed -- not a valid verdicts JSON');}};
   rd.readAsText(file);}
 
@@ -428,7 +450,8 @@ function buildPanel(d){
     b.onclick=()=>{const on=!hasTag(d.r,v);setTag(d.r,v,on);
       b.classList.toggle('on',on);b.style.background=on?VCOLORS[v]:'transparent';
       const tl=tileByRel[d.r];if(tl){const tb=tl.querySelector(`.vtag[data-v="${v}"]`);if(tb)tb.classList.toggle('on',on);}
-      saveV();refreshCounts();if(activeVerdicts.size)applyFilter();};
+      saveV();refreshCounts();rsCompleteness.updateCounts();
+      if(activeVerdicts.size||rsCompleteness.mode()!=='all')applyFilter();};
     vt.appendChild(b);}
 }
 function syncLBTags(r){if(lbRel!==r)return;const vt=document.getElementById('lbvtags');if(!vt)return;
@@ -460,6 +483,8 @@ function buildCatChips(){
 window.addEventListener('DOMContentLoaded',()=>{
   loadV();orderedRels=DATA.map(d=>d.r);
   buildCatChips();build();
+  rsCompleteness.init({key:KV,sectionSel:'.run-sec,.cat-sec',cellSel:'.tile[data-rel]',
+    tagsOf:tagsOf,onFilter:applyFilter});
   document.getElementById('total').textContent=DATA.length;
   document.getElementById('matchn').textContent=DATA.filter(d=>d.w).length+' / '+DATA.length;
   document.getElementById('footstat').textContent=`${DATA.length} images across ${__NRUNS__} runs (${__NIMGS__} raw files deduped to one representative per id/version); ${__MATCHED__} matched to a prompt.`;

--- a/tools/art_review/review_style.py
+++ b/tools/art_review/review_style.py
@@ -20,12 +20,24 @@ this module instead of hand-rolling CSS. It provides:
                            row, name/sublabel, blurb, expandable prompt, verdict
                            chip slot.
   * verdict machinery   -- per-cell like/dislike/favour/disfavour/promote chips,
-                           localStorage persistence, filter-by-verdict, and
-                           HIDE-ON-VERDICT ("hide decided") as a first-class
-                           behaviour: decided cells leave the live queue so you
-                           can clear hundreds without getting tired. Export /
-                           import JSON round-trips the flat {rel: [tags]} schema
-                           used by analyze_verdicts.py.
+                           localStorage persistence, filter-by-verdict, and a
+                           three-state completeness control (ALL / HIDE DECIDED /
+                           ONLY UNREVIEWED): any verdict tag moves a cell off
+                           unreviewed-neutral, so decided cells leave the live
+                           queue and you can clear hundreds without getting
+                           tired. Export / import JSON round-trips the flat
+                           {rel: [tags]} schema used by analyze_verdicts.py.
+  * completeness UX     -- COMPLETENESS_JS / COMPLETENESS_CSS /
+                           completeness_controls(): sections render COLLAPSED by
+                           default (expand state persists per-section in
+                           localStorage; expand-all / collapse-all in the
+                           header), every section header carries a live
+                           "unreviewed N / M" rollup (parents aggregate their
+                           sub-sections via DOM containment), and ONLY-UNREVIEWED
+                           mode force-expands sections and hides any section with
+                           0 unreviewed -- the completeness pass. The count
+                           rollup has a pure-Python mirror, rollup_counts()
+                           (run `python review_style.py --selftest`).
 
 Compare-mode hook (issue #745): every cell carries data-rel; a future compare
 mode can collect cells marked via a "compare" pin into a side-by-side tray.
@@ -34,6 +46,8 @@ See README "compare-and-contrast mode" note. Stdlib only; ASCII only.
 
 import datetime
 import html as _html
+import re as _re
+import sys as _sys
 
 # ---------------------------------------------------------------- vocabulary
 
@@ -170,6 +184,96 @@ pointer-events:none;}
 """
 )
 
+# completeness-pass chrome, shared verbatim by the contact sheet and the hero
+# gallery template (both consume this constant -- keep it selector-generic):
+# live "unreviewed N / M" pill per section head; ONLY-UNREVIEWED mode hides
+# sections with 0 unreviewed (data-unrev kept current by COMPLETENESS_JS).
+COMPLETENESS_CSS = """
+.rs-cc{color:var(--dim);font-size:10px;font-family:monospace;border:1px solid var(--line);
+border-radius:9px;padding:1px 7px;white-space:nowrap;}
+.rs-cc.has-unrev{color:var(--amber2);border-color:#5a4a2a;}
+body.rs-only [data-unrev="0"]{display:none;}
+body.rs-only .caret{opacity:.35;}
+"""
+
+BASE_CSS += COMPLETENESS_CSS
+
+# ---------------------------------------------------------------- completeness JS
+
+# Shared engine: collapsed-by-default sections with per-section localStorage
+# expand state + expand/collapse-all, the ALL / HIDE DECIDED / ONLY UNREVIEWED
+# three-state, and the live unreviewed/total rollup (parents aggregate children
+# because querySelectorAll on a parent section sees descendant cells).
+# Consumers: VERDICT_JS below, gen_contact_sheet.py, hero_gallery_template.html
+# (injected by gen_hero_gallery.py). Pure-Python mirror: rollup_counts().
+COMPLETENESS_JS = r"""
+window.rsCompleteness=(function(){
+  const cfg={key:null,sectionSel:'.rs-section',cellSel:'.rs-cell[data-rel]',
+    tagsOf:function(){return [];},onFilter:null};
+  let exp={};      // secid -> 1 == user expanded (sections default COLLAPSED)
+  let mode='all';  // 'all' | 'hide' (hide decided) | 'only' (only unreviewed)
+  let inited=false;
+  function skey(){return (cfg.key||('rsui:'+document.title))+':expanded';}
+  function load(){try{exp=JSON.parse(localStorage.getItem(skey()))||{};}catch(e){exp={};}}
+  function save(){try{localStorage.setItem(skey(),JSON.stringify(exp));}catch(e){}}
+  function sections(){return Array.from(document.querySelectorAll(cfg.sectionSel));}
+  function secId(s,i){return s.dataset.secid||('sec'+i);}
+  function applyCollapse(){const force=(mode==='only'); // completeness pass opens everything
+    sections().forEach((s,i)=>{s.classList.toggle('collapsed',!force&&!exp[secId(s,i)]);});}
+  function toggle(sec){const i=sections().indexOf(sec);const id=secId(sec,i);
+    const col=sec.classList.toggle('collapsed');
+    if(col)delete exp[id];else exp[id]=1;save();}
+  function setAll(open){exp={};if(open)sections().forEach((s,i)=>{exp[secId(s,i)]=1;});
+    save();applyCollapse();}
+  function markMode(){document.body.classList.toggle('rs-only',mode==='only');
+    for(const b of document.querySelectorAll('[data-rsmode]'))
+      b.classList.toggle('on',b.dataset.rsmode===mode);}
+  function setMode(m){mode=m;markMode();applyCollapse();updateCounts();
+    if(cfg.onFilter)cfg.onFilter();}
+  function cellPass(tags){return mode==='all'||!(tags&&tags.length);}
+  function updateCounts(){for(const s of sections()){
+    let un=0,tot=0;
+    for(const c of s.querySelectorAll(cfg.cellSel)){tot++;
+      const t=cfg.tagsOf(c.dataset.rel);if(!(t&&t.length))un++;}
+    s.dataset.unrev=un;
+    const el=s.querySelector('.rs-cc');
+    if(el){el.textContent=tot?('unreviewed '+un+' / '+tot):'';
+      el.classList.toggle('has-unrev',un>0);}}}
+  function init(c){Object.assign(cfg,c||{});load();applyCollapse();markMode();updateCounts();
+    if(!inited){inited=true;
+      const ea=document.getElementById('rs-expandall');if(ea)ea.onclick=()=>setAll(true);
+      const ca=document.getElementById('rs-collapseall');if(ca)ca.onclick=()=>setAll(false);
+      for(const b of document.querySelectorAll('[data-rsmode]'))
+        b.onclick=()=>setMode(b.dataset.rsmode);}
+  }
+  window.addEventListener('DOMContentLoaded',()=>{if(!inited)init({});});
+  return {init:init,toggle:toggle,setAll:setAll,setMode:setMode,
+    cellPass:cellPass,updateCounts:updateCounts,mode:()=>mode};
+})();
+window.rsSecToggle=function(sec){window.rsCompleteness.toggle(sec);};
+"""
+
+
+def completeness_controls(default_mode="all"):
+    """Header controls for the completeness pass: the ALL / HIDE DECIDED /
+    ONLY UNREVIEWED three-state plus expand-all / collapse-all. Buttons are
+    wired by COMPLETENESS_JS (data-rsmode / rs-expandall / rs-collapseall)."""
+
+    def b(m, label):
+        on = " on" if m == default_mode else ""
+        return f'<button class="toggle{on}" data-rsmode="{m}">{label}</button>'
+
+    return (
+        '<span class="row-label">show</span>'
+        + b("all", "all")
+        + b("hide", "hide decided")
+        + b("only", "only unreviewed")
+        + '<span class="row-label">sections</span>'
+        '<button class="btn" id="rs-expandall">expand all</button>'
+        '<button class="btn" id="rs-collapseall">collapse all</button>'
+    )
+
+
 # ---------------------------------------------------------------- verdict JS
 
 VERDICT_JS = r"""
@@ -187,13 +291,13 @@ function hasTag(r,t){return tagsOf(r).indexOf(t)>=0;}
 function setTag(r,t,on){let a=V[r]?V[r].slice():[];const i=a.indexOf(t);
   if(on&&i<0)a.push(t);else if(!on&&i>=0)a.splice(i,1);
   if(a.length)V[r]=a;else delete V[r];}
-let activeVerdicts=new Set(),hideDecided=false;
+let activeVerdicts=new Set();
 const cells=Array.from(document.querySelectorAll('.rs-cell[data-rel]'));
 function applyFilter(){
   let shown=0,hidden=0;
   for(const c of cells){
     const r=c.dataset.rel,tags=tagsOf(r);let ok=true;
-    if(hideDecided&&tags.length)ok=false;
+    if(!rsCompleteness.cellPass(tags))ok=false;
     if(ok&&activeVerdicts.size){let m=false;
       for(const v of activeVerdicts)if(tags.indexOf(v)>=0){m=true;break;}
       if(!m)ok=false;}
@@ -231,8 +335,8 @@ window.addEventListener('DOMContentLoaded',()=>{
       b.style.setProperty('--vc',VCOLORS[v]);
       if(hasTag(r,v))b.classList.add('on');
       b.onclick=e=>{e.stopPropagation();const on=!hasTag(r,v);setTag(r,v,on);
-        b.classList.toggle('on',on);saveV();refreshCounts();
-        if(hideDecided||activeVerdicts.size)applyFilter();};
+        b.classList.toggle('on',on);saveV();refreshCounts();rsCompleteness.updateCounts();
+        if(rsCompleteness.mode()!=='all'||activeVerdicts.size)applyFilter();};
       vt.appendChild(b);
     }
   }
@@ -240,8 +344,8 @@ window.addEventListener('DOMContentLoaded',()=>{
     vc.onclick=()=>{const v=vc.dataset.v;
       if(activeVerdicts.has(v)){activeVerdicts.delete(v);vc.classList.remove('on');}
       else{activeVerdicts.add(v);vc.classList.add('on');}applyFilter();};}
-  const hb=document.getElementById('rs-hidedecided');
-  if(hb)hb.onclick=()=>{hideDecided=!hideDecided;hb.classList.toggle('on',hideDecided);applyFilter();};
+  rsCompleteness.init({key:KEY,sectionSel:'.rs-section',cellSel:'.rs-cell[data-rel]',
+    tagsOf:tagsOf,onFilter:applyFilter});
   const ex=document.getElementById('rs-export');
   if(ex)ex.onclick=()=>{download(EXPORT_NAME,JSON.stringify(V,null,2),'application/json');
     toast('Exported '+EXPORT_NAME);};
@@ -252,7 +356,7 @@ window.addEventListener('DOMContentLoaded',()=>{
       rd.onload=()=>{try{const obj=JSON.parse(rd.result);
         if(typeof obj!=='object'||Array.isArray(obj))throw 0;
         V=obj;saveV();for(const c of cells)syncCell(c);
-        refreshCounts();applyFilter();toast('Imported verdicts');
+        refreshCounts();rsCompleteness.updateCounts();applyFilter();toast('Imported verdicts');
       }catch(err){toast('Import failed -- not a valid verdicts JSON');}};
       rd.readAsText(f);e.target.value='';});}
   const sw=document.getElementById('rs-storewarn');
@@ -271,9 +375,11 @@ def _verdict_toolbar():
     )
     return (
         '<div class="controls">'
-        '<span class="row-label">verdict</span>' + vchips + " "
-        '<button class="toggle" id="rs-hidedecided">hide decided '
-        '(<span id="rs-hiddenn">0</span> hidden)</button> '
+        '<span class="row-label">verdict</span>'
+        + vchips
+        + " "
+        + completeness_controls()
+        + '<span class="count-tag"><span id="rs-hiddenn">0</span> hidden</span> '
         '<button class="btn" id="rs-export">export JSON</button>'
         '<button class="btn primary" id="rs-import">import JSON</button>'
         '<input type="file" id="rs-importfile" accept="application/json,.json" style="display:none">'
@@ -290,14 +396,21 @@ def esc(s):
 
 
 def section(title, body_html, count=None, accent=None, head_extra=""):
-    """Collapsible titled section. accent = CSS colour for the heading rule."""
+    """Collapsible titled section. accent = CSS colour for the heading rule.
+
+    Renders COLLAPSED by default (completeness UX): COMPLETENESS_JS restores
+    per-section expand state from localStorage, keyed by a slug of the title,
+    and keeps the head's "unreviewed N / M" pill (.rs-cc) live.
+    """
     style = f' style="--accent:{accent}"' if accent else ""
     cls = "rs-sec-head accent" if accent else "rs-sec-head"
     count_tag = f' <span class="count-tag">{count}</span>' if count is not None else ""
+    secid = _re.sub(r"[^a-z0-9]+", "-", str(title).lower()).strip("-") or "section"
     return (
-        f'<section class="rs-section"{style}>'
-        f'<div class="{cls}" onclick="this.parentNode.classList.toggle(\'collapsed\')">'
-        f'<span class="caret">v</span>{esc(title)}{count_tag}{head_extra}</div>'
+        f'<section class="rs-section collapsed" data-secid="{esc(secid)}"{style}>'
+        f'<div class="{cls}" onclick="rsSecToggle(this.parentNode)">'
+        f'<span class="caret">v</span>{esc(title)}{count_tag}'
+        f'<span class="rs-cc"></span>{head_extra}</div>'
         f'<div class="body">{body_html}</div></section>'
     )
 
@@ -413,12 +526,14 @@ def page(
     if verdict_key:
         footer_bits.append(
             "Verdicts persist to this browser's localStorage under key "
-            f'"{verdict_key}"; hide decided shrinks the live queue as you triage; '
-            "export JSON to make decisions durable."
+            f'"{verdict_key}"; sections open collapsed (expand state remembered); '
+            "show: all / hide decided / only unreviewed -- only-unreviewed is the "
+            "completeness pass (any verdict tag = decided; sections with 0 "
+            "unreviewed disappear); export JSON to make decisions durable."
         )
     if footer_note:
         footer_bits.append(footer_note)
-    scripts = ""
+    scripts = f"<script>{COMPLETENESS_JS}</script>"
     if verdict_js:
         scripts += f"<script>{verdict_js}</script>"
     if extra_js:
@@ -461,3 +576,77 @@ def write_ascii(path, html_text):
         raise ValueError(f"non-ascii chars in generated HTML: {bad!r}")
     with open(path, "w", encoding="ascii", newline="\n") as fh:
         fh.write(html_text)
+
+
+# ---------------------------------------------------------------- rollup (pure)
+
+
+def rollup_counts(section_tree, verdicts):
+    """Pure mirror of COMPLETENESS_JS's updateCounts() rollup.
+
+    section_tree -- {"id": str, "cells": [rel, ...], "children": [tree, ...]}
+    verdicts     -- {rel: [tags]} (the flat verdict schema); a missing rel or an
+                    empty tag list means UNREVIEWED (any tag = decided).
+
+    Returns {section_id: (unreviewed, total)} where a parent's counts include
+    every descendant's cells -- in the JS this aggregation falls out of
+    querySelectorAll on the parent element seeing descendant cells.
+    """
+    out = {}
+
+    def walk(sec):
+        un = tot = 0
+        for rel in sec.get("cells", ()):
+            tot += 1
+            if not verdicts.get(rel):
+                un += 1
+        for child in sec.get("children", ()):
+            cu, ct = walk(child)
+            un += cu
+            tot += ct
+        out[sec["id"]] = (un, tot)
+        return un, tot
+
+    walk(section_tree)
+    return out
+
+
+def _selftest():
+    """Check the count-rollup logic (python mirror of the JS)."""
+    tree = {
+        "id": "batch",
+        "cells": ["root_a"],
+        "children": [
+            {"id": "batch/chars", "cells": ["b", "c"], "children": []},
+            {"id": "batch/props", "cells": ["d", "e", "f"], "children": []},
+        ],
+    }
+    verdicts = {
+        "b": ["like"],  # decided
+        "e": ["dislike", "favour"],  # decided (multi-tag still one item)
+        "f": [],  # empty list == unreviewed (schema drops empty keys)
+        "ghost": ["promote"],  # verdict for a cell not on the sheet: ignored
+    }
+    got = rollup_counts(tree, verdicts)
+    assert got["batch/chars"] == (1, 2), got
+    assert got["batch/props"] == (2, 3), got
+    # parent = own cells + sum of children: (1,1) + (1,2) + (2,3)
+    assert got["batch"] == (4, 6), got
+    # all-decided section -> 0 unreviewed (ONLY-UNREVIEWED mode hides it)
+    solo = rollup_counts({"id": "s", "cells": ["x"], "children": []}, {"x": ["promote"]})
+    assert solo["s"] == (0, 1), solo
+    # no verdicts at all -> everything unreviewed
+    fresh = rollup_counts(tree, {})
+    assert fresh["batch"] == (6, 6), fresh
+    # sanity: the JS engine string carries the same vocabulary + hooks
+    for needle in ("cellPass", "updateCounts", "data-rsmode", "rs-expandall", "rs-cc"):
+        assert needle in COMPLETENESS_JS, needle
+    assert 'body.rs-only [data-unrev="0"]' in COMPLETENESS_CSS
+    print("review_style selftest OK (rollup + completeness hooks)")
+
+
+if __name__ == "__main__":
+    if "--selftest" in _sys.argv:
+        _selftest()
+    else:
+        print("usage: python review_style.py --selftest")


### PR DESCRIPTION
Pip's three review-tool feature requests (2026-07-26), implemented ONCE in the shared module and inherited by every sheet.

## The three behaviours

1. **Collapsed by default** -- session/batch sections render CLOSED on page open; per-section expand state persists in localStorage (survives reload); `expand all` / `collapse all` buttons in the header.
2. **Three-state show control** -- `ALL / HIDE DECIDED / ONLY UNREVIEWED`. Any verdict tag moves an item off unreviewed-neutral. ONLY UNREVIEWED is the completeness pass: sections with 0 unreviewed disappear entirely and the remaining sections force-open, so the queue is exactly the items judgment has not reached.
3. **Rolled-up counts** -- every section header carries a live `unreviewed N / M` pill; batch/run headers aggregate their category sub-sections (rollup falls out of DOM containment); counts update on every verdict click, bulk apply, and JSON import.

## Where it lives

- `tools/art_review/review_style.py` -- new `COMPLETENESS_JS` / `COMPLETENESS_CSS` / `completeness_controls()`; `section()` now renders collapsed with a stable `data-secid` + count pill; `page()` ships the engine on every sheet; the old `hide decided` toggle folded into the three-state.
- `tools/art_review/gen_contact_sheet.py` -- imports the engine + controls from the module; sections wired through `rsCompleteness` (secids = run / run+cat).
- `tools/art_review/hero_gallery_template.html` + `gen_hero_gallery.py` -- template keeps its own style but the engine is injected from the module via `__RS_COMPLETENESS_JS__` / `__RS_COMPLETENESS_CSS__` placeholders (no drift copy).
- `tools/art_review/README.md` -- convention + migration table updated.

## Verification

- `python tools/art_review/review_style.py --selftest` -- pure-Python mirror of the count-rollup (parent = own cells + sum of children; empty tag list = unreviewed) plus hook-presence checks.
- Regenerated all three sheets (contact sheet, hero gallery, quirk icons); `node --check` passes on every embedded script block; outputs ASCII-clean.
- Regenerated copies placed in Pip's main checkout at `art_source/pixellab_contact_sheet.html` and `art_generated/hero_gallery.html` (both gitignored regenerables; art referenced by relative path, not embedded).

Semantics note for review: with unreviewed defined as "zero tags", HIDE DECIDED and ONLY UNREVIEWED filter the same cells; the deliberate difference is that ONLY UNREVIEWED additionally force-opens sections and vanishes zero-unreviewed sections (the completeness pass), while HIDE DECIDED respects your manual collapse state and composes with the other filters as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)