### PR TITLE
feat(perflog): mark/gauge APIs, ISO timestamps, rotation + 5 instrumentation sites (save/load, scene loads, office repopulate, event pool)

### DIFF
--- a/godot/autoload/event_service.gd
+++ b/godot/autoload/event_service.gd
@@ -338,6 +338,9 @@ func _transform_all_events() -> void:
 
 	events_transformed.emit(transformed_events.size())
 	print("[EventService] Transformed %d events" % transformed_events.size())
+	# Observability only (see godot/autoload/perf_log.gd): point-in-time size of the
+	# rebuilt event pool. Never touches state/RNG/scoring, never branched on.
+	PerfLog.gauge("event_pool_size", transformed_events.size())
 
 
 func _transform_event(raw: Dictionary) -> Dictionary:

--- a/godot/autoload/perf_log.gd
+++ b/godot/autoload/perf_log.gd
@@ -2,8 +2,9 @@ extends Node
 ## PerfLog -- dev-mode performance logger for the load-bearing turn/month loop.
 ##
 ## OBSERVABILITY ONLY. It reads a monotonic clock (Time.get_ticks_usec) and, at most,
-## the turn number a caller hands it. It NEVER touches game state, RNG, or scoring, so it
-## has ZERO gameplay/determinism effect (ladder stays L2). Every public method early-returns
+## display-only values a caller hands it (turn number, counts, labels). It NEVER touches
+## game state, RNG, or scoring, so it has ZERO gameplay/determinism effect (ladder stays L2).
+## Every public method early-returns
 ## a no-op unless BuildInfo.is_dev_build() is true, so a clean release cut (DEV_BUILD=false)
 ## makes normal players see nothing -- no file writes, no console spam.
 ##
@@ -17,9 +18,17 @@ extends Node
 ##   PerfLog.begin("turn_resolution", {"turn": t}); ...; PerfLog.end("turn_resolution")
 ##   var sw := PerfLog.time_section("turn_resolution"); ...; sw.stop()   # stopwatch helper
 ##   PerfLog.check_iterations("month_playback", i, 400)                  # loop tripwire
+##   PerfLog.mark("scene_ready", {"scene": "watch"})                     # one-line stamped event
+##   PerfLog.gauge("office_sprites", 12)                                 # point-in-time count
 ##
 ## Callers must treat the tripwire returns as OBSERVATION ONLY -- never break/branch game
 ## logic on them, or the logger would fork behavior. It watches; it does not steer.
+##
+## FILE FORMAT (2026-07-27 tightening, for later story-mining/parsing): every line written
+## to perf.log leads with an ISO-8601 UTC wall-clock timestamp and a fixed TYPE field
+## (BEGIN/END/MARK/GAUGE/WARN/ITER), then the existing free-text body, so a later parser can
+## split reliably on the first two whitespace-delimited fields. ASCII only; ctx renders as
+## trailing key=value pairs, stable field order.
 
 ## Default wall-time threshold (ms) above which a timed section is flagged. A whole turn
 ## resolving in >1s is well past anything the current sim should need -- picked as a loud
@@ -33,6 +42,13 @@ const MAX_WARNINGS := 128
 
 ## Dev log trail. Append-only; created lazily under user://logs (same dir as LogExporter).
 const LOG_PATH := "user://logs/perf.log"
+const LOG_DIR := "user://logs"
+const ROTATED_LOG_NAME := "perf.log.1"
+
+## Size-based rotation: once perf.log reaches this many bytes, the NEXT write rotates it to
+## perf.log.1 (overwriting any prior rotation) and starts a fresh perf.log. Keeps a session's
+## worth of story-mineable trail without unbounded growth across a long dev session.
+const MAX_LOG_BYTES := 5 * 1024 * 1024
 
 signal anomaly_flagged(message: String)
 
@@ -94,6 +110,7 @@ func begin(section: String, ctx: Dictionary = {}) -> void:
 	if not is_active():
 		return
 	_open[section] = {"start_usec": Time.get_ticks_usec(), "ctx": ctx}
+	_write_line("BEGIN", "section=%s%s" % [section, _kv_suffix(ctx)])
 
 
 ## End a named section started with begin(). Returns elapsed ms (0.0 if unmatched/inactive).
