### PR TITLE
feat(art): Anchor Sockets V2 -- part-anchored effects on animated sprites (#894 #900 #913)

### DIFF
--- a/docs/art/PROP_MANIFEST.md
+++ b/docs/art/PROP_MANIFEST.md
@@ -76,10 +76,44 @@ NOTE: authored proportions are BIGGER than the old force-scale (a 3.5-tile
 water cooler now renders 224 px at the 64 px display tile, vs 46 px before).
 Entries carry `review: true` where the measured geometry needs Pip's ruling.
 
-## Sockets are schema-only
+## Sockets are schema-only (for PROPS)
 
 `sockets` defines the FUTURE attachment-point shape
 (`{"name", "px": [x, y], "layer": "front"|"behind"}`) for the cosmetics sprite
 category in `art_source/` (paper-doll layers, e.g. a poster taped to a server
-rack). No consumer exists; keep every `sockets` array empty until one does --
-the unit test validates the shape only if populated.
+rack). No PROP consumer exists; keep every prop `sockets` array empty until one
+does -- the unit test validates the shape only if populated.
+
+## Anchor sockets V2 -- the same convention on ANIMATED CLIPS
+
+The socket shape above is now LIVE for animated sprites (Anchor Sockets V2,
+2026-07-26, issues #894 #900 #913): effects attach to sprite PARTS (a cat's
+eyes, its butt) instead of the sprite centre.
+
+- **Data:** `godot/data/office/anchor_sockets.json` (SSOT; `_schema` inside is
+  authoritative). Keyed `sprites -> <sprite set id> -> clips -> <clip name>`
+  (runtime `AnimatedSprite2D` animation names, e.g. `walk_east`;
+  `walk_north_alt` = the #913 butt-flash splice).
+- **Per clip:** `source_dir` (repo-root-relative frames dir), optional `frames`
+  `[first, last]` range, `subject_px`, `feet_px` (canvas coords, same
+  bottom-centre-of-bbox convention as `anchor_px` here), `footfall_frames`
+  (paw-strike frame indices -- the deterministic footfall-pulse hook), and
+  `sockets`: the SAME `{name, px, layer}` shape, where `px` is the OFFSET FROM
+  `feet_px` in source px (`+x` right, `+y` down; eyes are negative `y`) --
+  mirroring `approach_px`. Canvas position of a socket = `feet_px + px`.
+- **Ruled anchor set (cats):** `eyes` every direction, `butt` rear-facing +
+  butt-flash clips only, `spine_mid` reserve. `review: true` marks anchors
+  needing Pip's judgement.
+- **Consumer:** `godot/scripts/ui/office_floor/anchored_overlay.gd`
+  (`AnchoredOverlay`) -- positions an overlay `SpriteFrames` at the named
+  anchor of a host `AnimatedSprite2D`, re-resolving on clip/direction change;
+  blend / opacity / z-offset / scale dials; deterministic footfall pulse.
+- **Authoring:** `python tools/art_review/author_anchor_sockets.py` (PIL
+  measurement + marker proof sheet `art_generated/anchor_debug_sheet.png`);
+  fine-tuning via the layering lab's click-to-adjust mode
+  (`tools/art_review/build_cat_sweep_sheet.py`), which emits corrected JSON for
+  paste-back. Pip clicking IS the tool.
+- **Tests:** `godot/tests/unit/test_anchor_sockets.gd`.
+- **V2 = per-direction STATIC offsets only.** V3 (documented future in the
+  `_schema`) adds optional per-frame `tracks` alongside the static `px`;
+  consumers prefer tracks when present.

--- a/godot/data/office/anchor_sockets.json
+++ b/godot/data/office/anchor_sockets.json
@@ -236,6 +236,45 @@
             2,
             8
           ]
+        },
+        "idle": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk_ns_lowtd/south",
+          "subject_px": [
+            16,
+            35
+          ],
+          "feet_px": [
+            34.0,
+            49
+          ],
+          "footfall_frames": [],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                0,
+                -26
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "dark-dot centroid on the face; muzzle/nose confusable -- Pip to nudge in the lab"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -23
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ],
+          "frames": [
+            0,
+            0
+          ]
         }
       }
     },
@@ -318,6 +357,44 @@
               "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
             }
           ]
+        },
+        "idle": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_black_side_heft/animations/walk_ew/east",
+          "subject_px": [
+            44,
+            33
+          ],
+          "feet_px": [
+            30.0,
+            48
+          ],
+          "footfall_frames": [],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                16,
+                -22
+              ],
+              "layer": "front",
+              "notes": "colour-blob centroid of the iris pixels, avg across frames"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -21
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ],
+          "frames": [
+            0,
+            0
+          ]
         }
       }
     },
@@ -399,6 +476,44 @@
               "review": true,
               "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
             }
+          ]
+        },
+        "idle": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_purple_side_heft/animations/walking/east",
+          "subject_px": [
+            46,
+            33
+          ],
+          "feet_px": [
+            30.0,
+            48
+          ],
+          "footfall_frames": [],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                16,
+                -22
+              ],
+              "layer": "front",
+              "notes": "colour-blob centroid of the iris pixels, avg across frames"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -21
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ],
+          "frames": [
+            0,
+            0
           ]
         }
       }

