### PR TITLE
docs(runsheet): sequencing fixes -- Friday-league dependency chain + shipped-skeleton scope shift

### DIFF
--- a/docs/game-design/RUNSHEET_2026-07-27_to_29.md
+++ b/docs/game-design/RUNSHEET_2026-07-27_to_29.md
@@ -78,8 +78,11 @@ blocks around the CEO chunks.
 
 1. Early-game decisions CONTENT depth -- the ruling must land; the full
    options tables can be drafted by agents Tuesday and reviewed Wednesday.
-2. The 0016 first-league-cycle DATE -- can move to Wednesday's W3 cadence
-   block with no build cost (nothing Tuesday depends on it).
+2. ~~The 0016 first-league-cycle DATE~~ -- SLIP REVOKED (2026-07-26
+   evening): the Friday 07-31 league target (cadence ruling) ANSWERS the
+   date question and creates a hard chain: Mon ratify pack FORMAT ->
+   Tue build pack schema + 0015 strip -> Wed author the actual pack +
+   league notes -> Fri league. The 0016 ratify may NOT slip.
 3. ADR prose -- rulings recorded as bullet minutes are enough; Fable
    wordsmiths overnight.
    NOT allowed to slip: rulings 1-5, 7, 8 -- Tuesday is hollow without them.
@@ -109,12 +112,23 @@ the model.
 
 Mechanics lanes (each exists only if its Monday ruling lands as recommended):
 
+0. NOTE (2026-07-26): the quirk SKELETON already shipped (#910 -- universal
+   quirk-doom stream, appetite satisfaction, promise kept/broken, dossier
+   card). Monday's R2 ratifies the shipped shape + names sweep targets;
+   Tuesday gets a BALANCE-SWEEP lane (W_quirk_doom, appetite/promise
+   constants) instead of a wiring lane.
 1. **#613 effort-economy MINIMAL** -- per-researcher `focus_topic` +
    topic-tagged accrual + idea-carrying papers (the S-cut from the gap doc).
 2. **ADR-0010 adoption v1** -- absorption partition + adoption-credit ->
    typed dampers (possibly batched with lane 1 as ONE ladder fork).
 3. **ADR-0015 data-strip errand** -- re-author ~66 literal doom fields, fix
-   the "-N doom" fiction strings, add the clobber guard test.
+   the "-N doom" fiction strings, add the clobber guard test. SEQUENCE
+   EARLY Tuesday: the 0016 pack schema (lane 7) must be born clean of
+   printed doom, so the strip (or at minimum the clean schema definition)
+   precedes pack authoring.
+3b. **ADR-0016 pack format + first pack scaffold** -- schema + worked
+   example per Monday's ratify, clean-of-printed-doom by construction
+   (depends on 3); Wednesday authors the real Fri 07-31 pack content.
 4. **Early-game decisions scaffolding** -- data/action stubs for the ruled
    early-game structure (offices 1-of-3, scouting actions), content depth per
    ruling 6.


### PR DESCRIPTION
Closing sequencing review of the ADR/DQ ordering: the Friday 07-31 league target (Pip's cadence ruling) converts the 0016 first-cycle date from slippable to a hard Mon->Tue->Wed->Fri chain; the 0015 strip explicitly precedes the pack schema it keeps clean; Monday R2's scope shifts from deciding quirk wiring to pricing the skeleton that shipped today (#910). REVIEW THIS FIRST in the sweep -- Monday morning runs off this doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)