### PR TITLE
fix(ci): close GitHub Actions script-injection + repair silent version-sync (2 stacked mechanisms)

### DIFF
--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -332,6 +332,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Explicitly drive the website version sync. Required because this workflow
+  # publishes the release with GITHUB_TOKEN, and a release published by a
+  # GITHUB_TOKEN-authored action does NOT fire the `release: published` event
+  # that sync-game-version.yml otherwise listens on (GitHub loop-prevention).
+  # workflow_call runs it in-line (no event, no suppression) and inherits
+  # CROSS_REPO_TOKEN -- no new PAT, least privilege.
+  sync-website-version:
+    name: Sync Version to Website
+    needs: create-github-release
+    if: needs.create-github-release.result == 'success'
+    uses: ./.github/workflows/sync-game-version.yml
+    with:
+      target_version: ${{ github.event.inputs.version || github.ref_name }}
+    secrets: inherit
+
   deploy-feeds:
     name: Deploy Feeds to Website
     runs-on: ubuntu-latest

--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -82,20 +82,25 @@ jobs:
       - name: Create triage issue on validation failure
         if: failure() && !inputs.skip_validation
         uses: actions/github-script@v7
+        env:
+          # SECURITY: user-influenced (dispatch input / tag name) -- must not
+          # be templated into the script text; read via process.env as data
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
         with:
           script: |
             const fs = require('fs');
             const report = fs.readFileSync('validation_report.txt', 'utf8');