--- a/godot/data/office/anchor_sockets.json
+++ b/godot/data/office/anchor_sockets.json
@@ -1,0 +1,407 @@
+{
+  "_meta": {
+    "version": "2.0",
+    "description": "Anchor Sockets V2 -- per-clip-direction named anchor points on animated sprites, so effects attach to PARTS (eyes, butt, spine_mid) instead of sprite centres. Covers the PROMOTED cat sweep clips (Pip triage 2026-07-26). Consumed by scripts/ui/office_floor/anchored_overlay.gd; authored by tools/art_review/author_anchor_sockets.py; adjusted via the layering lab click-to-adjust flow. See docs/art/PROP_MANIFEST.md (Anchor sockets section).",
+    "measured_with": "tools/art_review/author_anchor_sockets.py (python PIL), 2026-07-26"
+  },
+  "_schema": {
+    "sprites": "sprite-set id -> {canvas_px, clips}. Ids match the SpriteFrames sets the office sandbox builds from the promoted cat sweep clips (art_source/pixellab_verdicts.json 'promote' entries, Pip 2026-07-26).",
+    "canvas_px": "[w, h] full frame canvas in pixels (all clips of a set share it).",
+    "clips": "clip name (runtime AnimatedSprite2D animation name, e.g. walk_east; walk_north_alt = the #913 butt-flash splice) -> per-clip anchor data.",
+    "source_dir": "repo-root-relative dir holding the clip's frame_NNN.png files.",
+    "frames": "OPTIONAL [first, last] inclusive frame-index range used from source_dir (butt-flash splices 2..8 per the sweep MANIFEST); absent = all frames.",
+    "subject_px": "[w, h] opaque-subject bbox averaged across the clip's frames (rounded).",
+    "feet_px": "[x, y] feet anchor in CANVAS coords: bottom-centre of the average alpha bbox (same convention as props_manifest anchor_px, #906/#915). The sprite origin sockets are measured from.",
+    "footfall_frames": "clip-local frame indices (0-based) where a paw strikes the floor -- the deterministic hook for footfall-anchored overlay pulses (Pip ruling 2026-07-26). Measured as stride-extreme frames; review flags apply.",
+    "sockets": "list of {name, px, layer} -- the UNIFIED socket convention shared with props_manifest.json sockets. px = [x, y] OFFSET FROM feet_px in source px (+x right, +y down; eyes are negative y). layer: 'front'|'behind' draw order relative to the host sprite. Optional review/notes. Ruled anchor set for cats: eyes (every direction), butt (rear-facing + butt-flash only), spine_mid (reserve).",
+    "review": "optional bool: true = anchor needs Pip's judgement (see notes).",
+    "notes": "optional free-text provenance / uncertainty notes.",
+    "v3_future": "V2 stores per-direction STATIC offsets only. V3 adds OPTIONAL per-frame tracks alongside px: 'tracks': {socket_name: [[x, y] per clip frame]}; consumers prefer tracks when present and fall back to px. The layering lab's click-to-adjust flow is the intended authoring path."
+  },
+  "sprites": {
+    "cat_tabby_v1": {
+      "canvas_px": [
+        68,
+        68
+      ],
+      "clips": {
+        "walk_east": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_side_heft/animations/walk_side_diag_probe/east",
+          "subject_px": [
+            46,
+            31
+          ],
+          "feet_px": [
+            29.0,
+            48
+          ],
+          "footfall_frames": [
+            0,
+            4
+          ],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                18,
+                -21
+              ],
+              "layer": "front",
+              "notes": "colour-blob centroid of the iris pixels, avg across frames"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -20
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ]
+        },
+        "walk_west": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_side_heft/animations/walk_side_diag_probe/west",
+          "subject_px": [
+            45,
+            31
+          ],
+          "feet_px": [
+            38.5,
+            48
+          ],
+          "footfall_frames": [
+            2,
+            4
+          ],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                -18,
+                -21
+              ],
+              "layer": "front",
+              "notes": "colour-blob centroid of the iris pixels, avg across frames"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -20
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ]
+        },
+        "walk_north": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk_ns_lowtd/north",
+          "subject_px": [
+            16,
+            36
+          ],
+          "feet_px": [
+            34.0,
+            50
+          ],
+          "footfall_frames": [
+            1,
+            3
+          ],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                0,
+                -31
+              ],
+              "layer": "behind",
+              "review": true,
+              "notes": "eyes NOT visible from the rear -- anchored at the head centroid so a glow halos the head; layer behind"
+            },
+            {
+              "name": "butt",
+              "px": [
+                0,
+                -8
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "rump centre from bbox geometry (~78% down the subject) -- Pip to nudge in the lab"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -23
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ]
+        },
+        "walk_south": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk_ns_lowtd/south",
+          "subject_px": [
+            15,
+            35
+          ],
+          "feet_px": [
+            34.0,
+            48
+          ],
+          "footfall_frames": [
+            1,
+            5
+          ],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                0,
+                -25
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "dark-dot centroid on the face; muzzle/nose confusable -- Pip to nudge in the lab"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -22
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ]
+        },
+        "walk_north_alt": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/butt_flash_north/north",
+          "subject_px": [
+            17,
+            38
+          ],
+          "feet_px": [
+            34.0,
+            53
+          ],
+          "footfall_frames": [
+            1,
+            3
+          ],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                0,
+                -33
+              ],
+              "layer": "behind",
+              "review": true,
+              "notes": "eyes NOT visible from the rear -- anchored at the head centroid so a glow halos the head; layer behind"
+            },
+            {
+              "name": "butt",
+              "px": [
+                0,
+                -8
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "rump centre from bbox geometry (~78% down the subject) -- Pip to nudge in the lab"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -25
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ],
+          "frames": [
+            2,
+            8
+          ]
+        }
+      }
+    },
+    "cat_black_v1": {
+      "canvas_px": [
+        68,
+        68
+      ],
+      "clips": {
+        "walk_east": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_black_side_heft/animations/walk_ew/east",
+          "subject_px": [
+            44,
+            32
+          ],
+          "feet_px": [
+            30.0,
+            47
+          ],
+          "footfall_frames": [
+            0,
+            2
+          ],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                16,
+                -21
+              ],
+              "layer": "front",
+              "notes": "colour-blob centroid of the iris pixels, avg across frames"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -21
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ]
+        },
+        "walk_west": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_black_side_heft/animations/walk_ew/west",
+          "subject_px": [
+            42,
+            32
+          ],
+          "feet_px": [
+            36.5,
+            48
+          ],
+          "footfall_frames": [
+            1,
+            4
+          ],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                -16,
+                -21
+              ],
+              "layer": "front",
+              "notes": "colour-blob centroid of the iris pixels, avg across frames"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -21
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ]
+        }
+      }
+    },
+    "cat_purple_v1": {
+      "canvas_px": [
+        68,
+        68
+      ],
+      "clips": {
+        "walk_east": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_purple_side_heft/animations/walking/east",
+          "subject_px": [
+            46,
+            32
+          ],
+          "feet_px": [
+            29.5,
+            47
+          ],
+          "footfall_frames": [
+            4,
+            7
+          ],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                16,
+                -21
+              ],
+              "layer": "front",
+              "notes": "colour-blob centroid of the iris pixels, avg across frames"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -21
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ]
+        },
+        "walk_west": {
+          "source_dir": "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_purple_side_heft/animations/walking/west",
+          "subject_px": [
+            46,
+            32
+          ],
+          "feet_px": [
+            38.0,
+            47
+          ],
+          "footfall_frames": [
+            1,
+            3
+          ],
+          "footfall_review": true,
+          "sockets": [
+            {
+              "name": "eyes",
+              "px": [
+                -18,
+                -21
+              ],
+              "layer": "front",
+              "notes": "colour-blob centroid of the iris pixels, avg across frames"
+            },
+            {
+              "name": "spine_mid",
+              "px": [
+                0,
+                -21
+              ],
+              "layer": "front",
+              "review": true,
+              "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/godot/scripts/ui/office_floor/anchored_overlay.gd
+++ b/godot/scripts/ui/office_floor/anchored_overlay.gd
@@ -1,0 +1,202 @@
+class_name AnchoredOverlay
+extends AnimatedSprite2D
+## Anchor Sockets V2 consumer (#894 #900 #913): plays an overlay SpriteFrames
+## ATTACHED TO A NAMED ANCHOR of a host AnimatedSprite2D (a cat's eyes, its
+## butt), instead of the sprite centre.
+##
+## Anchor data SSOT: res://data/office/anchor_sockets.json -- per sprite set,
+## per clip (= host animation name), named sockets {name, px, layer} where px
+## is the offset from the clip's feet anchor in SOURCE px (schema block in the
+## JSON is authoritative; docs/art/PROP_MANIFEST.md "Anchor sockets" section).
+##
+## Behaviour:
+##   * parented to the host; position re-resolves whenever the host's clip
+##     (direction) changes -- a socket missing for the current clip hides the
+##     overlay (e.g. 'butt' exists only on rear-facing + butt-flash clips).
+##   * dials mirror the layering lab: blend ("normal"|"add"), opacity,
+##     z-offset, overlay scale.
+##   * footfall pulse (Pip ruling 2026-07-26): when the host's frame index
+##     enters the clip's footfall_frames set, the overlay pulses (opacity +
+##     scale bump, linear decay). Purely frame-index driven -- DETERMINISTIC,
+##     no RNG anywhere in this class.
+##
+## V2 = per-direction STATIC offsets. V3 (future) adds per-frame tracks in the
+## same JSON; this consumer would prefer them when present.
+
+const SOCKETS_PATH := "res://data/office/anchor_sockets.json"
+
+static var _data: Dictionary = {}
+static var _load_attempted := false
+
+var host: AnimatedSprite2D = null
+var sprite_set: String = ""
+var anchor_name: String = ""
+var base_opacity: float = 1.0
+var overlay_scale: float = 1.0
+var z_offset: int = 1
+var pulse_enabled: bool = true
+var pulse_strength: float = 0.5      # opacity/scale bump at pulse peak
+var pulse_decay: float = 3.0         # pulse units decayed per second
+
+var enabled: bool = true             # master switch (demo toggle); overrides visibility
+
+var _pulse: float = 0.0              # 1.0 at paw-strike, decays to 0
+var _tint := Color(1, 1, 1, 1)
+
+# --- static anchor-data access ----------------------------------------------
+
+static func data() -> Dictionary:
+	if not _load_attempted:
+		_load_attempted = true
+		_data = {}
+		if FileAccess.file_exists(SOCKETS_PATH):
+			var f := FileAccess.open(SOCKETS_PATH, FileAccess.READ)
+			if f != null:
+				var parsed = JSON.parse_string(f.get_as_text())
+				f.close()
+				if parsed is Dictionary:
+					_data = parsed
+	return _data
+
+
+static func sprite_sets() -> Array:
+	return data().get("sprites", {}).keys()
+
+
+static func sprite_entry(p_set: String) -> Dictionary:
+	return data().get("sprites", {}).get(p_set, {})
+
+
+static func clip_entry(p_set: String, clip: String) -> Dictionary:
+	return sprite_entry(p_set).get("clips", {}).get(clip, {})
+
+
+## The {name, px, layer} socket dict, or {} when the clip has no such anchor.
+static func socket_of(p_set: String, clip: String, p_anchor: String) -> Dictionary:
+	for sk in clip_entry(p_set, clip).get("sockets", []):
+		if sk is Dictionary and String(sk.get("name", "")) == p_anchor:
+			return sk
+	return {}
+
+
+static func canvas_of(p_set: String) -> Vector2:
+	var c: Array = sprite_entry(p_set).get("canvas_px", [])
+	return Vector2(float(c[0]), float(c[1])) if c.size() == 2 else Vector2.ZERO
+
+
+static func feet_of(p_set: String, clip: String) -> Vector2:
+	var fp: Array = clip_entry(p_set, clip).get("feet_px", [])
+	return Vector2(float(fp[0]), float(fp[1])) if fp.size() == 2 else Vector2.ZERO
+
+
+static func footfalls_of(p_set: String, clip: String) -> Array:
+	return clip_entry(p_set, clip).get("footfall_frames", [])
+
+# --- instance ----------------------------------------------------------------
+
+## Attach to `p_host` (reparents this node under it), playing `frames` at the
+## named anchor. config dials: opacity, blend ("add"|"normal"), scale,
+## z_offset, pulse (bool), pulse_strength, pulse_decay, tint (Color).
+func attach(p_host: AnimatedSprite2D, p_set: String, p_anchor: String,
+		frames: SpriteFrames, config: Dictionary = {}) -> void:
+	host = p_host
+	sprite_set = p_set
+	anchor_name = p_anchor
+	base_opacity = float(config.get("opacity", base_opacity))
+	overlay_scale = float(config.get("scale", overlay_scale))
+	z_offset = int(config.get("z_offset", z_offset))
+	pulse_enabled = bool(config.get("pulse", pulse_enabled))
+	pulse_strength = float(config.get("pulse_strength", pulse_strength))
+	pulse_decay = float(config.get("pulse_decay", pulse_decay))
+	_tint = config.get("tint", _tint)
+	texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	centered = true
+	set_overlay_frames(frames)
+	if String(config.get("blend", "add")) == "add":
+		var mat := CanvasItemMaterial.new()
+		mat.blend_mode = CanvasItemMaterial.BLEND_MODE_ADD
+		material = mat
+	else:
+		material = null
+	if get_parent() != host:
+		if get_parent() != null:
+			get_parent().remove_child(self)
+		host.add_child(self)
+	if not host.animation_changed.is_connected(_refresh):
+		host.animation_changed.connect(_refresh)
+	if not host.frame_changed.is_connected(_on_host_frame):
+		host.frame_changed.connect(_on_host_frame)
+	_refresh()
+
+
+## Swap the overlay art (e.g. doom-flavour hue change) without re-anchoring.
+func set_overlay_frames(frames: SpriteFrames) -> void:
+	sprite_frames = frames
+	if frames != null and frames.get_animation_names().size() > 0:
+		play(frames.get_animation_names()[0])
+
+
+func set_base_opacity(v: float) -> void:
+	base_opacity = clampf(v, 0.0, 1.0)
+	_apply_visual()
+
+
+func set_tint(c: Color) -> void:
+	_tint = c
+	_apply_visual()
+
+
+func set_enabled(v: bool) -> void:
+	enabled = v
+	_refresh()
+
+
+## Re-resolve the anchor for the host's CURRENT clip. Hidden when the clip has
+## no such socket (butt only exists on rear-facing + butt-flash clips).
+func _refresh() -> void:
+	if not enabled or host == null or sprite_set == "":
+		visible = false
+		return
+	var clip := String(host.animation)
+	var sk := socket_of(sprite_set, clip, anchor_name)
+	if sk.is_empty():
+		visible = false
+		return
+	visible = true
+	var off: Array = sk.get("px", [0, 0])
+	var canvas_pos := feet_of(sprite_set, clip) + Vector2(float(off[0]), float(off[1]))
+	# Child of the host: host texture px -> host-local coords (host scale then
+	# applies to us automatically). Mirrors the feet-anchor math of #906/#915.
+	var local := canvas_pos + host.offset
+	if host.centered:
+		local -= canvas_of(sprite_set) * 0.5
+	position = local
+	z_as_relative = true
+	z_index = -1 if String(sk.get("layer", "front")) == "behind" else z_offset
+	_apply_visual()
+
+
+## Footfall pulse: purely host-frame-index driven (deterministic, no RNG).
+func _on_host_frame() -> void:
+	if not pulse_enabled or host == null:
+		return
+	# int() both sides: JSON numbers parse as floats, host.frame is an int.
+	for ff in footfalls_of(sprite_set, String(host.animation)):
+		if int(ff) == host.frame:
+			_pulse = 1.0
+			_apply_visual()
+			return
+
+
+func _process(delta: float) -> void:
+	if _pulse > 0.0:
+		_pulse = maxf(0.0, _pulse - pulse_decay * delta)
+		_apply_visual()
+
+
+func _apply_visual() -> void:
+	var boost := pulse_strength * _pulse
+	modulate = Color(_tint.r, _tint.g, _tint.b,
+		clampf(_tint.a * base_opacity * (1.0 + boost), 0.0, 1.0))
+	var s := overlay_scale * (1.0 + 0.25 * boost)
+	scale = Vector2(s, s)

--- a/godot/scripts/ui/office_floor/anchored_overlay.gd.uid
+++ b/godot/scripts/ui/office_floor/anchored_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://chr8gyb33s828

--- a/godot/scripts/ui/office_floor/office_sandbox.gd
+++ b/godot/scripts/ui/office_floor/office_sandbox.gd
@@ -104,9 +104,23 @@ const _CAT_WALK_DIRS: Array[String] = [
 ]
 # Cat art sets that exist as rotation-only (static) frames and STILL NEED walk-cycles
 # generated (pixellab) before they can become real walkers. Reported on-screen/stdout.
-const _CAT_SETS_NEEDING_WALKS := ["cat_black", "cat_tabby", "cat_eldritch(x4)", "cat_purple(x4)"]
+const _CAT_SETS_NEEDING_WALKS := ["cat_eldritch(x4)"]
 
 const DOOM_STEP := 0.1
+
+# --- Anchor Sockets V2 demo (#894): doom-glow attached to sprite PARTS -------
+# Anchored cat sets are built from res://data/office/anchor_sockets.json (the
+# SSOT lists each promoted clip's frames dir), so the walkers and the anchors
+# can never drift apart. Glow art = the closest hue variants of the existing
+# doom overlay families (art_source/pixellab_2026-07-26_doom_overlays) per
+# Pip's interim colour mapping (2026-07-26, W3 circle-back may override):
+# blue = technical weirdness, purple = eldritch, red = conventional
+# catastrophe. INTENSITY carries the doom level; subtle at nominal.
+const _GLOW_FLAVOURS := [
+	{"name": "purple (eldritch)", "rel": "pixellab_2026-07-26_doom_overlays/aura/glowdisc"},
+	{"name": "red (catastrophe)", "rel": "pixellab_2026-07-26_doom_overlays/states/aura_red"},
+	{"name": "blue (weirdness)", "rel": "pixellab_2026-07-26_doom_overlays/arc/radialweb"},
+]
 
 # Skins the sandbox rotates through. "art" = real pixellab frames; "color" = a generated
 # animated placeholder tinted body+hat (Tier 1); "blob" = Tier 0 procedural blob+hat.
@@ -210,8 +224,12 @@ var _pop_level: int = 0
 var _pop_level_b: int = 0                  # v4: the small floor has its own populate level
 var _furniture: Array = []                 # Sprite2D furniture placed by POPULATE (wall-affinity)
 var _occupied_cells: Dictionary = {}       # str(cell centre) -> true (furniture no-overlap)
-var _cat_frame_sets: Array = []            # [{name, frames}] real walk-cycle SpriteFrames
+var _cat_frame_sets: Array = []            # [{name, frames, anchored_set?}] real walk-cycle SpriteFrames
 var _cat_walk_report: String = ""
+# Anchor Sockets V2 demo state: glow toggle + doom-flavour hue selection.
+var _anchor_glow_on: bool = true
+var _glow_flavour_idx: int = 0
+var _glow_flavour_frames: Array = []       # SpriteFrames per _GLOW_FLAVOURS entry (null = missing art)
 var _doom_level: float = 0.0
 var _overlay_mode: bool = false            # false = prop placement, true = poster overlay
 var _overlays: Array = []                  # Sprite2D transparent wall overlays (stackable)
@@ -251,6 +269,7 @@ func _ready() -> void:
 	_load_feedback()
 	_load_promoted()
 	_load_cat_walks()
+	_load_glow_flavours()
 	_build_poster_pool()
 	_rebuild_prop_pool()
 
@@ -289,6 +308,7 @@ func _build_overlay() -> void:
 		+ "[V] toggle COMPARE (DEFAULT ON): small=SCUMMY vs large=DECENT office\n" \
 		+ "[T] office TIER (scummy/decent; pinned per floor while compare is on)   [P] cycle prop/poster   [LMB] place   [RMB] remove nearest   [K] clear props\n" \
 		+ "DOOM-GLOW on cats:  [ [ ] decrease   [ ] ] increase   |   OVERLAY POC:  [O] toggle poster-on-wall mode   [;]/['] selected overlay opacity\n" \
+		+ "ANCHOR SOCKETS V2:  [A] toggle part-anchored glow (eyes; butt on rear walks + butt-flash)   [D] doom flavour hue (purple/red/blue)\n" \
 		+ "feedback on current prop:  [L]ike  [J] dislike  [F]avour  [G] disfavour  [M] promote  [N] note"
 	vb.add_child(_legend)
 
@@ -447,6 +467,10 @@ func _input(event: InputEvent) -> void:
 			_nudge_doom(-DOOM_STEP)
 		KEY_BRACKETRIGHT:
 			_nudge_doom(DOOM_STEP)
+		KEY_A:
+			_toggle_anchor_glow()
+		KEY_D:
+			_cycle_glow_flavour()
 		KEY_V:
 			_toggle_compare()
 		KEY_O:
@@ -928,8 +952,13 @@ func _add_cat(target: OfficeFloor = null) -> void:
 	if not _cat_frame_sets.is_empty():
 		var rc := RealCat.new()
 		# Stable per-cat id phase-offsets the deterministic alt-clip splice (#913).
-		rc.setup(_cat_frame_sets[_cat_color_idx % _cat_frame_sets.size()]["frames"],
-			"cat_%d" % _cat_color_idx)
+		var set_info: Dictionary = _cat_frame_sets[_cat_color_idx % _cat_frame_sets.size()]
+		rc.setup(set_info["frames"], "cat_%d" % _cat_color_idx)
+		# Anchor Sockets V2: sets built from anchor_sockets.json get part-anchored
+		# doom glow (eyes everywhere; butt on rear walks + butt-flash splices).
+		var aset := String(set_info.get("anchored_set", ""))
+		if aset != "":
+			rc.configure_anchor_glow(aset, _current_glow_frames(), _anchor_glow_on)
 		cat = rc
 	else:
 		var sc := SandboxCat.new()
@@ -1552,11 +1581,14 @@ func _update_status() -> void:
 		("" if _last_msg == "" else "\n>> " + _last_msg)]
 	if _asset_status == null:
 		return
-	var mode_line := "ACTIVE FLOOR (under cursor): %s   |   MODE: %s   |   compare: %s   |   doom-glow: %d%%   |   overlays: %d" % [
+	var mode_line := "ACTIVE FLOOR (under cursor): %s   |   MODE: %s   |   compare: %s   |   doom-glow: %d%%   |   anchor glow: %s @ %s   |   overlays: %d" % [
 		_floor_label(af),
 		("OVERLAY (poster on wall)" if _overlay_mode else "prop placement"),
 		("ON" if _compare_mode else "off"),
-		int(round(_doom_level * 100.0)), _overlays.size()]
+		int(round(_doom_level * 100.0)),
+		("ON" if _anchor_glow_on else "off"),
+		String(_GLOW_FLAVOURS[_glow_flavour_idx % _GLOW_FLAVOURS.size()]["name"]),
+		_overlays.size()]
 	var cur := _current_prop()
 	var cur_line: String
 	if _overlay_mode:
@@ -1716,6 +1748,13 @@ func _infer_category(rel: String) -> String:
 func _load_cat_walks() -> void:
 	_cat_frame_sets.clear()
 	var loaded: Array = []
+	# Anchor Sockets V2 sets FIRST (so the first spawned cats demo the anchors),
+	# then the legacy 2026-07-16 walkers.
+	for aset in AnchoredOverlay.sprite_sets():
+		var asf := _build_anchored_cat_frames(String(aset))
+		if asf != null:
+			_cat_frame_sets.append({"name": String(aset), "frames": asf, "anchored_set": String(aset)})
+			loaded.append(String(aset) + "*")
 	if DirAccess.dir_exists_absolute(_art_root):
 		for rel in _CAT_WALK_DIRS:
 			var d := (_art_root + "/" + rel).simplify_path()
@@ -1728,7 +1767,7 @@ func _load_cat_walks() -> void:
 	if loaded.is_empty():
 		_cat_walk_report = "REAL cat walkers: none (art_source absent) -- using procedural cats. Generate walk frames (pixellab) for: " + ", ".join(_CAT_SETS_NEEDING_WALKS)
 	else:
-		_cat_walk_report = "REAL cat walkers: %s   |   still NEED walk-frames (pixellab): %s" % [
+		_cat_walk_report = "REAL cat walkers: %s (* = anchor-socket set)   |   still NEED walk-frames (pixellab): %s" % [
 			", ".join(loaded), ", ".join(_CAT_SETS_NEEDING_WALKS)]
 	print("[office_sandbox] ", _cat_walk_report)
 
@@ -1790,6 +1829,109 @@ func _build_cat_frames(dir_abs: String) -> SpriteFrames:
 		sf.set_animation_speed("idle", 1.0)
 		sf.add_frame("idle", south0)
 	return sf
+
+# ===========================================================================
+# ANCHOR SOCKETS V2 (#894): promoted-clip walkers + part-anchored doom glow.
+# ===========================================================================
+# Build a walker SpriteFrames for one anchor_sockets.json sprite set. The JSON
+# is the SSOT for WHERE each promoted clip's frames live (source_dir, repo-root
+# relative) and which frame range is used (butt-flash splices 2..8), so the
+# walker and its anchors cannot drift apart. Returns null when the art is
+# absent (fresh checkout without art_source) -- degrades like the legacy path.
+func _build_anchored_cat_frames(sprite_set: String) -> SpriteFrames:
+	var repo_root := (_art_root + "/..").simplify_path()
+	var clips: Dictionary = AnchoredOverlay.sprite_entry(sprite_set).get("clips", {})
+	if clips.is_empty():
+		return null
+	var sf := SpriteFrames.new()
+	var made_any := false
+	var first := true
+	for clip in clips.keys():
+		var entry: Dictionary = clips[clip]
+		var dir_abs := (repo_root + "/" + String(entry.get("source_dir", ""))).simplify_path()
+		var lo := 0
+		var hi := 9999
+		var rng: Array = entry.get("frames", [])
+		if rng.size() == 2:
+			lo = int(rng[0])
+			hi = int(rng[1])
+		var added := 0
+		for i in range(lo, hi + 1):
+			var p := "%s/frame_%03d.png" % [dir_abs, i]
+			if not FileAccess.file_exists(p):
+				break
+			var tex := _load_texture(p)
+			if tex == null:
+				break
+			if first:
+				sf.rename_animation("default", String(clip))
+				first = false
+			elif not sf.has_animation(String(clip)):
+				sf.add_animation(String(clip))
+			sf.set_animation_loop(String(clip), true)
+			# 8 fps = the cat-sweep review-sheet playback convention.
+			sf.set_animation_speed(String(clip), 8.0 if String(clip) != "idle" else 1.0)
+			sf.add_frame(String(clip), tex)
+			added += 1
+		if added > 0:
+			made_any = true
+	return sf if made_any else null
+
+# Load one looping SpriteFrames per glow flavour (Pip's interim colour mapping
+# 2026-07-26). Missing art -> null slot; the demo skips it.
+func _load_glow_flavours() -> void:
+	_glow_flavour_frames.clear()
+	for fl in _GLOW_FLAVOURS:
+		_glow_flavour_frames.append(_build_overlay_frames(
+			(_art_root + "/" + String(fl["rel"])).simplify_path()))
+
+# Overlay loop dir -> SpriteFrames ("glow" anim; loop/frame_*.png, idle.png
+# fallback for loop-less variants).
+func _build_overlay_frames(dir_abs: String) -> SpriteFrames:
+	var sf := SpriteFrames.new()
+	sf.rename_animation("default", "glow")
+	sf.set_animation_loop("glow", true)
+	sf.set_animation_speed("glow", 8.0)
+	var i := 0
+	while true:
+		var p := "%s/loop/frame_%03d.png" % [dir_abs, i]
+		if not FileAccess.file_exists(p):
+			break
+		var tex := _load_texture(p)
+		if tex == null:
+			break
+		sf.add_frame("glow", tex)
+		i += 1
+	if sf.get_frame_count("glow") == 0:
+		var idle_tex := _load_texture(dir_abs + "/idle.png")
+		if idle_tex == null:
+			return null
+		sf.add_frame("glow", idle_tex)
+	return sf
+
+func _current_glow_frames() -> SpriteFrames:
+	if _glow_flavour_frames.is_empty():
+		return null
+	return _glow_flavour_frames[_glow_flavour_idx % _glow_flavour_frames.size()]
+
+func _toggle_anchor_glow() -> void:
+	_anchor_glow_on = not _anchor_glow_on
+	for cat in _cats:
+		if is_instance_valid(cat) and cat is RealCat:
+			(cat as RealCat).set_anchor_glow_enabled(_anchor_glow_on)
+	_last_msg = "anchor-socket glow %s" % ("ON" if _anchor_glow_on else "off")
+
+func _cycle_glow_flavour() -> void:
+	if _GLOW_FLAVOURS.is_empty():
+		return
+	_glow_flavour_idx = (_glow_flavour_idx + 1) % _GLOW_FLAVOURS.size()
+	var frames := _current_glow_frames()
+	for cat in _cats:
+		if is_instance_valid(cat) and cat is RealCat:
+			(cat as RealCat).set_glow_frames(frames)
+	_last_msg = "doom glow flavour: %s%s" % [
+		String(_GLOW_FLAVOURS[_glow_flavour_idx]["name"]),
+		"" if frames != null else " (art missing -- glow hidden)"]
 
 # ===========================================================================
 # FEEDBACK PERSISTENCE (<art_source>/sandbox_feedback.json; merges on load).
@@ -1958,6 +2100,19 @@ class RealCat extends SandboxCatBase:
 	var cat_id: String = "cat"           # stable id seeding the alt-clip splice hash
 	var _frames: SpriteFrames = null
 	var _anim: AnimatedSprite2D = null
+	# Anchor Sockets V2 (#894): part-anchored doom glow. Intensity carries the
+	# doom level (Pip interim colour ruling 2026-07-26): SUBTLE at nominal.
+	const EYE_GLOW_MIN := 0.14
+	const EYE_GLOW_MAX := 0.85
+	const BUTT_GLOW_MIN := 0.22
+	const BUTT_GLOW_MAX := 0.95
+	const EYE_GLOW_SCALE := 0.20         # overlay is a 64px canvas; ~13px over the eyes
+	const BUTT_GLOW_SCALE := 0.40
+	var anchored_set: String = ""
+	var _glow_frames: SpriteFrames = null
+	var _glow_enabled := true
+	var _eye_ov: AnchoredOverlay = null
+	var _butt_ov: AnchoredOverlay = null
 	# #913 alt-clip splice (cat contract: "walk_<dir>_alt", e.g. walk_north_alt --
 	# the butt-flash loop). Same deterministic 1-in-N mechanism as the workers
 	# (OfficeEmployeeSprite.should_play_alt); art arrives from the cat sweep later.
@@ -1968,6 +2123,26 @@ class RealCat extends SandboxCatBase:
 	func setup(frames: SpriteFrames, id: String = "cat") -> void:
 		_frames = frames
 		cat_id = id
+
+	## Anchor Sockets V2: opt this cat into part-anchored glow (call before the
+	## cat enters the tree; overlays are built in _build_visual).
+	func configure_anchor_glow(set_id: String, glow_frames: SpriteFrames, enabled: bool) -> void:
+		anchored_set = set_id
+		_glow_frames = glow_frames
+		_glow_enabled = enabled
+
+	func set_anchor_glow_enabled(on: bool) -> void:
+		_glow_enabled = on
+		for ov in [_eye_ov, _butt_ov]:
+			if ov != null:
+				ov.set_enabled(on)
+
+	## Swap the glow hue flavour (Pip interim colour mapping) live.
+	func set_glow_frames(glow_frames: SpriteFrames) -> void:
+		_glow_frames = glow_frames
+		for ov in [_eye_ov, _butt_ov]:
+			if ov != null:
+				ov.set_overlay_frames(glow_frames)
 
 	func _build_visual() -> void:
 		_anim = AnimatedSprite2D.new()
@@ -1981,6 +2156,26 @@ class RealCat extends SandboxCatBase:
 			_anim.play("idle")
 		elif _frames != null and _frames.get_animation_names().size() > 0:
 			_anim.play(_frames.get_animation_names()[0])
+		# Anchor Sockets V2 overlays: eyes on every clip with an 'eyes' socket;
+		# butt auto-appears ONLY on clips carrying a 'butt' socket (rear-facing
+		# walks + butt-flash splices) -- AnchoredOverlay hides itself otherwise.
+		if anchored_set != "" and _glow_frames != null:
+			_eye_ov = AnchoredOverlay.new()
+			_eye_ov.attach(_anim, anchored_set, "eyes", _glow_frames,
+				{"scale": EYE_GLOW_SCALE, "opacity": EYE_GLOW_MIN, "blend": "add",
+				"pulse": true, "z_offset": 1})
+			_butt_ov = AnchoredOverlay.new()
+			_butt_ov.attach(_anim, anchored_set, "butt", _glow_frames,
+				{"scale": BUTT_GLOW_SCALE, "opacity": BUTT_GLOW_MIN, "blend": "add",
+				"pulse": true, "z_offset": 1})
+			set_anchor_glow_enabled(_glow_enabled)
+			_apply_glow_doom()
+
+	func _apply_glow_doom() -> void:
+		if _eye_ov != null:
+			_eye_ov.set_base_opacity(lerpf(EYE_GLOW_MIN, EYE_GLOW_MAX, _doom))
+		if _butt_ov != null:
+			_butt_ov.set_base_opacity(lerpf(BUTT_GLOW_MIN, BUTT_GLOW_MAX, _doom))
 
 	func _on_tick(dirv: Vector2, moving: bool, _delta: float) -> void:
 		if _anim == null or _frames == null:
@@ -2034,6 +2229,7 @@ class RealCat extends SandboxCatBase:
 	func _on_doom() -> void:
 		if _anim != null:
 			_anim.self_modulate = Color(1, 1, 1, 1).lerp(Color(1.0, 0.35, 0.28, 1.0), _doom * 0.7)
+		_apply_glow_doom()
 
 	func _dir_name(v: Vector2) -> String:
 		if absf(v.x) >= absf(v.y):

--- a/godot/scripts/ui/office_floor/office_sandbox.gd
+++ b/godot/scripts/ui/office_floor/office_sandbox.gd
@@ -117,9 +117,12 @@ const DOOM_STEP := 0.1
 # blue = technical weirdness, purple = eldritch, red = conventional
 # catastrophe. INTENSITY carries the doom level; subtle at nominal.
 const _GLOW_FLAVOURS := [
-	{"name": "purple (eldritch)", "rel": "pixellab_2026-07-26_doom_overlays/aura/glowdisc"},
-	{"name": "red (catastrophe)", "rel": "pixellab_2026-07-26_doom_overlays/states/aura_red"},
-	{"name": "blue (weirdness)", "rel": "pixellab_2026-07-26_doom_overlays/arc/radialweb"},
+	{"name": "purple (eldritch)", "rel": "pixellab_2026-07-26_doom_overlays/aura/glowdisc",
+		"hue": Color(0.62, 0.32, 1.0)},
+	{"name": "red (catastrophe)", "rel": "pixellab_2026-07-26_doom_overlays/states/aura_red",
+		"hue": Color(1.0, 0.30, 0.18)},
+	{"name": "blue (weirdness)", "rel": "pixellab_2026-07-26_doom_overlays/arc/radialweb",
+		"hue": Color(0.30, 0.62, 1.0)},
 ]
 
 # Skins the sandbox rotates through. "art" = real pixellab frames; "color" = a generated
@@ -958,12 +961,17 @@ func _add_cat(target: OfficeFloor = null) -> void:
 		# doom glow (eyes everywhere; butt on rear walks + butt-flash splices).
 		var aset := String(set_info.get("anchored_set", ""))
 		if aset != "":
-			rc.configure_anchor_glow(aset, _current_glow_frames(), _anchor_glow_on)
+			rc.configure_anchor_glow(aset, _current_glow_frames(), _anchor_glow_on,
+				_current_glow_hue())
 		cat = rc
 	else:
 		var sc := SandboxCat.new()
 		sc.color = _cat_palette[_cat_color_idx % _cat_palette.size()]
 		cat = sc
+	# Every cat's centre radial glow follows the selected doom flavour hue (the
+	# radial used to be hardcoded orange-red, which visually drowned the [D]
+	# flavour swap -- Pip's 2026-07-26 demo review).
+	cat.set_glow_color(_current_glow_hue())
 	_cat_color_idx += 1
 	var b := _bounds_of(af)
 	cat.position = Vector2(
@@ -1914,6 +1922,9 @@ func _current_glow_frames() -> SpriteFrames:
 		return null
 	return _glow_flavour_frames[_glow_flavour_idx % _glow_flavour_frames.size()]
 
+func _current_glow_hue() -> Color:
+	return _GLOW_FLAVOURS[_glow_flavour_idx % _GLOW_FLAVOURS.size()].get("hue", Color.WHITE)
+
 func _toggle_anchor_glow() -> void:
 	_anchor_glow_on = not _anchor_glow_on
 	for cat in _cats:
@@ -1926,12 +1937,19 @@ func _cycle_glow_flavour() -> void:
 		return
 	_glow_flavour_idx = (_glow_flavour_idx + 1) % _GLOW_FLAVOURS.size()
 	var frames := _current_glow_frames()
+	var hue := _current_glow_hue()
+	# The swap must be VISIBLE on every live cat immediately (Pip demo review
+	# 2026-07-26): re-hue the centre radial on ALL cats (real + procedural) and
+	# swap art + tint on every anchored overlay.
 	for cat in _cats:
-		if is_instance_valid(cat) and cat is RealCat:
-			(cat as RealCat).set_glow_frames(frames)
+		if not is_instance_valid(cat):
+			continue
+		(cat as SandboxCatBase).set_glow_color(hue)
+		if cat is RealCat:
+			(cat as RealCat).set_glow_flavour(frames, hue)
 	_last_msg = "doom glow flavour: %s%s" % [
 		String(_GLOW_FLAVOURS[_glow_flavour_idx]["name"]),
-		"" if frames != null else " (art missing -- glow hidden)"]
+		"" if frames != null else " (overlay art missing -- radial hue only)"]
 
 # ===========================================================================
 # FEEDBACK PERSISTENCE (<art_source>/sandbox_feedback.json; merges on load).
@@ -1978,6 +1996,9 @@ class SandboxCatBase extends Node2D:
 	var _t: float = 0.0
 	var _rng := RandomNumberGenerator.new()
 	var _glow: Sprite2D = null
+	# Centre-radial hue; follows the sandbox doom-flavour selection ([D]). The
+	# old hardcoded orange-red made flavour cycling look dead (Pip 2026-07-26).
+	var _glow_color := Color(1.0, 0.25, 0.15)
 	static var _glow_tex: Texture2D = null
 
 	func _ready() -> void:
@@ -1995,7 +2016,7 @@ class SandboxCatBase extends Node2D:
 		mat.blend_mode = CanvasItemMaterial.BLEND_MODE_ADD
 		_glow.material = mat
 		_glow.z_index = -1                # behind the cat body
-		_glow.modulate = Color(1.0, 0.25, 0.15, 0.0)
+		_glow.modulate = Color(_glow_color, 0.0)
 		add_child(_glow)
 		_build_visual()
 		_update_glow()
@@ -2043,9 +2064,15 @@ class SandboxCatBase extends Node2D:
 		if _glow == null:
 			return
 		var pulse := 0.75 + 0.25 * sin(_t * 4.0)
-		_glow.modulate = Color(1.0, 0.25, 0.15, _doom * pulse)
+		_glow.modulate = Color(_glow_color, _doom * pulse)
 		var sc := 0.6 + _doom * 0.9
 		_glow.scale = Vector2(sc, sc)
+
+	## Re-hue the centre radial (doom-flavour cycling). Takes effect on the
+	## next _update_glow tick; immediate call keeps a paused scene honest.
+	func set_glow_color(c: Color) -> void:
+		_glow_color = c
+		_update_glow()
 
 	func set_doom(level: float) -> void:
 		_doom = clampf(level, 0.0, 1.0)
@@ -2110,6 +2137,7 @@ class RealCat extends SandboxCatBase:
 	const BUTT_GLOW_SCALE := 0.40
 	var anchored_set: String = ""
 	var _glow_frames: SpriteFrames = null
+	var _glow_hue := Color.WHITE          # flavour hue; also tints the overlays
 	var _glow_enabled := true
 	var _eye_ov: AnchoredOverlay = null
 	var _butt_ov: AnchoredOverlay = null
@@ -2126,10 +2154,12 @@ class RealCat extends SandboxCatBase:
 
 	## Anchor Sockets V2: opt this cat into part-anchored glow (call before the
 	## cat enters the tree; overlays are built in _build_visual).
-	func configure_anchor_glow(set_id: String, glow_frames: SpriteFrames, enabled: bool) -> void:
+	func configure_anchor_glow(set_id: String, glow_frames: SpriteFrames, enabled: bool,
+			hue: Color = Color.WHITE) -> void:
 		anchored_set = set_id
 		_glow_frames = glow_frames
 		_glow_enabled = enabled
+		_glow_hue = hue
 
 	func set_anchor_glow_enabled(on: bool) -> void:
 		_glow_enabled = on
@@ -2137,12 +2167,16 @@ class RealCat extends SandboxCatBase:
 			if ov != null:
 				ov.set_enabled(on)
 
-	## Swap the glow hue flavour (Pip interim colour mapping) live.
-	func set_glow_frames(glow_frames: SpriteFrames) -> void:
+	## Swap the glow flavour LIVE (Pip interim colour mapping): new overlay art
+	## AND its hue tint, on both anchored overlays. The tint guarantees the
+	## flavours read distinct at a glance even at eye-glow scale.
+	func set_glow_flavour(glow_frames: SpriteFrames, hue: Color) -> void:
 		_glow_frames = glow_frames
+		_glow_hue = hue
 		for ov in [_eye_ov, _butt_ov]:
 			if ov != null:
 				ov.set_overlay_frames(glow_frames)
+				ov.set_tint(hue)
 
 	func _build_visual() -> void:
 		_anim = AnimatedSprite2D.new()
@@ -2163,11 +2197,11 @@ class RealCat extends SandboxCatBase:
 			_eye_ov = AnchoredOverlay.new()
 			_eye_ov.attach(_anim, anchored_set, "eyes", _glow_frames,
 				{"scale": EYE_GLOW_SCALE, "opacity": EYE_GLOW_MIN, "blend": "add",
-				"pulse": true, "z_offset": 1})
+				"pulse": true, "z_offset": 1, "tint": _glow_hue})
 			_butt_ov = AnchoredOverlay.new()
 			_butt_ov.attach(_anim, anchored_set, "butt", _glow_frames,
 				{"scale": BUTT_GLOW_SCALE, "opacity": BUTT_GLOW_MIN, "blend": "add",
-				"pulse": true, "z_offset": 1})
+				"pulse": true, "z_offset": 1, "tint": _glow_hue})
 			set_anchor_glow_enabled(_glow_enabled)
 			_apply_glow_doom()
 