@@ -113,6 +130,27 @@ func time_section(section: String, ctx: Dictionary = {}) -> Stopwatch:
 	return Stopwatch.new(self, section, Time.get_ticks_usec(), ctx)
 
 
+## --- One-line events ---------------------------------------------------------
+
+## Stamp a single unpaired event -- no begin/end matching, just "this happened, here's when
+## and with what context". No-op when inactive; feeds the same ring buffer + file trail as
+## timed sections. ctx is display-only (e.g. {"scene": "watch"}) -- never branch on it.
+func mark(label: String, ctx: Dictionary = {}) -> void:
+	if not is_active():
+		return
+	_push(_entries, {"kind": "mark", "label": label, "ctx": ctx}, MAX_ENTRIES)
+	_write_line("MARK", "label=%s%s" % [label, _kv_suffix(ctx)])
+
+
+## Record a point-in-time count/value (e.g. gauge("office_sprites", 12)). No-op when
+## inactive; feeds the same ring buffer + file trail as timed sections.
+func gauge(name: String, value, ctx: Dictionary = {}) -> void:
+	if not is_active():
+		return
+	_push(_entries, {"kind": "gauge", "name": name, "value": value, "ctx": ctx}, MAX_ENTRIES)
+	_write_line("GAUGE", "name=%s value=%s%s" % [name, str(value), _kv_suffix(ctx)])
+
+
 ## --- Iteration tripwire ----------------------------------------------------
 
 ## Flag a WARNING if a loop's iteration count blows past a sane bound -- the cheap