+            const version = process.env.RELEASE_VERSION;
 
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `🚨 Data Validation Failed for Release ${{ github.event.inputs.version || github.ref_name }}`,
+              title: `[!] Data Validation Failed for Release ${version}`,
               body: `## Validation Failure
 
             The release pipeline has halted due to data validation errors.
 
-            **Version:** ${{ github.event.inputs.version || github.ref_name }}
+            **Version:** ${version}
             **Workflow Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ### Validation Report
@@ -153,9 +158,11 @@ jobs:
           echo "SUCCESS All validation checks passed!"
 
       - name: Build all platforms
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
         run: |
-          VERSION="${{ github.event.inputs.version || github.ref_name }}"
-          echo "🎮 Building P(Doom) $VERSION for all platforms..."
+          VERSION="$RELEASE_VERSION"
+          echo "Building P(Doom) $VERSION for all platforms..."
           python scripts/build_all_platforms.py --version "$VERSION" --godot-path "$(which godot)"
 
       - name: Upload Windows build
@@ -196,8 +203,10 @@ jobs:
           pip install -r requirements.txt
 
       - name: Generate release metadata
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
         run: |
-          VERSION="${{ github.event.inputs.version || github.ref_name }}"
+          VERSION="$RELEASE_VERSION"
           echo "MEMO Generating metadata for $VERSION..."
           python scripts/generate_release_metadata.py --version "$VERSION"
 
@@ -218,8 +227,10 @@ jobs:
 
       - name: Generate release manifest
         id: manifest
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
         run: |
-          VERSION="${{ github.event.inputs.version || github.ref_name }}"
+          VERSION="$RELEASE_VERSION"
           COMMIT_HASH="${{ github.sha }}"
           DATA_HASH="${{ needs.validate-data.outputs.validation_hash }}"
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -280,8 +291,10 @@ jobs:
 
       - name: Extract changelog
         id: changelog
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
         run: |
-          VERSION="${{ github.event.inputs.version || github.ref_name }}"
+          VERSION="$RELEASE_VERSION"
           VERSION_NUM="${VERSION#v}"
 
           # Extract changelog (simplified version)
@@ -348,13 +361,17 @@ jobs:
     steps:
       - name: Release Success Notification
         if: needs.create-github-release.result == 'success'
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
         run: |
-          echo "SUCCESS Release ${{ github.event.inputs.version || github.ref_name }} published successfully!"
-          echo "🎮 Game builds created for Windows, Linux, and macOS"
-          echo "📡 Feeds generated and ready for website consumption"
+          echo "SUCCESS Release $RELEASE_VERSION published successfully!"
+          echo "Game builds created for Windows, Linux, and macOS"
+          echo "Feeds generated and ready for website consumption"
 
       - name: Release Failure Notification
         if: needs.create-github-release.result == 'failure'
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
         run: |
-          echo "ERROR Release ${{ github.event.inputs.version || github.ref_name }} failed!"
+          echo "ERROR Release $RELEASE_VERSION failed!"
           echo "Check the workflow logs for details"

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -68,12 +68,15 @@ jobs:
 
     - name: Ladder Bump Heuristic (advisory)
       if: github.event_name == 'pull_request'
+      env:
+        # SECURITY: branch name is user-influenced -- pass via env, not inline
+        BASE_REF: ${{ github.base_ref }}
       run: |
         echo "Build-vs-ladder split: warn when gameplay-surface files changed without a"
         echo "ladder_version.txt bump (or vice versa). Advisory smell detector, never blocks;"
         echo "reviewer acks against the spec Section 3.3 checklist."
-        git fetch origin ${{ github.base_ref }} --depth=1
-        python tools/check_ladder_bump.py --base origin/${{ github.base_ref }} || true
+        git fetch origin "$BASE_REF" --depth=1
+        python tools/check_ladder_bump.py --base "origin/$BASE_REF" || true
 
     - name: Web Export System Check
       run: |

--- a/.github/workflows/release-sync-monitor.yml
+++ b/.github/workflows/release-sync-monitor.yml
@@ -1,0 +1,67 @@
+name: Release Sync Monitor
+
+# Belt-and-braces LOUD failure detector for the version-sync pipeline.
+#
+# The primary sync path (sync-game-version.yml, driven from enhanced-release.yml
+# via workflow_call) can still silently no-op if someone changes how releases
+# are cut. This job independently compares the latest PUBLISHED game release
+# against what the website currently advertises, and FAILS RED (plus ::error::)
+# when they diverge -- which means the primary path did not run. A red scheduled
+# run is the loud signal; re-fire the sync with:
+#   gh workflow run sync-game-version.yml -f target_version=vX.Y.Z
+#
+# Read-only: no writes to any repo. Uses CROSS_REPO_TOKEN only to READ the
+# (possibly private) website file.
+
+on:
+  schedule:
+    - cron: '17 6 * * *'  # daily 06:17 UTC, offset off the hour
+  workflow_dispatch: {}
+
+jobs:
+  check-website-in-sync:
+    runs-on: ubuntu-latest
+    if: github.repository == 'PipFoweraker/pdoom1'
+    steps:
+      - name: Compare latest release against website current version
+        env:
+          # GITHUB_TOKEN reads this repo's releases; CROSS_REPO_TOKEN reads the
+          # website repo. Both used read-only.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEBSITE_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Latest non-draft, non-prerelease release tag on the game repo
+          LATEST_TAG=$(gh api repos/${GITHUB_REPOSITORY}/releases \
+            --jq 'map(select(.draft == false and .prerelease == false)) | .[0].tag_name')
+          LATEST="${LATEST_TAG#v}"
+
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+            echo "No published stable release found; nothing to check."
+            exit 0
+          fi
+
+          # What the website currently advertises. Read-only; tolerate a missing
+          # file (warn, do not fail) so a first-time setup does not false-alarm.
+          WEB_RAW=$(GH_TOKEN="$WEBSITE_TOKEN" gh api \
+            repos/PipFoweraker/pdoom1-website/contents/data/current-game-version.json \
+            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+
+          if [ -z "$WEB_RAW" ]; then
+            echo "::warning::Could not read website current-game-version.json (missing or unreadable); skipping strict check."
+            exit 0
+          fi
+
+          WEB_VERSION=$(printf '%s' "$WEB_RAW" | jq -r '.current_version // empty')
+
+          echo "Latest published release: $LATEST"
+          echo "Website current version:  $WEB_VERSION"
+
+          if [ "$WEB_VERSION" = "$LATEST" ]; then
+            echo "IN SYNC: website matches the latest published release."
+            exit 0
+          fi
+
+          echo "::error::Website version ($WEB_VERSION) does not match latest published release ($LATEST). The version-sync pipeline did not run for this release. Re-fire: gh workflow run sync-game-version.yml -f target_version=v$LATEST"
+          exit 1

--- a/.github/workflows/sync-dev-blog.yml
+++ b/.github/workflows/sync-dev-blog.yml
@@ -68,6 +68,10 @@ jobs:
 
       - name: Sync blog entries to website
         if: steps.changes.outputs.changed_files != ''
+        env:
+          # SECURITY: filenames from git diff are author-controlled text --
+          # pass via env (data), never inline ${{ }} in the script
+          CHANGED_FILES: ${{ steps.changes.outputs.changed_files }}
         run: |
           echo "LAUNCH Syncing blog entries to website..."
 
@@ -75,8 +79,8 @@ jobs:
           mkdir -p website/public/blog
           mkdir -p website/public/dev-notes
 
-          # Copy changed entries
-          for file in ${{ steps.changes.outputs.changed_files }}; do
+          # Copy changed entries (word-splitting on spaces is intended)
+          for file in $CHANGED_FILES; do
             if [ -f "$file" ]; then
               filename=$(basename "$file")
               echo "DOCUMENT Copying $filename to website"
@@ -123,9 +127,11 @@ jobs:
 
       - name: Notification
         if: steps.changes.outputs.changed_files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changes.outputs.changed_files }}
         run: |
           echo "CELEBRATION Dev blog sync completed!"
-          echo "METRICS Synced entries: ${{ steps.changes.outputs.changed_files }}"
+          echo "METRICS Synced entries: $CHANGED_FILES"
           echo "GLOBAL Changes will be live on the website shortly"
 
       - name: No changes notification

--- a/.github/workflows/sync-game-version.yml
+++ b/.github/workflows/sync-game-version.yml
@@ -35,19 +35,32 @@ jobs:
       with:
         python-version: '3.11'
 
+    # SECURITY: release name/body/tag and dispatch inputs are user-authored
+    # text. They must only enter scripts via env: vars (read as data), never
+    # via inline ${{ }} templating inside run: blocks -- Actions substitutes
+    # ${{ }} into the script TEXT before bash sees it, so a release body with
+    # backtick-wrapped commit hashes executed them as commands (exit 127 on
+    # every v0.13.1 release-event run of this workflow).
     - name: Extract Version Information
       id: version_info
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        RELEASE_NAME_IN: ${{ github.event.release.name }}
+        RELEASE_BODY_IN: ${{ github.event.release.body }}
+        RELEASE_URL_IN: ${{ github.event.release.html_url }}
+        IS_PRERELEASE_IN: ${{ github.event.release.prerelease }}
+        INPUT_TARGET_VERSION: ${{ github.event.inputs.target_version }}
       run: |
         # Extract version from release or input
-        if [ "${{ github.event_name }}" = "release" ]; then
-          VERSION="${{ github.event.release.tag_name }}"
+        if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+          VERSION="$RELEASE_TAG"
           VERSION_CLEAN="${VERSION#v}"
-          RELEASE_NAME="${{ github.event.release.name }}"
-          RELEASE_BODY="${{ github.event.release.body }}"
-          RELEASE_URL="${{ github.event.release.html_url }}"
-          IS_PRERELEASE="${{ github.event.release.prerelease }}"
+          RELEASE_NAME="$RELEASE_NAME_IN"
+          RELEASE_BODY="$RELEASE_BODY_IN"
+          RELEASE_URL="$RELEASE_URL_IN"
+          IS_PRERELEASE="$IS_PRERELEASE_IN"
         else
-          VERSION="${{ github.event.inputs.target_version }}"
+          VERSION="$INPUT_TARGET_VERSION"
           VERSION_CLEAN="${VERSION#v}"
           RELEASE_NAME="Manual Sync: $VERSION"
           RELEASE_BODY="Manually triggered version sync"
@@ -55,15 +68,22 @@ jobs:
           IS_PRERELEASE="false"
         fi
 
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "version_clean=$VERSION_CLEAN" >> $GITHUB_OUTPUT
-        echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
-        echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
-        echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+        {
+          echo "version=$VERSION"
+          echo "version_clean=$VERSION_CLEAN"
+          # release_name is free text: emit with a random heredoc delimiter so
+          # a crafted name cannot inject additional outputs
+          delim="gh_out_$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n')"
+          echo "release_name<<$delim"
+          echo "$RELEASE_NAME"
+          echo "$delim"
+          echo "release_url=$RELEASE_URL"
+          echo "is_prerelease=$IS_PRERELEASE"
+        } >> "$GITHUB_OUTPUT"
 
         # Extract release date
         RELEASE_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
+        echo "release_date=$RELEASE_DATE" >> "$GITHUB_OUTPUT"
 
         echo "=== Version Information ==="
         echo "Version: $VERSION"
@@ -74,6 +94,8 @@ jobs:
 
     - name: Extract Game Version Details
       id: game_details
+      env:
+        VERSION_CLEAN: ${{ steps.version_info.outputs.version_clean }}
       run: |
         # Read version from version.txt (single source of truth)
         if [ -f "version.txt" ]; then
@@ -81,19 +103,20 @@ jobs:
           echo "Read version from version.txt: $GAME_VERSION"
         else
           # Fallback to release tag version
-          GAME_VERSION="${{ steps.version_info.outputs.version_clean }}"
+          GAME_VERSION="$VERSION_CLEAN"
           echo "version.txt not found, using release tag: $GAME_VERSION"
         fi
 
-        echo "game_version=$GAME_VERSION" >> $GITHUB_OUTPUT
+        echo "game_version=$GAME_VERSION" >> "$GITHUB_OUTPUT"
 
         # Extract changelog section for this version
         if [ -f "CHANGELOG.md" ]; then
           python3 << 'EOF'
+        import os
         import re
         import sys
 
-        version = "${{ steps.version_info.outputs.version_clean }}"
+        version = os.environ.get("VERSION_CLEAN", "")
 
         try:
             with open('CHANGELOG.md', 'r', encoding='utf-8') as f:
@@ -120,26 +143,34 @@ jobs:
         EOF
         fi
 
-        echo "game_version=$GAME_VERSION" >> $GITHUB_OUTPUT
+        echo "game_version=$GAME_VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Create Website Version Data
       id: website_data
+      env:
+        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
+        RELEASE_NAME: ${{ steps.version_info.outputs.release_name }}
+        RELEASE_DATE: ${{ steps.version_info.outputs.release_date }}
+        RELEASE_URL: ${{ steps.version_info.outputs.release_url }}
+        IS_PRERELEASE: ${{ steps.version_info.outputs.is_prerelease }}
+        VERSION_TAG: ${{ steps.version_info.outputs.version }}
       run: |
-        # Create version data file for website
+        # Create version data file for website. Env vars expand as data;
+        # release_name is free text so it is JSON-escaped via jq.
         cat > website_version_update.json << EOF
         {
-          "game_version": "${{ steps.game_details.outputs.game_version }}",
-          "display_version": "v${{ steps.game_details.outputs.game_version }}",
-          "release_name": "${{ steps.version_info.outputs.release_name }}",
-          "release_date": "${{ steps.version_info.outputs.release_date }}",
-          "release_url": "${{ steps.version_info.outputs.release_url }}",
-          "is_prerelease": ${{ steps.version_info.outputs.is_prerelease }},
+          "game_version": "$GAME_VERSION",
+          "display_version": "v$GAME_VERSION",
+          "release_name": $(printf '%s' "$RELEASE_NAME" | jq -Rs .),
+          "release_date": "$RELEASE_DATE",
+          "release_url": "$RELEASE_URL",
+          "is_prerelease": $IS_PRERELEASE,
           "changelog_section": $(cat changelog_section.txt | jq -Rs .),
           "sync_timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
           "sync_source": "pdoom1-game-release",
           "assets": {
-            "download_url": "${{ steps.version_info.outputs.release_url }}",
-            "source_zip": "https://github.com/PipFoweraker/pdoom1/archive/refs/tags/${{ steps.version_info.outputs.version }}.zip",
+            "download_url": "$RELEASE_URL",
+            "source_zip": "https://github.com/PipFoweraker/pdoom1/archive/refs/tags/$VERSION_TAG.zip",
             "changelog_url": "https://github.com/PipFoweraker/pdoom1/blob/main/CHANGELOG.md"
           },
           "requirements": {
@@ -162,6 +193,12 @@ jobs:
     - name: Update Website Repository
       env:
         GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
+        RELEASE_NAME: ${{ steps.version_info.outputs.release_name }}
+        RELEASE_DATE: ${{ steps.version_info.outputs.release_date }}
+        RELEASE_URL: ${{ steps.version_info.outputs.release_url }}
+        IS_PRERELEASE: ${{ steps.version_info.outputs.is_prerelease }}
+        VERSION_TAG: ${{ steps.version_info.outputs.version }}
       run: |
         # Clone website repository
         git clone https://x-access-token:${GITHUB_TOKEN}@github.com/${WEBSITE_REPO}.git website-repo
@@ -171,34 +208,43 @@ jobs:
         git config user.name "Game Version Sync Bot"
         git config user.email "actions@github.com"
 
+        # Derive status strings once (was inline expression ternaries)
+        if [ "$IS_PRERELEASE" = "true" ]; then
+          RELEASE_STATUS="prerelease"
+          RELEASE_STATUS_LABEL="Pre-release"
+        else
+          RELEASE_STATUS="stable"
+          RELEASE_STATUS_LABEL="Stable Release"
+        fi
+
         # Create version content directory if it doesn't exist
-        mkdir -p content/game-versions/v${{ steps.game_details.outputs.game_version }}
+        mkdir -p "content/game-versions/v$GAME_VERSION"
         mkdir -p data/versions
 
         # Copy version data
-        cp ../website_version_update.json data/versions/v${{ steps.game_details.outputs.game_version }}.json
+        cp ../website_version_update.json "data/versions/v$GAME_VERSION.json"
 
-        # Create release notes content
-        cat > content/game-versions/v${{ steps.game_details.outputs.game_version }}/release-notes.md << 'EOF'
+        # Create release notes content (env vars expand as data)
+        cat > "content/game-versions/v$GAME_VERSION/release-notes.md" << EOF
         ---
-        title: "${{ steps.version_info.outputs.release_name }}"
-        version: "${{ steps.game_details.outputs.game_version }}"
-        release_date: "${{ steps.version_info.outputs.release_date }}"
+        title: "$RELEASE_NAME"
+        version: "$GAME_VERSION"
+        release_date: "$RELEASE_DATE"
         type: "game-release"
-        status: "${{ steps.version_info.outputs.is_prerelease == 'true' && 'prerelease' || 'stable' }}"
-        download_url: "${{ steps.version_info.outputs.release_url }}"
+        status: "$RELEASE_STATUS"
+        download_url: "$RELEASE_URL"
         ---
 
-        # ${{ steps.version_info.outputs.release_name }}
+        # $RELEASE_NAME
 
-        **Version:** v${{ steps.game_details.outputs.game_version }}
-        **Release Date:** ${{ steps.version_info.outputs.release_date }}
-        **Status:** ${{ steps.version_info.outputs.is_prerelease == 'true' && 'Pre-release' || 'Stable Release' }}
+        **Version:** v$GAME_VERSION
+        **Release Date:** $RELEASE_DATE
+        **Status:** $RELEASE_STATUS_LABEL
 
         ## Download
 
-        - [Download Game](${{ steps.version_info.outputs.release_url }})
-        - [View Source Code](https://github.com/PipFoweraker/pdoom1/tree/${{ steps.version_info.outputs.version }})
+        - [Download Game]($RELEASE_URL)
+        - [View Source Code](https://github.com/PipFoweraker/pdoom1/tree/$VERSION_TAG)
         - [Full Changelog](https://github.com/PipFoweraker/pdoom1/blob/main/CHANGELOG.md)
 
         ## Release Notes
@@ -206,16 +252,16 @@ jobs:
         EOF
 
         # Append changelog content
-        cat ../changelog_section.txt >> content/game-versions/v${{ steps.game_details.outputs.game_version }}/release-notes.md
+        cat ../changelog_section.txt >> "content/game-versions/v$GAME_VERSION/release-notes.md"
 
         # Update current version tracking
         cat > data/current-game-version.json << EOF
         {
-          "current_version": "${{ steps.game_details.outputs.game_version }}",
-          "display_version": "v${{ steps.game_details.outputs.game_version }}",
-          "release_date": "${{ steps.version_info.outputs.release_date }}",
-          "release_name": "${{ steps.version_info.outputs.release_name }}",
-          "status": "${{ steps.version_info.outputs.is_prerelease == 'true' && 'prerelease' || 'stable' }}",
+          "current_version": "$GAME_VERSION",
+          "display_version": "v$GAME_VERSION",
+          "release_date": "$RELEASE_DATE",
+          "release_name": $(printf '%s' "$RELEASE_NAME" | jq -Rs .),
+          "status": "$RELEASE_STATUS",
           "last_updated": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
         }
         EOF
@@ -226,34 +272,40 @@ jobs:
         if git diff --staged --quiet; then
           echo "No changes to commit"
         else
-          git commit -m "feat: sync game version v${{ steps.game_details.outputs.game_version }}
+          git commit -m "feat: sync game version v$GAME_VERSION
 
-        - Add release notes for v${{ steps.game_details.outputs.game_version }}
+        - Add release notes for v$GAME_VERSION
         - Update current version tracking
         - Sync from pdoom1 repository release
 
-        Automated sync from: ${{ github.repository }}@${{ github.sha }}"
+        Automated sync from: $GITHUB_REPOSITORY@$GITHUB_SHA"
 
           git push origin main
-          echo "SUCCESS Successfully updated website with game version v${{ steps.game_details.outputs.game_version }}"
+          echo "SUCCESS Successfully updated website with game version v$GAME_VERSION"
         fi
 
     - name: Update Version History
       env:
         GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
+        RELEASE_NAME: ${{ steps.version_info.outputs.release_name }}
+        RELEASE_DATE: ${{ steps.version_info.outputs.release_date }}
+        RELEASE_URL: ${{ steps.version_info.outputs.release_url }}
+        IS_PRERELEASE: ${{ steps.version_info.outputs.is_prerelease }}
+        FORCE_SYNC: ${{ github.event.inputs.force_sync }}
       run: |
         cd website-repo
 
-        # Update version history JSON
+        # Update version history JSON (untrusted values read from env as data)
         python3 << 'EOF'
         import json
         import os
         from datetime import datetime
 
-        version = "${{ steps.game_details.outputs.game_version }}"
-        release_date = "${{ steps.version_info.outputs.release_date }}"
-        release_name = "${{ steps.version_info.outputs.release_name }}"
-        is_prerelease = "${{ steps.version_info.outputs.is_prerelease }}" == "true"
+        version = os.environ.get("GAME_VERSION", "")
+        release_date = os.environ.get("RELEASE_DATE", "")
+        release_name = os.environ.get("RELEASE_NAME", "")
+        is_prerelease = os.environ.get("IS_PRERELEASE", "") == "true"
 
         # Load existing version history
         history_file = "data/version-history.json"
@@ -266,7 +318,7 @@ jobs:
         # Check if version already exists
         existing_version = next((v for v in history["versions"] if v["version"] == version), None)
 
-        if existing_version and not "${{ github.event.inputs.force_sync }}" == "true":
+        if existing_version and not os.environ.get("FORCE_SYNC", "") == "true":
             print(f"Version {version} already exists in history")
         else:
             # Add or update version entry
@@ -277,7 +329,7 @@ jobs:
                 "release_name": release_name,
                 "status": "prerelease" if is_prerelease else "stable",
                 "type": "minor" if ".0" in version else "patch",
-                "download_url": "${{ steps.version_info.outputs.release_url }}",
+                "download_url": os.environ.get("RELEASE_URL", ""),
                 "changelog_url": f"/game/releases/v{version}"
             }
 
@@ -304,7 +356,7 @@ jobs:
         # Commit version history update
         if ! git diff --quiet data/version-history.json; then
           git add data/version-history.json
-          git commit -m "update: version history with v${{ steps.game_details.outputs.game_version }}"
+          git commit -m "update: version history with v$GAME_VERSION"
           git push origin main
           echo "SUCCESS Updated version history"
         fi
@@ -312,31 +364,33 @@ jobs:
     - name: Trigger Website Rebuild
       env:
         GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
       run: |
-        # Trigger website rebuild via repository dispatch
+        # Trigger website rebuild via repository dispatch. Payload is built
+        # with jq so the version string is passed as data, not spliced JSON.
+        PAYLOAD=$(jq -n \
+          --arg game_version "$GAME_VERSION" \
+          --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+          '{event_type: "game_version_sync", client_payload: {game_version: $game_version, sync_source: "pdoom1-release", timestamp: $timestamp}}')
+
         curl -X POST \
           -H "Authorization: token ${GITHUB_TOKEN}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/${WEBSITE_REPO}/dispatches \
-          -d '{
-            "event_type": "game_version_sync",
-            "client_payload": {
-              "game_version": "${{ steps.game_details.outputs.game_version }}",
-              "sync_source": "pdoom1-release",
-              "timestamp": "'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'"
-            }
-          }'
+          -d "$PAYLOAD"
 
         echo "SUCCESS Triggered website rebuild"
 
     - name: Notify Data Repository (Future)
       env:
         GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
+        RELEASE_DATE: ${{ steps.version_info.outputs.release_date }}
       run: |
         # Placeholder for future data repository notification
         echo "=== Data Repository Notification (Future) ==="
-        echo "Game Version: v${{ steps.game_details.outputs.game_version }}"
-        echo "Release Date: ${{ steps.version_info.outputs.release_date }}"
+        echo "Game Version: v$GAME_VERSION"
+        echo "Release Date: $RELEASE_DATE"
         echo "Status: Ready for data batch compatibility validation"
 
         # Future implementation will:
@@ -349,26 +403,23 @@ jobs:
         #   -H "Authorization: token ${GITHUB_TOKEN}" \
         #   -H "Accept: application/vnd.github.v3+json" \
         #   https://api.github.com/repos/${DATA_REPO}/dispatches \
-        #   -d '{
-        #     "event_type": "game_version_update",
-        #     "client_payload": {
-        #       "game_version": "${{ steps.game_details.outputs.game_version }}",
-        #       "compatibility_check": true,
-        #       "timestamp": "'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'"
-        #     }
-        #   }'
+        #   -d "$(jq -n --arg game_version "$GAME_VERSION" \
+        #     --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+        #     '{event_type: "game_version_update", client_payload: {game_version: $game_version, compatibility_check: true, timestamp: $timestamp}}')"
 
     - name: Summary
+      env:
+        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
       run: |
         echo "=== Game Version Sync Complete ==="
-        echo "SUCCESS Game Version: v${{ steps.game_details.outputs.game_version }}"
+        echo "SUCCESS Game Version: v$GAME_VERSION"
         echo "SUCCESS Website Repository: Updated with release content"
         echo "SUCCESS Version History: Updated with new release"
         echo "SUCCESS Website Rebuild: Triggered"
         echo "REFRESH Data Integration: Placeholder ready for future implementation"
         echo ""
         echo "Website will be updated with:"
-        echo "- Release notes at /game/releases/v${{ steps.game_details.outputs.game_version }}"
+        echo "- Release notes at /game/releases/v$GAME_VERSION"
         echo "- Updated version badge and current version display"
         echo "- Version history page with new release"
         echo "- Download links and compatibility information"

--- a/.github/workflows/sync-game-version.yml
+++ b/.github/workflows/sync-game-version.yml
@@ -14,6 +14,25 @@ on:
         required: false
         type: boolean
         default: false
+  # Reusable entrypoint: the Enhanced Release workflow calls this directly at
+  # the end of a CI-published release. Necessary because a release PUBLISHED by
+  # a GITHUB_TOKEN-authored action does NOT fire the `release: published` event
+  # (GitHub loop-prevention), so the event trigger above silently never runs for
+  # CI releases -- confirmed for v0.13.1 (published by github-actions[bot]).
+  workflow_call:
+    inputs:
+      target_version:
+        description: 'Game version to sync (e.g., v0.6.0)'
+        required: true
+        type: string
+      force_sync:
+        description: 'Force sync even if version already exists'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      CROSS_REPO_TOKEN:
+        required: true
 
 env:
   WEBSITE_REPO: 'PipFoweraker/pdoom1-website'
@@ -49,7 +68,9 @@ jobs:
         RELEASE_BODY_IN: ${{ github.event.release.body }}
         RELEASE_URL_IN: ${{ github.event.release.html_url }}
         IS_PRERELEASE_IN: ${{ github.event.release.prerelease }}
-        INPUT_TARGET_VERSION: ${{ github.event.inputs.target_version }}
+        # inputs.* is populated for BOTH workflow_dispatch and workflow_call
+        # (null for release events, where the release.* fields above are used)
+        INPUT_TARGET_VERSION: ${{ inputs.target_version }}
       run: |
         # Extract version from release or input
         if [ "$GITHUB_EVENT_NAME" = "release" ]; then
@@ -292,7 +313,7 @@ jobs:
         RELEASE_DATE: ${{ steps.version_info.outputs.release_date }}
         RELEASE_URL: ${{ steps.version_info.outputs.release_url }}
         IS_PRERELEASE: ${{ steps.version_info.outputs.is_prerelease }}
-        FORCE_SYNC: ${{ github.event.inputs.force_sync }}
+        FORCE_SYNC: ${{ inputs.force_sync }}
       run: |
         cd website-repo
 


### PR DESCRIPTION
## Security: GitHub Actions script injection + durable version-sync fix

The v0.13.1 website-sync silence had **two stacked failure mechanisms**. This PR fixes both.

### Mechanism 1 -- script injection (untrusted context in `run:` blocks)

GitHub Actions substitutes `${{ }}` expressions into the `run:`/`script:` TEXT before the shell/interpreter sees it. Any user-authored field templated inline is therefore executable code, not data.

**Verified live, not theoretical:** the release-event runs of `sync-game-version.yml` for v0.13.1 (2026-07-26) failed exit 127 in "Extract Version Information" -- the release body's backtick-wrapped commit hashes executed as command substitution:

```
line 23: 409535dc0215d5e7bf4ff1b83025e8da98d7b4ef: command not found
```

Fix pattern is the house style from `dev-blog-automation.yml` (c7ee336f, PR #862): every untrusted value enters the script via an `env:` block and is read as data -- quoted `"$VAR"` in bash, `os.environ` in python, `process.env` in github-script JS.

### Mechanism 2 -- the `published` event never fired for CI-cut releases

Even with mechanism 1 fixed, CI-published releases would STILL not sync. A release **published by a `GITHUB_TOKEN`-authored action does not fire the `release: published` event** (GitHub's loop-prevention). v0.13.1 was published by `github-actions[bot]`, so `sync-game-version.yml`'s event trigger never ran on publish -- zero runs, not a failure. Proof by contrast: v0.13.0 was published by a human (`PipFoweraker`), its `published` event fired, and sync succeeded (run 30089072605). The red runs on v0.13.1 were all human `edited` events (which DO fire) hitting mechanism 1.

**Durable fix (least-privilege option a):** the Enhanced Release workflow now calls `sync-game-version.yml` directly via `workflow_call` after it creates the release. A reusable-workflow call is an in-line invocation, not an event, so it is immune to the `GITHUB_TOKEN` suppression; `secrets: inherit` reuses the existing `CROSS_REPO_TOKEN` -- no new PAT (rejected option b). Added as belt-and-braces (option c): `release-sync-monitor.yml`, a daily read-only job that compares the latest published release to the website's `current_version` and **fails RED with `::error::` when they diverge** -- a loud signal that the primary path did not run, with the re-fire command in the message.

## Audit -- every workflow in `.github/workflows/`, verdict per file

| Workflow | Verdict |
|---|---|
| sync-game-version.yml | **FIXED** (both mechanisms) -- injection: release tag/name/body/url, dispatch inputs, and every tainted step output moved to `env:`; `release_name` JSON-escaped via `jq -Rs`; `GITHUB_OUTPUT` multiline write uses a random heredoc delimiter; repo-dispatch payload built with `jq --arg`. Sync-silence: added `workflow_call` entrypoint (inputs switched `github.event.inputs.*` -> `inputs.*`, populated for both dispatch and call) |
| enhanced-release.yml | **FIXED** (both) -- injection: `inputs.version \|\| ref_name` (dispatch input / tag name; git refnames may contain backticks and `$`) in 4 bash steps + 2 notification echoes -> `env:`; the `actions/github-script` triage-issue step templated it into JS with `issues: write` -> now `process.env.RELEASE_VERSION`; emoji on touched lines -> ASCII. Sync-silence: new `sync-website-version` job calls the reusable sync via `workflow_call` (`secrets: inherit`) |
| release-sync-monitor.yml | **NEW** -- daily read-only LOUD monitor; fails red when the website version lags the latest published release |
| sync-dev-blog.yml | **FIXED** -- `steps.changes.outputs.changed_files` (git-diff filenames, author-controlled) looped unquoted in bash -> `env:` |
| quality-checks.yml | **FIXED** -- `github.base_ref` (branch name) in `run:` -> `env:` |
| dev-blog-automation.yml | Clean -- already fixed on main (c7ee336f / PR #862; identical content to the stale `fix/gha-injection` branch d143465a, which needs no cherry-pick and can be deleted) |
| sync-documentation.yml | Clean -- `changed_files` built from `matrix` constants; `force_sync` is a typed boolean (renders only `true`/`false`) |
| enhanced-cicd-pipeline.yml | Clean -- `ref_name` use is inside a job gated `if: github.ref == 'refs/heads/main'`; rest are own-pipeline scores/results/sha |
| data-validation.yml | Clean -- sha/ref/run_id/actor only (constrained or write-access-only) |
| godot-tests.yml | Clean -- `needs.*.result` trusted enums |
| docs-sync.yml, pre-release-checks.yml, release-reminder.yml | Clean -- no context interpolation in scripts |

Residual `${{ }}` left inside `run:` blocks are write-access-only or workflow-generated values (sha, run ids, own-step hashes/scores, typed booleans, matrix constants) -- audited and accepted; the sweep targeted unprivileged/user-authored text.

## Testing

Extracted the actual `run:` text of the three extraction steps from the YAML and executed them locally (bash + jq 1.7.1) under three cases: release event with hostile name+body (backticks, `$()`, single/double quotes, multiline), the v0.13.1 dispatch path, and a hostile `target_version` input. All exit 0, no command execution (marker-file canaries untouched), output JSON valid with hostile strings preserved as literal data, changelog extraction for 0.13.1 works. All 12 workflow files YAML-validated.

## Important limitation: tag-time refs

Workflows run from the ref that triggered them. This fix protects future runs triggered from main (release published/edited, workflow_dispatch, PRs). Runs triggered by OLD tags execute the workflow file AS OF THAT TAG -- those historical copies stay vulnerable/broken until re-tagged. Practically: `release: [published, edited]` and `workflow_dispatch` resolve the workflow from the default branch, so the failing sync path IS cured on merge; but tag-push-triggered workflows (enhanced-release.yml `on: push: tags`) only get the fix for tags created after this merges.

## Today's dispatch run (v0.13.1) + full red-run tally

`workflow_dispatch` run 30185908321 (03:16 UTC) **succeeded** -- all 11 steps green; it synced v0.13.1 release notes + `data/versions/v0.13.1.json` + version history to pdoom1-website and triggered the rebuild. The dispatch path never templated the release body (static string), which is why it dodged the bug. **No re-fire needed** for v0.13.1 -- the website is current.

Full failure tally today (7 red `release`-event runs, all mechanism-1 injection, all human `edited` events -- the `published` event never fired at all per mechanism 2): 00:56 UTC x2 (30182027589, 30182027601), 01:05 (30182296187), 01:10 (30182443154), 02:42 (30184991554), 03:19 (30185979497), 03:55 (30186930044). Any further edit to the v0.13.1 release body before this merges will keep failing red -- harmless, the dispatch already synced.

## Follow-up: pdoom1-website has the same class (NOT fixed here, read-only audit)

52 risky interpolations inside `run:`/`script:` blocks across 15 workflow files. Highest severity first:

- **post-issue-to-forum.yml:79,89** -- `github.event.issue.title` / `issue.body` inline in bash: ANY GitHub user can open an issue -> unprivileged injection. Fix first.
- **bug-report.yml:276-292** -- `client_payload.*` / `inputs.*` (fed from the web bug-report form via repository_dispatch) templated into bash.
- **update-game-status.yml:62-115** -- `client_payload.version/status/warning/phase/progress` and dispatch inputs spliced into an `args=` string (single quotes around some do NOT help -- substitution happens before bash parsing).
- **sync-design-notes.yml:48,50; sync-design-tokens.yml:61; sync-pdoom1-docs.yml:50,52** -- `inputs.ref` / `client_payload.ref` into bash/`GITHUB_OUTPUT`.
- **auto-deploy-on-push.yml:26** -- `head_commit.message` echoed inline (commit messages are free text).
- **version-aware-deploy.yml:76,116-118,162-166; weekly-deployment.yml:181-185; deploy-dreamhost.yml:70; extract-analytics.yml:67-74; snapshot-analytics.yml:42; weekly-league-reset.yml:77** -- dispatch inputs (maintainer-typed; `deployment_notes` is free text and also lands unescaped in JSON).

Recommend an issue on pdoom1-website tracking these, same env-var pattern.

Generated with [Claude Code](https://claude.com/claude-code)