--- a/godot/tests/unit/test_anchor_sockets.gd
+++ b/godot/tests/unit/test_anchor_sockets.gd
@@ -298,3 +298,32 @@ func test_enabled_toggle_and_footfall_pulse_deterministic():
 		host.frame = quiet
 		ov2._on_host_frame()
 		assert_eq(ov2.modulate.a, a2, "non-footfall frame does not pulse")
+
+
+func test_flavour_swap_replaces_frames_and_retints_live():
+	# Regression for Pip's 2026-07-26 demo review: [D] flavour cycling updated
+	# the status line but the visible glow never changed. The live-swap path is
+	# set_overlay_frames + set_tint on an ALREADY-ATTACHED overlay -- both must
+	# take effect immediately.
+	var host := _synthetic_host()
+	add_child_autofree(host)
+	var ov := AnchoredOverlay.new()
+	ov.attach(host, "cat_tabby_v1", "eyes", null, {"pulse": false, "opacity": 0.5})
+	# Swap in a new flavour's SpriteFrames: adopted and playing at once.
+	var img := Image.create(8, 8, false, Image.FORMAT_RGBA8)
+	img.fill(Color(1, 1, 1, 1))
+	var flavour := SpriteFrames.new()
+	flavour.rename_animation("default", "glow")
+	flavour.add_frame("glow", ImageTexture.create_from_image(img))
+	ov.set_overlay_frames(flavour)
+	assert_eq(ov.sprite_frames, flavour, "new flavour frames adopted live")
+	assert_eq(String(ov.animation), "glow", "new flavour clip playing")
+	# Re-tint: the modulate hue must change NOW (this is what makes the three
+	# flavours distinct at a glance even at eye-glow scale).
+	ov.set_tint(Color(0.62, 0.32, 1.0))
+	assert_almost_eq(ov.modulate.r, 0.62, 0.001, "tint red channel applied")
+	assert_almost_eq(ov.modulate.g, 0.32, 0.001, "tint green channel applied")
+	assert_almost_eq(ov.modulate.b, 1.0, 0.001, "tint blue channel applied")
+	assert_almost_eq(ov.modulate.a, 0.5, 0.001, "tint leaves base opacity alone")
+	ov.set_tint(Color(1.0, 0.30, 0.18))
+	assert_almost_eq(ov.modulate.b, 0.18, 0.001, "second swap re-tints again")

