### PR TITLE
feat(balance): price the doom.streams.action_* keys + missing-key guard (#971)

### DIFF
--- a/godot/data/actions/core.json
+++ b/godot/data/actions/core.json
@@ -41,7 +41,7 @@
 		{
 			"id": "publish_paper",
 			"name": "Publish Safety Paper",
-			"description": "Publish research to reduce p(doom)",
+			"description": "Publish research to raise global alarm (adopted safety concern)",
 			"costs": {
 				"research": 20,
 				"action_points": 1
@@ -67,7 +67,7 @@
 		{
 			"id": "team_building",
 			"name": "Team Building",
-			"description": "Improve morale, reduce doom slightly",
+			"description": "Improve morale",
 			"costs": {
 				"money": 10000,
 				"action_points": 1

--- a/godot/data/balance/defaults.json
+++ b/godot/data/balance/defaults.json
@@ -91,7 +91,21 @@
 			"alarm_decay": 0.985,
 			"panic_decay": 0.97,
 			"leak_panic_scale": 0.02,
-			"W_quirk_doom": 0.5
+			"W_quirk_doom": 0.5,
+			"action_safety_absorb": 4.0,
+			"action_safety_alarm": 0.03,
+			"action_paper_alarm": 3.0,
+			"action_audit_absorb": 1.0,
+			"action_desperation_absorb": 0.0,
+			"action_lobby_pressure": 0.5,
+			"action_lobby_alarm": 0.5,
+			"action_warning_alarm": 0.6,
+			"action_acquire_frontier": 60.0,
+			"action_sabotage_frontier": 200.0,
+			"action_sabotage_panic": 5.0,
+			"action_opensource_alarm": 0.6,
+			"action_opensource_diffusion": 0.0,
+			"action_conference_alarm": 0.6
 		}
 	},
 	"salaries": {

--- a/godot/tests/unit/test_balance_key_coverage.gd
+++ b/godot/tests/unit/test_balance_key_coverage.gd
@@ -1,0 +1,49 @@
+extends GutTest
+## Guard test for issue #971: Balance.num("doom.streams.action_*", ...) call sites in
+## actions.gd silently fall back to 0.0 (or a code-side default) when their key is
+## missing from defaults.json -- exactly how publish_paper/safety_research/audit_safety
+## shipped as no-ops post-ADR-0015. This scans actions.gd for every Balance.num() key
+## literal and asserts it resolves against defaults.json, so a future new stream key
+## added to actions.gd without a matching defaults.json entry fails CI instead of
+## degrading silently to its in-code fallback.
+
+const ACTIONS_SRC_PATH := "res://scripts/core/actions.gd"
+const DEFAULTS_PATH := "res://data/balance/defaults.json"
+
+
+func test_every_balance_num_key_in_actions_exists_in_defaults() -> void:
+	var src: String = FileAccess.get_file_as_string(ACTIONS_SRC_PATH)
+	assert_false(src.is_empty(), "expected to read %s" % ACTIONS_SRC_PATH)
+
+	var regex := RegEx.new()
+	regex.compile("Balance\\.num\\(\\s*\"([^\"]+)\"")
+	var matches := regex.search_all(src)
+	assert_gt(matches.size(), 0, "expected at least one Balance.num() call site in actions.gd")
+
+	var defaults_text: String = FileAccess.get_file_as_string(DEFAULTS_PATH)
+	var json := JSON.new()
+	var err := json.parse(defaults_text)
+	assert_eq(err, OK, "defaults.json should parse as valid JSON")
+	var data = json.get_data()
+	assert_true(data is Dictionary, "defaults.json root should be an object")
+
+	var missing: Array[String] = []
+	var seen: Dictionary = {}
+	for m in matches:
+		var key: String = m.get_string(1)
+		if seen.has(key):
+			continue
+		seen[key] = true
+		var node = data
+		var found := true
+		for part in key.split("."):
+			if node is Dictionary and node.has(part):
+				node = node[part]
+			else:
+				found = false
+				break
+		if not found:
+			missing.append(key)
+
+	assert_eq(missing.size(), 0,
+		"Balance.num() keys referenced in actions.gd but missing from defaults.json (silent 0.0/code-fallback): %s" % [missing])

--- a/godot/tests/unit/test_balance_key_coverage.gd.uid
+++ b/godot/tests/unit/test_balance_key_coverage.gd.uid
@@ -1,0 +1,1 @@
+uid://ddo7bjvnvtane


### PR DESCRIPTION
## Summary

The ADR-0015 migration rewired action doom effects through Balance-priced doom streams but never added the `doom.streams.action_*` keys to `godot/data/balance/defaults.json`. `Balance.num()` silently falls back to its call-site default, which was `0.0` for several streams -- so `publish_paper`'s alarm bump, `safety_research`'s absorption, and `audit_safety`'s scrutiny were mechanically no-ops despite the code comments and UI copy claiming otherwise (#971).

## Keys added (all 14 `doom.streams.action_*` keys referenced in `actions.gd`)

Bucketed per the mid-flight ruling: **coverage, not rebalance** for keys that already had a working non-zero code-side fallback; gentle first-pass non-zero for the actual #971 no-op bugs; explicit `0.0` for the two intentionally-zero keys so the guard test covers them too.

| Key | Value | Bucket | Rationale |
|---|---|---|---|
| `action_safety_absorb` | `4.0` | #971 bug -- gentle first price | Was hard 0.0, no intentional-zero comment ("a follow-up lane prices the action"). Set to half the passive `safety_absorb_gain` (8.0/tick) as a one-shot per-researcher action bonus on top of continuous passive accrual. |
| `action_safety_alarm` | `0.03` | #971 bug -- gentle first price | Same `safety_research` call site; set just under the passive `alarm_gain` (0.05/tick) per researcher. |
| `action_paper_alarm` | `3.0` | #971 bug -- gentle first price | `publish_paper` was previously a flat -3 doom; ports that magnitude onto the alarm stream (relief via `W_alarm`) since the pre-ADR-0015 literal is the only calibration anchor available. |
| `action_audit_absorb` | `1.0` | #971 bug -- gentle first price | Multiplied by `(5 + safety_researchers)` scrutiny scalar already in code, so a coefficient well below the passive 8.0/tick gain avoids over-pricing a single action call. |
| `action_desperation_absorb` | `0.0` | intentional zero | Code comment: "Priced at 0 in v1; the SECRET compounding liability... is intact." Added explicitly so the guard test covers it. |
| `action_opensource_diffusion` | `0.0` | intentional zero | Code comment: "general_capability contribution priced at 0 pending a design ruling" (DQ-21 S1.1 tension flagged). Added explicitly for guard coverage. |
| `action_lobby_pressure` | `0.5` | working fallback -- ported verbatim | `Balance.num("doom.streams.action_lobby_pressure", 0.5)` |
| `action_lobby_alarm` | `0.5` | working fallback -- ported verbatim | `Balance.num("doom.streams.action_lobby_alarm", 0.5)` |
| `action_warning_alarm` | `0.6` | working fallback -- ported verbatim | `Balance.num("doom.streams.action_warning_alarm", 0.6)` |
| `action_acquire_frontier` | `60.0` | working fallback -- ported verbatim | `Balance.num("doom.streams.action_acquire_frontier", 60.0)` |
| `action_sabotage_frontier` | `200.0` | working fallback -- ported verbatim | `Balance.num("doom.streams.action_sabotage_frontier", 200.0)` |
| `action_sabotage_panic` | `5.0` | working fallback -- ported verbatim | `Balance.num("doom.streams.action_sabotage_panic", 5.0)` |
| `action_opensource_alarm` | `0.6` | working fallback -- ported verbatim | `Balance.num("doom.streams.action_opensource_alarm", 0.6)` |
| `action_conference_alarm` | `0.6` | working fallback -- ported verbatim | `Balance.num("doom.streams.action_conference_alarm", 0.6)` |

No re-tuning of already-working numbers; balance sweeps trail this PR later per the audacity ruling.

## Also fixed

- `godot/data/actions/core.json`: `publish_paper` description updated from stale "Publish research to reduce p(doom)" to "Publish research to raise global alarm (adopted safety concern)" -- matches what the action fires post-ADR-0015.
- `team_building` description trimmed from "Improve morale, reduce doom slightly" to "Improve morale" -- `actions.gd:508` only reduces researcher burnout, no doom write.

## Guard test

`godot/tests/unit/test_balance_key_coverage.gd`: scans `actions.gd` for every `Balance.num("...", ...)` key literal via regex and asserts each resolves against `defaults.json`. A future stream key added to `actions.gd` without a matching `defaults.json` entry now fails CI instead of silently degrading to its in-code (often `0.0`) fallback -- this is exactly how #971 shipped undetected.

## Test plan

- [x] `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -- 810 tests, 0 failures, 86/86 files collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)