### PR TITLE
tools(art_review): shared bulk-select / mass-tag across all review sheets

### DIFF
--- a/tools/art_review/README.md
+++ b/tools/art_review/README.md
@@ -44,6 +44,16 @@ extracted from the contact sheet / hero gallery, and it provides:
     pass: sections with 0 unreviewed disappear and the rest force-open, so the
     queue is exactly the items judgment has not reached. The rollup logic has a
     pure-Python mirror: `python tools/art_review/review_style.py --selftest`.
+  * bulk-select (ported from `gen_contact_sheet.py`, 2026-07-27): a checkbox
+    per cell, shift-click range select, a "select all visible" button, and a
+    fixed bulk apply/remove bar (one +tag/-tag pair per verdict) -- all baked
+    into `BULK_CSS` + the `VERDICT_JS` closure. Selection is keyed off
+    `data-rel` (the same compare-mode handle below) and shift-click ranges /
+    select-all-visible both skip cells hidden by the current show-filter, so
+    ONLY UNREVIEWED never silently pulls a filtered-out cell into a bulk
+    action. Automatic for ANY sheet that passes `verdict_key` to `page(...)`
+    -- no per-sheet wiring needed, no markup changes to existing `rs-cell`
+    callers.
 
 Compare-mode hook (issue #745): every `image_cell` carries `data-rel`, the
 stable handle a compare-and-contrast mode needs. The planned shape: a "compare"
@@ -66,18 +76,53 @@ Sheets on the shared style:
         floor-tiled strip, animated walk players. --source-root points at the
         checkout holding the A/B frames when they live in another worktree.
 
+    python tools/art_review/gen_prop_grain_sheet.py
+        -> art_generated/prop_grain_vanguard_sheet.html
+        Prop native-grain re-base decision sheet (#900/#925): current vs
+        native-grain candidates on a floor strip with a worker for scale;
+        verdict chips (exports prop_grain_verdicts.json).
+
+    python tools/art_review/build_worker_rebase_sheet.py
+        -> art_generated/worker_rebase_sheet.html
+        Worker 64px re-base review (#900/#793): 8 variants + walks + state
+        pilot; verdict chips (exports worker_rebase_verdicts.json).
+
+    python tools/art_review/build_cat_sweep_sheet.py
+        -> art_generated/cat_sweep_sheet.html
+        Cat refinement sweep clips (#900): animated review + anchor-offset
+        lab tool; verdict chips (exports cat_sweep_verdicts.json).
+
+    python tools/art_review/build_cat_refinement_sheet.py
+        -> art_generated/cat_refinement_sheet.html
+        Cat refinement batch (#900/#912/#913/#923): review-fix clips +
+        3 new roster cats; verdict chips (exports cat_refinement_verdicts.json).
+
 ### Migration status
 
 | tool | on review_style? | notes |
 |---|---|---|
 | gen_quirk_icon_sheet.py | YES | born on it (replaces the #909 inline one-off) |
-| build_cat_angle_ab_sheet.py | YES | ported 2026-07-26 (layout CSS stays sheet-local) |
-| gen_contact_sheet.py | PARTIAL | imports VERDICTS/VERDICT_COLORS + COMPLETENESS_JS/CSS + completeness_controls() from review_style; page CSS still inline -- it IS the style source |
+| build_cat_angle_ab_sheet.py | YES | ported 2026-07-26 (layout CSS stays sheet-local); no verdict_key -- comparison sheet, no bulk-select bar |
+| gen_prop_grain_sheet.py | YES | born on it; gained shared bulk-select 2026-07-27 (verdict_key set -> automatic) |
+| build_worker_rebase_sheet.py | YES | born on it; gained shared bulk-select 2026-07-27 (verdict_key set -> automatic) |
+| build_cat_sweep_sheet.py | YES | born on it; gained shared bulk-select 2026-07-27 (verdict_key set -> automatic) |
+| build_cat_refinement_sheet.py | YES | born on it; gained shared bulk-select 2026-07-27 (verdict_key set -> automatic) |
+| gen_contact_sheet.py | PARTIAL | imports VERDICTS/VERDICT_COLORS + COMPLETENESS_JS/CSS + completeness_controls() from review_style; page CSS still inline -- it IS the style source. Has its own hand-rolled bulk-select (the port source for review_style's version); NOT migrated to the shared bulk-select in this pass -- see follow-up rule below |
 | gen_hero_gallery.py + hero_gallery_template.html | PARTIAL | template keeps its own style/verdict colours, but the completeness engine is injected from review_style (`__RS_COMPLETENESS_JS__` / `__RS_COMPLETENESS_CSS__` placeholders) -- full style migration still a follow-up |
 | serve_review.py | NO (follow-up) | different verdict model (keep/iterate/discard, server-persisted); adopt BASE_CSS only |
 
 Follow-up rule: migrate a legacy tool only when its output can be verified
 against a pre-migration render (the gen_contact_sheet.py byte-diff pattern).
+
+2026-07-27: bulk-select (checkbox + shift-click range + select-all-visible +
+bulk apply/remove bar) ported from gen_contact_sheet.py INTO review_style.py
+(`BULK_CSS` + the `VERDICT_JS` closure), so it is now automatic for every
+sheet that sets `verdict_key` in `page(...)`. gen_contact_sheet.py itself was
+left untouched -- it is the flagship sprite triage sheet and its own
+bulk-select markup/JS differs enough (grid layout, run/category grouping,
+CSV export, copy-to-clipboard) that a safe migration needs the byte-diff
+verification pattern this README already calls for; that stays a follow-up,
+not risked in this pass.
 
 
 ## Pipeline -- sprites
@@ -188,6 +233,10 @@ TRACKED (the durable human decisions + the tools):
     tools/art_review/hero_gallery_template.html
     tools/art_review/gen_quirk_icon_sheet.py
     tools/art_review/build_cat_angle_ab_sheet.py
+    tools/art_review/gen_prop_grain_sheet.py
+    tools/art_review/build_worker_rebase_sheet.py
+    tools/art_review/build_cat_sweep_sheet.py
+    tools/art_review/build_cat_refinement_sheet.py
     tools/art_review/analyze_verdicts.py
     tools/art_review/README.md
     art_source/pixellab_verdicts.json      (sprite triage decisions)
@@ -199,6 +248,10 @@ REGENERABLE, so gitignored (rebuilt any time from source + inventory):
     art_generated/hero_gallery.html
     art_generated/quirk_icons_sheet.html
     art_generated/cat_angle_ab.html
+    art_generated/prop_grain_vanguard_sheet.html
+    art_generated/worker_rebase_sheet.html
+    art_generated/cat_sweep_sheet.html
+    art_generated/cat_refinement_sheet.html
     art_source/promote_list.txt
     art_source/favour_list.txt
     art_source/disfavour_dislike_list.txt

--- a/tools/art_review/review_style.py
+++ b/tools/art_review/review_style.py
@@ -27,6 +27,15 @@ this module instead of hand-rolling CSS. It provides:
                            queue and you can clear hundreds without getting
                            tired. Export / import JSON round-trips the flat
                            {rel: [tags]} schema used by analyze_verdicts.py.
+  * bulk-select         -- ported from gen_contact_sheet.py (issue #900/#912
+                           follow-up): a checkbox per cell, shift-click range
+                           select (keyed off data-rel, respects the current
+                           show-filter -- hidden cells never enter a shift
+                           range or select-all-visible), a "select all visible"
+                           button in the verdict toolbar, and a fixed bulk
+                           apply/remove bar (one +tag/-tag button pair per
+                           verdict). Automatic whenever a sheet passes
+                           verdict_key to page() -- no per-sheet wiring needed.
   * completeness UX     -- COMPLETENESS_JS / COMPLETENESS_CSS /
                            completeness_controls(): sections render COLLAPSED by
                            default (expand state persists per-section in
@@ -196,7 +205,29 @@ body.rs-only [data-unrev="0"]{display:none;}
 body.rs-only .caret{opacity:.35;}
 """
 
+# bulk-select chrome (ported from gen_contact_sheet.py, issue #900/#912
+# follow-up): per-cell checkbox, .sel highlight, and the fixed bulk apply/
+# remove bar. Shared by every sheet that passes verdict_key to page().
+BULK_CSS = """
+main{padding-bottom:76px;}
+.rs-selbox{position:absolute;top:6px;left:6px;width:16px;height:16px;cursor:pointer;
+z-index:3;accent-color:var(--amber);margin:0;}
+.rs-cell.sel{border-color:var(--amber2);box-shadow:0 0 0 1px var(--amber2) inset;}
+.rs-bulkbar{position:fixed;left:0;right:0;bottom:0;z-index:40;
+background:linear-gradient(0deg,#221d16,#1a1611);border-top:1px solid #5a4a2a;
+padding:10px 18px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;
+box-shadow:0 -3px 14px #000a;transform:translateY(110%);transition:transform .18s;}
+.rs-bulkbar.on{transform:translateY(0);}
+.rs-bulkbar .rs-selcount{color:var(--amber2);font-family:monospace;font-size:13px;font-weight:600;}
+.rs-bulkbar .sep{color:var(--line);}
+.rs-bulk-add,.rs-bulk-del{border-radius:6px;font-size:11px;padding:5px 9px;border:1px solid var(--line);
+background:var(--bg3);color:var(--dim);cursor:pointer;font-family:monospace;}
+.rs-bulk-add:hover{background:var(--vc);color:#12100c;border-color:var(--vc);}
+.rs-bulk-del:hover{background:#3a2020;border-color:#cc5a4a;color:#e8b0a8;}
+"""
+
 BASE_CSS += COMPLETENESS_CSS
+BASE_CSS += BULK_CSS
 
 # ---------------------------------------------------------------- completeness JS
 
@@ -318,6 +349,38 @@ function refreshCounts(){
 }
 function syncCell(c){const r=c.dataset.rel;
   for(const b of c.querySelectorAll('.vtag'))b.classList.toggle('on',hasTag(r,b.dataset.v));}
+// ---- bulk-select (ported from gen_contact_sheet.py, issue #900/#912 follow-up) ----
+// data-rel is the stable handle (README compare-mode note); shift-click range
+// select walks DOM order and skips cells hidden by the current show-filter.
+const cellByRel={};for(const c of cells)cellByRel[c.dataset.rel]=c;
+const selected=new Set();
+let lastClickedIdx=null;
+function setSel(rel,on){const c=cellByRel[rel];if(!c)return;
+  if(on){selected.add(rel);c.classList.add('sel');}else{selected.delete(rel);c.classList.remove('sel');}
+  const cb=c.querySelector('.rs-selbox');if(cb)cb.checked=on;}
+function onSelClick(rel,shift,checked){
+  const idx=cells.indexOf(cellByRel[rel]);
+  if(shift&&lastClickedIdx!==null){
+    const [a,b]=[Math.min(lastClickedIdx,idx),Math.max(lastClickedIdx,idx)];
+    for(let i=a;i<=b;i++){const c=cells[i];
+      if(c.style.display==='none')continue; // never silently pull in filtered-out cells
+      setSel(c.dataset.rel,checked);}
+  }else{setSel(rel,checked);}
+  lastClickedIdx=idx;updateSelUI();
+}
+function selectAllVisible(){const vis=cells.filter(c=>c.style.display!=='none').map(c=>c.dataset.rel);
+  const allSel=vis.length&&vis.every(r=>selected.has(r));
+  for(const r of vis)setSel(r,!allSel);updateSelUI();}
+function clearSel(){for(const r of[...selected])setSel(r,false);updateSelUI();}
+function updateSelUI(){const n=selected.size;
+  const sc=document.getElementById('rs-selcountn');if(sc)sc.textContent=n;
+  const bar=document.getElementById('rs-bulkbar');if(bar)bar.classList.toggle('on',n>0);}
+function bulkApply(v,on){for(const r of selected){setTag(r,v,on);
+  const c=cellByRel[r];if(!c)continue;const b=c.querySelector(`.vtag[data-v="${v}"]`);
+  if(b)b.classList.toggle('on',on);}
+  saveV();refreshCounts();rsCompleteness.updateCounts();
+  if(rsCompleteness.mode()!=='all'||activeVerdicts.size)applyFilter();
+  toast(`${on?'Set':'Removed'} ${v} on ${selected.size} item(s)`);}
 let toastT=null;
 function toast(msg){const el=document.getElementById('toast');if(!el)return;
   el.textContent=msg;el.classList.add('on');
@@ -339,11 +402,26 @@ window.addEventListener('DOMContentLoaded',()=>{
         if(rsCompleteness.mode()!=='all'||activeVerdicts.size)applyFilter();};
       vt.appendChild(b);
     }
+    const cb=document.createElement('input');cb.type='checkbox';cb.className='rs-selbox';
+    cb.title='select';
+    cb.addEventListener('click',e=>{e.stopPropagation();onSelClick(r,e.shiftKey,cb.checked);});
+    c.insertBefore(cb,c.firstChild);
   }
   for(const vc of document.querySelectorAll('.vchip[data-v]')){
     vc.onclick=()=>{const v=vc.dataset.v;
       if(activeVerdicts.has(v)){activeVerdicts.delete(v);vc.classList.remove('on');}
       else{activeVerdicts.add(v);vc.classList.add('on');}applyFilter();};}
+  const sav=document.getElementById('rs-selallvis');if(sav)sav.onclick=selectAllVisible;
+  const addWrap=document.getElementById('rs-bulkadd'),delWrap=document.getElementById('rs-bulkdel');
+  if(addWrap&&delWrap){
+    for(const v of VERDICTS){
+      const a=document.createElement('button');a.className='rs-bulk-add';a.textContent='+'+v;
+      a.style.setProperty('--vc',VCOLORS[v]);a.onclick=()=>bulkApply(v,true);addWrap.appendChild(a);
+      const d=document.createElement('button');d.className='rs-bulk-del';d.textContent='-'+v;
+      d.onclick=()=>bulkApply(v,false);delWrap.appendChild(d);
+    }
+  }
+  const cs=document.getElementById('rs-clearsel');if(cs)cs.onclick=clearSel;
   rsCompleteness.init({key:KEY,sectionSel:'.rs-section',cellSel:'.rs-cell[data-rel]',
     tagsOf:tagsOf,onFilter:applyFilter});
   const ex=document.getElementById('rs-export');
@@ -380,9 +458,29 @@ def _verdict_toolbar():
         + " "
         + completeness_controls()
         + '<span class="count-tag"><span id="rs-hiddenn">0</span> hidden</span> '
+        '<button class="btn" id="rs-selallvis">select all visible</button>'
         '<button class="btn" id="rs-export">export JSON</button>'
         '<button class="btn primary" id="rs-import">import JSON</button>'
         '<input type="file" id="rs-importfile" accept="application/json,.json" style="display:none">'
+        "</div>"
+    )
+
+
+def _bulk_bar():
+    """Fixed bulk apply/remove bar (ported from gen_contact_sheet.py). Buttons
+    for +tag/-tag per verdict are populated by VERDICT_JS; only rendered when
+    the sheet has a verdict toolbar (verdict_key set)."""
+    return (
+        '<div class="rs-bulkbar" id="rs-bulkbar">'
+        '<span class="rs-selcount"><span id="rs-selcountn">0</span> selected</span>'
+        '<span class="sep">|</span>'
+        '<span class="row-label">apply</span>'
+        '<span id="rs-bulkadd" style="display:flex;gap:5px;flex-wrap:wrap"></span>'
+        '<span class="sep">|</span>'
+        '<span class="row-label">remove</span>'
+        '<span id="rs-bulkdel" style="display:flex;gap:5px;flex-wrap:wrap"></span>'
+        '<span class="sep">|</span>'
+        '<button class="btn" id="rs-clearsel">clear selection</button>'
         "</div>"
     )
 
@@ -501,8 +599,10 @@ def page(
     verdict_bar = ""
     verdict_js = ""
     store_warn = ""
+    bulk_bar = ""
     if verdict_key:
         verdict_bar = _verdict_toolbar()
+        bulk_bar = _bulk_bar()
         store_warn = (
             '<span class="badge" id="rs-storewarn" style="display:none;color:#d88">'
             "localStorage off -- verdicts wont persist (use Export)</span>"
@@ -529,7 +629,9 @@ def page(
             f'"{verdict_key}"; sections open collapsed (expand state remembered); '
             "show: all / hide decided / only unreviewed -- only-unreviewed is the "
             "completeness pass (any verdict tag = decided; sections with 0 "
-            "unreviewed disappear); export JSON to make decisions durable."
+            "unreviewed disappear); export JSON to make decisions durable. "
+            "Batch-select: checkbox + shift-click range per cell, select all "
+            "visible (respects the current show-filter), bulk apply/remove bar."
         )
     if footer_note:
         footer_bits.append(footer_note)
@@ -562,6 +664,7 @@ def page(
 <footer>
   {' '.join(footer_bits)}
 </footer>
+{bulk_bar}
 <div id="toast"></div>
 {scripts}
 </body>


### PR DESCRIPTION
## Summary

Pip's ask: "We don't seem to have the group select / mass add thing from one of the image set functions... uplift and ensure consistency for that functionality across galleries."

- Ported the bulk-select machinery (checkbox per cell, shift-click range select, select-all-visible, bulk apply/remove verdict bar) from `gen_contact_sheet.py` into `review_style.py` as shared `BULK_CSS` + additions inside the `VERDICT_JS` closure -- same pattern as the existing `COMPLETENESS_JS`/`COMPLETENESS_CSS`/`completeness_controls()` trio.
- It composes with the existing per-cell verdict chips, localStorage persistence, export/import JSON (flat `{rel: [tags]}` schema unchanged), and the three-state ALL / HIDE DECIDED / ONLY UNREVIEWED show control.
- Selection keys off `data-rel` (the README's compare-mode stable handle). Shift-click range select and "select all visible" both skip cells hidden by the current show-filter, so ONLY UNREVIEWED never silently pulls a filtered-out cell into a bulk action.
- **Automatic for every sheet that passes `verdict_key` to `page(...)`** -- no per-sheet wiring needed. That means `gen_prop_grain_sheet.py`, `build_worker_rebase_sheet.py`, `build_cat_sweep_sheet.py`, and `build_cat_refinement_sheet.py` all gain the feature on next regen with zero code changes of their own (checked: all four already build cells with `data-rel` + `rs-vtags` and call `rs.page(..., verdict_key=...)`).
- `gen_quirk_icon_sheet.py` (also `verdict_key`-driven) gains it too.
- `build_cat_angle_ab_sheet.py` has no `verdict_key` (pure comparison sheet, no verdict tags) so correctly gets the shared CSS but no bulk bar renders.
- `gen_contact_sheet.py` (the flagship sprite triage sheet, and the port source) is **left untouched** -- its own hand-rolled bulk-select differs enough (grid layout, run/category grouping, CSV export, copy-to-clipboard) that a safe migration needs the README's byte-diff verification pattern; not risked in this pass. Documented as a follow-up in the migration table.
- Updated `tools/art_review/README.md`: shared-house-style bullet list, "Sheets on the shared style" list (added the four newer builders, previously undocumented), migration status table, tracked/regenerable file lists, and a 2026-07-27 changelog note explaining the migration decision.

## Test plan

- [x] `python tools/art_review/review_style.py --selftest` passes
- [x] Regenerated all five affected sheets in the worktree: `gen_quirk_icon_sheet.py`, `gen_prop_grain_sheet.py`, `build_worker_rebase_sheet.py`, `build_cat_sweep_sheet.py`, `build_cat_refinement_sheet.py` -- all wrote successfully
- [x] Regenerated `build_cat_angle_ab_sheet.py` (no verdict_key) -- confirmed no `<div id="rs-bulkbar">` renders, only the (harmless, unused) shared CSS rules
- [x] Manually inspected emitted HTML/JS: checkbox creation, shift-click range logic (skips `display:none` cells), select-all-visible (filters on `style.display`), bulk apply/remove wiring, `.rs-selbox` / `.rs-bulkbar` CSS all present and correctly scoped
- [x] No non-ASCII characters introduced (checked both changed files)
- [x] `git status` after regenerating sheets shows only the two tracked source files modified -- all regenerated `art_generated/*.html` stay gitignored as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)