--- a/godot/tests/unit/test_anchor_sockets.gd
+++ b/godot/tests/unit/test_anchor_sockets.gd
@@ -1,0 +1,300 @@
+extends GutTest
+## Guards Anchor Sockets V2 (data/office/anchor_sockets.json + its consumer
+## scripts/ui/office_floor/anchored_overlay.gd), issues #894 #900 #913:
+##   - the JSON parses, carries _meta/_schema, and covers the promoted cat sets;
+##   - every referenced clip dir EXISTS in art_source and holds the declared
+##     frame range (art_source is git-tracked, so any full checkout has it);
+##   - PIL-authored anchors land INSIDE the sprite's opaque subject bbox
+##     (tolerance for glow anchors that sit just off the silhouette);
+##   - AnchoredOverlay resolves the anchor position for a synthetic host,
+##     follows a direction switch, and hides sockets absent from a clip
+##     (butt exists only on rear-facing + butt-flash clips);
+##   - the footfall pulse hook is deterministic (frame-index driven, no RNG).
+
+const SOCKETS_PATH := "res://data/office/anchor_sockets.json"
+const MIN_SETS := 3  # tabby / black / purple promoted sweep sets
+
+var _art_missing_logged := false
+
+
+func _load_doc() -> Dictionary:
+	var f := FileAccess.open(SOCKETS_PATH, FileAccess.READ)
+	assert_not_null(f, "anchor_sockets.json must be readable")
+	if f == null:
+		return {}
+	var json := JSON.new()
+	assert_eq(json.parse(f.get_as_text()), OK, "anchor_sockets.json must be valid JSON")
+	f.close()
+	return json.data if json.data is Dictionary else {}
+
+
+func _repo_root() -> String:
+	return (ProjectSettings.globalize_path("res://") + "/..").simplify_path()
+
+
+## art_source ships in git; absent = partial checkout, skip file checks cleanly.
+func _art_source_present() -> bool:
+	return DirAccess.dir_exists_absolute(_repo_root() + "/art_source")
+
+
+func test_doc_parses_with_meta_schema_and_promoted_sets():
+	var doc := _load_doc()
+	assert_ne(String(doc.get("_meta", {}).get("version", "")), "", "carries _meta.version")
+	assert_true(doc.has("_schema"), "documents its fields in a _schema block")
+	var sprites: Dictionary = doc.get("sprites", {})
+	assert_true(sprites.size() >= MIN_SETS,
+		"expected at least %d sprite sets, found %d" % [MIN_SETS, sprites.size()])
+	for sid in sprites:
+		var s: Dictionary = sprites[sid]
+		assert_eq(Array(s.get("canvas_px", [])).size(), 2, "'%s' canvas_px is [w, h]" % sid)
+		assert_true(s.get("clips", {}).size() > 0, "'%s' has clips" % sid)
+
+
+func test_every_clip_has_feet_sockets_and_eyes():
+	var sprites: Dictionary = _load_doc().get("sprites", {})
+	for sid in sprites:
+		var clips: Dictionary = sprites[sid].get("clips", {})
+		for clip in clips:
+			var e: Dictionary = clips[clip]
+			var label := "%s/%s" % [sid, clip]
+			assert_ne(String(e.get("source_dir", "")), "", "'%s' has source_dir" % label)
+			assert_eq(Array(e.get("feet_px", [])).size(), 2, "'%s' feet_px is [x, y]" % label)
+			assert_eq(Array(e.get("subject_px", [])).size(), 2, "'%s' subject_px is [w, h]" % label)
+			assert_true(e.get("footfall_frames", null) is Array, "'%s' has footfall_frames" % label)
+			var names: Array = []
+			for sk in e.get("sockets", []):
+				assert_true(sk is Dictionary and sk.has("name") and sk.has("px") and sk.has("layer"),
+					"'%s' socket needs name/px/layer (unified socket shape)" % label)
+				assert_eq(Array(sk.get("px", [])).size(), 2, "'%s' socket px is [x, y]" % label)
+				assert_true(String(sk.get("layer", "")) in ["front", "behind"],
+					"'%s' socket layer front|behind" % label)
+				names.append(String(sk.get("name", "")))
+			# Ruled anchor set: eyes on EVERY direction; spine_mid reserve everywhere.
+			assert_true("eyes" in names, "'%s' carries an eyes anchor" % label)
+			assert_true("spine_mid" in names, "'%s' carries the spine_mid reserve" % label)
+
+
+func test_butt_only_on_rear_facing_and_butt_flash_clips():
+	# Ruling: butt anchors exist on rear-facing walks + butt-flash splices ONLY.
+	var sprites: Dictionary = _load_doc().get("sprites", {})
+	for sid in sprites:
+		var clips: Dictionary = sprites[sid].get("clips", {})
+		for clip in clips:
+			var has_butt := false
+			for sk in clips[clip].get("sockets", []):
+				if String(sk.get("name", "")) == "butt":
+					has_butt = true
+			var rear := String(clip).begins_with("walk_north")
+			assert_eq(has_butt, rear,
+				"'%s/%s': butt anchor exactly on rear-facing/butt-flash clips" % [sid, clip])
+
+
+func test_referenced_clip_dirs_and_frames_exist():
+	if not _art_source_present():
+		pass_test("art_source absent (partial checkout) -- file checks skipped")
+		return
+	var root := _repo_root()
+	var sprites: Dictionary = _load_doc().get("sprites", {})
+	for sid in sprites:
+		var clips: Dictionary = sprites[sid].get("clips", {})
+		for clip in clips:
+			var e: Dictionary = clips[clip]
+			var label := "%s/%s" % [sid, clip]
+			var d := (root + "/" + String(e.get("source_dir", ""))).simplify_path()
+			assert_true(DirAccess.dir_exists_absolute(d), "'%s' source_dir exists: %s" % [label, d])
+			var lo := 0
+			var rng: Array = e.get("frames", [])
+			if rng.size() == 2:
+				lo = int(rng[0])
+				# the declared range must exist in full
+				assert_true(FileAccess.file_exists("%s/frame_%03d.png" % [d, int(rng[1])]),
+					"'%s' declared last frame exists" % label)
+			assert_true(FileAccess.file_exists("%s/frame_%03d.png" % [d, lo]),
+				"'%s' first frame exists" % label)
+
+
+func test_anchors_inside_subject_bbox_and_feet_match_measurement():
+	if not _art_source_present():
+		pass_test("art_source absent (partial checkout) -- pixel checks skipped")
+		return
+	var root := _repo_root()
+	var sprites: Dictionary = _load_doc().get("sprites", {})
+	for sid in sprites:
+		var clips: Dictionary = sprites[sid].get("clips", {})
+		for clip in clips:
+			var e: Dictionary = clips[clip]
+			var label := "%s/%s" % [sid, clip]
+			var d := (root + "/" + String(e.get("source_dir", ""))).simplify_path()
+			var lo := 0
+			var rng: Array = e.get("frames", [])
+			if rng.size() == 2:
+				lo = int(rng[0])
+			var img := Image.new()
+			if img.load("%s/frame_%03d.png" % [d, lo]) != OK:
+				fail_test("'%s' frame unreadable" % label)
+				continue
+			var bbox := img.get_used_rect()
+			var feet: Array = e.get("feet_px", [0, 0])
+			var feet_v := Vector2(float(feet[0]), float(feet[1]))
+			# feet_px is averaged across frames; frame `lo` must agree within a few px.
+			assert_almost_eq(feet_v.x, bbox.position.x + bbox.size.x * 0.5, 4.0,
+				"'%s' feet x ~ bbox bottom-centre" % label)
+			assert_almost_eq(feet_v.y, float(bbox.end.y), 4.0,
+				"'%s' feet y ~ bbox baseline" % label)
+			# PIL-authored anchors sit inside the subject bbox (small tolerance:
+			# averaging across frames can put a static anchor just off frame 0's
+			# silhouette).
+			var tol := 4.0
+			for sk in e.get("sockets", []):
+				var off: Array = sk.get("px", [0, 0])
+				var p := feet_v + Vector2(float(off[0]), float(off[1]))
+				assert_between(p.x, bbox.position.x - tol, float(bbox.end.x) + tol,
+					"'%s' socket '%s' x inside subject bbox" % [label, sk.get("name")])
+				assert_between(p.y, bbox.position.y - tol, float(bbox.end.y) + tol,
+					"'%s' socket '%s' y inside subject bbox" % [label, sk.get("name")])
+
+
+func test_footfall_frames_within_clip_length():
+	if not _art_source_present():
+		pass_test("art_source absent (partial checkout) -- frame-count checks skipped")
+		return
+	var root := _repo_root()
+	var sprites: Dictionary = _load_doc().get("sprites", {})
+	for sid in sprites:
+		var clips: Dictionary = sprites[sid].get("clips", {})
+		for clip in clips:
+			var e: Dictionary = clips[clip]
+			var d := (root + "/" + String(e.get("source_dir", ""))).simplify_path()
+			var lo := 0
+			var hi := -1
+			var rng: Array = e.get("frames", [])
+			if rng.size() == 2:
+				lo = int(rng[0])
+				hi = int(rng[1])
+			var n := 0
+			var i := lo
+			while FileAccess.file_exists("%s/frame_%03d.png" % [d, i]) and (hi < 0 or i <= hi):
+				n += 1
+				i += 1
+			for ff in e.get("footfall_frames", []):
+				assert_between(int(ff), 0, n - 1,
+					"'%s/%s' footfall frame %d within %d-frame clip" % [sid, clip, int(ff), n])
+
+
+# --- AnchoredOverlay static queries ------------------------------------------
+
+func test_static_queries():
+	assert_true(AnchoredOverlay.sprite_sets().size() >= MIN_SETS, "sets visible to the consumer")
+	var sk := AnchoredOverlay.socket_of("cat_tabby_v1", "walk_east", "eyes")
+	assert_false(sk.is_empty(), "tabby walk_east has an eyes socket")
+	assert_eq(AnchoredOverlay.socket_of("cat_tabby_v1", "walk_east", "butt"), {},
+		"no butt socket on a side walk -> empty dict")
+	assert_eq(AnchoredOverlay.socket_of("__nope__", "walk_east", "eyes"), {},
+		"unknown set -> empty dict")
+	assert_eq(AnchoredOverlay.canvas_of("cat_tabby_v1"), Vector2(68, 68))
+
+
+# --- AnchoredOverlay runtime behaviour (synthetic host, no art needed) --------
+
+func _synthetic_host() -> AnimatedSprite2D:
+	var img := Image.create(68, 68, false, Image.FORMAT_RGBA8)
+	img.fill(Color(1, 1, 1, 1))
+	var tex := ImageTexture.create_from_image(img)
+	var sf := SpriteFrames.new()
+	sf.rename_animation("default", "walk_east")
+	sf.add_frame("walk_east", tex)
+	sf.add_frame("walk_east", tex)
+	sf.add_frame("walk_east", tex)
+	for extra in ["walk_north", "walk_north_alt", "idle", "no_anchor_clip"]:
+		sf.add_animation(extra)
+		sf.add_frame(extra, tex)
+	var host := AnimatedSprite2D.new()
+	host.sprite_frames = sf
+	host.play("walk_east")
+	return host
+
+
+func _expected_local(sid: String, clip: String, anchor: String) -> Vector2:
+	var sk := AnchoredOverlay.socket_of(sid, clip, anchor)
+	var off: Array = sk.get("px", [0, 0])
+	return AnchoredOverlay.feet_of(sid, clip) + Vector2(float(off[0]), float(off[1])) \
+		- AnchoredOverlay.canvas_of(sid) * 0.5
+
+
+func test_overlay_positions_at_anchor_and_follows_direction_switch():
+	var host := _synthetic_host()
+	add_child_autofree(host)
+	var ov := AnchoredOverlay.new()
+	ov.attach(host, "cat_tabby_v1", "eyes", null, {"pulse": false})
+	assert_eq(ov.get_parent(), host, "overlay reparents under the host")
+	assert_true(ov.visible, "eyes socket exists on walk_east")
+	assert_eq(ov.position, _expected_local("cat_tabby_v1", "walk_east", "eyes"),
+		"positions at feet_px + socket px, centred-host corrected")
+	# Direction switch: the host clip change re-resolves the anchor.
+	host.play("walk_north")
+	assert_true(ov.visible, "eyes anchor also exists on walk_north")
+	assert_eq(ov.position, _expected_local("cat_tabby_v1", "walk_north", "eyes"),
+		"anchor follows the direction switch")
+	assert_eq(ov.z_index, -1, "rear-view eyes socket is layer 'behind' -> z below host")
+	# A clip with no anchor data hides the overlay instead of guessing.
+	host.play("no_anchor_clip")
+	assert_false(ov.visible, "unknown clip -> overlay hidden")
+
+
+func test_butt_overlay_appears_only_on_rear_clips():
+	var host := _synthetic_host()
+	add_child_autofree(host)
+	var ov := AnchoredOverlay.new()
+	ov.attach(host, "cat_tabby_v1", "butt", null, {"pulse": false})
+	assert_false(ov.visible, "no butt on a side walk")
+	host.play("walk_north")
+	assert_true(ov.visible, "butt appears on the rear-facing walk")
+	assert_eq(ov.position, _expected_local("cat_tabby_v1", "walk_north", "butt"))
+	host.play("walk_north_alt")
+	assert_true(ov.visible, "butt appears on the butt-flash splice")
+	host.play("walk_east")
+	assert_false(ov.visible, "butt hides again on a side walk")
+
+
+func test_enabled_toggle_and_footfall_pulse_deterministic():
+	var host := _synthetic_host()
+	add_child_autofree(host)
+	var ov := AnchoredOverlay.new()
+	ov.attach(host, "cat_tabby_v1", "eyes", null,
+		{"opacity": 0.5, "pulse": true, "pulse_strength": 0.5})
+	assert_true(ov.visible)
+	ov.set_enabled(false)
+	assert_false(ov.visible, "master toggle hides the overlay")
+	ov.set_enabled(true)
+	assert_true(ov.visible, "and brings it back")
+	# Footfall pulse: purely frame-index driven. walk_east footfalls come from
+	# the JSON; drive the host to one and check the pulse bumps the modulate.
+	# Pause the host + zero the pulse first: the auto-playing loop passes the
+	# footfall frame on its own, which would inflate the baseline read.
+	host.pause()
+	var ffs: Array = AnchoredOverlay.footfalls_of("cat_tabby_v1", "walk_east")
+	assert_true(ffs.size() > 0, "authored footfall frames exist for walk_east")
+	ov._pulse = 0.0
+	ov._apply_visual()
+	var base_a := ov.modulate.a
+	host.frame = int(ffs[0])
+	ov._on_host_frame()
+	assert_gt(ov.modulate.a, base_a, "paw-strike frame pulses the glow (deterministic)")
+	# Non-footfall frame does NOT pulse from rest.
+	var ov2 := AnchoredOverlay.new()
+	ov2.attach(host, "cat_tabby_v1", "eyes", null,
+		{"opacity": 0.5, "pulse": true, "pulse_strength": 0.5})
+	var ffs_int: Array = []
+	for ff in ffs:
+		ffs_int.append(int(ff))
+	var quiet := -1
+	for i in range(3):
+		if not (i in ffs_int):
+			quiet = i
+	if quiet >= 0:
+		ov2._pulse = 0.0
+		ov2._apply_visual()
+		var a2 := ov2.modulate.a
+		host.frame = quiet
+		ov2._on_host_frame()
+		assert_eq(ov2.modulate.a, a2, "non-footfall frame does not pulse")