@@ -123,7 +161,7 @@ func check_iterations(loop_name: String, count: int, sane_bound: int, ctx: Dicti
 		return false
 	if count <= sane_bound:
 		return false
-	_flag("RUNAWAY loop '%s' hit %d iterations (sane bound %d)" % [loop_name, count, sane_bound], ctx)
+	_flag("RUNAWAY loop '%s' hit %d iterations (sane bound %d)" % [loop_name, count, sane_bound], ctx, "ITER")
 	return true
 
 
@@ -174,25 +212,44 @@ func _record(section: String, start_usec: int, ctx: Dictionary) -> float:
 	var over := elapsed_ms > threshold
 	var entry := {"section": section, "ms": elapsed_ms, "over": over, "ctx": ctx}
 	_push(_entries, entry, MAX_ENTRIES)
-	_write_line("[PerfLog] %-22s %8.2f ms%s%s" % [
-		section, elapsed_ms, ("  <<< OVER" if over else ""), _ctx_suffix(ctx)])
+	var body := "section=%s ms=%.2f" % [section, elapsed_ms]
+	if over:
+		body += " over=true"
+	body += _kv_suffix(ctx)
+	_write_line("END", body)
 	if over:
 		_flag("SLOW section '%s' took %.1f ms (threshold %.0f ms)" % [section, elapsed_ms, threshold], ctx)
 	return elapsed_ms
 
 
-func _flag(message: String, ctx: Dictionary) -> void:
+## type is the file TYPE field for this warning ("WARN" for a slow section, "ITER" for a
+## runaway-loop trip). The in-memory _warnings line keeps the legacy "[WARN]" tag regardless
+## of type -- callers/tests match on the message text (SLOW/RUNAWAY), not that tag.
+func _flag(message: String, ctx: Dictionary, type: String = "WARN") -> void:
 	var line := "[PerfLog][WARN] " + message + _ctx_suffix(ctx)
 	_push(_warnings, line, MAX_WARNINGS)
 	# print (not push_warning): in a dev checkout these are expected dev signals, and
 	# push_warning can be mis-counted as an engine fault by strict test tooling.
 	print(line)
-	_write_line(line)
+	_write_line(type, message + _kv_suffix(ctx))
 	anomaly_flagged.emit(message)
 
 
+## Legacy in-memory suffix (Dictionary.to_string() shape) -- kept for the _warnings buffer's
+## text, which existing callers/tests match by substring only. File lines use _kv_suffix().
 func _ctx_suffix(ctx: Dictionary) -> String:
 	return ("  " + str(ctx)) if not ctx.is_empty() else ""
+
+
+## Stable key=value ctx rendering for the file trail (a later parser splits on TYPE, then
+## reads trailing key=value pairs). Insertion order; "" when ctx is empty.
+func _kv_suffix(ctx: Dictionary) -> String:
+	if ctx.is_empty():
+		return ""
+	var parts: Array = []
+	for k in ctx.keys():
+		parts.append("%s=%s" % [k, str(ctx[k])])
+	return " " + " ".join(parts)
 
 
 func _push(buf: Array, item, cap: int) -> void:
@@ -201,12 +258,16 @@ func _push(buf: Array, item, cap: int) -> void:
 		buf.pop_front()
 
 
-func _write_line(line: String) -> void:
+## Compose and append one line: "<ISO-8601 UTC timestamp>Z <TYPE> <body>". TYPE is one of
+## BEGIN/END/MARK/GAUGE/WARN/ITER (see the file-format doc at the top of this file).
+func _write_line(type: String, body: String) -> void:
 	if not _file_logging or not is_active():
 		return
 	var dir := DirAccess.open("user://")
 	if dir != null and not dir.dir_exists("logs"):
 		dir.make_dir("logs")
+	_rotate_if_needed()
+	var line := "%s %s %s" % [_timestamp(), type, body]
 	var f: FileAccess
 	if FileAccess.file_exists(LOG_PATH):
 		f = FileAccess.open(LOG_PATH, FileAccess.READ_WRITE)
@@ -217,3 +278,35 @@ func _write_line(line: String) -> void:
 	if f != null:
 		f.store_line(line)
 		f.close()
+
+
+## Current wall-clock as an ISO-8601 UTC string, e.g. "2026-07-27T13:45:01Z".
+func _timestamp() -> String:
+	return "%sZ" % Time.get_datetime_string_from_system(true)
+
+
+## Pure size-vs-threshold decision, split out so tests can exercise it without touching
+## user://. True means the CURRENT perf.log has grown past the rotation threshold.
+static func should_rotate(current_size_bytes: int, threshold_bytes: int = MAX_LOG_BYTES) -> bool:
+	return current_size_bytes >= threshold_bytes
+
+
+## Size-based rotation: when perf.log has reached MAX_LOG_BYTES, move it to perf.log.1
+## (clobbering any prior rotation) so the next write starts a fresh perf.log. Runs at the
+## top of every file write; a no-op on a small/missing log (the common case).
+func _rotate_if_needed() -> void:
+	if not FileAccess.file_exists(LOG_PATH):
+		return
+	var f := FileAccess.open(LOG_PATH, FileAccess.READ)
+	if f == null:
+		return
+	var size := f.get_length()
+	f.close()
+	if not should_rotate(size):
+		return
+	var dir := DirAccess.open(LOG_DIR)
+	if dir == null:
+		return
+	if dir.file_exists(ROTATED_LOG_NAME):
+		dir.remove(ROTATED_LOG_NAME)
+	dir.rename("perf.log", ROTATED_LOG_NAME)

--- a/godot/autoload/scene_transition.gd
+++ b/godot/autoload/scene_transition.gd
@@ -84,6 +84,14 @@ func change_scene(target_scene: String) -> void:
 
 
 func _run_transition() -> void:
+	# Observability only (see godot/autoload/perf_log.gd): wall-clock timing around the
+	# deferred scene swap, the one sanctioned chokepoint (see class doc), so this single
+	# instrumentation point covers every scene load. Never touches state/RNG/scoring, never
+	# branched on, and does NOT alter the always-deferred transition logic below.
+	var sw := PerfLog.time_section("scene_load", {
+		"target": (_pending_target if not _pending_reload else "<reload>"),
+	})
+
 	# Runs on a clean idle frame (out of any input/signal callstack).
 	if _pending_fade:
 		fade_rect.mouse_filter = Control.MOUSE_FILTER_STOP
@@ -98,6 +106,7 @@ func _run_transition() -> void:
 		await fade_in()
 		fade_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
+	sw.stop()
 	_pending_target = ""
 	_pending_reload = false
 	_pending_fade = false

--- a/godot/scripts/core/save_load.gd
+++ b/godot/scripts/core/save_load.gd
@@ -28,13 +28,19 @@ static func build_envelope(state: GameState) -> Dictionary:
 
 
 static func save_game(state: GameState, path: String = QUICKSAVE_PATH) -> Error:
+	# Observability only (see godot/autoload/perf_log.gd): wall-clock timing + display-only
+	# ctx (path, turn). Never touches state/RNG/scoring, never branched on.
+	var sw := PerfLog.time_section("save", {"path": path, "turn": (state.turn if state != null else -1)})
 	if state == null:
+		sw.stop()
 		return ERR_INVALID_PARAMETER
 	var err := DirAccess.make_dir_recursive_absolute(SAVE_DIR)
 	if err != OK and err != ERR_ALREADY_EXISTS:
+		sw.stop()
 		return err
 	var f := FileAccess.open(path, FileAccess.WRITE)
 	if f == null:
+		sw.stop()
 		return FileAccess.get_open_error()
 	# full_precision=true is LOAD-BEARING: the default truncates float decimals,
 	# which shifts every restored float by ulps -- the drift then compounds turn
@@ -42,6 +48,7 @@ static func save_game(state: GameState, path: String = QUICKSAVE_PATH) -> Error:
 	f.store_string(JSON.stringify(build_envelope(state), "\t", true, true))
 	f.close()
 	print("[SaveLoad] Saved turn %d to %s" % [state.turn, path])
+	sw.stop()
 	return OK
 
 
@@ -50,17 +57,24 @@ static func has_save(path: String = QUICKSAVE_PATH) -> bool:
 
 
 static func load_envelope(path: String = QUICKSAVE_PATH) -> Dictionary:
+	# Observability only (see godot/autoload/perf_log.gd): wall-clock timing + display-only
+	# ctx (path). Never touches state/RNG/scoring, never branched on.
+	var sw := PerfLog.time_section("load", {"path": path})
 	if not FileAccess.file_exists(path):
+		sw.stop()
 		return {}
 	var f := FileAccess.open(path, FileAccess.READ)
 	if f == null:
+		sw.stop()
 		return {}
 	var text := f.get_as_text()
 	f.close()
 	var parsed = JSON.parse_string(text)
 	if not (parsed is Dictionary):
 		print("[SaveLoad] Corrupt save (not a JSON object): %s" % path)
+		sw.stop()
 		return {}
+	sw.stop()
 	return parsed
 
 

--- a/godot/scripts/ui/office_floor/office_floor.gd
+++ b/godot/scripts/ui/office_floor/office_floor.gd
@@ -287,8 +287,19 @@ func _bounds() -> Rect2:
 		s = custom_minimum_size
 	return Rect2(Vector2(8, 8), s - Vector2(16, 16))
 
+## Observability only (see godot/autoload/perf_log.gd): the Titan-phase scaling cliff this
+## class's own doc comment flags above (hundreds of staff, one-sprite-each not viable) makes
+## the roster rebuild the thing worth watching first. A tighter threshold than the 1000 ms
+## default (still cosmetic, never touches game state/RNG/scoring, never branched on).
+const ROSTER_REBUILD_WARN_MS := 50.0
+var _roster_threshold_set := false
+
 ## Replace/refresh the rendered roster from a snapshot (read-only; copies values).
 func set_roster(snapshot: Array) -> void:
+	if not _roster_threshold_set:
+		PerfLog.set_threshold("office_roster_rebuild", ROSTER_REBUILD_WARN_MS)
+		_roster_threshold_set = true
+	var sw := PerfLog.time_section("office_roster_rebuild", {"count": snapshot.size()})
 	var b := _bounds()
 	var z := _zones(b)
 	var seen: Dictionary = {}
@@ -337,6 +348,8 @@ func set_roster(snapshot: Array) -> void:
 			_sprites.erase(id)
 			_appearance.erase(id)
 	queue_redraw()
+	PerfLog.gauge("office_sprites", _sprites.size())
+	sw.stop()
 
 ## Number of employee sprites currently on the floor (the walker count). Read-only;
 ## the WATCH integration + its guard test assert this tracks the live staff count.

--- a/godot/tests/unit/test_perf_log.gd
+++ b/godot/tests/unit/test_perf_log.gd
@@ -140,3 +140,84 @@ func test_entries_ring_buffer_is_bounded():
 		PerfLog.end("ring_%d" % i)
 	assert_eq(PerfLog.get_entries().size(), PerfLog.MAX_ENTRIES,
 		"the rolling log must cap at MAX_ENTRIES (oldest dropped)")
+
+
+# --- mark() / gauge() -------------------------------------------------------
+
+func test_mark_records_an_entry_with_label_and_ctx():
+	PerfLog.mark("scene_ready", {"scene": "watch"})
+	var entries := PerfLog.get_entries()
+	assert_eq(entries.size(), 1, "mark() should record exactly one entry")
+	assert_eq(entries[0]["kind"], "mark", "entry should be tagged kind=mark")
+	assert_eq(entries[0]["label"], "scene_ready", "entry should carry the mark label")
+	assert_eq(entries[0]["ctx"]["scene"], "watch", "entry should carry the caller context")
+
+
+func test_mark_is_noop_when_inactive():
+	PerfLog.set_enabled_override(false)
+	PerfLog.mark("gated_mark")
+	assert_eq(PerfLog.get_entries().size(), 0, "mark() must no-op while the gate is off")
+
+
+func test_gauge_records_an_entry_with_name_and_value():
+	PerfLog.gauge("office_sprites", 12, {"turn": 3})
+	var entries := PerfLog.get_entries()
+	assert_eq(entries.size(), 1, "gauge() should record exactly one entry")
+	assert_eq(entries[0]["kind"], "gauge", "entry should be tagged kind=gauge")
+	assert_eq(entries[0]["name"], "office_sprites", "entry should carry the gauge name")
+	assert_eq(entries[0]["value"], 12, "entry should carry the gauge value")
+	assert_eq(entries[0]["ctx"]["turn"], 3, "entry should carry the caller context")
+
+
+func test_gauge_is_noop_when_inactive():
+	PerfLog.set_enabled_override(false)
+	PerfLog.gauge("gated_gauge", 1)
+	assert_eq(PerfLog.get_entries().size(), 0, "gauge() must no-op while the gate is off")
+
+
+# --- Rotation ----------------------------------------------------------------
+
+func test_should_rotate_true_past_threshold():
+	assert_true(PerfLog.should_rotate(PerfLog.MAX_LOG_BYTES, PerfLog.MAX_LOG_BYTES),
+		"a log exactly at the threshold should rotate")
+	assert_true(PerfLog.should_rotate(PerfLog.MAX_LOG_BYTES + 1, PerfLog.MAX_LOG_BYTES),
+		"a log past the threshold should rotate")
+
+
+func test_should_rotate_false_under_threshold():
+	assert_false(PerfLog.should_rotate(100, PerfLog.MAX_LOG_BYTES),
+		"a small log should not rotate")
+
+
+# --- File line shape ---------------------------------------------------------
+# Enables real file logging briefly to check the written line shape, then removes the file
+# and restores hermetic settings -- the only test in this suite that touches user://.
+
+func test_written_line_has_timestamp_and_type_fields():
+	var re := RegEx.new()
+	re.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z (BEGIN|END|MARK|GAUGE|WARN|ITER) ")
+
+	PerfLog.set_file_logging(true)
+	if FileAccess.file_exists(PerfLog.LOG_PATH):
+		DirAccess.remove_absolute(PerfLog.LOG_PATH)
+	PerfLog.begin("line_shape_section", {"turn": 1})
+	PerfLog.end("line_shape_section")
+	PerfLog.mark("line_shape_mark")
+	PerfLog.gauge("line_shape_gauge", 5)
+	PerfLog.set_file_logging(false)
+
+	var f := FileAccess.open(PerfLog.LOG_PATH, FileAccess.READ)
+	assert_not_null(f, "perf.log should exist after a real write")
+	if f == null:
+		return
+	var lines: Array = []
+	while not f.eof_reached():
+		var line := f.get_line()
+		if not line.is_empty():
+			lines.append(line)
+	f.close()
+	DirAccess.remove_absolute(PerfLog.LOG_PATH)
+
+	assert_gte(lines.size(), 4, "begin+end+mark+gauge should write at least 4 lines")
+	for line in lines:
+		assert_not_null(re.search(line), "line should start with an ISO-8601 timestamp + TYPE field: %s" % line)


### PR DESCRIPTION
## Summary

Extends the existing dev-gated `PerfLog` autoload (`godot/autoload/perf_log.gd`) per the 2026-07-27 observability scout -- instrumentation only, no new architecture. Motivation: capture this week's build pace in logs/timestamps to build a story of it later.

**PerfLog API additions**
- `mark(label, ctx={})` -- one-line stamped event, no begin/end pairing.
- `gauge(name, value, ctx={})` -- point-in-time count/value.
- Both no-op when `BuildInfo.is_dev_build()` is off (same gate as everything else here), both feed the same ring buffer (`get_entries()`) and file trail.

**File format tightening (story-mining)**
- Every line written to `user://logs/perf.log` now leads with an ISO-8601 UTC timestamp and a fixed `TYPE` field (`BEGIN`/`END`/`MARK`/`GAUGE`/`WARN`/`ITER`), then `key=value` ctx pairs in stable order -- a later parser can split reliably.
- `begin()` now also writes a `BEGIN` line (previously only `end()`/`Stopwatch.stop()` wrote), so a timeline shows section starts, not just ends.
- `check_iterations()` warnings now write as `ITER` (was folded into the same `WARN` type as slow-section warnings); the in-memory `_warnings` buffer text is unchanged so existing `SLOW`/`RUNAWAY` substring assertions still hold.

**Rotation**
- Size-based: once `perf.log` reaches ~5MB, the next write renames it to `perf.log.1` (clobbering any prior rotation) and starts fresh.
- The size-vs-threshold decision is a pure `static func should_rotate(size, threshold)` so it's unit-tested directly without touching `user://` (writing a real 5MB log in a unit test wasn't practical).

