### PR TITLE
fix(hiring): drain stranded pending_hire_queue back to the pool each turn (#952)

### DIFF
--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -528,9 +528,29 @@ func _step_execute_queued_actions(results: Array) -> bool:
 		# Record action in verification hash
 		VerificationTracker.record_action(action_id, state)
 
+	_restore_stranded_hires(results)
+
 	# Clear queued actions
 	state.queued_actions.clear()
 	return all_success
+
+func _restore_stranded_hires(results: Array) -> void:
+	"""#952: queue_candidate_hire removes the candidate from the pool the moment the
+	hire is queued, but if the hire action fails at execution (eg cash ran dry from an
+	earlier action this turn), execute_action bails on the affordability check before
+	_hire_from_pool ever dequeues them -- the candidate was stuck in pending_hire_queue
+	forever: not in the pool, never employed, invisible. Hires only span a single
+	turn's action step, so anyone still queued after it is stranded by definition:
+	return them to the pool, or narrate the walk-away if the pool refilled to cap."""
+	while not state.pending_hire_queue.is_empty():
+		var cand: Researcher = state.pending_hire_queue.pop_front()
+		if state.candidate_pool.size() < state.MAX_CANDIDATES:
+			state.candidate_pool.append(cand)
+			results.append({"success": true,
+				"message": "%s was never hired (deal fell through) -- back in the candidate pool." % cand.researcher_name})
+		else:
+			results.append({"success": true,
+				"message": "%s was never hired and the pool is full -- they took another offer." % cand.researcher_name})
 
 func _step_publish_papers(results: Array) -> void:
 	"""Check for paper publication (research threshold).

--- a/godot/tests/unit/test_turn_manager.gd
+++ b/godot/tests/unit/test_turn_manager.gd
@@ -489,3 +489,48 @@ func test_starting_pool_does_not_grow_across_turns():
 		turn_manager.execute_turn()
 	assert_eq(state.candidate_pool.size(), start_size,
 		"pool size is unchanged across turns without sourcing (no free refill)")
+
+func test_stranded_pending_hire_returns_to_pool():
+	# #952: a queued hire whose action fails at execution (cash ran dry mid-turn) used
+	# to leave the candidate stuck in pending_hire_queue forever -- out of the pool,
+	# never employed, invisible. The action step must drain the queue back to the pool.
+	var cand := Researcher.new()
+	cand.generate_random(state.rng)
+	cand.specialization = "safety"
+	# Simulate game_manager.queue_candidate_hire: into the queue (candidate was
+	# removed from the pool at queue time, so we only append to the queue here).
+	state.pending_hire_queue.append(cand)
+	var pool_before: int = state.candidate_pool.size()
+	var staff_before: int = state.researchers.size()
+	state.money = 0.0  # hire_safety_researcher costs $60k -> affordability bail
+	state.queued_actions.append("hire_safety_researcher")
+	var results := []
+	turn_manager._step_execute_queued_actions(results)
+	assert_eq(state.pending_hire_queue.size(), 0, "queue must drain every action step")
+	assert_eq(state.candidate_pool.size(), pool_before + 1,
+		"stranded candidate returns to the pool")
+	assert_eq(state.researchers.size(), staff_before, "failed hire employs nobody")
+
+func test_stranded_hire_with_full_pool_walks_away_visibly():
+	# #952 edge: if the pool refilled to cap while the hire was queued, the stranded
+	# candidate cannot be re-admitted -- they walk, but with a visible log line, never
+	# a silent vanish.
+	while state.candidate_pool.size() < state.MAX_CANDIDATES:
+		var filler := Researcher.new()
+		filler.generate_random(state.rng)
+		state.candidate_pool.append(filler)
+	var cand := Researcher.new()
+	cand.generate_random(state.rng)
+	cand.specialization = "safety"
+	state.pending_hire_queue.append(cand)
+	state.money = 0.0
+	state.queued_actions.append("hire_safety_researcher")
+	var results := []
+	turn_manager._step_execute_queued_actions(results)
+	assert_eq(state.pending_hire_queue.size(), 0, "queue must drain even at pool cap")
+	assert_eq(state.candidate_pool.size(), state.MAX_CANDIDATES, "cap still respected")
+	var narrated := false
+	for r in results:
+		if String(r.get("message", "")).find("took another offer") != -1:
+			narrated = true
+	assert_true(narrated, "the walk-away is narrated, not silent")


### PR DESCRIPTION
Fixes the verified half of #952.

## Bug

`queue_candidate_hire` (game_manager.gd:251) removes the candidate from `candidate_pool` the moment the hire is queued, but `execute_action` bails on the affordability check (actions.gd:231) BEFORE the `hire_*_researcher` arm calls `_hire_from_pool`. On that path the candidate was stuck in `pending_hire_queue` forever: not in the pool, never employed, invisible -- and the queue round-trips through saves, so the leak persisted.

Trigger in normal play: cash drops between queuing and execution (an earlier action in the same turn's execution order), so the hire fails and the candidate silently vanishes.

## Fix

New `_restore_stranded_hires` step at the end of `_step_execute_queued_actions`: hires only span a single turn's action step, so anyone still queued after it is stranded by definition -- return them to the pool, or narrate the walk-away in the results log if the pool refilled to cap (never a silent vanish). No RNG touched (stream-neutral); also self-heals stranded candidates in existing saves on their next turn.

## Tests

Two guard tests in `test_turn_manager.gd`: failed hire returns the candidate to the pool and employs nobody; full-pool edge drains the queue, respects the cap, and narrates the walk-away.

Fast gate: 801 tests, 0 failures, 85/85 files collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)