### PR TITLE
docs(content): home the creative-director pack (role, pipeline, scripts, voice kit)

### DIFF
--- a/docs/content/FORMATS_MENU.md
+++ b/docs/content/FORMATS_MENU.md
@@ -1,0 +1,85 @@
+# Formats menu -- pick per video
+
+> Status: DRAFT for Pip review, 2026-07-26. Effort estimates are Pip-hours
+> (agent hours excluded), first-time vs once-templated. YouTube success/fail
+> notes are craft heuristics, not measured facts. [heuristic]
+
+## 1. The 60-90s explainer  << DO THIS FIRST
+
+- What: "What is P(Doom)?" -- one video that says what the game is, shows it,
+  and claims the core idea-space terms. Voiceover over captured footage.
+- Script skeleton: HOOK ("I'm making a strategy game about the number AI
+  researchers argue about at parties") -> PROMISE -> 3 beats: (1) you run an
+  AI safety lab, turn by turn; (2) doom is a system, not a score -- show the
+  meter and an event; (3) the world pushes back -- rivals/events/cat. ->
+  BUTTON: download link.
+- Capture needs: 5-8 shots, ~15-30s each: menu, early turns, an event popup,
+  doom meter moving, office floor with cat, one ending screen.
+- Effort (Pip): 4-6h first time, 2-3h templated. Most of it is capture play.
+- Succeeds when [heuristic]: hook lands inside 10s; title carries the search
+  terms; footage matches the sentence being spoken (shot discipline).
+- Fails when [heuristic]: opens with logo/branding; tries to explain every
+  mechanic; runs past 100s.
+- Why first: cheapest per unit of idea-space claimed; becomes the channel's
+  pinned "what is this" answer; every later video links back to it; the
+  no-voice fallback variant still works if recording stalls.
+
+## 2. One-mechanic explainer shorts (30-60s, repeatable)
+
+- What: one short per mechanic: the Liability Ledger, doom streams, the cat,
+  Attention, hiring, the league. Vertical-friendly framing from the start.
+- Script skeleton: NAME the mechanic in sentence one -> show it doing its
+  thing -> one design-reason sentence ("why: mitigation is a loan") -> button.
+- Capture needs: 2-3 tight shots of that one system; sandbox stage often
+  enough -- no full run needed.
+- Effort (Pip): 1-2h each once the pipeline exists. Batch capture 3 at once.
+- Succeeds when [heuristic]: single idea, loopable ending, legible UI at
+  phone size (check capture at 1080x1920 or crop-safe center framing).
+- Fails when [heuristic]: needs prior context; UI text unreadable small.
+- Role: the steady cadence filler between bigger videos; each one claims a
+  long-tail search phrase ("AI safety game ledger mechanic").
+
+## 3. Devlog (3-6 min, monthly, rides the release train)
+
+- What: "what changed and why" per monthly release -- design reasoning out
+  loud, from the ADRs and devblog seeds. The community-building format.
+- Script skeleton: this month's ONE headline change -> the design problem it
+  solves (ADR reasoning, honestly, including what we rejected) -> show it ->
+  what's next month -> button.
+- Capture needs: mixed -- game footage + optionally editor/sandbox footage.
+  Face optional; voice basically required (text-card devlogs read as
+  changelogs, not devlogs).
+- Effort (Pip): 3-5h per month. The script is half-written by the release
+  notes + devblog seeds already.
+- Succeeds when [heuristic]: cadence held (monthly, same week as release);
+  personality and honest reasoning -- devlog audiences come for the designer's
+  head, not polish.
+- Fails when [heuristic]: irregular cadence; reading patch notes aloud;
+  scope-creeping into a lecture.
+- Note: this is the format most tied to Pip-the-person. Decide identity
+  exposure before starting it.
+
+## 4. Teaser trailer (45-75s, once, HOLD)
+
+- What: the polished first-impression asset: pure captured footage + composed
+  score (trailer_trudge exists) + title cards. No voiceover needed.
+- Script skeleton: mood build (office, music) -> systems montage accelerating
+  with the score -> doom spike -> title card -> release date/link.
+- Capture needs: the best 12-20 shots the game can produce; wants round-2 art
+  landed first; timing cut to the music (this is the one format where the
+  ffmpeg-only path will hurt -- expect the Shotcut escape hatch).
+- Effort (Pip): 10-20h spread over days, mostly gate-and-retake cycles.
+- Succeeds when [heuristic]: every frame is the game at its best; music does
+  the emotional work; under 75s.
+- Fails when [heuristic]: shipped early as first impression with placeholder
+  art -- a mediocre trailer anchors the game's perceived quality worse than
+  no trailer.
+- HOLD until: round-2 art landed + a store/download page worth pointing at.
+  Steam page later would re-use it.
+
+## Order of play
+
+1. Explainer (this week -- it unblocks "telling people" with a link to send).
+2. Two or three mechanic shorts (batch-captured, drip-published).
+3. First devlog on the next release-train cycle.
+4. Trailer after round-2 art + WS-3 mechanics settle.

--- a/docs/content/PROC_VIDEO_PIPELINE.md
+++ b/docs/content/PROC_VIDEO_PIPELINE.md
@@ -1,0 +1,129 @@
+# Procedure: one video, idea to published
+
+> Status: DRAFT for Pip review, 2026-07-26 (rev 2, same day). Written so a
+> non-technical hire can follow it. Each step says WHO (Pip / agent / anyone)
+> and produces one artifact. Godot facts verified against the official docs
+> AND the capture path was PROVEN end-to-end on Pip's machine 2026-07-26
+> (see step 3). Pip rulings now baked in: VOICE YES (primary), FACE NO.
+
+## Step 0 -- Voice register (once, before video #1)
+
+Run VOICE_VARIANT_KIT.md: one 30-minute session, one fixed passage, four
+registers, two takes each; pick a dominant register + one accent register
+and write the pick into ROLE_CREATIVE_DIRECTOR.md. Every later video
+inherits that one line.
+
+## Step 1 -- Idea (WHO: Pip picks, anyone proposes)
+
+- Pick a format from FORMATS_MENU.md and a topic.
+- Topic sources, in preference order: devblog story seeds (docs/devblog/),
+  a game mechanic that exists and demos well, a release-note highlight.
+- Artifact: one line in the content backlog: format + topic + hook sentence.
+
+## Step 2 -- Script (WHO: agent drafts, Pip gates)
+
+- Agent drafts from the script template (below) + the topic's source material.
+- Pip taste-gate: approve / redraft-with-notes. Do NOT wordsmith in the gate;
+  notes only, agent redrafts.
+- Script template (all formats):
+  1. HOOK (first 5-10 s, one sentence, no logos, no "hi guys")
+  2. PROMISE (what the viewer will understand by the end)
+  3. 3-5 BEATS (each beat = one claim + one on-screen shot)
+  4. BUTTON (last line: punchline or call-to-action, one only)
+- Every line annotated with its SHOT (see step 3 shot-list).
+- Artifact: `script.md` + `shotlist.md` in the video's working folder.
+
+## Step 3 -- Capture (WHO: Pip plays; agent prepares)
+
+Canonical capture = Godot Movie Maker mode (offline render: perfect frame
+pacing and clean audio regardless of machine speed; the game stays playable
+while recording, it just may not run at real-time speed -- expect input to
+feel slower; play deliberately).
+
+One-time setup (agent does, once, committed to repo):
+- Project settings under Editor > Movie Writer: set FPS 60, Video Quality 0.9,
+  and check Mix Rate is divisible by FPS (desync guard).
+- Use the `movie` feature tag for capture-only overrides (e.g. resolution
+  1920x1080 via Display > Window > Size overrides) so normal play is untouched.
+
+Per-shot procedure (Pip) -- PROVEN command (ran clean 2026-07-26):
+1. From a terminal:
+   `"C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe" --path "G:/Documents/Organising_Life/Code/pdoom1/godot" --write-movie "G:/tmp/pdoom1-video-masters/<video>/<shot>.avi" --fixed-fps 60 --resolution 1920x1080`
+2. Play the beat the shotlist describes. Slightly slower than natural.
+3. Quit with the window X button (NEVER Ctrl+C -- it corrupts the AVI's
+   duration metadata). For STATIC/scripted shots, append `--quit-after N`
+   (N = seconds x 60) -- verified to finalize the file cleanly.
+4. One retake max per shot at this stage; gaps are fixable in assembly.
+5. Data-rate reality (measured): ~18 MB/s, ~1.1 GB/min, AVI 4GB cap =>
+   max ~3.5 min per shot. Game audio records at current volume settings;
+   set music LOW for ambience shots. Do NOT use --headless.
+
+Notes:
+- Output formats: `.avi` (MJPEG, fast, 4GB cap per file) for normal shots;
+  `.png` sequence + wav for shots needing transparency (overlay effects).
+  OGV also exists (editor builds only) but AVI is our default. [Both
+  transcode to mp4 in assembly anyway.]
+- The office sandbox (dev tool) is a legitimate capture stage for staged
+  shots: spawn/populate/cat-walk/doom-glow scenes without playing a full run.
+- Masters live OUTSIDE the repo: `G:/tmp/pdoom1-video-masters/<video>/`
+  (same policy as art masters).
+
+## Step 4 -- Voiceover (WHO: Pip)
+
+Minimal tooling: Audacity (free). One-page procedure:
+1. Same room, same mic position every time (consistency beats quality).
+2. Read the whole script once as a warm-up. Do not record the warm-up.
+3. Record TWO full takes, straight through, mistakes and all. Do not stop
+   for errors -- just repeat the flubbed sentence and keep going.
+4. Export each take as WAV (48000 Hz) into the video's masters folder.
+5. Stop. Two takes is the rule. The assembler picks lines per-take.
+- Fallback (no-voice day): skip; the format's text-card variant is used.
+
+## Step 5 -- Assembly (WHO: agent writes script, anyone runs it)
+
+DECISION: ffmpeg-scripted assembly, not a GUI editor.
+- Why: fits the procedural philosophy (a video is re-renderable from a
+  script; patching = edit script, re-run); zero new GUI skill for Pip; the
+  assembly script IS the handover artifact; diffable in git.
+- Cost (honest): fine timing feel is slower to iterate than dragging clips in
+  a GUI; complex motion graphics are out of scope. Escape hatch: if a video
+  needs human-feel cutting, Shotcut (free) is the named GUI -- but any video
+  that needs it should probably be re-scoped first.
+- Mechanics: per-video `assemble.sh` (committed) that: transcodes AVI masters
+  to h264 mp4, trims clips to the shotlist's in/out points, concatenates,
+  ducks music under voice, burns title cards from a text file, outputs
+  `<video>_vN.mp4`. Music from godot/assets/audio/music/.
+- Artifact: `assemble.sh` + rendered `_vN.mp4` in masters folder.
+- Pip taste-gate on the render: approve / notes / re-render.
+
+## Step 6 -- Thumbnail + title (WHO: agent drafts 2-3, Pip picks)
+
+- Title follows the idea-space strategy: plain-language + the claimed term.
+  Pattern: "<hook> | P(Doom) - the AI safety strategy game".
+- Thumbnail: one game still (hero art or capture frame) + max 4 words of
+  text. Agent produces 2-3 variants (existing gpt-image-1 pipeline or a
+  capture frame + ImageMagick caption -- keep it scripted).
+- Artifact: `thumb.png` 1280x720.
+
+## Step 7 -- YouTube upload checklist (WHO: Pip now, hire later)
+
+1. [ ] Upload `_vN.mp4`; title from step 6.
+2. [ ] Description: 2 lines from the script's PROMISE + game download link +
+       devblog link. First 2 lines matter (shown before the fold).
+3. [ ] Tags: the claimed idea-space terms (keep a standing list in this doc).
+4. [ ] Thumbnail from step 6. End screen: subscribe + one other video.
+5. [ ] Visibility: Public. (Unlisted first ONLY if gate wasn't done on the
+       final render.)
+6. [ ] Log the URL in the content backlog line; done.
+
+## Step 8 -- Instagram re-cut (DEFERRED)
+
+- Not now. When activated: per-video `recut_vertical.sh` producing 9:16
+  <60s cuts from the same masters. No new capture, no new voice.
+
+## Working-folder convention
+
+`G:/tmp/pdoom1-video-masters/<yyyy-mm>-<slug>/`
+  script.md shotlist.md takes/ shots/ assemble.sh out/
+Repo keeps: script.md, shotlist.md, assemble.sh (small, text, diffable).
+Masters dir keeps: AVI/WAV/mp4 (big, binary).

--- a/docs/content/ROLE_CREATIVE_DIRECTOR.md
+++ b/docs/content/ROLE_CREATIVE_DIRECTOR.md
@@ -1,0 +1,79 @@
+# Role: Creative Director (content/video), P(Doom)1
+
+> Status: DRAFT for Pip review, 2026-07-26. Not committed anywhere yet.
+>
+> PROPOSED PERMANENT HOME: `pdoom1/docs/content/` (procedures live next to the
+> game they capture; `pdoom1-website` is a publish TARGET the pipeline pushes to,
+> not the home of the process). Tradeoff: if content ops later outgrows the game
+> repo (multi-game, hires with no code access), lift the whole `docs/content/`
+> dir into its own repo -- the docs are written to survive that move.
+
+## 1. What the Creative Director DECIDES (cannot be proceduralized)
+
+These are the calls only Pip (or a future hire he trusts) makes. Everything not
+on this list should live in a procedure.
+
+- **Taste gates.** Approve/reject each script, each final cut, each thumbnail.
+  One pass, binary, with notes. (Same shape as the art triage verdicts --
+  reuse that muscle.)
+- **Voice of the project.** Register and tone: how dark, how earnest, how much
+  AI-safety discourse vs pure game content. Set once as a style note, revisit
+  quarterly, enforce via the taste gate.
+- **What gets made next.** Pick from FORMATS_MENU.md; order the backlog.
+- **Idea-space strategy.** Which search terms / niches we are claiming
+  ("P(Doom)", "AI safety game", "AI doom simulator"...) -- titles and topics
+  follow from this, procedurally.
+- **Identity exposure.** How much Pip face/voice appears. This is a personal
+  call with a real cost either way (see Open Questions).
+
+## 2. What is PROCEDURAL (delegated to procedures + agents, later to a hire)
+
+- Script drafting (from devblog seeds, game systems, ADRs) -> template in
+  PROC_VIDEO_PIPELINE.md step 2. Agent drafts, Pip taste-gates.
+- Capture -> Godot Movie Maker mode, fully scripted (step 3).
+- Assembly -> ffmpeg scripts checked into the repo (step 5). Re-runnable:
+  patch the script, re-render the video. This is the "iteration and patching"
+  property Pip asked for -- a video becomes a build artifact, not a craft object.
+- Upload/publish -> checklist (step 7). Metadata (title/description/tags)
+  drafted procedurally from the script.
+- Re-cuts (Instagram/Shorts) -> deferred; will be another ffmpeg script over
+  the same source clips.
+
+## 3. Minimal irreducible skill list for Pip
+
+Honest list. Everything else is "run a script" or "review and say yes/no".
+
+1. **Reading a script aloud into a microphone, twice.** (Voiceover delivery.
+   Only real new skill. Gets better free with reps; procedure includes a
+   warm-up + two-take rule so it never becomes a perfectionism sink.)
+2. **Binary taste gates with one-line notes.** Already practiced (art triage).
+3. **Playing the game on camera** -- i.e. playing deliberately and slightly
+   slower than normal while Movie Maker mode records. No editing skill needed.
+4. NOT required: video editing, motion graphics, thumbnail design tools,
+   audio engineering. These are procedural or agent-drafted.
+
+## 4. Maturity ladder
+
+- **L0 (today):** Pip + agents. Agent drafts script + shot list; Pip records
+  capture + voice; agent assembles via ffmpeg; Pip gates; Pip uploads.
+  Everything logged in the repo.
+- **L1 (steady state, solo):** One video per release-train cycle (monthly)
+  plus opportunistic shorts. The pipeline docs are the SSOT; any agent can
+  run any step except voice and gates.
+- **L2 (first hire):** Hand the hire PROC_VIDEO_PIPELINE.md. They take
+  capture, assembly-script authoring, upload, and re-cuts. Pip keeps section 1
+  (decisions) only. Test of the docs: the hire should produce a publishable
+  short in their first week without asking Pip a process question.
+- **L3 (later):** Hire proposes formats and scripts; Pip is purely the gate.
+
+## 5. Standing constraints
+
+- ASCII-only in committed docs (repo rule).
+- Music: use the in-repo composed score (godot/assets/audio/music/). Note for
+  the first hire: confirm and record the license/ownership line for these
+  tracks in this doc before any monetized upload. [confirm rights provenance]
+- Every format has a NO-VOICE fallback variant (text cards + music) so a
+  video is never blocked on recording energy.
+- Nothing over 1MB goes in git except final thumbnails if needed; rendered
+  videos live outside the repo (masters dir / YouTube itself is the archive).
+  Capture scripts and ffmpeg scripts DO go in git -- they are the video.

--- a/docs/content/SCRIPT_EXPLAINER_V1.md
+++ b/docs/content/SCRIPT_EXPLAINER_V1.md
@@ -1,0 +1,53 @@
+# Script: "What is P(Doom)?" -- 60-90s explainer, V1
+
+> Status: DRAFT for Pip taste-gate, 2026-07-26. Voiced-primary (Pip ruling:
+> voice YES, face NO). Register: written neutral-wry so any register from the
+> voice-variant session works without a rewrite. ~185 words VO ~= 72s spoken
+> at 2.5 w/s; with breathing room and shot-led pauses lands 80-90s.
+> Companion: SHOTLIST_EXPLAINER_V1.md (shots S1-S8), VOICE_VARIANT_KIT.md.
+
+## VO script (line / est. seconds / shot)
+
+| # | VO line | ~s | Shot |
+|---|---------|----|------|
+| 1 | HOOK: "There's a number AI researchers argue about at parties. It's the probability that this all goes horribly wrong. I made it into a strategy game." | 9 | S1 |
+| 2 | PROMISE: "This is P(Doom). You run an AI safety lab -- and the game is about what that number does while you try to move it." | 8 | S2 |
+| 3 | "It's turn-based. Every month you spend money, attention, and researchers you can't fully trust -- on research, on funding, on keeping the lights on." | 10 | S3 |
+| 4 | "Doom isn't a score I hand you. It's a system: streams of risk flowing from labs, rivals, and hype -- and you can see the plumbing." | 9 | S4 |
+| 5 | "Every mitigation is a loan. The ledger remembers what you promised, and it bills you when the fuse runs out." | 8 | S5 |
+| 6 | "Meanwhile, your office is alive. Researchers have quirks. Some of them leak. There is a cat. The simulation never lies to you -- but the characters will." | 11 | S6 |
+| 7 | "Rivals race ahead whether you're ready or not. Most runs end badly. The leaderboard ranks how long you kept the lights on -- and the world intact." | 10 | S7 |
+| 8 | BUTTON: "It's free, it's in alpha, and it breaks in interesting ways. Link below. Play it, lose, and tell me what broke." | 8 | S8 |
+
+Total VO ~73s. Do not add lines; if a beat must grow, another must shrink.
+
+## Delivery notes (any register)
+
+- Line 1 lands on "horribly wrong" -- tiny beat before "I made it into a
+  strategy game."
+- Line 6: "There is a cat." is its own sentence. Do not decorate it.
+- Line 8: "tell me what broke" is the brand voice of the feedback culture --
+  keep it plain, not jokey.
+
+## Title / description (step 6-7 of the pipeline)
+
+- Title: "I made a strategy game about P(Doom) | the AI safety game"
+  (claims: "P(Doom)", "AI safety game" -- pending Pip's idea-space term pick).
+- Description first 2 lines: "You run an AI safety lab. Doom is a system, not
+  a score. Free alpha below -- play it, lose, tell me what broke."
+  + download link + devblog link.
+
+## Appendix: no-voice fallback (text cards)
+
+Same shots, VO lines become 6 cards (merge 3+4, merge 6+7). Card text max 12
+words each, ASCII chrome style:
+
+1. "There's a number AI researchers argue about at parties."
+2. "P(Doom): you run an AI safety lab."
+3. "Turn-based. Money, attention, researchers you can't fully trust."
+4. "Doom is a system, not a score. Every mitigation is a loan."
+5. "Your office is alive. Researchers leak. There is a cat."
+6. ">> Free alpha. Play it. Lose. Tell me what broke."
+
+Cards burn in via assemble.sh (drawtext); music carries the pacing; each card
+holds ~2.5s + shot runs underneath.

--- a/docs/content/SHOTLIST_EXPLAINER_V1.md
+++ b/docs/content/SHOTLIST_EXPLAINER_V1.md
@@ -1,0 +1,55 @@
+# Shot list: "What is P(Doom)?" explainer V1
+
+> Status: DRAFT, 2026-07-26. Companion to SCRIPT_EXPLAINER_V1.md.
+> Capture = Godot Movie Maker mode, PROVEN on this machine today (see
+> "Proven command + gotchas" below). Masters:
+> `G:/tmp/pdoom1-video-masters/2026-07-explainer/shots/`.
+
+## Proven command + gotchas (verified 2026-07-26, GTX 1070, Godot 4.5.1)
+
+Working command (ran end-to-end, output verified):
+
+    "C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe" --path "G:/Documents/Organising_Life/Code/pdoom1/godot" --write-movie "G:/tmp/pdoom1-video-masters/2026-07-explainer/shots/<shot>.avi" --fixed-fps 60 --resolution 1920x1080
+
+Verified facts and gotchas:
+- Output: MJPEG AVI, ~18 MB/s (~1.1 GB/min). The AVI 4GB cap means MAX ~3.5
+  MINUTES PER SHOT -- fine for this list; never leave it running.
+- **`--quit-after N` frames gives a CLEAN finalized file** (proof: 300 frames
+  -> header reads exactly 300 frames / 60fps / 5.0s). Use it for static or
+  scripted shots (N = seconds x 60). For interactive shots, quit via the
+  window X button. NEVER Ctrl+C (corrupts duration metadata).
+- Do NOT use --headless -- Movie Maker needs the rendering window; a game
+  window appears and plays in slightly-slower-than-real-time. Input works;
+  play deliberately.
+- AUDIO: game audio IS recorded into the AVI at your current volume settings
+  (session log showed Master 60% / Music 18%). For VO-led shots this is fine
+  (assembly ducks or drops it); for the S6 office shot consider Settings ->
+  music low so SFX/ambience survives as a bed.
+- Expect first-run stderr class-cache noise if the checkout was freshly
+  imported; harmless.
+
+## Shots (capture 2-3x the VO line length; cut points need fat)
+
+| Shot | Feeds line | Source / where | What to do | Capture len |
+|------|-----------|----------------|------------|-------------|
+| S1 | 1 HOOK | Real game: doom instrument close-up (main HUD) | Sit on the doom meter/streams readout mid-run; small mouse drift only, let the number breathe. Static-ish: `--quit-after 1800` (30s). | 30s |
+| S2 | 2 PROMISE | Real game: title/menu -> new run | From welcome screen, start a run, land on the first month. Window-X quit. | 30s |
+| S3 | 3 turn loop | Real game: early turns | Queue 2-3 actions (hire, fundraise, research), end month, watch resolution feed. The rhythm is the shot. | 45s |
+| S4 | 4 doom system | Real game: doom instrument / streams breakdown | Open the streams/instrument view, hover items so rows highlight; one month tick so numbers move. | 30s |
+| S5 | 5 ledger | Real game: ledger screen | Open ledger with 3+ entries incl. a promise; hover one so the counterparty/fuse reads; close. | 30s |
+| S6 | 6 office+cat | OFFICE SANDBOX (legit stage): compare view | Populate the large floor (workers walking, cat wandering); 10s calm wide, then follow the cat. Music LOW first. | 45s |
+| S7 | 7 rivals/endgame | Real game: an event popup + a game-over screen | Bank two mini-shots: (a) a juicy event dialog appearing; (b) a run's ending screen + leaderboard. Any lost run from S2-S5 play works. | 30s+20s |
+| S8 | 8 BUTTON | Title card (no capture) | Built in assembly: logo/wordmark still + download URL + ">> tell me what broke". Uses hero logo art (core_resource_icons logo or wordmark when picked). | n/a |
+
+Total tape ~4.5 min for ~80s of video -- correct ratio; resist capturing more.
+
+## Session plan (one sitting, ~60-90 min)
+
+1. Prep: sandbox worktree launched once to warm caches; masters dir created;
+   music volume set for S6.
+2. Capture order: S2 -> S3 -> S4 -> S5 -> S7 (one continuous run gives all
+   five; keep playing until you lose, that loss IS S7b). Then S1 (static),
+   then S6 (sandbox).
+3. One retake max per shot. Gaps are assembly's problem, not capture's.
+4. Rename files to shot ids immediately; a wrong-named master costs more
+   later than 10 seconds now.

--- a/docs/content/VOICE_VARIANT_KIT.md
+++ b/docs/content/VOICE_VARIANT_KIT.md
@@ -1,0 +1,72 @@
+# Voice variant kit -- finding the professional-pdoom register
+
+> Status: DRAFT for Pip, 2026-07-26. Purpose: answer the register question BY
+> RECORDING, not by deciding upfront. One 30-minute session, one fixed
+> passage, several registers, then a pick. Two-take rule throughout: this is
+> a probe, not a studio day.
+
+## The fixed passage (~85 words, ~34s at 2.5 w/s)
+
+Read THIS, identically, in every register. It deliberately contains wry lines
+("argue about at parties", "There is a cat.") and one earnest line ("I
+genuinely think...") so registers differentiate audibly:
+
+    There's a number AI researchers argue about at parties -- the
+    probability that this all goes horribly wrong. I made it into a
+    strategy game. You run a safety lab. Doom is a system, not a score.
+    Every mitigation is a loan, and the ledger always collects. Your
+    researchers have quirks. Some of them leak. There is a cat.
+    I genuinely think games can help us reason about this risk.
+    Play it, lose, and tell me what broke.
+
+## The registers (record in this order)
+
+| id | Register | One-line direction |
+|----|----------|--------------------|
+| a | deadpan-dark documentary | Flat, unhurried, let the dark lines sit; think narrator who has seen things. |
+| b | earnest indie-dev | Warm, direct, slightly faster; you're telling a friend what you built and why it matters. |
+| c | wry-but-warm educator | Half-smile audible; lands jokes without leaning on them; teacherly confidence. |
+| d | free take | Whatever feels like YOU after a/b/c. Often the winner. |
+
+Two takes per register, straight through, mistakes and all (flub -> repeat the
+sentence -> keep going; never stop the recording). 8 takes total, ~15 min of
+tape.
+
+## Recording procedure (Audacity, once per session)
+
+1. Same room, same mic position as you'll always use. Door closed, fan off.
+2. Audacity: Project Rate 48000 Hz (bottom-left). Record 5s of room silence
+   FIRST (this is your noise profile; keep it at the head of the session).
+3. Record all 8 takes in one long track, saying "REGISTER A, TAKE ONE" etc.
+   before each -- slate out loud, it makes splitting trivial.
+4. Effect > Noise Reduction: Get Profile on the silence, apply defaults to
+   the whole track. Once. Do not fiddle further.
+5. Export per take: File > Export Audio, WAV 48kHz, into
+   `G:/tmp/pdoom1-video-masters/voice-variants-2026-07/` named
+   `a_1.wav, a_2.wav, b_1.wav ... d_2.wav`. Also export one MP3 per register
+   (best take) for easy phone listening.
+6. Stop at 30 minutes regardless of state. Incomplete beats overworked.
+
+## Self-review rubric (next day, fresh ears, phone speaker)
+
+Score each register 1-5 on:
+- SUSTAINABLE: could I do 10 minutes of this without strain?
+- IDENTITY: does this sound like the person who made THIS game?
+- MEMORY: play best-takes to one friend, unlabelled; which line do they quote
+  back an hour later, and from which register?
+- CRINGE-PROOF: still fine on the third listen?
+
+## Decision rule
+
+Pick ONE dominant register (highest total; SUSTAINABLE breaks ties -- a
+register you can't repeat weekly is a trap). Keep ONE accent register for
+contrast moments (e.g. deadpan for doom lines inside an earnest video).
+Write the pick as one line in ROLE_CREATIVE_DIRECTOR.md ("House register:
+X, accent: Y") -- that line is the whole style guide for voice.
+
+## Why this works [craft rationale]
+
+Register chosen by audition beats register chosen by argument: the mouth
+knows things the planner doesn't, the fixed passage isolates the variable
+(same words, same mic, same day), and the friend-memory test measures the
+only thing that matters downstream -- what listeners retain.


### PR DESCRIPTION
Six content-production docs from session scratchpad to docs/content/: role definition, video pipeline SOP (voice-primary, proven capture command), formats menu, 73s explainer script with no-voice fallback, voice-variant kit, shot list. Survives session end; feeds the YouTube workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)