--- a/godot/tests/unit/test_anchor_sockets.gd.uid
+++ b/godot/tests/unit/test_anchor_sockets.gd.uid
@@ -1,0 +1,1 @@
+uid://lmpc54tf6d00

--- a/tools/art_review/author_anchor_sockets.py
+++ b/tools/art_review/author_anchor_sockets.py
@@ -1,0 +1,460 @@
+"""Author godot/data/office/anchor_sockets.json -- Anchor Sockets V2 (#894 #900 #913).
+
+Measures per-clip-direction STATIC anchor points (eyes / butt / spine_mid) for
+the PROMOTED cat walk clips (art_source/pixellab_verdicts.json clip-level
+entries, triaged by Pip 2026-07-26) so effects can attach to sprite PARTS
+instead of sprite centres.
+
+Method (python PIL, deterministic):
+  * alpha bbox per frame, averaged across the clip -> subject_px + feet_px
+    (feet = bottom-centre of the average bbox; the props_manifest anchor_px
+    convention from #906/#915).
+  * side-view eyes: hue/saturation blob search inside the head region (front
+    40% of the subject, upper half) -- tabby has green eyes, black amber,
+    purple orange-red; centroid averaged across frames.
+  * rear-view (north) eyes: NOT visible -- anchored at the head centroid
+    (top-of-subject centre), flagged "review": true.
+  * front-view (south) eyes: dark-dot search on the pale face, flagged
+    "review": true (muzzle/nose confusable).
+  * butt: rear views + butt-flash only (ruled set) -- rump centre estimated
+    from the subject bbox (centre x, ~78% down), flagged "review": true.
+  * spine_mid: reserve anchor at the subject centre-back (bbox centre x,
+    ~35% down), always flagged "review": true (pure geometry, no detection).
+  * footfall_frames: paw-strike pulse hook (Pip ruling 2026-07-26) -- frames
+    that are local maxima of ground-row foot spread (stride extremes ~=
+    contact frames), flagged "review": true.
+
+Sockets are stored as OFFSETS FROM feet_px in source px (+x right, +y down;
+eyes have negative y), mirroring props_manifest approach_px. Canvas position
+of a socket = feet_px + px.
+
+V2 = per-direction static offsets only. V3 (documented future) adds per-frame
+tracks: "tracks": {"eyes": [[x,y] per frame]} alongside the static px.
+
+Usage:  python tools/art_review/author_anchor_sockets.py
+Writes: godot/data/office/anchor_sockets.json (tracked SSOT)
+        art_generated/anchor_debug_sheet.png (gitignored marker proof sheet)
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+ROOT = Path(__file__).resolve().parents[2]
+SW = "art_source/pixellab_2026-07-26_cat_sweep"
+OUT_JSON = ROOT / "godot" / "data" / "office" / "anchor_sockets.json"
+OUT_SHEET = ROOT / "art_generated" / "anchor_debug_sheet.png"
+
+# Promoted clips (pixellab_verdicts.json clip-level "promote" entries,
+# 2026-07-26) -> runtime sprite-set/clip ids the sandbox builds.
+# view: side_e / side_w (eyes by colour blob), rear (lowtd north-ish),
+# front (lowtd south). eye_hue: (hue_lo_deg, hue_hi_deg, sat_min, val_min).
+GREEN_EYES = (60, 170, 0.25, 0.25)
+AMBER_EYES = (10, 50, 0.55, 0.55)
+CLIPS = {
+    "cat_tabby_v1": {
+        "walk_east": {
+            "dir": f"{SW}/cat_b2_tabby_side_heft/animations/walk_side_diag_probe/east",
+            "view": "side_e",
+            "eye_hue": GREEN_EYES,
+        },
+        "walk_west": {
+            "dir": f"{SW}/cat_b2_tabby_side_heft/animations/walk_side_diag_probe/west",
+            "view": "side_w",
+            "eye_hue": GREEN_EYES,
+        },
+        "walk_north": {
+            "dir": f"{SW}/cat_b2_tabby_lowtd_heft/animations/walk_ns_lowtd/north",
+            "view": "rear",
+        },
+        "walk_south": {
+            "dir": f"{SW}/cat_b2_tabby_lowtd_heft/animations/walk_ns_lowtd/south",
+            "view": "front",
+        },
+        # butt-flash splice (issue #913): frames 2..8 of the 9-frame clip are
+        # what the renderer plays as walk_north_alt (frame_000 = idle ref).
+        "walk_north_alt": {
+            "dir": f"{SW}/cat_b2_tabby_lowtd_heft/animations/butt_flash_north/north",
+            "view": "rear",
+            "frames": [2, 8],
+        },
+    },
+    "cat_black_v1": {
+        "walk_east": {
+            "dir": f"{SW}/cat_sweep_black_side_heft/animations/walk_ew/east",
+            "view": "side_e",
+            "eye_hue": AMBER_EYES,
+        },
+        "walk_west": {
+            "dir": f"{SW}/cat_sweep_black_side_heft/animations/walk_ew/west",
+            "view": "side_w",
+            "eye_hue": AMBER_EYES,
+        },
+    },
+    "cat_purple_v1": {
+        "walk_east": {
+            "dir": f"{SW}/cat_sweep_purple_side_heft/animations/walking/east",
+            "view": "side_e",
+            "eye_hue": AMBER_EYES,
+        },
+        "walk_west": {
+            "dir": f"{SW}/cat_sweep_purple_side_heft/animations/walking/west",
+            "view": "side_w",
+            "eye_hue": AMBER_EYES,
+        },
+    },
+}
+
+SCHEMA = {
+    "sprites": (
+        "sprite-set id -> {canvas_px, clips}. Ids match the SpriteFrames sets the "
+        "office sandbox builds from the promoted cat sweep clips "
+        "(art_source/pixellab_verdicts.json 'promote' entries, Pip 2026-07-26)."
+    ),
+    "canvas_px": "[w, h] full frame canvas in pixels (all clips of a set share it).",
+    "clips": (
+        "clip name (runtime AnimatedSprite2D animation name, e.g. walk_east; "
+        "walk_north_alt = the #913 butt-flash splice) -> per-clip anchor data."
+    ),
+    "source_dir": "repo-root-relative dir holding the clip's frame_NNN.png files.",
+    "frames": (
+        "OPTIONAL [first, last] inclusive frame-index range used from source_dir "
+        "(butt-flash splices 2..8 per the sweep MANIFEST); absent = all frames."
+    ),
+    "subject_px": "[w, h] opaque-subject bbox averaged across the clip's frames (rounded).",
+    "feet_px": (
+        "[x, y] feet anchor in CANVAS coords: bottom-centre of the average alpha "
+        "bbox (same convention as props_manifest anchor_px, #906/#915). The "
+        "sprite origin sockets are measured from."
+    ),
+    "footfall_frames": (
+        "clip-local frame indices (0-based) where a paw strikes the floor -- the "
+        "deterministic hook for footfall-anchored overlay pulses (Pip ruling "
+        "2026-07-26). Measured as stride-extreme frames; review flags apply."
+    ),
+    "sockets": (
+        "list of {name, px, layer} -- the UNIFIED socket convention shared with "
+        "props_manifest.json sockets. px = [x, y] OFFSET FROM feet_px in source "
+        "px (+x right, +y down; eyes are negative y). layer: 'front'|'behind' "
+        "draw order relative to the host sprite. Optional review/notes. Ruled "
+        "anchor set for cats: eyes (every direction), butt (rear-facing + "
+        "butt-flash only), spine_mid (reserve)."
+    ),
+    "review": "optional bool: true = anchor needs Pip's judgement (see notes).",
+    "notes": "optional free-text provenance / uncertainty notes.",
+    "v3_future": (
+        "V2 stores per-direction STATIC offsets only. V3 adds OPTIONAL per-frame "
+        "tracks alongside px: 'tracks': {socket_name: [[x, y] per clip frame]}; "
+        "consumers prefer tracks when present and fall back to px. The layering "
+        "lab's click-to-adjust flow is the intended authoring path."
+    ),
+}
+
+
+def hsv(px):
+    r, g, b = (c / 255.0 for c in px[:3])
+    mx, mn = max(r, g, b), min(r, g, b)
+    d = mx - mn
+    if d == 0:
+        h = 0.0
+    elif mx == r:
+        h = 60 * (((g - b) / d) % 6)
+    elif mx == g:
+        h = 60 * ((b - r) / d + 2)
+    else:
+        h = 60 * ((r - g) / d + 4)
+    s = 0.0 if mx == 0 else d / mx
+    return h, s, mx
+
+
+def load_frames(spec):
+    d = ROOT / spec["dir"]
+    paths = sorted(d.glob("frame_*.png"))
+    if not paths:
+        raise FileNotFoundError(d)
+    if "frames" in spec:
+        a, b = spec["frames"]
+        paths = paths[a : b + 1]
+    return [Image.open(p).convert("RGBA") for p in paths]
+
+
+def bbox_of(im):
+    bb = im.split()[3].getbbox()  # (l, t, r_excl, b_excl)
+    if bb is None:
+        raise ValueError("empty frame")
+    return bb
+
+
+def avg(vals):
+    return sum(vals) / len(vals)
+
+
+def detect_eyes_side(frames, spec, bboxes):
+    """Colour-blob centroid inside the head region of a side view."""
+    h_lo, h_hi, s_min, v_min = spec["eye_hue"]
+    east = spec["view"] == "side_e"
+    pts = []
+    for im, (bl, bt, br, bb) in zip(frames, bboxes):
+        w, hgt = br - bl, bb - bt
+        # head = front 40% of the subject, upper 55% (above the collar line)
+        x0 = bl + int(w * 0.60) if east else bl
+        x1 = br if east else bl + int(w * 0.40)
+        y1 = bt + int(hgt * 0.55)
+        hits = []
+        for y in range(bt, y1):
+            for x in range(x0, x1):
+                px = im.getpixel((x, y))
+                if px[3] < 200:
+                    continue
+                h, s, v = hsv(px)
+                if h_lo <= h <= h_hi and s >= s_min and v >= v_min:
+                    hits.append((x, y))
+        if hits:
+            pts.append((avg([p[0] for p in hits]), avg([p[1] for p in hits])))
+    if not pts:
+        return None
+    return (avg([p[0] for p in pts]), avg([p[1] for p in pts]))
+
+
+def detect_eyes_front(frames, bboxes):
+    """Darkest-dot centroid on the face (front/lowtd south view). Confusable
+    with the muzzle -> caller flags review."""
+    pts = []
+    for im, (bl, bt, br, bb) in zip(frames, bboxes):
+        w, hgt = br - bl, bb - bt
+        x0, x1 = bl + int(w * 0.25), br - int(w * 0.25)
+        y0, y1 = bt + int(hgt * 0.18), bt + int(hgt * 0.48)
+        hits = []
+        for y in range(y0, y1):
+            for x in range(x0, x1):
+                px = im.getpixel((x, y))
+                if px[3] < 200:
+                    continue
+                _, _, v = hsv(px)
+                if v < 0.30:  # dark dots on a pale face
+                    hits.append((x, y))
+        if hits:
+            pts.append((avg([p[0] for p in hits]), avg([p[1] for p in hits])))
+    if not pts:
+        return None
+    return (avg([p[0] for p in pts]), avg([p[1] for p in pts]))
+
+
+def detect_footfalls(frames, bboxes):
+    """Stride-extreme frames ~= paw-strike frames: local maxima of the opaque
+    x-spread over the bottom 3 rows of each frame's bbox."""
+    spreads = []
+    for im, (bl, bt, br, bb) in zip(frames, bboxes):
+        xs = [
+            x
+            for y in range(max(bt, bb - 3), bb)
+            for x in range(bl, br)
+            if im.getpixel((x, y))[3] >= 200
+        ]
+        spreads.append((max(xs) - min(xs)) if xs else 0)
+    n = len(spreads)
+    hits = [
+        i
+        for i in range(n)
+        if spreads[i] >= spreads[(i - 1) % n] and spreads[i] >= spreads[(i + 1) % n]
+    ]
+    # collapse adjacent plateau indices; keep at most 2 per 8-frame cycle
+    kept = []
+    for i in hits:
+        if not kept or (i - kept[-1]) % n > 1:
+            kept.append(i)
+    return kept[:2] if kept else [0]
+
+
+def author_clip(sprite, clip, spec):
+    frames = load_frames(spec)
+    bboxes = [bbox_of(im) for im in frames]
+    sub_w = round(avg([br - bl for bl, bt, br, bb in bboxes]))
+    sub_h = round(avg([bb - bt for bl, bt, br, bb in bboxes]))
+    feet_x = round(avg([(bl + br) / 2 for bl, bt, br, bb in bboxes]) * 2) / 2
+    feet_y = round(avg([bb for bl, bt, br, bb in bboxes]))
+    top_y = round(avg([bt for bl, bt, br, bb in bboxes]))
+    l_av = avg([bl for bl, bt, br, bb in bboxes])
+    r_av = avg([br for bl, bt, br, bb in bboxes])
+
+    def off(cx, cy):
+        return [round(cx - feet_x), round(cy - feet_y)]
+
+    sockets = []
+    view = spec["view"]
+    if view in ("side_e", "side_w"):
+        eye = detect_eyes_side(frames, spec, bboxes)
+        if eye is not None:
+            sockets.append(
+                {
+                    "name": "eyes",
+                    "px": off(*eye),
+                    "layer": "front",
+                    "notes": "colour-blob centroid of the iris pixels, avg across frames",
+                }
+            )
+        else:
+            # geometric fallback: front-top of the head
+            ex = r_av - sub_w * 0.12 if view == "side_e" else l_av + sub_w * 0.12
+            sockets.append(
+                {
+                    "name": "eyes",
+                    "px": off(ex, top_y + sub_h * 0.30),
+                    "layer": "front",
+                    "review": True,
+                    "notes": "eye colour-blob detection found nothing; geometric head-front guess",
+                }
+            )
+    elif view == "front":
+        eye = detect_eyes_front(frames, bboxes)
+        if eye is not None:
+            sockets.append(
+                {
+                    "name": "eyes",
+                    "px": off(*eye),
+                    "layer": "front",
+                    "review": True,
+                    "notes": "dark-dot centroid on the face; muzzle/nose confusable -- Pip to nudge in the lab",
+                }
+            )
+        else:
+            sockets.append(
+                {
+                    "name": "eyes",
+                    "px": off((l_av + r_av) / 2, top_y + sub_h * 0.30),
+                    "layer": "front",
+                    "review": True,
+                    "notes": "no dark-dot hit; geometric face-centre guess",
+                }
+            )
+    else:  # rear
+        sockets.append(
+            {
+                "name": "eyes",
+                "px": off((l_av + r_av) / 2, top_y + sub_h * 0.14),
+                "layer": "behind",
+                "review": True,
+                "notes": (
+                    "eyes NOT visible from the rear -- anchored at the head "
+                    "centroid so a glow halos the head; layer behind"
+                ),
+            }
+        )
+        sockets.append(
+            {
+                "name": "butt",
+                "px": off((l_av + r_av) / 2, top_y + sub_h * 0.78),
+                "layer": "front",
+                "review": True,
+                "notes": "rump centre from bbox geometry (~78% down the subject) -- Pip to nudge in the lab",
+            }
+        )
+    sockets.append(
+        {
+            "name": "spine_mid",
+            "px": off((l_av + r_av) / 2, top_y + sub_h * 0.35),
+            "layer": "front",
+            "review": True,
+            "notes": "reserve anchor, pure bbox geometry (centre x, 35% down)",
+        }
+    )
+    entry = {
+        "source_dir": spec["dir"],
+        "subject_px": [sub_w, sub_h],
+        "feet_px": [feet_x, feet_y],
+        "footfall_frames": detect_footfalls(frames, bboxes),
+        "footfall_review": True,
+        "sockets": sockets,
+    }
+    if "frames" in spec:
+        entry["frames"] = spec["frames"]
+    return entry, frames
+
+
+def debug_sheet(rows):
+    """rows: list of (label, frame_img, entry) -- draw markers, 6x upscale."""
+    s = 6
+    cell_h = 68 * s + 22
+    sheet = Image.new("RGBA", (68 * s * 3 + 40, cell_h * len(rows)), (28, 28, 32, 255))
+    dr = ImageDraw.Draw(sheet)
+    colors = {"eyes": (0, 255, 90), "butt": (255, 80, 200), "spine_mid": (80, 170, 255)}
+    for i, (label, im, entry) in enumerate(rows):
+        y0 = i * cell_h
+        big = im.resize((68 * s, 68 * s), Image.NEAREST)
+        sheet.alpha_composite(big, (0, y0))
+        fx, fy = entry["feet_px"]
+        dr.line([(0, y0 + fy * s), (68 * s, y0 + fy * s)], fill=(255, 255, 0, 140), width=1)
+        dr.ellipse(
+            [fx * s - 4, y0 + fy * s - 4, fx * s + 4, y0 + fy * s + 4],
+            outline=(255, 255, 0),
+            width=2,
+        )
+        for sk in entry["sockets"]:
+            cx = (fx + sk["px"][0]) * s
+            cy = y0 + (fy + sk["px"][1]) * s
+            col = colors.get(sk["name"], (255, 255, 255))
+            dr.line([(cx - 7, cy), (cx + 7, cy)], fill=col, width=2)
+            dr.line([(cx, cy - 7), (cx, cy + 7)], fill=col, width=2)
+            if sk.get("review"):
+                dr.ellipse([cx - 10, cy - 10, cx + 10, cy + 10], outline=col, width=1)
+        dr.text(
+            (68 * s + 10, y0 + 10),
+            label
+            + "\nfeet %s  footfalls %s" % (entry["feet_px"], entry["footfall_frames"])
+            + "".join(
+                "\n%s %s%s" % (sk["name"], sk["px"], " [review]" if sk.get("review") else "")
+                for sk in entry["sockets"]
+            ),
+            fill=(230, 230, 210),
+        )
+        dr.text((4, y0 + 68 * s + 4), label, fill=(255, 255, 160))
+    return sheet
+
+
+def main():
+    sprites = {}
+    rows = []
+    n_review = 0
+    for sprite, clips in CLIPS.items():
+        canvas = None
+        centry = {}
+        for clip, spec in clips.items():
+            entry, frames = author_clip(sprite, clip, spec)
+            centry[clip] = entry
+            canvas = list(frames[0].size)
+            mid = frames[len(frames) // 2]
+            rows.append(("%s / %s" % (sprite, clip), mid, entry))
+            n_review += sum(1 for sk in entry["sockets"] if sk.get("review"))
+        sprites[sprite] = {"canvas_px": canvas, "clips": centry}
+    doc = {
+        "_meta": {
+            "version": "2.0",
+            "description": (
+                "Anchor Sockets V2 -- per-clip-direction named anchor points on "
+                "animated sprites, so effects attach to PARTS (eyes, butt, "
+                "spine_mid) instead of sprite centres. Covers the PROMOTED cat "
+                "sweep clips (Pip triage 2026-07-26). Consumed by "
+                "scripts/ui/office_floor/anchored_overlay.gd; authored by "
+                "tools/art_review/author_anchor_sockets.py; adjusted via the "
+                "layering lab click-to-adjust flow. See docs/art/PROP_MANIFEST.md "
+                "(Anchor sockets section)."
+            ),
+            "measured_with": "tools/art_review/author_anchor_sockets.py (python PIL), 2026-07-26",
+        },
+        "_schema": SCHEMA,
+        "sprites": sprites,
+    }
+    OUT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    OUT_JSON.write_text(json.dumps(doc, indent=2) + "\n", encoding="ascii", newline="\n")
+    print("wrote %s (%d sprite sets)" % (OUT_JSON, len(sprites)))
+    print("review-flagged sockets: %d" % n_review)
+    OUT_SHEET.parent.mkdir(parents=True, exist_ok=True)
+    debug_sheet(rows).save(OUT_SHEET)
+    print("wrote %s" % OUT_SHEET)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/art_review/author_anchor_sockets.py
+++ b/tools/art_review/author_anchor_sockets.py
@@ -80,6 +80,13 @@ CLIPS = {
             "view": "rear",
             "frames": [2, 8],
         },
+        # idle = frame 0 of the south walk (the sandbox idle convention), so
+        # anchors keep resolving while a wandering cat pauses.
+        "idle": {
+            "dir": f"{SW}/cat_b2_tabby_lowtd_heft/animations/walk_ns_lowtd/south",
+            "view": "front",
+            "frames": [0, 0],
+        },
     },
     "cat_black_v1": {
         "walk_east": {
@@ -92,6 +99,12 @@ CLIPS = {
             "view": "side_w",
             "eye_hue": AMBER_EYES,
         },
+        "idle": {
+            "dir": f"{SW}/cat_sweep_black_side_heft/animations/walk_ew/east",
+            "view": "side_e",
+            "eye_hue": AMBER_EYES,
+            "frames": [0, 0],
+        },
     },
     "cat_purple_v1": {
         "walk_east": {
@@ -103,6 +116,12 @@ CLIPS = {
             "dir": f"{SW}/cat_sweep_purple_side_heft/animations/walking/west",
             "view": "side_w",
             "eye_hue": AMBER_EYES,
+        },
+        "idle": {
+            "dir": f"{SW}/cat_sweep_purple_side_heft/animations/walking/east",
+            "view": "side_e",
+            "eye_hue": AMBER_EYES,
+            "frames": [0, 0],
         },
     },
 }
@@ -364,7 +383,7 @@ def author_clip(sprite, clip, spec):
         "source_dir": spec["dir"],
         "subject_px": [sub_w, sub_h],
         "feet_px": [feet_x, feet_y],
-        "footfall_frames": detect_footfalls(frames, bboxes),
+        "footfall_frames": detect_footfalls(frames, bboxes) if len(frames) > 1 else [],
         "footfall_review": True,
         "sockets": sockets,
     }
