### PR TITLE
docs(process): G..N release timing model + release_timeline.py miner (v0.13.1 first data row)

### DIFF
--- a/docs/process/RELEASE_CHECKLIST.md
+++ b/docs/process/RELEASE_CHECKLIST.md
@@ -89,6 +89,37 @@ This document provides a comprehensive checklist for releasing new versions of P
 - [ ] Confirm version number displays correctly in released version
 - [ ] Check that all documentation links work correctly
 
+### 7.5 Stage-Gate Verification (G..N timing model)
+
+Per [RELEASE_TIMING_MODEL.md](RELEASE_TIMING_MODEL.md): every stage must emit a LOUD,
+checkable artifact -- verify each one explicitly. Silence is never evidence of success
+(on v0.13.1 the website sync failed 6 times with zero signal).
+
+- [ ] **I (gate)**: go/no-go decision recorded (issue comment or this checklist) before tagging
+- [ ] **J/K (CI build + upload)**: release workflow run is green for the tag:
+  ```bash
+  gh run list --workflow=enhanced-release.yml --limit 1
+  ```
+- [ ] **K (assets)**: ALL expected platform zips present with plausible sizes (~80-130 MB each) --
+  count them, do not assume:
+  ```bash
+  gh release view v0.1.0 --json assets --jq '.assets[] | "\(.name) \(.size)"'
+  ```
+- [ ] **L (cross-repo sync)**: a GREEN `sync-game-version` run exists at-or-after publish.
+  Note: a release published by CI's own `GITHUB_TOKEN` does NOT fire the `published`
+  trigger -- if no run appears, dispatch manually:
+  ```bash
+  gh run list --workflow=sync-game-version.yml --limit 5
+  gh workflow run sync-game-version.yml -f target_version=v0.1.0
+  ```
+- [ ] **L (website)**: website actually shows the new version (look at it, not the workflow)
+- [ ] **M (deploy + social)**: announcement posted; record the post URL
+- [ ] **N (league functioning)**: league shows fresh activity on the new version's board-key
+- [ ] **Timing row**: append this release's measured timings and commit the CSV:
+  ```bash
+  python tools/release_timeline.py v0.1.0 --append
+  ```
+
 ## Post-Release Tasks
 
 ### 8. Communication & Documentation

