### PR TITLE
data(art): 2026-07-27 breakfast triage exports (prop grain + worker re-base + cat sweep)

### DIFF
--- a/art_source/cat_sweep_verdicts.json
+++ b/art_source/cat_sweep_verdicts.json
@@ -1,0 +1,337 @@
+{
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_side_heft/animations/walk/east": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_side_heft/animations/walk/west": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk/north": [
+    "like",
+    "promote",
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk/south": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_black_side_heft/animations/walk/west": [
+    "disfavour",
+    "promote",
+    "like",
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_black_side_heft/animations/walk/east": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/walk/north": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/walk/south": [
+    "favour",
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_eldritch_side_heft/animations/walk/east": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_eldritch_side_heft/animations/walk/west": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/walk/north": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/walk/south": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/walk/south": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/walk/north": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_purple_side_heft/animations/walk/east": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_purple_side_heft/animations/walk/west": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/butt_flash_north/north": [
+    "promote",
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/embers/flecks": [
+    "like",
+    "favour",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/arc/radialweb": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/arc/branching": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/embers/faint": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/wisp/tendrils": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/wisp/slim": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/wisp/curl": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/aura/spikysigil": [
+    "like",
+    "favour",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/aura/glowdisc": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/aura/smokering": [
+    "like",
+    "favour",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/flame/tongue": [
+    "like",
+    "favour",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/flame/lowwide": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/flame/sparking": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/void/jaggedrift": [
+    "promote",
+    "favour",
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/void/tentacles": [
+    "favour",
+    "promote",
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/void/vortex": [
+    "like",
+    "favour",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/states/aura_amber": [
+    "promote",
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/states/aura_red": [
+    "promote",
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/states/wisp_blue": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/states/embers_red": [
+    "like",
+    "promote"
+  ],
+  "lab/tabby_lowtd_south+aura_glowdisc": [
+    "like",
+    "promote"
+  ],
+  "lab/black_lowtd_north+wisp_slim": [
+    "promote"
+  ],
+  "lab/eldritch_side_east+arc_radialweb": [
+    "like",
+    "promote"
+  ],
+  "lab/purple_lowtd_south+void_vortex": [
+    "promote"
+  ],
+  "lab/tabby_side_east+embers_motes": [
+    "like",
+    "promote"
+  ],
+  "lab/black_lowtd_south+flame_lowwide": [
+    "like",
+    "favour",
+    "promote"
+  ],
+  "lab/tabby_lowtd_east+states_aura_amber": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_side_heft/animations/walk/north-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_side_heft/animations/walk/south-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk/north-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk/south-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_side_heft/animations/walk/south-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk/south-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_side_heft/animations/walk/north-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk/north-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_black_side_heft/animations/walk/north-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_black_side_heft/animations/walk/south-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_black_side_heft/animations/walk/south-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_black_side_heft/animations/walk/north-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/walk/north-east": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/walk/south-east": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/walk/south-west": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/walk/north-west": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_eldritch_side_heft/animations/walk/north-east": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_eldritch_side_heft/animations/walk/south-east": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_eldritch_side_heft/animations/walk/south-west": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_eldritch_side_heft/animations/walk/north-west": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_purple_side_heft/animations/walk/south-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_purple_side_heft/animations/walk/north-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_purple_side_heft/animations/walk/south-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_sweep_purple_side_heft/animations/walk/north-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/walk/south-west": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/walk/south-east": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/walk/north-east": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/walk/north-west": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/butt_flash_north/north": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/butt_flash_north/north": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/butt_flash_north/north": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/sitting/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/licking/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/sitting/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/licking/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/sitting/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/licking/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/sitting/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/licking/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/embers/motes": [
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_doom_overlays/arc/zigzag": [
+    "favour"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/walk/north-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/walk/south-east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/walk/south-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/walk/north-west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/walk/east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_purple_r2b/animations/walk/west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/walk/east": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_eldritch_r2/animations/walk/west": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/walk/east": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_black/animations/walk/west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk/east": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_cat_sweep/cat_b2_tabby_lowtd_heft/animations/walk/west": [
+    "dislike"
+  ]
+}

--- a/art_source/prop_grain_verdicts.json
+++ b/art_source/prop_grain_verdicts.json
@@ -1,0 +1,109 @@
+{
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/water_cooler_decent_native_r2.png": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/water_cooler_scummy_native_r1.png": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/water_cooler_scummy_native_r2.png": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/water_cooler_decent_native_r3.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/water_cooler_decent_native_r1.png": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/manifest_scale/water_cooler_manifestscale_r1.png": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/manifest_scale/water_cooler_manifestscale_r2.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/dial/water_cooler_dial_medium_r1.png": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/filing_cabinet_scummy_native_r1.png": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/filing_cabinet_scummy_native_r2.png": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/filing_cabinet_decent_native_r3.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/filing_cabinet_decent_native_r2.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/filing_cabinet_decent_native_r1.png": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/manifest_scale/filing_cabinet_manifestscale_r2.png": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/manifest_scale/filing_cabinet_manifestscale_r1.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/dial/filing_cabinet_dial_medium_r1.png": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/server_cluster_native_r1.png": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/server_cluster_native_r2.png": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/server_cluster_native_r3.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/manifest_scale/server_cluster_manifestscale_r2.png": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/manifest_scale/server_cluster_manifestscale_r1.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/dial/server_cluster_dial_medium_r1.png": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/desk_decent_native_r1.png": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/desk_scummy_native_r1.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/desk_scummy_native_r2.png": [
+    "promote",
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/desk_decent_native_r2.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/dial/desk_dial_medium_r1.png": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/door_decent_native_r1.png": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/door_decent_native_r2.png": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/door_scummy_native_r1.png": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/native/door_scummy_native_r2.png": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_prop_grain_vanguard/dial/door_dial_medium_r1.png": [
+    "like",
+    "promote"
+  ]
+}

--- a/art_source/worker_rebase_verdicts.json
+++ b/art_source/worker_rebase_verdicts.json
@@ -1,0 +1,197 @@
+{
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_hijab_f/rotations": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_hijab_f/animations/walk/south": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_hijab_f/animations/walk/south-east": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_hijab_f/animations/walk/east": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_hijab_f/animations/walk/north-east": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_hijab_f/animations/walk/north": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_hijab_f/animations/walk/north-west": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_hijab_f/animations/walk/west": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_hijab_f/animations/walk/south-west": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m/rotations": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m/animations/walk/south": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m/animations/walk/south-east": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m/animations/walk/east": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m/animations/walk/north-east": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m/animations/walk/north": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m/animations/walk/north-west": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m/animations/walk/west": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m/animations/walk/south-west": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_wheelchair_f/rotations": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_wheelchair_f/animations/roll/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_wheelchair_f/animations/roll/east": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_wheelchair_f/animations/roll/west": [
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_wheelchair_f/animations/roll/north": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_crutch_m/rotations": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_crutch_m/animations/walk/south": [
+    "promote",
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_crutch_m/animations/walk/east": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_crutch_m/animations/walk/north": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_crutch_m/animations/walk/west": [
+    "like",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_crutch_m_v2/rotations": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_glasses_badge_m/rotations": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_glasses_badge_m/animations/walk/south": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_glasses_badge_m/animations/walk/south-east": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_glasses_badge_m/animations/walk/east": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_glasses_badge_m/animations/walk/north-east": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_glasses_badge_m/animations/walk/north": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_glasses_badge_m/animations/walk/north-west": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_glasses_badge_m/animations/walk/west": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_glasses_badge_m/animations/walk/south-west": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_grey_f/rotations": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_grey_f/animations/walk/south": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_grey_f/animations/walk/south-east": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_grey_f/animations/walk/east": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_grey_f/animations/walk/north-east": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_grey_f/animations/walk/north": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_grey_f/animations/walk/north-west": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_grey_f/animations/walk/west": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_grey_f/animations/walk/south-west": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_headphones_m/rotations": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_headphones_m/animations/walk/south": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_headphones_m/animations/walk/south-east": [
+    "promote",
+    "dislike",
+    "disfavour"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_headphones_m/animations/walk/east": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_headphones_m/animations/walk/north-east": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_headphones_m/animations/walk/north-west": [
+    "promote",
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_headphones_m/animations/walk/west": [
+    "promote",
+    "like"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_headphones_m/animations/walk/south-west": [
+    "dislike"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_headphones_m/animations/walk/north": [
+    "dislike",
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m_state_working/rotations": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m_state_idle/rotations": [
+    "promote"
+  ],
+  "art_source/pixellab_2026-07-26_worker_rebase/worker_black_m_state_stressed/rotations": [
+    "promote"
+  ]
+}


### PR DESCRIPTION
Durability PR for this morning's WS-3a breakfast triage: three verdict JSONs exported from the review sheets, per the tracked-source rule in tools/art_review/README.md.

- **prop_grain_verdicts.json** -- #948 prop native-grain vanguard tile-height rulings; gates the ~500-gen prop re-base lane
- **worker_rebase_verdicts.json** -- #947 64px worker re-base triage; gates variant wiring
- **cat_sweep_verdicts.json** -- 8-dir cat sweep; Pip confirms heftier-cat direction (supersedes the untracked 07-26 export)

Reconcile digest (rulings extracted + gap investigation) follows in a separate report; this PR is data-only, no tooling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)