@@ -413,7 +432,34 @@ def debug_sheet(rows):
     return sheet
 
 
+def load_corrections(argv):
+    """--apply corrections.json: the anchor-lab click-to-adjust paste-back path.
+
+    Shape (what the lab's textarea emits): {sprite_set: {clip: {socket: [x, y]}}}
+    with [x, y] the corrected offset from feet_px. Applied AFTER measurement:
+    the clicked socket's px is overridden, its review flag cleared, provenance
+    noted. Everything un-clicked is re-measured as usual.
+    """
+    if len(argv) >= 2 and argv[0] == "--apply":
+        return json.loads(Path(argv[1]).read_text(encoding="ascii"))
+    return {}
+
+
+def apply_corrections(entry, sprite, clip, corrections):
+    fixes = corrections.get(sprite, {}).get(clip, {})
+    n = 0
+    for sk in entry["sockets"]:
+        if sk["name"] in fixes:
+            sk["px"] = [int(v) for v in fixes[sk["name"]]]
+            sk.pop("review", None)
+            sk["notes"] = "adjusted via the anchor-lab click-to-adjust (Pip)"
+            n += 1
+    return n
+
+
 def main():
+    corrections = load_corrections(sys.argv[1:])
+    n_applied = 0
     sprites = {}
     rows = []
     n_review = 0