--- a/docs/process/RELEASE_TIMING_MODEL.md
+++ b/docs/process/RELEASE_TIMING_MODEL.md
@@ -1,0 +1,171 @@
+# Release Timing Model -- the G..N stage-gate chain
+
+Status: v1, first data row 2026-07-26 (v0.13.1). Owner: Pip.
+Source: Pip's release-pipeline timing braindump (2026-07-26), variable names
+preserved verbatim. Companion tool: `tools/release_timeline.py`; data file:
+`docs/process/release_timings.csv`.
+
+## Why this exists
+
+Pip anchors release timing on personal commitments (Rektango Fridays 5:30PM):
+the question is never "how long does a release take in the abstract" but "when
+must each stage START so the league is visibly WORKING before the anchor". So
+the model works BACKWARD from N, and every stage duration is a measured number
+from real releases, not a guess. First-cycle numbers are expected to be bad --
+that is the point; each release appends a row and the estimates tighten
+(antifragility/iterability, below).
+
+Architecture qualities the pipeline is held to (Pip's list): **legibility**,
+**LOUD failures AND successes** (no silent either), **antifragility**,
+**iterability**.
+
+All timestamps in this doc are UTC. Pip local (Melbourne) is UTC+10 in July,
+so 00:07Z = 10:07 local.
+
+## The chain
+
+```
+  G --------> H --------> I --------> J --------> K --------> L --------> M --------> N
+  last        last        human       build       upload      confirm     deploy +    watch the
+  B-quality   A-quality   gate +      each OS     assets      across      public      league deploy
+  submission  submission  checklist   variant                 repos       social      start
+  cutoff      cutoff      go/nogo     (min J-K                            process     FUNCTIONING
+                                      gap)
+  artifact:   artifact:   artifact:   artifact:   artifact:   artifact:   artifact:   artifact:
+  (none yet)  (none yet)  go/nogo     green       assets      sync run    post URL    league page
+                          recorded    release     N>=expected GREEN at/   exists      shows fresh
+                          + tag       workflow    w/ sizes    after                   activity
+                          pushed      run         on release  publish
+```
+
+Working backward: N is the deadline; M must finish before N can be observed;
+L before M (do not announce what has not synced); K before L; J before K;
+I decides what enters J; H and G bound what I is allowed to consider.
+
+## Variable definitions
+
+| Var | Definition (Pip's words) | Loud-success artifact to check |
+|---|---|---|
+| G | last-submission cutoff for B-quality items | cutoff time recorded; anything after G waits for next train |
+| H | last-submission cutoff for A-quality items | cutoff time recorded; H > G |
+| I | human-architected gate + checklist; go/nogo on gated evidence in dev/SIT flows deciding patch scope | go/nogo written down (issue comment or checklist); tag pushed = "go" executed |
+| J | building each OS variant (minimise the J-K gap via serialisation/parallelisation) | build workflow run green, or local build_release.py stamp-verified output per platform |
+| K | uploading | `gh release view <tag>`: asset count >= expected, sizes plausible (~80-130 MB per platform zip) |
+| L | confirmation across repos | sync-game-version run GREEN at-or-after publish; website shows the new version |
+| M | deploy + public social-media process | post/announcement URL exists |
+| N | watching the league deploy start functioning | league shows fresh activity on the new version's board-key |
+
+## KEY STRUCTURAL FINDING: the J-K gap is solved by PATH SELECTION
+
+The measured data shows the J-K gap problem Pip flagged is already solved --
+not by optimising either stage, but by choosing which path runs them:
+
+- **CI path (the norm): J+K together = ~5 minutes for ALL platforms.**
+  v0.13.1 measured: tag pushed 00:03:15Z -> Enhanced Release workflow green
+  00:07:49Z (4m34s), assets on the release at 00:07:26Z (tag 10:02 -> assets
+  10:07 Pip-local). K_ci ~= 0 because CI uploads from datacenter pipes.
+  CAVEAT: this holds only once PR #919's packaging completeness holds at the
+  next tag -- at v0.13.1 the CI batch was MISSING the Windows and Linux zips
+  (see measured table), which is exactly what #919 fixed after the fact.
+- **Local path (the FALLBACK for CI-down days, not the norm):**
+  J_local ~5 min/platform (`tools/build_release.py`, stamp-verified).
+  K_local at the measured 42.5 KB/s uplink = ~37 min per 90 MB zip, ~2h for
+  3 platforms serialized. The local math stays documented here because the
+  fallback must remain executable, but a 2-hour K is never the plan.
+
+Consequence for backward planning: on the CI path, J+K is a rounding error
+and the schedule is dominated by I (human gate) and L (sync confirmation).
+On the fallback path, add ~2h of upload and start that much earlier.
+
+## Measured v0.13.1 -- the first data row
+
+Verbatim output of `python tools/release_timeline.py v0.13.1`
+(run 2026-07-26):
+
+```
+Release timeline for v0.13.1 (published 2026-07-26 00:07:25Z)
+| Stage                         | Start (UTC)          | End (UTC)            | Duration | Notes                                                     |
+|-------------------------------|----------------------|----------------------|----------|-----------------------------------------------------------|
+| G last B-quality submission   | n/a                  | n/a                  | n/a      | unmeasured                                                |
+| H last A-quality submission   | n/a                  | n/a                  | n/a      | unmeasured                                                |
+| I gate (proxy: last PR merge) | 2026-07-25 12:23:46Z | 2026-07-26 00:03:15Z | 11h39m   | PR #887 -> tag push                                       |
+| J+K CI build+upload           | 2026-07-26 00:03:15Z | 2026-07-26 00:07:49Z | 4m34s    | Enhanced Release with Validation & Feeds: success         |
+| K assets (CI batch)           | 2026-07-26 00:07:26Z | 2026-07-26 00:07:26Z | 1s       | 7 assets within grace of publish                          |
+| K late asset (local fallback) | 2026-07-26 00:07:25Z | 2026-07-26 02:04:40Z | 1h57m    | PDoom-Windows-v0.13.1.zip (90.7 MB) after publish         |
+| K late asset (local fallback) | 2026-07-26 00:07:25Z | 2026-07-26 02:42:39Z | 2h35m    | PDoom-Linux-v0.13.1.zip (83.8 MB) after publish           |
+| L cross-repo sync             | 2026-07-26 00:56:23Z | 2026-07-26 03:16:37Z | 3h09m    | 6 failed run(s) before green; green was a MANUAL dispatch |
+| M deploy + social process     | n/a                  | n/a                  | n/a      | unmeasured                                                |
+| N league observed working     | n/a                  | n/a                  | n/a      | unmeasured                                                |
+```
+
+Reading notes on this row:
+
+- The 11h39m I-duration includes an overnight gap (PR #887 merged mid-day,
+  tag pushed next morning) -- human latency, not process latency. The model
+  keeps it anyway: backward planning has to schedule around sleep too.
+- The CI batch (7 assets in 1s) contained the macOS zips and the feed/manifest
+  JSON but NOT the Windows or Linux zips -- those arrived +1h57m and +2h35m
+  after publish via the local fallback path. This is the packaging
+  incompleteness PR #919 closed; the next tag is the test of whether the CI
+  path now carries all platforms.
+- G, H, M, N are unmeasured because no naturally-occurring artifact records
+  them yet. Expected; they gain artifacts as the process matures (M gets a
+  post URL, N gets a league observation; G/H need the cutoffs to be declared
+  somewhere timestamped, e.g. an issue comment).
+
+## L is where releases die silently: the canonical example
+
+The model's loud-failure requirement is not theoretical. On v0.13.1 the
+`sync-game-version` workflow (game version -> website) failed **6 times with
+zero signal to anyone**, and the website sat on the old version for ~3h until
+a human noticed and dispatched it manually (green at 03:16:37Z, +3h09m after
+publish). Two independent silent mechanisms stacked:
+
+1. **The `published` trigger never fired at all.** The release was published
+   by the CI workflow using its own `GITHUB_TOKEN`, and GitHub suppresses
+   workflow events caused by `GITHUB_TOKEN` actions (recursion guard). Zero
+   runs, zero red X, zero anything -- the purest silent failure: absence of
+   evidence presented as nothing-to-see.
+2. **An injection bug killed every run that DID fire.** The workflow
+   interpolates the release body directly into a bash assignment
+   (`RELEASE_BODY="${{ ... }}"`); a body containing quotes/backticks (ours
+   had a markdown table and inline code) breaks the shell script at the
+   "Extract Version Information" step. The later `edited`-event runs
+   (00:56Z x2, 01:05Z, 01:10Z, 02:42Z, and one more at 03:19Z after the
+   manual green) all died this way -- red in the Actions tab, but nothing
+   watches the Actions tab.
+
+Design rule this produces: **a stage is not done when its job ran; a stage is
+done when its ARTIFACT is checked**. Sync is done when a green run exists
+at-or-after publish AND the website shows the version -- checked, not
+assumed. `docs/process/RELEASE_CHECKLIST.md` section 7.5 now carries a
+per-stage verification line for exactly this.
+
+## Antifragility / iterability
+
+- Every release appends one timing row:
+  `python tools/release_timeline.py <tag> --append` writes to
+  `docs/process/release_timings.csv` (skips if the tag is already recorded);
+  commit the CSV with the release wrap-up.
+- The script mines only naturally-occurring artifacts (tag ref, workflow
+  runs, asset `created_at`, PR merges) -- no extra bookkeeping to forget.
+- Each failure that reaches this doc becomes a named example and usually a
+  new checkable artifact, so the pipeline gets stronger from being hit
+  (v0.13.1 contributed: the silent-sync example, the packaging-completeness
+  caveat, and two mining bugs fixed in the script itself).
+- Quality mapping: legibility = this doc + the ASCII table; loud
+  success/failure = per-stage artifacts in the checklist; antifragility =
+  failures convert to checks; iterability = the CSV tightens estimates every
+  cycle.
+
+## Cross-links
+
+- Issue #917 -- deploy: robust cross-OS releases (Windows/Linux/macOS); this
+  model is its measurement layer.
+- PR #919 -- complete release zip packaging (#917 increment 1); the CI-path
+  claim above is conditional on it holding at the next tag.
+- `docs/process/RELEASE_CHECKLIST.md` -- section 7.5 stage-gate verification.
+- `docs/process/BRANCHING_STRATEGY.md`, `docs/ROADMAP.md` -- release-train
+  cadence the anchors sit inside.
+- Planning intent: durations here feed Pip's energy/time planning -- work
+  backward from the anchor commitment through N..G with measured numbers.

--- a/docs/process/release_timings.csv
+++ b/docs/process/release_timings.csv
@@ -1,0 +1,2 @@
+tag,last_pr_merged_utc,tag_pushed_utc,ci_run_start_utc,ci_run_end_utc,ci_minutes,release_published_utc,initial_asset_count,late_asset_count,last_late_asset_utc,sync_fail_count,sync_green_utc,l_minutes_after_publish,m_utc,n_utc
+v0.13.1,2026-07-25T12:23:46Z,2026-07-26T00:03:15Z,2026-07-26T00:03:15Z,2026-07-26T00:07:49Z,4.6,2026-07-26T00:07:25Z,7,2,2026-07-26T02:42:39Z,6,2026-07-26T03:16:37Z,189.2,,

--- a/tools/release_timeline.py
+++ b/tools/release_timeline.py
@@ -1,0 +1,383 @@
+"""Mine GitHub timestamps for a release tag into a stage-gate timing table.
+
+Maps naturally-occurring release artifacts (tag push, workflow runs, release
+assets, sync-workflow runs, PR merges) onto the G..N release timing model
+documented in docs/process/RELEASE_TIMING_MODEL.md. Prints an ASCII timing
+table and an append-friendly CSV row for docs/process/release_timings.csv.
+
+Usage:
+    python tools/release_timeline.py            # latest release
+    python tools/release_timeline.py v0.13.1    # specific tag
+    python tools/release_timeline.py v0.13.1 --append   # also append CSV row
+
+Requires: gh CLI authenticated for the repo. Stdlib only otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+DEFAULT_REPO = "PipFoweraker/pdoom1"
+SYNC_WORKFLOW = "sync-game-version.yml"
+# Assets created more than this long after publish are treated as late
+# (i.e. uploaded via the local fallback path, not the CI path).
+LATE_ASSET_GRACE = timedelta(minutes=15)
+# How long after publish we still attribute manual sync dispatches to this
+# release.
+SYNC_DISPATCH_WINDOW = timedelta(hours=24)
+
+CSV_COLUMNS = [
+    "tag",
+    "last_pr_merged_utc",
+    "tag_pushed_utc",
+    "ci_run_start_utc",
+    "ci_run_end_utc",
+    "ci_minutes",
+    "release_published_utc",
+    "initial_asset_count",
+    "late_asset_count",
+    "last_late_asset_utc",
+    "sync_fail_count",
+    "sync_green_utc",
+    "l_minutes_after_publish",
+    "m_utc",
+    "n_utc",
+]
+
+
+def gh_api(repo: str, path: str) -> dict | list:
+    """Call `gh api` and return parsed JSON. Raises on gh failure."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/{path}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed: {result.stderr.strip()}")
+    return json.loads(result.stdout)
+
+
+def parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def fmt_ts(value: datetime | None) -> str:
+    return value.strftime("%Y-%m-%d %H:%M:%SZ") if value else "n/a"
+
+
+def fmt_iso(value: datetime | None) -> str:
+    return value.strftime("%Y-%m-%dT%H:%M:%SZ") if value else ""
+
+
+def fmt_dur(start: datetime | None, end: datetime | None) -> str:
+    if not start or not end:
+        return "n/a"
+    seconds = int((end - start).total_seconds())
+    sign = "-" if seconds < 0 else ""
+    seconds = abs(seconds)
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{sign}{hours}h{minutes:02d}m"
+    if minutes:
+        return f"{sign}{minutes}m{secs:02d}s"
+    return f"{sign}{secs}s"
+
+
+def gather(repo: str, tag: str | None) -> dict:
+    """Collect every timestamped artifact for the tag from the GitHub API."""
+    if tag:
+        release = gh_api(repo, f"releases/tags/{tag}")
+    else:
+        release = gh_api(repo, "releases/latest")
+        tag = release["tag_name"]
+
+    published = parse_ts(release.get("published_at"))
+
+    # Resolve the tag to its commit SHA. Never use target_commitish: it is a
+    # branch name whose HEAD keeps moving after the tag (learned on v0.13.1,
+    # where it attributed a post-tag PR to the release).
+    ref = gh_api(repo, f"git/ref/tags/{tag}")
+    obj = ref["object"]
+    if obj["type"] == "tag":  # annotated tag: dereference once
+        obj = gh_api(repo, f"git/tags/{obj['sha']}")["object"]
+    sha = obj["sha"]
+
+    # PRs whose merge produced the tagged commit -- proxy for gate I.
+    prs = gh_api(repo, f"commits/{sha}/pulls")
+    if not isinstance(prs, list):
+        prs = []
+    merged_prs = sorted(
+        (
+            p
+            for p in prs
+            if p.get("merged_at") and (not published or parse_ts(p["merged_at"]) <= published)
+        ),
+        key=lambda p: p["merged_at"],
+    )
+    last_pr = merged_prs[-1] if merged_prs else None
+
+    # Workflow runs triggered by pushing the tag. The release workflow's
+    # created_at is the best available proxy for the tag-push instant.
+    # Match on workflow path first; a bare name match on "release" grabs the
+    # wrong run (Pre-Release Checks) -- also learned on v0.13.1.
+    runs = gh_api(repo, f"actions/runs?head_branch={tag}&event=push&per_page=100")
+    push_runs = runs.get("workflow_runs", [])
+    ci_run = next(
+        (r for r in push_runs if r.get("path", "").endswith("enhanced-release.yml")),
+        None,
+    )
+    if ci_run is None:
+        ci_run = next(
+            (
+                r
+                for r in push_runs
+                if "release" in r["name"].lower() and "pre-release" not in r["name"].lower()
+            ),
+            None,
+        )
+
+    # Sync-workflow runs: release-event runs for this tag, plus manual
+    # dispatches shortly after publish (the recovery path).
+    sync = gh_api(repo, f"actions/workflows/{SYNC_WORKFLOW}/runs?per_page=100")
+    sync_runs = []
+    for run in sync.get("workflow_runs", []):
+        started = parse_ts(run["run_started_at"])
+        if run["head_branch"] == tag:
+            sync_runs.append(run)
+        elif (
+            run["event"] == "workflow_dispatch"
+            and published
+            and started
+            and published <= started <= published + SYNC_DISPATCH_WINDOW
+        ):
+            sync_runs.append(run)
+    sync_runs.sort(key=lambda r: r["run_started_at"])
+
+    assets = sorted(release.get("assets", []), key=lambda a: a["created_at"])
+    initial, late = [], []
+    for asset in assets:
+        created = parse_ts(asset["created_at"])
+        if published and created and created > published + LATE_ASSET_GRACE:
+            late.append(asset)
+        else:
+            initial.append(asset)
+
+    return {
+        "tag": tag,
+        "release": release,
+        "published": published,
+        "last_pr": last_pr,
+        "ci_run": ci_run,
+        "sync_runs": sync_runs,
+        "initial_assets": initial,
+        "late_assets": late,
+    }
+
+
+def build_rows(data: dict) -> list[tuple[str, str, str, str, str]]:
+    """Stage rows: (stage, start, end, duration, notes)."""
+    rows: list[tuple[str, str, str, str, str]] = []
+    published = data["published"]
+
+    rows.append(("G last B-quality submission", "n/a", "n/a", "n/a", "unmeasured"))
+    rows.append(("H last A-quality submission", "n/a", "n/a", "n/a", "unmeasured"))
+
+    last_pr = data["last_pr"]
+    ci_run = data["ci_run"]
+    tag_pushed = parse_ts(ci_run["created_at"]) if ci_run else None
+    if last_pr:
+        merged = parse_ts(last_pr["merged_at"])
+        rows.append(
+            (
+                "I gate (proxy: last PR merge)",
+                fmt_ts(merged),
+                fmt_ts(tag_pushed),
+                fmt_dur(merged, tag_pushed),
+                f"PR #{last_pr['number']} -> tag push",
+            )
+        )
+    else:
+        rows.append(("I gate (proxy: last PR merge)", "n/a", "n/a", "n/a", "no PR found"))
+
+    if ci_run:
+        start = parse_ts(ci_run["run_started_at"])
+        end = parse_ts(ci_run["updated_at"])
+        rows.append(
+            (
+                "J+K CI build+upload",
+                fmt_ts(start),
+                fmt_ts(end),
+                fmt_dur(start, end),
+                f"{ci_run['name']}: {ci_run['conclusion']}",
+            )
+        )
+    else:
+        rows.append(("J+K CI build+upload", "n/a", "n/a", "n/a", "no release run found"))
+
+    initial = data["initial_assets"]
+    if initial:
+        first = parse_ts(initial[0]["created_at"])
+        last = parse_ts(initial[-1]["created_at"])
+        rows.append(
+            (
+                "K assets (CI batch)",
+                fmt_ts(first),
+                fmt_ts(last),
+                fmt_dur(published, last),
+                f"{len(initial)} assets within grace of publish",
+            )
+        )
+    for asset in data["late_assets"]:
+        created = parse_ts(asset["created_at"])
+        size_mb = asset["size"] / (1024 * 1024)
+        rows.append(
+            (
+                "K late asset (local fallback)",
+                fmt_ts(published),
+                fmt_ts(created),
+                fmt_dur(published, created),
+                f"{asset['name']} ({size_mb:.1f} MB) after publish",
+            )
+        )
+
+    sync_runs = data["sync_runs"]
+    fails = [r for r in sync_runs if r["conclusion"] != "success"]
+    green = next((r for r in sync_runs if r["conclusion"] == "success"), None)
+    if sync_runs:
+        first = parse_ts(sync_runs[0]["run_started_at"])
+        green_ts = parse_ts(green["run_started_at"]) if green else None
+        note = f"{len(fails)} failed run(s) before green"
+        if green and green["event"] == "workflow_dispatch":
+            note += "; green was a MANUAL dispatch"
+        rows.append(
+            (
+                "L cross-repo sync",
+                fmt_ts(first),
+                fmt_ts(green_ts),
+                fmt_dur(published, green_ts),
+                note,
+            )
+        )
+    else:
+        rows.append(("L cross-repo sync", "n/a", "n/a", "n/a", "no sync runs found"))
+
+    rows.append(("M deploy + social process", "n/a", "n/a", "n/a", "unmeasured"))
+    rows.append(("N league observed working", "n/a", "n/a", "n/a", "unmeasured"))
+    return rows
+
+
+def print_table(tag: str, published: datetime | None, rows: list) -> None:
+    headers = ("Stage", "Start (UTC)", "End (UTC)", "Duration", "Notes")
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    def line(cells: tuple) -> str:
+        return "| " + " | ".join(c.ljust(w) for c, w in zip(cells, widths)) + " |"
+
+    sep = "|" + "|".join("-" * (w + 2) for w in widths) + "|"
+    print(f"Release timeline for {tag} (published {fmt_ts(published)})")
+    print(line(headers))
+    print(sep)
+    for row in rows:
+        print(line(row))
+
+
+def csv_row(data: dict) -> dict[str, str]:
+    published = data["published"]
+    ci_run = data["ci_run"]
+    ci_start = parse_ts(ci_run["run_started_at"]) if ci_run else None
+    ci_end = parse_ts(ci_run["updated_at"]) if ci_run else None
+    last_pr = data["last_pr"]
+    late = data["late_assets"]
+    sync_runs = data["sync_runs"]
+    fails = [r for r in sync_runs if r["conclusion"] != "success"]
+    green = next((r for r in sync_runs if r["conclusion"] == "success"), None)
+    green_ts = parse_ts(green["run_started_at"]) if green else None
+    ci_minutes = f"{(ci_end - ci_start).total_seconds() / 60:.1f}" if ci_start and ci_end else ""
+    l_minutes = (
+        f"{(green_ts - published).total_seconds() / 60:.1f}" if green_ts and published else ""
+    )
+    return {
+        "tag": data["tag"],
+        "last_pr_merged_utc": fmt_iso(parse_ts(last_pr["merged_at"]) if last_pr else None),
+        "tag_pushed_utc": fmt_iso(parse_ts(ci_run["created_at"]) if ci_run else None),
+        "ci_run_start_utc": fmt_iso(ci_start),
+        "ci_run_end_utc": fmt_iso(ci_end),
+        "ci_minutes": ci_minutes,
+        "release_published_utc": fmt_iso(published),
+        "initial_asset_count": str(len(data["initial_assets"])),
+        "late_asset_count": str(len(late)),
+        "last_late_asset_utc": fmt_iso(parse_ts(late[-1]["created_at"]) if late else None),
+        "sync_fail_count": str(len(fails)),
+        "sync_green_utc": fmt_iso(green_ts),
+        "l_minutes_after_publish": l_minutes,
+        "m_utc": "",
+        "n_utc": "",
+    }
+
+
+def append_csv(path: Path, row: dict[str, str]) -> str:
+    """Append the row unless the tag is already recorded. Returns a status."""
+    exists = path.exists()
+    if exists:
+        with path.open(newline="", encoding="ascii") as handle:
+            if any(r.get("tag") == row["tag"] for r in csv.DictReader(handle)):
+                return f"skip: {row['tag']} already in {path}"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", newline="", encoding="ascii") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS, lineterminator="\n")
+        if not exists:
+            writer.writeheader()
+        writer.writerow(row)
+    return f"appended {row['tag']} to {path}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("tag", nargs="?", help="release tag (default: latest release)")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="owner/name")
+    parser.add_argument(
+        "--append",
+        action="store_true",
+        help="append the CSV row to docs/process/release_timings.csv",
+    )
+    parser.add_argument(
+        "--csv-path",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "docs" / "process" / "release_timings.csv",
+        help="CSV file to append to (with --append)",
+    )
+    args = parser.parse_args()
+
+    try:
+        data = gather(args.repo, args.tag)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    rows = build_rows(data)
+    print_table(data["tag"], data["published"], rows)
+
+    row = csv_row(data)
+    print()
+    print("CSV row (" + ",".join(CSV_COLUMNS) + "):")
+    print(",".join(row[c] for c in CSV_COLUMNS))
+    if args.append:
+        print(append_csv(args.csv_path, row))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Operationalises Pip's 2026-07-26 release-pipeline timing braindump into a measured stage-gate model plus a tool that keeps it honest from naturally-occurring artifacts.

- **docs/process/RELEASE_TIMING_MODEL.md** -- the G->H->I->J->K->L->M->N chain (Pip's variable names preserved: G/H submission cutoffs, I human gate, J build, K upload, L cross-repo confirm, M deploy+social, N league observed working), ASCII stage diagram, per-stage loud-success artifacts, and today's measured v0.13.1 values as the first data row.
- **tools/release_timeline.py** -- given a tag (default latest), mines gh api for tag push, workflow runs, release publish, per-asset created_at, sync runs, and pre-tag PR merges; prints the ASCII timing table and appends a CSV row (stdlib + gh subprocess only; black/ruff clean).
- **docs/process/release_timings.csv** -- created with header + the v0.13.1 row; every release appends one (antifragility: estimates tighten each cycle).
- **docs/process/RELEASE_CHECKLIST.md** -- new section 7.5: one explicit, checkable verification line per stage.

## Key structural finding

The J-K gap is solved by **path selection**, not stage optimisation: the CI path built+uploaded in **4m34s** (tag 00:03:15Z -> Enhanced Release green 00:07:49Z, assets at 00:07:26Z), while the local fallback costs ~2h of upload at the measured 42.5 KB/s uplink. Local math stays documented as the CI-down fallback. Conditional on PR #919's packaging completeness holding at the next tag -- v0.13.1's CI batch was missing the Windows (+1h57m) and Linux (+2h35m) zips.

## Canonical silent failure (why the model exists)

sync-game-version failed **6 times with zero signal** on v0.13.1: the `published` trigger never fired (release published via CI's own GITHUB_TOKEN, which GitHub suppresses), and every `edited`-event run died on a release-body shell-injection bug (`RELEASE_BODY="${{ ... }}"`). Website sat stale ~3h; green only via manual dispatch at 03:16:37Z (+3h09m after publish).

## Measured v0.13.1 timeline

| Stage | Duration | Notes |
|---|---|---|
| I gate (last PR merge -> tag) | 11h39m | PR #887 -> tag push (includes overnight) |
| J+K CI build+upload | 4m34s | Enhanced Release: success |
| K late assets (local fallback) | +1h57m / +2h35m | Windows 90.7 MB / Linux 83.8 MB |
| L cross-repo sync | +3h09m | 6 red runs; green was MANUAL dispatch |
| G, H, M, N | unmeasured | no timestamped artifact yet -- expected |

Refs #917 (this is its measurement layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)