**Tests** (`godot/tests/unit/test_perf_log.gd`): updated for the WARN/ITER split; added `mark()`/`gauge()` coverage (including the inactive-gate no-op case); `should_rotate()` coverage; and one file-line-shape test that briefly enables real file logging, checks every written line matches `^<timestamp>Z (BEGIN|END|MARK|GAUGE|WARN|ITER) `, then deletes the file -- the only test in the suite that touches `user://`.

**Instrumentation (5 sites)**
- `godot/scripts/core/save_load.gd`: `time_section("save")` / `("load")` around the file write/read path, ctx = path (+ turn for save).
- `godot/autoload/scene_transition.gd`: `time_section("scene_load")` around the deferred swap in `_run_transition()` -- the single sanctioned nav chokepoint (`SceneTransition.go_to()`/`.reload()`), so one instrumentation point covers every scene load in the game. **Transition logic itself is untouched** -- the always-deferred contract is load-bearing (v0.11.0 leaderboard crash history); this is timing only, wrapped around the existing body.
- `godot/scripts/ui/office_floor/office_floor.gd`: `time_section("office_roster_rebuild")` around `set_roster()` with a tighter 50ms threshold (`set_threshold`) -- the file's own doc comment flags the Titan-phase (hundreds-of-staff) scaling cliff -- plus `gauge("office_sprites", count)`.
- `godot/autoload/event_service.gd`: `gauge("event_pool_size", n)` after `_transform_all_events()` rebuilds `transformed_events`.

## Determinism note

Every new call site reads `Time.get_ticks_usec()` / wall clock plus display-only ctx (path, turn, counts, labels) the caller hands in. Nothing touches game state, RNG, or scoring, and nothing branches on any PerfLog return value -- same contract as the rest of PerfLog (ladder stays L2).

## Ladder-bump note

`tools/check_ladder_bump.py` flags `godot/scripts/core/save_load.gd` as a gameplay-surface file changed without a `ladder_version.txt` bump. This is a timing-only wrap (no logic change, verified by reading the diff) -- accepted per the 2026-07-27 audacity ruling (daily ladder bumps Mon-Wed), advisory-only, not blocking.

## Test plan

- [x] `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -- **806 tests, 0 failures**, 85/85 files collected.
- [x] Verified `git status` only touched the 6 intended files (no `.import`/`.uid` churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)