### PR TITLE
docs(ws3): three-day W-3 split (Mon ratify / Tue build / Wed W-3b-W-4) + blow-by-blow runsheet

### DIFF
--- a/docs/RELEASE_CALENDAR.html
+++ b/docs/RELEASE_CALENDAR.html
@@ -52,9 +52,10 @@
   <div class="now">&gt;&gt; You are here: Sat 26 Jul 2026 &middot; build 0.13.1 &middot; ladder L2</div>
 
   <div class="month">July 2026</div>
-  <div class="row"><div class="when">Mon-Tue<br>27-28</div><div class="what"><span class="tag t-patch">patch</span><span class="theme">v0.13.1 build</span> <span class="meta">-- from release/v0.13; honesty pass; ladder stays L2</span></div></div>
-  <div class="row"><div class="when"><b>Wed 29</b></div><div class="what"><span class="tag t-design">WS-3</span><span class="theme">Workshop 3 -- mechanics</span> <span class="meta">-- crisp parts, brutal decisions (#811)</span></div></div>
-  <div class="row"><div class="when">Fri 31</div><div class="what"><span class="tag t-seed">seed</span>weekly seed rotation <span class="meta">-- L2</span></div></div>
+  <div class="row"><div class="when"><b>Mon 27</b></div><div class="what"><span class="tag t-design">W-3a</span><span class="theme">Workshop 3a -- ratify + build-gating decisions</span> <span class="meta">-- FINISH_OR_DROP x5; early-game, #613, tile-grid, office camera (#811)</span></div></div>
+  <div class="row"><div class="when"><b>Tue 28</b></div><div class="what"><span class="tag t-patch">build</span><span class="theme">Build day -- Fable fan-out of Monday's rulings</span> <span class="meta">-- + art re-base; Pip: CEO chunks + drive-by approvals</span></div></div>
+  <div class="row"><div class="when"><b>Wed 29</b></div><div class="what"><span class="tag t-design">W-3b/W-4</span><span class="theme">Workshop 3b/4 -- colour, decorating, cadence, review, next epoch</span> <span class="meta">-- eve of the one-year anniversary (first issue 2025-07-30)</span></div></div>
+  <div class="row"><div class="when"><b>Fri 31</b></div><div class="what"><span class="tag t-seed">seed</span><span class="theme">weekly seed rotation + Friday league target</span> <span class="meta">-- L2; Rektango 17:30 anchor</span></div></div>
 
   <div class="month">August 2026</div>
   <div class="row"><div class="when"><b>Fri 7</b></div><div class="what"><span class="tag t-epoch">epoch -> L3</span><span class="theme">v0.14 "Per-tick &amp; People"</span> <span class="meta">(prov.) -- per-tick resolution + people &amp; money cohesion</span></div></div>
@@ -71,6 +72,6 @@
   <div class="row"><div class="when"><b>Fri 2</b></div><div class="what"><span class="tag t-epoch">epoch -> L5</span><span class="theme">v0.16 "Sightings"</span> <span class="meta">(prov.) -- rivals begin; wider event pool from pdoom-data</span></div></div>
   <div class="row"><div class="when">Fri 9 / 16 / 23 / 30</div><div class="what"><span class="tag t-seed">seed</span>weekly seeds <span class="meta">-- L5</span></div></div>
 
-  <footer>Provisional Theme names beyond v0.13 are unblessed (no-lies standard). Source: RELEASE_NOMENCLATURE.md + ROADMAP.md &middot; rendered 2026-07-25.</footer>
+  <footer>Provisional Theme names beyond v0.13 are unblessed (no-lies standard). Source: RELEASE_NOMENCLATURE.md + ROADMAP.md + WORKSHOP_3_PREP.md &middot; rendered 2026-07-26 (W-3 three-day restructure).</footer>
 </div>
 </body></html>

--- a/docs/game-design/RUNSHEET_2026-07-27_to_29.md
+++ b/docs/game-design/RUNSHEET_2026-07-27_to_29.md
@@ -1,0 +1,204 @@
+# Runsheet: Mon 2026-07-27 .. Wed 2026-07-29 (W-3a / build day / W-3b-W-4)
+
+> Status: OPERATIONAL RUNSHEET, written 2026-07-26 evening from Pip's
+> restructure ruling (issue #811; agenda detail in `WORKSHOP_3_PREP.md`;
+> ratify-block detail in `WS3_FINISH_OR_DROP.md`). This doc is the
+> blow-by-blow: what happens when, what feeds each decision, what each block
+> must emit, and what is sacrificial if the day runs hot.
+>
+> Anniversary frame: Pip's first GitHub issue was 2025-07-30. Thu 2026-07-30
+> is the one-year mark; this week is built so its eve (Wednesday) shows what a
+> year produced -- decide Monday, build Tuesday, review + plan Wednesday.
+
+## Standing constraints (all three days)
+
+- **CEO chunks:** 3x 2-hour day-job blocks across Mon+Tue, exact times TBD by
+  Pip. Every chunk below is a PLACEHOLDER marked MOVABLE -- slide them, keep
+  the workshop blocks' morning + late-afternoon shape and the hard stops.
+- **Feed triage:** one 30-min slot each day. Manifund launched + 20 contacts
+  messaged Sunday night -- inbound is expected; the slot exists so it does NOT
+  leak into workshop blocks.
+- **Energy discipline:** Sunday was enormous. Hard stops are real stops; no
+  heroics; unfinished items go to the slip-list, not into the evening.
+- **Friday anchor:** Fri 2026-07-31 17:30 Rektango is the weekly timing
+  anchor; Wednesday's W3 block preps the Friday league target so nothing about
+  Friday is improvised.
+
+---
+
+## Monday 2026-07-27 -- W-3a: ratify + build-gating decisions
+
+**Goal:** every build-gating item exits with a RULING (ship / kill / defer)
+so Tuesday's fan-out starts from briefs, not conversation. ~4.5h of workshop
+blocks around the CEO chunks.
+
+### Schedule (times AEST; workshop blocks fixed-shape, chunks MOVABLE)
+
+| Time | Block |
+|---|---|
+| 0800-0830 | Feed triage (Manifund + contact replies). Timebox hard. |
+| 0830-0850 | **R0 Frame** -- state the 3-day win condition + Monday's decision queue. |
+| 0850-0935 | **R1 THE RATIFY BLOCK** -- the 5 FINISH_OR_DROP questions. |
+| 0935-1035 | **R2 Substrate + #613 scheduling** -- streams model, polyvirate axes, MINIMAL/MODERATE sequencing, AP-pool death date. |
+| 1035-1045 | Break. Morning hard stop if a chunk needs the late morning. |
+| 1045-1245 | [CEO CHUNK 1 -- MOVABLE placeholder] |
+| 1300-1500 | [CEO CHUNK 2 -- MOVABLE placeholder] |
+| 1500-1545 | **R3a Office economy + spatial rulings** -- money loop, tile-grid addressing, office-view real-estate/camera, early-game decisions content. |
+| 1545-1630 | **R4 Lane scoping** -- Monday rulings -> sized, dependency-tagged Tuesday lanes. |
+| 1630-1700 | **R5 Emit** -- Fable takes the lane list; build-brief + ADR drafting runs overnight. |
+| **1700** | **HARD STOP.** |
+
+### Inputs ready (read/open before each block)
+
+- R1: `WS3_FINISH_OR_DROP.md` Section 0 table (all claims re-verified against
+  origin/main 2026-07-25) + `WORKSHOP_3_PREP.md` Appendix Section 2.
+- R2: `RESEARCH_STREAMS_PROPOSAL.md`, `RESEARCH_IDEA_PAPER_PIPELINE_GAP.md`
+  (MINIMAL/MODERATE/AMBITIOUS ladder), DQ-24 (ruled), `MAIN_UI_SEAM_MAP.md`
+  CARVE 1 status, Pip's banked pre-read leanings (~40/100 effort-units to the
+  substrate).
+- R3a: `OFFICE_ECONOMY_PROPOSAL.md`; #791/#793/#804; the sandbox v3
+  prototypes (PR #898: scaling, populate-up sequence + placement, cat walks,
+  doom-glow + overlay compositing) as the live demo for the tile-grid and
+  camera/real-estate calls; #811 item 1 for the early-game decisions content
+  list (offices 1-of-3, np/fp depth, first-funding modes, scouting actions,
+  onboarding->scouting handoff).
+- Cross-cutting: `CAPABILITY_UPLIFT_SCAN.md` open as the feasibility lens.
+
+### Decision list (expected outputs)
+
+| # | Decision | Expected output |
+|---|---|---|
+| 1-5 | The five FINISH_OR_DROP ratifications (0010 v1 downscope; 0011 MINIMAL/MODERATE; 0014 sequenced-after-0010; 0016 manual-pack-first + first-cycle date; 0015 data-strip errand) | 5 recorded rulings; any override noted with reason |
+| 6 | Early-game decisions design (#811 item 1) | content ruling + a scoped lane (or explicit defer of named sub-parts) |
+| 7 | Effort-economy scheduling (#613 keystone) | MINIMAL fast-follow + MODERATE milestone dated; AP-pool death named; ladder-fork batching call (batch with 0010-v1?) |
+| 8 | Tile-grid addressing | one addressing scheme ruled for the office view (Tuesday lanes build against it) |
+| 9 | Office-view real-estate/camera | ruling on office footprint/camera model (feeds W2 decorating math Wednesday) |
+
+### What can slip (Monday sacrificial list)
+
+1. Early-game decisions CONTENT depth -- the ruling must land; the full
+   options tables can be drafted by agents Tuesday and reviewed Wednesday.
+2. The 0016 first-league-cycle DATE -- can move to Wednesday's W3 cadence
+   block with no build cost (nothing Tuesday depends on it).
+3. ADR prose -- rulings recorded as bullet minutes are enough; Fable
+   wordsmiths overnight.
+   NOT allowed to slip: rulings 1-5, 7, 8 -- Tuesday is hollow without them.
+
+---
+
+## Tuesday 2026-07-28 -- BUILD DAY (Pip mostly ignores it)
+
+**Goal:** Monday's rulings become merged or reviewable PRs. Fable
+orchestrates; Pip's involvement is CEO chunks + three short drive-by windows.
+Orchestration per the standing lessons: push-per-step, narrow fan-out, tier
+the model.
+
+### Schedule
+
+| Time | Block |
+|---|---|
+| 0800-0830 | Feed triage. |
+| 0830-0900 | **Drive-by 1:** approve/adjust the overnight build briefs; Fable launches lanes. |
+| 0900-1100 | [CEO CHUNK 3 -- MOVABLE placeholder] (agents building) |
+| ~1230-1245 | **Drive-by 2:** mid-day PR pass -- unblock anything waiting on a call. |
+| afternoon | Agents continue; Pip free / day-job / rest. |
+| 1630-1700 | **Drive-by 3:** end-of-day PR pass -- merge green, park red, tag in-flight for W0. |
+| **1700** | **HARD STOP** -- unmerged lanes become Wednesday W0 input, not evening work. |
+
+### Anticipated build queues (from Monday's EXPECTED rulings -- re-cut to the actual ones)
+
+Mechanics lanes (each exists only if its Monday ruling lands as recommended):
+
+1. **#613 effort-economy MINIMAL** -- per-researcher `focus_topic` +
+   topic-tagged accrual + idea-carrying papers (the S-cut from the gap doc).
+2. **ADR-0010 adoption v1** -- absorption partition + adoption-credit ->
+   typed dampers (possibly batched with lane 1 as ONE ladder fork).
+3. **ADR-0015 data-strip errand** -- re-author ~66 literal doom fields, fix
+   the "-N doom" fiction strings, add the clobber guard test.
+4. **Early-game decisions scaffolding** -- data/action stubs for the ruled
+   early-game structure (offices 1-of-3, scouting actions), content depth per
+   ruling 6.
+5. **Tile-grid addressing** -- implement the ruled addressing scheme in the
+   office view.
+6. **Office-view real-estate/camera** -- apply the ruled footprint/camera
+   model (sandbox v3 -> game surface).
+
+Standing art re-base lanes (run regardless of Monday; already in flight):
+
+7. **Size-vanguard follow-through** -- PR #937 core-resource icon wiring is
+   parked awaiting Pip's in-engine approval; a drive-by yes unblocks the
+   re-base.
+8. **Icon/hero re-bases per the art-review pipeline v2** -- work the
+   `hero_verdicts.json` triage decisions + craft-primer rules (#938) through
+   the affected sets.
+
+If lane count strains attention, drop lanes 3 then 4 first (see slip list).
+
+### What can slip (Tuesday sacrificial list)
+
+1. Lane 3 (data-strip) -- pure debt removal, no player-facing change; slides
+   to any later day.
+2. Lane 4 content depth -- stubs may land with placeholder text; Wednesday
+   reviews.
+3. Any lane not green by 1700 -- parks as in-flight for W0. No evening
+   heroics; a parked lane is a Wednesday agenda line, not a failure.
+
+---
+
+## Wednesday 2026-07-29 -- W-3b / W-4: review, colour, cadence, next epoch
+
+**Goal:** Tuesday's builds reviewed and merged/parked; the deferred
+design items (colour, decorating, endgame, cadence) ruled; the next epoch
+planned. Ends on the anniversary beat -- W-4 on the eve of year one.
+
+### Schedule
+
+| Time | Block |
+|---|---|
+| 0800-0830 | Feed triage. |
+| 0830-0930 | **W0 Review Tuesday's builds** -- merge/park call per PR; in-flight status explicit. |
+| 0930-1030 | **R3b Endgame + violence + cat doom-oracle** -- military-branch valence dial; what fires "violence arrives"; cat as higher-resolution doom instrument. |
+| 1030-1115 | **W1 Colour architecture circle-back** -- doom-glow + overlay-compositing prototypes as demo input. |
+| 1115-1200 | **W2 Interior-decorating math + office-fullness** -- downstream of Monday rulings 8-9 + Tuesday lanes 5-6. |
+| 1200-1300 | Lunch / buffer (absorbs any morning overrun -- this is the movable middle). |
+| 1300-1345 | **W3 League/content cadence + Friday league prep** -- ratify `RELEASE_AND_LEAGUE_CYCLE.html` (two-cadence + two-league); 0016 first-cycle date if it slipped Monday; set the Fri 07-31 seed + notes. |
+| 1345-1445 | **W4 Next-epoch planning** -- lane manifest completed, roadmap epoch assignments filled (v0.14 epoch Fri 08-07), WORKSHOP_2_BACKLOG updated. |
+| 1445-1515 | **Emit + commit** -- remaining ADRs, DQ index regenerated, calendar updated. |
+| 1515-1545 | **Anniversary beat** -- one year since issue #1 (2025-07-30): name what the year produced; seed the year-two frame (devblog fodder, not a work item). |
+| **1600** | **HARD STOP.** Thursday is the anniversary itself -- keep it light. |
+
+### Inputs ready
+
+- W0: Tuesday's PR list (Fable prepares a one-line status table overnight).
+- R3b: `ENDGAME_VIOLENCE_PROPOSAL.md`, `SEED_ENDGAME_AND_VIOLENCE.md`,
+  Pip's build-for-both leaning (valence as a tunable, not a hardcode).
+- W1: sandbox v3 doom-glow + overlay-compositing prototypes; the doom-colour
+  spec thread from the #758 art queue.
+- W2: Monday rulings 8-9 as fixed constraints; `OFFICE_ECONOMY_PROPOSAL.md`
+  upkeep model.
+- W3: `RELEASE_AND_LEAGUE_CYCLE.html`; `WS3_FINISH_OR_DROP.md` Section 4
+  (manual-pack-first recommendation + the pack-format born-clean constraint).
+- W4: the (by then) populated lane manifest; `docs/ROADMAP.md`.
+
+### Decision list (expected outputs)
+
+| # | Decision | Expected output |
+|---|---|---|
+| 1 | Per-PR merge/park (W0) | clean main + explicit park-list |
+| 2 | Endgame/violence trigger + military valence (R3b) | endgame/violence ADR (valence as dial) |
+| 3 | Cat doom-oracle shape (R3b) | ruling + lane or defer |
+| 4 | Colour architecture (W1) | ruling the art lanes build against |
+| 5 | Decorating math + fullness model (W2) | model + lane sizing |
+| 6 | Cadence + two-league ratification (W3) | ratified cycle doc + Fri 07-31 league plan |
+| 7 | Epoch assignments (W4) | roadmap "pending WS-3" gaps filled |
+
+### What can slip (Wednesday sacrificial list)
+
+1. R3b DEPTH -- endgame is the far tent-pole; a thin ADR with the valence
+   dial named beats a rushed full design. Cat doom-oracle can defer whole.
+2. The anniversary beat -- moves to Thursday 07-30 (the actual anniversary)
+   with zero cost; arguably better there.
+3. W2 decorating math -- if Tuesday's spatial lanes parked, this block
+   shrinks to constraints-capture and reschedules.
+   NOT allowed to slip: W0 (unreviewed builds rot fastest) and W3's Friday
+   prep (the league target is date-fixed).

--- a/docs/game-design/WORKSHOP_3_PREP.md
+++ b/docs/game-design/WORKSHOP_3_PREP.md
@@ -1,12 +1,35 @@
-# Workshop 3 -- Running Order (2026-07-29) + Prep Pack
+# Workshop 3 -- Three-Day Structure (Mon 2026-07-27 .. Wed 2026-07-29) + Prep Pack
 
-> Status: RUNNING ORDER for WS-3 (Wed 2026-07-29, 0800-1800 AEST, issue #811),
-> written 2026-07-25. Date pinned 2026-07-26 (earlier copies said "Wed 07-30",
-> but 07-30 is a Thursday; may move EARLIER at Pip's call, not later).
-> Sections R0-R6 are the day-of agenda. Sections 0-6 further down are the original
-> prep pack (2026-07-23) that fed this agenda -- BACKGROUND, partially superseded;
-> read the reconciliation note at the head of the appendix before trusting a detail
-> there.
+> Status: RUNNING ORDER for the W-3 block (issue #811), RESTRUCTURED 2026-07-26
+> evening at Pip's call: the single Wed 07-29 workshop becomes a THREE-DAY
+> structure (table below). The blow-by-blow schedule lives in
+> `RUNSHEET_2026-07-27_to_29.md`. Blocks R0-R5 are the agenda, now
+> RE-PARTITIONED across Monday and Wednesday by one gating rule (an item is
+> Monday iff its ruling gates Tuesday's build fan-out). Sections 0-6 further
+> down are the original prep pack (2026-07-23) that fed this agenda --
+> BACKGROUND, partially superseded; read the reconciliation note at the head of
+> the appendix before trusting a detail there.
+
+## The three days (pinned 2026-07-26 evening, anniversary-driven)
+
+Pip's first GitHub issue on this project was 2025-07-30. Thu 2026-07-30 is the
+one-year anniversary, and W-4 lands on its eve -- the restructure exists so the
+anniversary week SHOWS what a year produced: decide Monday, build Tuesday,
+review + plan the next epoch Wednesday.
+
+| Day | Name | What happens |
+|---|---|---|
+| **Mon 2026-07-27** | **W-3a** | The RATIFY block (`WS3_FINISH_OR_DROP.md`'s 5 questions) + build-gating decisions ONLY: early-game decisions design, effort-economy scheduling (#613 keystone), tile-grid addressing ruling, office-view real-estate/camera ruling. ~5 focused hours AROUND Pip's day-job CEO chunks. |
+| **Tue 2026-07-28** | **BUILD DAY** | Fable orchestrates the implementation fan-out of Monday's rulings + the in-flight art re-base. Pip mostly ignores it: CEO chunks + drive-by approvals only (the proven 27-PR co-orchestration mode). |
+| **Wed 2026-07-29** | **W-3b / W-4** | Colour architecture circle-back, interior-decorating math + office-fullness, league/content cadence + Friday league prep, REVIEW of Tuesday's builds, next-epoch planning. |
+
+Standing constraints (baked into the runsheet): 3x 2-hour day-job CEO chunks
+across Mon+Tue, exact times TBD by Pip -- schedules show them as MOVABLE
+placeholders, with workshop time as morning + late-afternoon blocks, hard
+stops, and a movable middle. 30-min feed-triage slots Mon+Tue+Wed (Manifund
+launched + 20 contacts messaged Sunday night -- inbound expected). Energy
+discipline: Sunday was enormous; hard stops, no heroics. Fri 2026-07-31 17:30
+Rektango remains the weekly anchor.
 
 ## The frame -- this is a CONVERGENCE workshop, not an exploration
 
@@ -39,16 +62,36 @@ INTERFACE complexity (reject / simplify) or DECISION complexity (the only kind t
 earns its keep)? Claude runs this as a standing MaRo-Rosewater / Rams check across
 every block.
 
-## Running order (timed; start early)
+## Running order -- Monday 2026-07-27 (W-3a): ratify + build-gating decisions
+
+Gating rule: an item sits on Monday IFF its ruling gates Tuesday's build
+fan-out. ~4.5h of blocks, fitted around the CEO chunks (see the runsheet).
 
 | Block | ~Time | What happens | Exit artifact |
 |---|---|---|---|
-| **R0 -- Frame** | 20m | State the win condition: by end of day every candidate mechanic is a scoped, Epoch-tagged build lane OR explicitly killed/deferred with a reason -- nothing leaves in "exploratory" status. | the decision queue |
-| **R1 -- Finish-or-drop the inheritance** | 45m | Walk `WS3_FINISH_OR_DROP.md` against the WS-2 ADR status table (Appendix Section 2). Each unbuilt/half-built WS-2 decision (0010 adoption, 0011 workstreams, 0014 conference-shape, 0016 league pipeline) + the ADR-0015 data-strip trap: ship / kill / defer. Clear the deck before adding new meat. | kill-list + keep-list |
-| **R2 -- The substrate** | 60m | `RESEARCH_STREAMS_PROPOSAL.md` (= the ADR-0011 L2 workstream substrate). Lock or reject the compute / non-compute stream model + the polyvirate axis set. FOUNDATIONAL: the rival RPS and the endgame both hang off the axes, so protect this timebox above all others. | ADR: research substrate + axes |
-| **R3 -- Economy + endgame** | 60m | `OFFICE_ECONOMY_PROPOSAL.md` (near-term money loop / upkeep; the office-era cost), then `ENDGAME_VIOLENCE_PROPOSAL.md` (the far tent-pole). The sharp ruling in endgame: is military a genuine winning branch or another desperation-trap? And what fires "violence arrives"? | rulings + endgame/violence ADR |
-| **R4 -- Scope + prioritise into lanes** | 45m | Every keep/build ruling -> a lane: size (S/M/L), dependencies, Epoch target (v0.14 vs v0.15), which carve-seam it lands on (the monolith is now carved to ~1940 lines; the R1-R6 controllers exist). This is where the roadmap epoch-assignments deferred as "pending WS-3" get filled in for real. | lane manifest + roadmap epochs |
-| **R5 -- Emit + commit** | 30m | Fable fans out: one build-brief agent per locked lane -> `BUILD_BRIEF_*` docs; the ADRs get written; roadmap updated; DQ index regenerated (`scripts/generate_dq_index.py`); WORKSHOP_2_BACKLOG parked-items updated; all committed. | stack of build-ready briefs |
+| **R0 -- Frame** | 20m | State the win condition for the three days: by Wednesday close every candidate mechanic is a scoped, Epoch-tagged build lane OR explicitly killed/deferred with a reason -- nothing leaves in "exploratory" status. Monday's narrower bar: every build-gating item exits with a RULING so Tuesday can fan out. | the decision queue |
+| **R1 -- Finish-or-drop the inheritance (THE RATIFY BLOCK)** | 45m | Walk `WS3_FINISH_OR_DROP.md`'s five ratify-in-minutes questions against the WS-2 ADR status table (Appendix Section 2). Each unbuilt/half-built WS-2 decision (0010 adoption, 0011 workstreams, 0014 conference-shape, 0016 league pipeline) + the ADR-0015 data-strip trap: ship / kill / defer. Clear the deck before adding new meat. | kill-list + keep-list |
+| **R2 -- The substrate + effort-economy scheduling** | 60m | `RESEARCH_STREAMS_PROPOSAL.md` (= the ADR-0011 L2 workstream substrate). Lock or reject the compute / non-compute stream model + the polyvirate axis set. Then the #613 keystone scheduling call: MINIMAL-now vs MODERATE-when, and when the legacy AP pool dies. FOUNDATIONAL: the rival RPS and the endgame both hang off the axes, so protect this timebox above all others. | ADR: research substrate + axes; #613 schedule |
+| **R3a -- Office economy + spatial rulings** | 45m | `OFFICE_ECONOMY_PROPOSAL.md` (near-term money loop / upkeep; the office-era cost) PLUS the two spatial calls that gate the office-view build lanes: the **tile-grid addressing ruling** and the **office-view real-estate/camera ruling** (sandbox v3 prototypes are the demo input). Also the early-game decisions design from #811 item 1 (offices 1-of-3, np/fp depth, first-funding modes, scouting actions, onboarding->scouting handoff) -- Pip's content calls. | rulings Tuesday builds against |
+| **R4 -- Scope + prioritise into lanes** | 45m | Every Monday keep/build ruling -> a lane: size (S/M/L), dependencies, Epoch target (v0.14 vs v0.15), which carve-seam it lands on (the monolith is now carved to ~1940 lines; the controllers exist). This emits Tuesday's build queue; the roadmap epoch-assignments deferred as "pending WS-3" get their first real fill here, finished Wednesday. | Tuesday's lane manifest |
+| **R5 -- Emit + commit** | 30m | Fable fans out overnight: one build-brief agent per locked lane -> `BUILD_BRIEF_*` docs; Monday's ADRs drafted; DQ index regenerated (`scripts/generate_dq_index.py`); all committed so Tuesday starts from briefs, not memory. | stack of build-ready briefs |
+
+## Tuesday 2026-07-28 -- BUILD DAY (not a workshop)
+
+No agenda blocks. Fable runs the fan-out of Monday's rulings + the standing
+art re-base lanes; Pip does CEO chunks + drive-by approvals only. The runsheet
+carries the anticipated build queues.
+
+## Running order -- Wednesday 2026-07-29 (W-3b / W-4): react, colour, cadence, next epoch
+
+| Block | ~Time | What happens | Exit artifact |
+|---|---|---|---|
+| **W0 -- Review Tuesday's builds** | 60m | Merge/park call per lane PR; anything half-done gets an explicit in-flight status, not silence. | merged lanes + park-list |
+| **R3b -- Endgame + violence (+ cat doom-oracle)** | 60m | `ENDGAME_VIOLENCE_PROPOSAL.md` (the far tent-pole). The sharp ruling: is military a genuine winning branch or another desperation-trap? And what fires "violence arrives"? Plus #811 item 3: the cat as a higher-resolution doom instrument (earn resolution, no printed deltas; rival-steal modifier stays HELD per Pip's T6 ruling). | rulings + endgame/violence ADR |
+| **W1 -- Colour architecture circle-back** | 45m | The deferred colour ruling, with the sandbox v3 doom-glow + overlay-compositing prototypes as the demo input. | colour architecture ruling |
+| **W2 -- Interior-decorating math + office-fullness** | 45m | How furniture/decoration accrues, what "full" means for an office tier, how fullness reads on screen -- downstream of Monday's tile-grid + real-estate rulings and Tuesday's office-view lanes. | decorating/fullness model |
+| **W3 -- League/content cadence + Friday league prep** | 45m | Ratify `RELEASE_AND_LEAGUE_CYCLE.html` (two-cadence model + two-league idea, #811 item 4); the ADR-0016 first-cycle date question lands here; prep the Fri 07-31 league target (seed rotation + notes). | cadence ratification + Friday plan |
+| **W4 -- Next-epoch planning + emit** | 60m | Finish the lane manifest + roadmap epoch assignments (v0.14 "Per-tick & People", Fri 08-07); WORKSHOP_2_BACKLOG parked-items updated; remaining ADRs written; DQ index regenerated; all committed. The anniversary beat: one year from issue #1 (2025-07-30) -- name what the year produced. | lane manifest + roadmap epochs |
 
 Two cross-cutting threads, not their own blocks:
 - **`CAPABILITY_UPLIFT_SCAN.md`** is the FEASIBILITY lens -- keep it open through R2-R4

--- a/docs/game-design/WS3_FINISH_OR_DROP.md
+++ b/docs/game-design/WS3_FINISH_OR_DROP.md
@@ -1,7 +1,10 @@
 # WS-3 finish-or-drop: the four unbuilt WS-2 ADRs
 
-> Status: DECISION PREP for Workshop 3 (Wed 2026-07-29). Drafted 2026-07-25 by a
-> research agent at Pip's request. Companion to `WORKSHOP_3_PREP.md` Section 2
+> Status: DECISION PREP for W-3a (Mon 2026-07-27) -- the opening RATIFY BLOCK
+> of the three-day W-3 structure (Mon W-3a / Tue build day / Wed W-3b-W-4;
+> restructured 2026-07-26, see `WORKSHOP_3_PREP.md` + the runsheet). Drafted
+> 2026-07-25 by a research agent at Pip's request. Companion to
+> `WORKSHOP_3_PREP.md` Section 2
 > (Decision-for-Pip 2A/2B) -- this doc turns "finish or formally drop the unbuilt
 > WS-2 ADRs" into five ratify-in-minutes questions.
 >


### PR DESCRIPTION
Implements Pip's 2026-07-26 evening restructure ruling (#811): the single Wed 07-29 workshop becomes a three-day block, anniversary-driven (first GitHub issue 2025-07-30; W-4 lands on its eve).

## The split
- **Mon 2026-07-27 = W-3a**: WS3_FINISH_OR_DROP's 5-question ratify block + build-gating decisions only (early-game decisions design, #613 effort-economy scheduling, tile-grid addressing, office-view real-estate/camera). ~5 focused hours around CEO chunks.
- **Tue 2026-07-28 = BUILD DAY**: Fable fan-out of Monday's rulings + the in-flight art re-base; Pip does CEO chunks + drive-by approvals only.
- **Wed 2026-07-29 = W-3b/W-4**: colour architecture circle-back, interior-decorating math + office-fullness, cadence + Fri 07-31 league prep, review of Tuesday's builds, next-epoch planning.

## Changes
- **WORKSHOP_3_PREP.md** -- three-day table at top; R0-R5 re-partitioned by one gating rule (an item is Monday iff its ruling gates Tuesday's fan-out). R3 split: R3a office economy + spatial rulings (Mon), R3b endgame/violence + cat doom-oracle (Wed). New Wednesday blocks W0-W4. All prior content kept; appendix untouched.
- **WS3_FINISH_OR_DROP.md** -- header re-dated to Mon 2026-07-27 (W-3a).
- **RELEASE_CALENDAR.html** -- WS-3 entry becomes the three-day block; Fri 07-31 gains the Friday league target + Rektango 17:30 anchor. Note: removed the stale "Mon-Tue 27-28 v0.13.1 build" patch row (0.13.1 is already the live build per the you-are-here line) -- shout if that row should survive.
- **NEW RUNSHEET_2026-07-27_to_29.md** -- per day: time-blocked schedule (CEO chunks as clearly-marked MOVABLE placeholders), goals, inputs-ready lists, decision lists with expected outputs, 30-min feed-triage slots (Manifund inbound), hard stops, and a named what-can-slip list. Tuesday carries the anticipated build queues: 6 mechanics lanes conditional on Monday's rulings + 2 standing art re-base lanes (#937 vanguard follow-through, hero/icon re-bases).

Issue #811 title + body already updated via `gh issue edit` (three-day paragraph replaces the single-day LOCKED line; agenda, thesis, prep list preserved with a day-mapping note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)