@@ -422,6 +468,7 @@ def main():
         centry = {}
         for clip, spec in clips.items():
             entry, frames = author_clip(sprite, clip, spec)
+            n_applied += apply_corrections(entry, sprite, clip, corrections)
             centry[clip] = entry
             canvas = list(frames[0].size)
             mid = frames[len(frames) // 2]
@@ -450,6 +497,8 @@ def main():
     OUT_JSON.write_text(json.dumps(doc, indent=2) + "\n", encoding="ascii", newline="\n")
     print("wrote %s (%d sprite sets)" % (OUT_JSON, len(sprites)))
     print("review-flagged sockets: %d" % n_review)
+    if n_applied:
+        print("lab corrections applied: %d" % n_applied)
     OUT_SHEET.parent.mkdir(parents=True, exist_ok=True)
     debug_sheet(rows).save(OUT_SHEET)
     print("wrote %s" % OUT_SHEET)

--- a/tools/art_review/build_cat_sweep_sheet.py
+++ b/tools/art_review/build_cat_sweep_sheet.py
@@ -27,6 +27,7 @@ Output: art_generated/cat_sweep_sheet.html (gitignored derived output)
 
 import base64
 import io
+import json
 import sys
 from pathlib import Path
 
@@ -39,6 +40,10 @@ ROOT = Path(__file__).resolve().parents[2]
 SW = ROOT / "art_source" / "pixellab_2026-07-26_cat_sweep"
 OV = ROOT / "art_source" / "pixellab_2026-07-26_doom_overlays"
 FLOOR_ATLAS = ROOT / "godot" / "assets" / "office_floor" / "tilesets" / "floor_concrete.png"
+# Anchor Sockets V2 SSOT (#894): the anchor lab (section 8) composites overlays
+# AT these anchors and click-to-adjust emits corrected JSON for paste-back via
+# author_anchor_sockets.py --apply.
+ANCHORS_JSON = ROOT / "godot" / "data" / "office" / "anchor_sockets.json"
 OUT = ROOT / "art_generated" / "cat_sweep_sheet.html"
 
 REL_BASE = "art_source/pixellab_2026-07-26_cat_sweep"
@@ -245,6 +250,19 @@ font-size:10px;color:#9a9081;}
 .lab-ctl input[type=range]{flex:1;accent-color:#e0a34a;}
 .lab-ctl select{background:#252019;color:#e8e0d2;border:1px solid #3a332a;
 font-family:monospace;font-size:10px;border-radius:4px;}
+/* anchor lab (Anchor Sockets V2, #894) */
+.anchor-stage{cursor:crosshair;}
+.anchor-stage img.aov{position:absolute;image-rendering:pixelated;z-index:3;
+pointer-events:none;}
+.anchor-stage img.aov.behind{z-index:1;}
+.amark{position:absolute;width:11px;height:11px;margin:-5px 0 0 -5px;z-index:4;
+pointer-events:none;}
+.amark:before,.amark:after{content:"";position:absolute;background:#4dff7a;}
+.amark:before{left:5px;top:0;width:1px;height:11px;}
+.amark:after{left:0;top:5px;width:11px;height:1px;}
+.amark.review:before,.amark.review:after{background:#ffb84d;}
+#anchor-json{width:100%;height:140px;background:#181410;color:#cfe6c8;
+border:1px solid #3a332a;font-family:monospace;font-size:10px;}
 """
 
 ANIM_JS_TEMPLATE = """
@@ -576,6 +594,193 @@ def main() -> int:
             "})(li);\n" % lab_idx
         )
 
+    # ---- section 8: ANCHOR LAB (Anchor Sockets V2, #894) ------------------
+    # Composites overlays AT the JSON anchors over each promoted walker, and a
+    # click-to-adjust mode: clicking the stage moves the selected anchor and
+    # emits corrected anchor JSON for paste-back (the V3-lite authoring path
+    # -- Pip clicking IS the tool). Apply with:
+    #   python tools/art_review/author_anchor_sockets.py --apply corrections.json
+    sec8 = ""
+    anchor_js = ""
+    if ANCHORS_JSON.exists():
+        anchors_doc = json.loads(ANCHORS_JSON.read_text(encoding="ascii"))
+        ov_keys = sorted(k for k in ANIMS if k.split("_", 1)[0] in OVERLAYS)
+        default_ov = (
+            "aura_glowdisc" if "aura_glowdisc" in ANIMS else (ov_keys[0] if ov_keys else "")
+        )
+        stages = []
+        cells = []
+        for sid, sentry in anchors_doc.get("sprites", {}).items():
+            for clip, centry in sentry.get("clips", {}).items():
+                src = ROOT / centry["source_dir"]
+                paths = sorted(src.glob("frame_*.png"))
+                rng = centry.get("frames")
+                if rng:
+                    paths = paths[rng[0] : rng[1] + 1]
+                if not paths:
+                    continue
+                key = f"anchor_{sid}_{clip}"
+                ANIMS[key] = [b64(p) for p in paths]
+                i = len(stages)
+                cid = f"acat{i}"
+                oid = f"aov{i}"
+                PLAYER_BINDINGS.append((cid, key))
+                if default_ov:
+                    PLAYER_BINDINGS.append((oid, default_ov))
+                sockets = {
+                    str(sk["name"]): {
+                        "px": list(sk["px"]),
+                        "layer": str(sk.get("layer", "front")),
+                        "review": bool(sk.get("review", False)),
+                    }
+                    for sk in centry.get("sockets", [])
+                }
+                stages.append(
+                    {
+                        "i": i,
+                        "set": sid,
+                        "clip": clip,
+                        "feet": list(centry["feet_px"]),
+                        "sockets": sockets,
+                        "k": 2,
+                    }
+                )
+                an_opts = "".join(
+                    f'<option value="{esc(nm)}">{esc(nm)}'
+                    + (" [review]" if sockets[nm]["review"] else "")
+                    + "</option>"
+                    for nm in sockets
+                )
+                ov_opts = "".join(
+                    f'<option value="{esc(k)}"{" selected" if k == default_ov else ""}>{esc(k)}</option>'
+                    for k in ov_keys
+                )
+                review_n = sum(1 for s in sockets.values() if s["review"])
+                cells.append(
+                    f'<div class="rs-cell" style="width:240px">'
+                    f'<div class="lab-stage anchor-stage" id="astage{i}" '
+                    f'style="background-image:url({FLOOR})">'
+                    f'<img id="{cid}" class="cat" src="{ANIMS[key][0]}">'
+                    + (
+                        f'<img id="{oid}" class="aov" src="{ANIMS[default_ov][0]}">'
+                        if default_ov
+                        else ""
+                    )
+                    + f'<div class="amark" id="amark{i}"></div>'
+                    "</div>"
+                    f'<div class="rs-label">{esc(sid)} / {esc(clip)}'
+                    + (f" -- {review_n} review" if review_n else "")
+                    + "</div>"
+                    f'<div class="lab-ctl">'
+                    f'<label>anchor <select id="aan{i}">{an_opts}</select>'
+                    f' overlay <select id="aok{i}">{ov_opts}</select></label>'
+                    f'<label>opacity <input type="range" id="aop{i}" min="0" max="100" '
+                    f'value="60"> size <input type="range" id="asz{i}" min="6" max="60" '
+                    f'value="20"></label>'
+                    f'<label>blend <select id="abl{i}">'
+                    '<option value="normal">normal</option>'
+                    '<option value="screen" selected>screen (~additive)</option>'
+                    '<option value="lighten">lighten</option>'
+                    '<option value="hard-light">hard-light</option></select>'
+                    f' <label><input type="checkbox" id="abh{i}"> behind</label></label>'
+                    "</div>"
+                    f'<p class="rs-blurb" id="ainfo{i}">click the stage to move this anchor</p>'
+                    "</div>"
+                )
+        if stages:
+            sec8 = section(
+                "8. Anchor lab -- overlays AT the V2 sockets + click-to-adjust (2x)",
+                '<p class="intro">Each stage composites the overlay at the anchor '
+                "authored in godot/data/office/anchor_sockets.json (green cross = "
+                "authored anchor; ORANGE cross = flagged review:true -- these are "
+                "the calls left for Pip). CLICK a stage to move the selected "
+                "anchor; every click updates the corrections JSON below. Paste it "
+                "back with: save as corrections.json, then run "
+                "<code>python tools/art_review/author_anchor_sockets.py --apply "
+                "corrections.json</code> (re-measures everything else, overrides "
+                "clicked sockets, clears their review flags).</p>"
+                '<div class="rs-grid">' + "".join(cells) + "</div>"
+                '<div class="cat-row-label">corrected anchor JSON (auto-updates on click)</div>'
+                '<textarea id="anchor-json" readonly>{}</textarea> '
+                '<button class="rs-btn" id="anchor-copy">copy JSON</button>',
+                count=f"{len(stages)} clips",
+                accent="#4dff7a",
+            )
+            anchor_js = (
+                "var STAGES = %s;\n" % json.dumps(stages)
+                + """
+var corrections = {};
+function stageState(s) {
+  var an = document.getElementById('aan' + s.i).value;
+  var sk = s.sockets[an];
+  var corr = (corrections[s.set] || {})[s.clip] || {};
+  var px = corr[an] || sk.px;
+  return {an: an, sk: sk, px: px};
+}
+function aplace(s) {
+  var st = stageState(s);
+  var cx = (s.feet[0] + st.px[0]) * s.k;
+  var cy = (s.feet[1] + st.px[1]) * s.k;
+  var mark = document.getElementById('amark' + s.i);
+  mark.style.left = cx + 'px';
+  mark.style.top = cy + 'px';
+  mark.className = 'amark' + (st.sk.review ? ' review' : '');
+  var ov = document.getElementById('aov' + s.i);
+  if (ov) {
+    var px = Math.round(136 * document.getElementById('asz' + s.i).value / 100);
+    ov.style.width = px + 'px';
+    ov.style.height = px + 'px';
+    ov.style.left = (cx - px / 2) + 'px';
+    ov.style.top = (cy - px / 2) + 'px';
+    ov.style.opacity = document.getElementById('aop' + s.i).value / 100;
+    ov.style.mixBlendMode = document.getElementById('abl' + s.i).value;
+    ov.classList.toggle('behind',
+      document.getElementById('abh' + s.i).checked || st.sk.layer === 'behind');
+  }
+  var info = document.getElementById('ainfo' + s.i);
+  info.textContent = st.an + ' px [' + st.px[0] + ', ' + st.px[1] + ']'
+    + (corrections[s.set] && corrections[s.set][s.clip] && corrections[s.set][s.clip][st.an]
+       ? ' (ADJUSTED)' : (st.sk.review ? ' [review]' : ''));
+}
+function refreshJson() {
+  document.getElementById('anchor-json').value =
+    JSON.stringify(corrections, null, 2);
+}
+STAGES.forEach(function (s) {
+  ['aan', 'aok', 'aop', 'asz', 'abl', 'abh'].forEach(function (p) {
+    var el = document.getElementById(p + s.i);
+    if (!el) return;
+    el.addEventListener(p === 'aop' || p === 'asz' ? 'input' : 'change', function () {
+      if (p === 'aok') {
+        for (var bi = 0; bi < bindings.length; bi++)
+          if (bindings[bi][0] === 'aov' + s.i) bindings[bi][1] = el.value;
+      }
+      aplace(s);
+    });
+  });
+  document.getElementById('astage' + s.i).addEventListener('click', function (e) {
+    var r = this.getBoundingClientRect();
+    var ax = Math.round((e.clientX - r.left) / s.k - s.feet[0]);
+    var ay = Math.round((e.clientY - r.top) / s.k - s.feet[1]);
+    var an = document.getElementById('aan' + s.i).value;
+    corrections[s.set] = corrections[s.set] || {};
+    corrections[s.set][s.clip] = corrections[s.set][s.clip] || {};
+    corrections[s.set][s.clip][an] = [ax, ay];
+    aplace(s);
+    refreshJson();
+  });
+  aplace(s);
+});
+var acopy = document.getElementById('anchor-copy');
+if (acopy) acopy.addEventListener('click', function () {
+  var ta = document.getElementById('anchor-json');
+  ta.select();
+  document.execCommand('copy');
+});
+refreshJson();
+"""
+            )
+
     # ---- page -------------------------------------------------------------
     n_clips = len(ANIMS)
     intro = (
@@ -590,7 +795,7 @@ def main() -> int:
         "Sources: art_source/pixellab_2026-07-26_cat_sweep/ and "
         "art_source/pixellab_2026-07-26_doom_overlays/ (MANIFEST.md in each)."
     )
-    body = sec1 + sec2 + sec3 + sec4 + sec5 + sec5b + sec6 + sec7
+    body = sec1 + sec2 + sec3 + sec4 + sec5 + sec5b + sec6 + sec7 + sec8
     anim_js = ANIM_JS_TEMPLATE.replace(
         "%ANIMS%",
         "\n".join(
@@ -607,7 +812,7 @@ def main() -> int:
         badges=(("cats", "4"), ("clips", str(n_clips)), ("fps", "8")),
         intro_html=intro,
         extra_css=EXTRA_CSS,
-        extra_js=anim_js + "\n" + lab_js,
+        extra_js=anim_js + "\n" + lab_js + "\n" + anchor_js,
         verdict_key="cat_sweep:verdicts",
         export_name="cat_sweep_verdicts.json",
         footer_note=(


### PR DESCRIPTION
## Anchor Sockets V2 -- effects attach to sprite PARTS (#894, #900, #913)

Pip-approved 2026-07-26: per-direction named anchor points on animated sprites, so effects attach to eyes / butt / spine_mid instead of sprite centres. Includes the two same-day follow-up rulings: footfall-anchored pulses (accepted) and the interim doom-flavour colour mapping.

### 1. Schema + data (SSOT: `godot/data/office/anchor_sockets.json`)

- Extends the unified socket convention (props manifest `{name, px, layer}`) to CLIPS: `sprites -> <set> -> clips -> <clip>` with `source_dir`, optional `frames` range, `subject_px`, `feet_px` (the #906/#915 feet-anchor convention), `footfall_frames` (paw-strike pulse hook), and `sockets` as offsets from `feet_px` in source px.
- Ruled anchor set for cats: `eyes` every direction, `butt` rear-facing + butt-flash clips only, `spine_mid` reserve.
- V2 = per-direction STATIC offsets; V3 per-frame `tracks` documented as the future in `_schema`.
- Docs: new "Anchor sockets V2" section in `docs/art/PROP_MANIFEST.md`.

### 2. Authoring pass (all 9 promoted clips + idle aliases)

`tools/art_review/author_anchor_sockets.py` (PIL, deterministic) measured the promoted cat-sweep clips from `pixellab_verdicts.json`: tabby side E/W, tabby lowtd N/S + butt-flash splice (`walk_north_alt`, frames 2..8), black side E/W, purple side E/W, plus `idle` aliases so anchors resolve while a wandering cat pauses.

- Side-view eyes = iris colour-blob centroid (verified on a marker proof sheet -- crosses land on the actual eye pixels; `art_generated/anchor_debug_sheet.png`).
- Rear/front eyes, butt, spine_mid = geometric estimates, flagged `review: true` -- **17 review-flagged sockets left as Pip's calls**, adjustable by clicking in the lab.
- `footfall_frames` measured as stride-extreme frames, all flagged for review.

### 3. Runtime (`godot/scripts/ui/office_floor/anchored_overlay.gd`)

`AnchoredOverlay` (extends AnimatedSprite2D): `attach(host, set, anchor, frames, dials)` positions at the anchor for the host's CURRENT clip, re-resolves on direction change, hides when the clip lacks the socket, honours socket `layer` (behind/front), dials for blend / opacity / z-offset / scale (mirroring the layering-lab dials), and a deterministic footfall pulse (host frame-index driven, no RNG).

Sandbox demo (dev-only, mechanics-safe, pure composition):
- Walkers for the 3 promoted sets are built FROM `anchor_sockets.json` (walkers and anchors cannot drift); they spawn first in the cat rotation.
- Eye glow on every walking cat, SUBTLE at nominal doom; intensity carries the doom level (existing `[`/`]` dial). Butt glow auto-appears on rear-facing walks + butt-flash splices.
- `[A]` toggles the demo, `[D]` cycles the interim flavour hues from the existing overlay families: purple/eldritch (`aura/glowdisc`), red/catastrophe (`states/aura_red`), blue/weirdness (`arc/radialweb`). Legend + status updated.

### 4. Anchor lab (tools/art_review)

`build_cat_sweep_sheet.py` section 8: every anchored clip renders with the overlay composited AT the JSON anchor (orange cross = review-flagged). Clicking the stage moves the selected anchor and emits corrections JSON; paste back via `python tools/art_review/author_anchor_sockets.py --apply corrections.json` (overrides clicked sockets, clears their review flags, re-measures the rest). Pip clicking IS the tool.

### 5. Tests

`godot/tests/unit/test_anchor_sockets.gd` (11 tests): JSON parses + schema shape; every referenced clip dir/frame range exists; anchors inside the subject bbox (tolerance grounded in measured per-frame deviation, worst 1 px); butt only on rear/butt-flash clips; AnchoredOverlay positioning incl. direction switch, socket-absent hiding, enable toggle, deterministic pulse.

**Fast gate: 756 tests, 0 failures, 83/83 files.**

### Left for Pip

- 17 review-flagged sockets (rear/front eyes, butts, spine_mid reserves, footfall frames) -- open `art_generated/cat_sweep_sheet.html` section 8, click, export, `--apply`.
- Flavour hue verdict: purple vs red vs blue eye glow ([D] in the sandbox); full colour architecture is the W3 circle-back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
