### PR TITLE
feat(office): a(3)-lite RenderGrid -- first-class Vector2i render-layer grid; sandbox ported off the string-key hack

### DIFF
--- a/godot/scripts/ui/office_floor/office_sandbox.gd
+++ b/godot/scripts/ui/office_floor/office_sandbox.gd
@@ -15,6 +15,15 @@ extends Control
 ##   - Props with a manifest entry (PropCatalogue, #907) place at their authored
 ##     scale + feet anchor and occupy their footprint_tiles cells.
 ##
+## v4.1 (a(3)-lite, ADR-0018 amendment 2026-07-27): all grid arithmetic moved to the
+## first-class RenderGrid type (scripts/ui/office_floor/render_grid.gd). The ad hoc
+## string-keyed 32px snap-hack -- `_snap_to_grid` / `_cell_of` / `_cell_key` plus a shared
+## `String -> true` `_occupied_cells` dictionary keyed by stringified cell CENTRES with an
+## "a|"/"b|" floor prefix -- is RETIRED. One RenderGrid per floor, Vector2i cells, occupancy
+## keyed by sprite instance id. No behaviour change is intended: same lattices, same
+## row-major enumeration order (so the seeded furniture draw is unchanged), same
+## skip-do-not-steal occupancy semantics.
+##
 ## Everything v2 shipped still works: promoted-asset loader, prop placement, skin/mood
 ## cycling, scummy/decent office STATE, and in-context feedback.
 ##
@@ -50,6 +59,8 @@ const MAX_CATS := 8
 const MAX_PLACED := 64
 
 # Tile grid props snap to (matches the 32px source tile scale; feels like desks-on-a-grid).
+# a(3)-lite (ADR-0018 amendment, 2026-07-27): this is now only the CELL SIZE fed to the
+# first-class RenderGrid; the snap/cell/occupancy arithmetic itself lives there.
 const GRID := 32.0
 # LEGACY fallback prop height for assets WITHOUT a manifest entry (#907 integration:
 # manifested props scale via PropCatalogue.height_px instead of this force-scale).
@@ -226,7 +237,21 @@ var _occupant_scale: float = OCCUPANT_SCALE_DEFAULT
 var _pop_level: int = 0
 var _pop_level_b: int = 0                  # v4: the small floor has its own populate level
 var _furniture: Array = []                 # Sprite2D furniture placed by POPULATE (wall-affinity)
-var _occupied_cells: Dictionary = {}       # str(cell centre) -> true (furniture no-overlap)
+# a(3)-lite (ADR-0018 amendment): occupancy now lives in first-class RenderGrid instances,
+# ONE PER FLOOR. This retires `_occupied_cells: Dictionary` -- a str(cell centre) -> true map
+# whose keys carried an "a|"/"b|" prefix purely to stop the two compare floors colliding on
+# identical local coordinates. Separate grid objects make that prefix unnecessary, and cells
+# are real Vector2i instead of stringified float centres.
+# Both grids are anchored to their floor's inner bounds by _grid_for() on every access, so a
+# compare-view relayout cannot leave the lattice behind.
+var _grid := RenderGrid.new(GRID)          # LARGE / single floor occupancy lattice
+var _grid_b := RenderGrid.new(GRID)        # compare-view SMALL floor occupancy lattice
+# Free-placement snap lattice, origin (0,0). PRESERVED BEHAVIOUR, not an oversight: the
+# ghost preview and manual prop drops have always snapped on a screen-origin lattice while
+# occupancy/populate use the bounds-anchored one (the two are 16px out of phase because
+# _bounds_of() insets by 16). Unifying them would visibly shift every manual placement, which
+# is out of scope for a port that must look identical; the mismatch is now at least explicit.
+var _snap_grid := RenderGrid.new(GRID, Vector2.ZERO)
 var _cat_frame_sets: Array = []            # [{name, frames, anchored_set?}] real walk-cycle SpriteFrames
 var _cat_walk_report: String = ""
 # Anchor Sockets V2 demo state: glow toggle + doom-flavour hue selection.
@@ -389,7 +414,7 @@ func _process(_delta: float) -> void:
 			_ghost.visible = false
 		else:
 			_ghost.visible = true
-			_ghost.position = _snap_to_grid(mouse)
+			_ghost.position = _snap_grid.snap(mouse)
 	if _marker != null:
 		if _overlay_mode:
 			var ov := _nearest_overlay(mouse, af)
@@ -781,6 +806,14 @@ func _place_prop() -> void:
 # #907: a manifested prop OCCUPIES its footprint_tiles cells (display tiles are 64px =
 # 2x2 sandbox grid cells each) so POPULATE furniture will not overlap it. Unmanifested
 # props keep the old behaviour (no occupancy -- the renderer used to just guess).
+#
+# a(3)-lite SEAM (ADR-0018 amendment): this is the first consumer of RenderGrid, and
+# WEDNESDAY'S DECORATING RENDER (W2) is the next one -- it will ask this same grid for
+# footprint cells, free cells, and snaps. The doctrine line W2 must not cross, restated:
+# DECOR VALUE KEYS OFF OWNERSHIP + TIER + SPEND (sim-side counts); PLACEMENT IS EXPRESSION.
+# Occupancy here exists so props do not overlap and walkers do not stand inside furniture --
+# a picture-correctness concern. The moment a decor bonus is priced by WHICH CELL a prop
+# sits in, a spatial fact has become a gameplay input and ADR-0018 is breached.
 func _occupy_prop_footprint(spr: Sprite2D, f: OfficeFloor, asset_id: String) -> void:
 	var mid := _manifest_id_for(spr.texture, asset_id)
 	if mid == "":
@@ -788,24 +821,14 @@ func _occupy_prop_footprint(spr: Sprite2D, f: OfficeFloor, asset_id: String) -> 
 	var fp := PropCatalogue.footprint(mid)
 	var w_px := fp.x * DISPLAY_TILE_PX
 	var d_px := fp.y * DISPLAY_TILE_PX
-	var keys: Array = []
+	var g := _grid_for(f)
 	# Feet-anchored: footprint extends up from the feet row, centred horizontally.
-	var y0 := spr.position.y - d_px + GRID * 0.5
-	var x0 := spr.position.x - w_px * 0.5 + GRID * 0.5
-	var cols := int(ceil(w_px / GRID))
-	var rows := int(ceil(d_px / GRID))
-	for r in range(rows):
-		for c in range(cols):
-			var cell := _cell_of(f, Vector2(x0 + c * GRID, y0 + r * GRID))
-			var key := _cell_key(f, cell)
-			if not _occupied_cells.has(key):
-				_occupied_cells[key] = true
-				keys.append(key)
-	spr.set_meta("occupied_keys", keys)
-
-func _release_prop_footprint(spr: Sprite2D) -> void:
-	for key in spr.get_meta("occupied_keys", []):
-		_occupied_cells.erase(String(key))
+	var first := g.cell_at(Vector2(
+		spr.position.x - w_px * 0.5 + GRID * 0.5,
+		spr.position.y - d_px + GRID * 0.5))
+	var span := Vector2i(int(ceil(w_px / GRID)), int(ceil(d_px / GRID)))
+	# Cells already held by other props are SKIPPED, not stolen (unchanged behaviour).
+	g.occupy(g.footprint_cells(first, span), spr.get_instance_id())
 
 # --- Tier-1 collision: feed prop/furniture footprints to the floors ----------
 # Walkers must never STAND inside furniture. Each floor gets the no-stand rects
@@ -858,7 +881,7 @@ func _remove_nearest_prop(at: Vector2) -> void:
 	if best >= 0:
 		var spr = _placed_props[best]
 		if is_instance_valid(spr):
-			_release_prop_footprint(spr)
+			_release_occupancy(spr)
 			spr.queue_free()
 		_placed_props.remove_at(best)
 		_sync_blocked_rects()
@@ -866,36 +889,31 @@ func _remove_nearest_prop(at: Vector2) -> void:
 func _clear_props() -> void:
 	for spr in _placed_props:
 		if is_instance_valid(spr):
-			_release_prop_footprint(spr)
+			_release_occupancy(spr)
 			spr.queue_free()
 	_placed_props.clear()
 	_sync_blocked_rects()
 
-func _snap_to_grid(pos: Vector2) -> Vector2:
-	return Vector2(
-		floor(pos.x / GRID) * GRID + GRID * 0.5,
-		floor(pos.y / GRID) * GRID + GRID * 0.5)
+# a(3)-lite: the occupancy lattice for one floor, re-anchored to that floor's current
+# inner bounds on every access (compare-view relayout moves them). Replaces the old
+# _cell_of / _cell_key pair -- addressing is Vector2i on a per-floor grid, so no string
+# key and no "a|"/"b|" disambiguation prefix exist any more.
+func _grid_for(f: OfficeFloor) -> RenderGrid:
+	var g := _grid_b if (f == _floor_b and _floor_b != null) else _grid
+	g.set_bounds(_bounds_of(f))
+	return g
 
-# Occupancy key for a grid cell of a specific floor (cells are floor-local, so the two
-# compare floors would otherwise collide on identical coordinates).
-func _cell_key(f: OfficeFloor, cell: Vector2) -> String:
-	return ("b|" if f == _floor_b and _floor_b != null else "a|") + str(cell)
-
-# Resolve a floor-local point to its occupancy cell CENTRE on the floor's bounds lattice
-# (the same lattice _pick_wall_cell enumerates, so occupancy from placed props and
-# populate furniture actually collide instead of living on offset grids).
-func _cell_of(f: OfficeFloor, pos: Vector2) -> Vector2:
-	var b := _bounds_of(f)
-	var c := floorf((pos.x - b.position.x) / GRID)
-	var r := floorf((pos.y - b.position.y) / GRID)
-	return Vector2(
-		b.position.x + c * GRID + GRID * 0.5,
-		b.position.y + r * GRID + GRID * 0.5)
+# Release every cell a sprite holds. Both grids are asked because a sprite's parent floor
+# may already be mid-teardown when this runs, and instance ids are unique across floors.
+func _release_occupancy(spr: Node) -> void:
+	var owner_id := spr.get_instance_id()
+	_grid.release(owner_id)
+	_grid_b.release(owner_id)
 
 # Grid-snap, but if the point is within one grid cell of a wall, snap flush to that wall
 # (furniture wall-affinity for manual placement; the POPULATE placer uses walls exclusively).
 func _grid_or_wall(pos: Vector2, b: Rect2) -> Vector2:
-	var snapped := _snap_to_grid(pos)
+	var snapped := _snap_grid.snap(pos)
 	if pos.x - b.position.x < GRID:
 		snapped.x = b.position.x + GRID * 0.5
 	elif b.end.x - pos.x < GRID:
@@ -1151,24 +1169,24 @@ func _apply_pop_stage(f: OfficeFloor = null) -> void:
 func _spawn_furniture(f: OfficeFloor = null) -> bool:
 	var af := f if f != null else _floor
 	var cell := _pick_wall_cell(af)
-	if cell == Vector2.INF:
+	if cell == RenderGrid.NO_CELL:
 		return false
 	var kinds := _FURN_KINDS.keys()
 	var kind := String(kinds[_rng.randi() % kinds.size()])
 	var tex := _furniture_tex(kind)
+	var g := _grid_for(af)
 	var spr := Sprite2D.new()
 	spr.texture = tex
 	spr.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	var base := _prop_scale(tex)
 	spr.set_meta("base_scale", base)
 	spr.scale = base * _occupant_scale
-	spr.position = cell
+	spr.position = g.cell_centre(cell)
 	spr.z_index = 2
-	var key := _cell_key(af, cell)
-	spr.set_meta("cell_key", key)
 	af.add_child(spr)
 	_furn_of(af).append(spr)
-	_occupied_cells[key] = true
+	# Occupancy is keyed by the sprite's instance id -- no "cell_key" meta string any more.
+	g.occupy_cell(cell, spr.get_instance_id())
 	return true
 
 func _remove_furniture(f: OfficeFloor = null) -> void:
@@ -1177,36 +1195,24 @@ func _remove_furniture(f: OfficeFloor = null) -> void:
 		return
 	var spr = furn.pop_back()
 	if is_instance_valid(spr):
-		_occupied_cells.erase(String(spr.get_meta("cell_key", "")))
+		_release_occupancy(spr)
 		spr.queue_free()
 
-# Return a random unoccupied grid cell centre on the floor PERIMETER (wall-affinity). Falls
-# back to any interior cell if the perimeter is full. Returns Vector2.INF if nothing free.
-func _pick_wall_cell(f: OfficeFloor = null) -> Vector2:
+# Return a random unoccupied CELL on the floor PERIMETER (wall-affinity). Falls back to any
+# interior cell if the perimeter is full. Returns RenderGrid.NO_CELL if nothing is free.
+# The grid's enumerators are row-major, so the seeded _rng draw over `pool` is stable --
+# same order the hand-rolled double loop this replaced produced.
+func _pick_wall_cell(f: OfficeFloor = null) -> Vector2i:
 	var af := f if f != null else _floor
-	var b := _bounds_of(af)
-	var cols := int(b.size.x / GRID)
-	var rows := int(b.size.y / GRID)
-	if cols < 2 or rows < 2:
-		return Vector2.INF
-	var edge: Array = []
-	var inner: Array = []
-	for r in range(rows):
-		for c in range(cols):
-			var centre := Vector2(
-				b.position.x + c * GRID + GRID * 0.5,
-				b.position.y + r * GRID + GRID * 0.5)
-			if _occupied_cells.has(_cell_key(af, centre)):
-				continue
-			if c == 0 or c == cols - 1 or r == 0 or r == rows - 1:
-				edge.append(centre)
-			else:
-				inner.append(centre)
-	var pool: Array = edge if not edge.is_empty() else inner
+	var g := _grid_for(af)
+	if g.cols() < 2 or g.rows() < 2:
+		return RenderGrid.NO_CELL
+	var pool := g.edge_cells(true)
 	if pool.is_empty():
-		return Vector2.INF
-	var chosen: Vector2 = pool[_rng.randi() % pool.size()]
-	return chosen
+		pool = g.interior_cells(true)
+	if pool.is_empty():
+		return RenderGrid.NO_CELL
+	return pool[_rng.randi() % pool.size()]
 
 func _furniture_tex(kind: String) -> Texture2D:
 	var spec: Array = _FURN_KINDS[kind]
@@ -1292,7 +1298,7 @@ func _exit_compare() -> void:
 			var spr = _placed_props[i]
 			if not is_instance_valid(spr) or spr.get_parent() == _floor_b:
 				if is_instance_valid(spr):
-					_release_prop_footprint(spr)
+					_release_occupancy(spr)
 				_placed_props.remove_at(i)
 		for i in range(_overlays.size() - 1, -1, -1):
 			if not is_instance_valid(_overlays[i]) or _overlays[i].get_parent() == _floor_b:
@@ -1302,12 +1308,11 @@ func _exit_compare() -> void:
 	_roster_b.clear()
 	for spr in _furniture_b:
 		if is_instance_valid(spr):
-			_occupied_cells.erase(String(spr.get_meta("cell_key", "")))
+			_release_occupancy(spr)
 	_furniture_b.clear()
-	# Drop any remaining small-floor occupancy records.
-	for key in _occupied_cells.keys():
-		if String(key).begins_with("b|"):
-			_occupied_cells.erase(key)
+	# Drop any remaining small-floor occupancy records. This used to be a prefix scan over a
+	# shared string-keyed dict ("b|..."); with a grid PER FLOOR it is one clear().
+	_grid_b.clear()
 	_pop_level_b = 0
 	_apply_floor_styles()   # restore the single-view tier
 	_rebuild_prop_pool()
@@ -1369,6 +1374,7 @@ func _spawn_starter_props() -> void:
 		Vector2(b.position.x + GRID * 0.5, b.end.y - GRID * 0.5),
 	]
 	var kinds: Array = ["desk", "plant", "cabinet"]
+	var g := _grid_for(_floor_b)
 	for i in range(spots.size()):
 		var tex := _furniture_tex(String(kinds[i]))
 		var spr := Sprite2D.new()
@@ -1379,9 +1385,7 @@ func _spawn_starter_props() -> void:
 		spr.scale = base * _occupant_scale
 		spr.position = spots[i]
 		spr.z_index = 2
-		var key := _cell_key(_floor_b, _cell_of(_floor_b, spots[i]))
-		spr.set_meta("cell_key", key)
-		_occupied_cells[key] = true
+		g.occupy_cell(g.cell_at(spots[i]), spr.get_instance_id())
 		_floor_b.add_child(spr)
 		_furniture_b.append(spr)
 	_sync_blocked_rects()
@@ -1531,7 +1535,10 @@ func _clear_furniture() -> void:
 		if is_instance_valid(spr):
 			spr.queue_free()
 	_furniture_b.clear()
-	_occupied_cells.clear()
+	# Unchanged behaviour: clearing furniture drops ALL occupancy on both floors, manually
+	# placed props included (it was one shared dict before; it is two grids now).
+	_grid.clear()
+	_grid_b.clear()
 	_sync_blocked_rects()
 
 # --- Bulk toys --------------------------------------------------------------

--- a/godot/scripts/ui/office_floor/render_grid.gd
+++ b/godot/scripts/ui/office_floor/render_grid.gd
@@ -1,0 +1,357 @@
+extends RefCounted
+class_name RenderGrid
+## First-class RENDER-LAYER grid: Vector2i col/row addressing, world<->cell
+## conversion, snap, footprint occupancy, neighbour + enumeration queries.
+##
+## AUTHORITY: ADR-0018 (render-only office doctrine), a(3)-lite amendment
+## 2026-07-27. Quoting the ruling: a first-class integer grid type "is approved
+## as RENDER-LAYER INFRASTRUCTURE. Its consumers are prop placement, decorating
+## render, walk theatre, and click-targets." And the scope guard, verbatim:
+## "this grid is explicitly NOT a pathfinding or simulation grid; nothing
+## sim-side may read cell state".
+##
+## THE ARROW RULE (non-negotiable, enforced by review not by the compiler):
+##   The sim owns counts and quantities; the render owns coordinates.
+## Consequences for this file, permanently:
+##   - NO import of / reference to GameState, TurnManager, or anything in
+##     scripts/core that models the simulation. This script has ZERO project
+##     dependencies by design (it only uses engine built-ins), which is also
+##     why it is headless-unit-testable with no scene tree.
+##   - NO signals out of here into core. It is a passive value/utility object.
+##   - Nothing here is serialized into a save, a replay, or a leaderboard
+##     payload. Cell coordinates are a frame-local rendering detail; ADR-0006
+##     replays record (action, entity_id), never positions.
+##
+## SEAM NOTE -- decorating render (Wednesday's W2 block):
+##   W2's decorating system is the next consumer of this type: it will ask the
+##   grid which cells a decor prop occupies, which cells are free, and where a
+##   prop snaps. That is legitimate -- placement is EXPRESSION.
+##   The line W2 must not cross, restating ADR-0018: DECOR VALUE KEYS OFF
+##   OWNERSHIP + TIER + SPEND (sim-side counts), NEVER OFF PLACEMENT. The moment
+##   a decor bonus is priced by WHERE a prop sits -- which cell, which room,
+##   adjacency to another prop -- a spatial fact has become a gameplay input and
+##   the doctrine is breached through the back door. Occupancy queries here
+##   exist to stop props overlapping and to keep walkers out of furniture, i.e.
+##   to make the picture correct. They are not an economy input, and no
+##   sim-side caller may read them.
+##
+## RETIRES: office_sandbox.gd's ad hoc string-keyed 32px snap-hack
+## (`_snap_to_grid` / `_cell_of` / `_cell_key` + a `String -> true`
+## `_occupied_cells` dictionary keyed by stringified cell CENTRES, with an
+## "a|"/"b|" prefix to stop the two compare floors colliding). That debt is
+## replaced here by real Vector2i keys and per-floor grid instances.
+##
+## DETERMINISM: every enumeration accessor (all_cells / free_cells /
+## edge_cells / interior_cells) returns ROW-MAJOR order, so a seeded-RNG draw
+## over the result is independent of Dictionary iteration order -- the same rule
+## PropCatalogue.ids() follows for ADR-0006.
+
+## Sentinel "no such cell" return (pick/query misses). A real cell can be
+## negative, so the sentinel has to sit outside any plausible lattice.
+const NO_CELL := Vector2i(-2147483647, -2147483647)
+
+## Smallest legal cell edge in world units. A zero/negative cell size would make
+## every conversion a division by zero, so it is clamped with a warning instead.
+const MIN_CELL_PX := 1.0
+
+## World-unit size of one cell. Non-square grids are supported (isometric /
+## letterboxed tiles); the office uses a square 32. Assign through
+## set_cell_size(), which clamps to MIN_CELL_PX -- a zero edge would make every
+## conversion a division by zero.
+var cell_size: Vector2 = Vector2(32.0, 32.0)
+
+## World position of cell (0, 0)'s top-left corner. Callers anchoring to a
+## Control's inner rect pass that rect's position (see set_bounds).
+var origin: Vector2 = Vector2.ZERO
+
+var _cols: int = 0            # 0 = unbounded (no enumeration, no containment test)
+var _rows: int = 0
+var _occupied: Dictionary = {}      # Vector2i -> owner (Variant)
+var _owner_cells: Dictionary = {}   # owner -> Array[Vector2i]
+
+
+## `p_cell_size` accepts a float (square cells) or a Vector2 (non-square).
+func _init(p_cell_size: Variant = 32.0, p_origin: Vector2 = Vector2.ZERO) -> void:
+	set_cell_size(p_cell_size)
+	origin = p_origin
+
+
+func set_cell_size(v: Variant) -> void:
+	var s := cell_size
+	if v is Vector2:
+		s = v
+	elif v is Vector2i:
+		s = Vector2(v)
+	elif v is float or v is int:
+		s = Vector2(float(v), float(v))
+	else:
+		push_warning("RenderGrid.set_cell_size: unsupported type, keeping %s" % cell_size)
+		return
+	cell_size = Vector2(maxf(s.x, MIN_CELL_PX), maxf(s.y, MIN_CELL_PX))
+
+
+# --- Bounds -------------------------------------------------------------------
+## Anchor the lattice to a world-space rect: origin becomes the rect's top-left
+## and the grid gains a finite col/row extent (whole cells only -- a trailing
+## partial cell is not addressable, matching the sandbox's `int(size / GRID)`).
+## Re-calling this after a layout change is cheap and is how a resizable floor
+## keeps its lattice aligned.
+func set_bounds(rect: Rect2) -> void:
+	origin = rect.position
+	_cols = maxi(0, floori(rect.size.x / cell_size.x))
+	_rows = maxi(0, floori(rect.size.y / cell_size.y))
+
+
+func clear_bounds() -> void:
+	_cols = 0
+	_rows = 0
+
+
+func has_bounds() -> bool:
+	return _cols > 0 and _rows > 0
+
+
+func cols() -> int:
+	return _cols
+
+
+func rows() -> int:
+	return _rows
+
+
+## World rect the bounded lattice covers (whole cells only). Rect2() if unbounded.
+func bounds_rect() -> Rect2:
+	if not has_bounds():
+		return Rect2()
+	return Rect2(origin, Vector2(_cols * cell_size.x, _rows * cell_size.y))
+
+
+## True when `cell` is inside the bounded extent. An UNBOUNDED grid contains
+## every cell (including negative ones) -- it is an infinite lattice by design.
+func contains(cell: Vector2i) -> bool:
+	if not has_bounds():
+		return true
+	return cell.x >= 0 and cell.y >= 0 and cell.x < _cols and cell.y < _rows
+
+
+## Perimeter test. Always false on an unbounded grid (no perimeter exists).
+func is_edge_cell(cell: Vector2i) -> bool:
+	if not has_bounds() or not contains(cell):
+		return false
+	return cell.x == 0 or cell.y == 0 or cell.x == _cols - 1 or cell.y == _rows - 1
+
+
+# --- World <-> cell conversion ------------------------------------------------
+## The cell containing `world`. Floor division, so it is correct for NEGATIVE
+## coordinates too: a point one pixel left of the origin lands in col -1, not 0
+## (integer truncation would wrongly fold -1..+1 into the same column).
+func cell_at(world: Vector2) -> Vector2i:
+	return Vector2i(
+		floori((world.x - origin.x) / cell_size.x),
+		floori((world.y - origin.y) / cell_size.y))
+
+
+## Top-left world corner of `cell`. Round-trip guarantee:
+## cell_at(cell_origin(c)) == c for every c.
+func cell_origin(cell: Vector2i) -> Vector2:
+	return origin + Vector2(cell.x * cell_size.x, cell.y * cell_size.y)
+
+
+## World centre of `cell`. Round-trip guarantee:
+## cell_at(cell_centre(c)) == c for every c.
+func cell_centre(cell: Vector2i) -> Vector2:
+	return cell_origin(cell) + cell_size * 0.5
+
+
+func cell_rect(cell: Vector2i) -> Rect2:
+	return Rect2(cell_origin(cell), cell_size)
+
+
+## Snap a world point to its cell CENTRE (the sandbox's placement snap).
+func snap(world: Vector2) -> Vector2:
+	return cell_centre(cell_at(world))
+
+
+## Snap a world point to its cell's top-left CORNER (tile-aligned blits).
+func snap_to_corner(world: Vector2) -> Vector2:
+	return cell_origin(cell_at(world))
+
+
+# --- Footprints ---------------------------------------------------------------
+## The `size.x` x `size.y` block of cells whose top-left is `anchor`, row-major.
+## A non-positive size is clamped to 1 (a prop always occupies at least itself).
+func footprint_cells(anchor: Vector2i, size: Vector2i) -> Array[Vector2i]:
+	var w := maxi(1, size.x)
+	var h := maxi(1, size.y)
+	var out: Array[Vector2i] = []
+	for r in range(h):
+		for c in range(w):
+			out.append(Vector2i(anchor.x + c, anchor.y + r))
+	return out
+
+
+## Every cell a world-space rect touches, row-major. A zero-size rect yields the
+## single cell containing its position; a rect flush to a cell boundary does NOT
+## pick up the next cell along (half-open on the far edge), so two rects laid
+## edge-to-edge occupy disjoint cell sets.
+func cells_in_rect(rect: Rect2) -> Array[Vector2i]:
+	var r := rect.abs()
+	var first := cell_at(r.position)
+	var far := r.position + r.size
+	var last := Vector2i(
+		ceili((far.x - origin.x) / cell_size.x) - 1,
+		ceili((far.y - origin.y) / cell_size.y) - 1)
+	last = Vector2i(maxi(last.x, first.x), maxi(last.y, first.y))
+	return footprint_cells(first, Vector2i(last.x - first.x + 1, last.y - first.y + 1))
+
+
+# --- Occupancy ----------------------------------------------------------------
+## Claim one cell for `owner`. Returns false if the cell was ALREADY claimed
+## (by anyone, including `owner`) -- claims never silently steal.
+func occupy_cell(cell: Vector2i, owner: Variant) -> bool:
+	if _occupied.has(cell):
+		return false
+	_occupied[cell] = owner
+	var held: Array = _owner_cells.get(owner, [])
+	held.append(cell)
+	_owner_cells[owner] = held
+	return true
+
+
+## Claim every free cell in `cells` for `owner`; already-claimed cells are
+## SKIPPED, not stolen. Returns the cells actually claimed (row-major, i.e. the
+## input's order filtered). Partial claims are deliberate: it reproduces the
+## sandbox's prior behaviour where a prop footprint overlapping existing
+## furniture recorded only the cells it genuinely took.
+func occupy(cells: Array, owner: Variant) -> Array[Vector2i]:
+	var claimed: Array[Vector2i] = []
+	for c in cells:
+		if c is Vector2i and occupy_cell(c, owner):
+			claimed.append(c)
+	return claimed
+
+
+func is_occupied(cell: Vector2i) -> bool:
+	return _occupied.has(cell)
+
+
+## The owner holding `cell`, or null when free.
+func owner_of(cell: Vector2i) -> Variant:
+	return _occupied.get(cell, null)
+
+
+## Cells currently held by `owner` (row-major within each occupy() call).
+func cells_of(owner: Variant) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for c in _owner_cells.get(owner, []):
+		out.append(c)
+	return out
+
+
+## Free everything `owner` holds. Returns how many cells were released; 0 is a
+## normal answer (callers release defensively on teardown).
+func release(owner: Variant) -> int:
+	var held: Array = _owner_cells.get(owner, [])
+	for c in held:
+		if _occupied.get(c, null) == owner:
+			_occupied.erase(c)
+	_owner_cells.erase(owner)
+	return held.size()
+
+
+## Free one cell regardless of who holds it.
+func release_cell(cell: Vector2i) -> void:
+	if not _occupied.has(cell):
+		return
+	var owner: Variant = _occupied[cell]
+	_occupied.erase(cell)
+	var held: Array = _owner_cells.get(owner, [])
+	held.erase(cell)
+	if held.is_empty():
+		_owner_cells.erase(owner)
+	else:
+		_owner_cells[owner] = held
+
+
+func occupied_count() -> int:
+	return _occupied.size()
+
+
+func clear() -> void:
+	_occupied.clear()
+	_owner_cells.clear()
+
+
+# --- Neighbours ---------------------------------------------------------------
+## 4-neighbourhood in a fixed order (N, W, E, S) so callers are deterministic.
+## Out-of-bounds neighbours are dropped on a BOUNDED grid and kept on an
+## unbounded one.
+func neighbours4(cell: Vector2i) -> Array[Vector2i]:
+	return _filter_contained([
+		cell + Vector2i(0, -1), cell + Vector2i(-1, 0),
+		cell + Vector2i(1, 0), cell + Vector2i(0, 1)])
+
+
+## 8-neighbourhood, row-major (NW, N, NE, W, E, SW, S, SE).
+func neighbours8(cell: Vector2i) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for dy in [-1, 0, 1]:
+		for dx in [-1, 0, 1]:
+			if dx == 0 and dy == 0:
+				continue
+			out.append(cell + Vector2i(dx, dy))
+	return _filter_contained(out)
+
+
+## Neighbours that are in-bounds AND unoccupied.
+func free_neighbours4(cell: Vector2i) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for c in neighbours4(cell):
+		if not is_occupied(c):
+			out.append(c)
+	return out
+
+
+func _filter_contained(cells: Array) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for c in cells:
+		if contains(c):
+			out.append(c)
+	return out
+
+
+# --- Enumeration (bounded grids only) -----------------------------------------
+## Every cell in the bounded extent, ROW-MAJOR. Empty on an unbounded grid --
+## enumerating an infinite lattice is a caller bug, not a thing to guess at.
+func all_cells() -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for r in range(_rows):
+		for c in range(_cols):
+			out.append(Vector2i(c, r))
+	return out
+
+
+func free_cells() -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for c in all_cells():
+		if not is_occupied(c):
+			out.append(c)
+	return out
+
+
+## Perimeter cells, row-major. `only_free` drops occupied ones.
+func edge_cells(only_free: bool = false) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for c in all_cells():
+		if is_edge_cell(c) and not (only_free and is_occupied(c)):
+			out.append(c)
+	return out
+
+
+## Non-perimeter cells, row-major. `only_free` drops occupied ones.
+func interior_cells(only_free: bool = false) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for c in all_cells():
+		if not is_edge_cell(c) and not (only_free and is_occupied(c)):
+			out.append(c)
+	return out

--- a/godot/scripts/ui/office_floor/render_grid.gd.uid
+++ b/godot/scripts/ui/office_floor/render_grid.gd.uid
@@ -1,0 +1,1 @@
+uid://bk2iqcmh30v6e

--- a/godot/tests/unit/test_office_sandbox_v3.gd
+++ b/godot/tests/unit/test_office_sandbox_v3.gd
@@ -98,15 +98,21 @@ func test_furniture_hugs_walls_and_never_shares_a_cell():
 	for _i in range(6):
 		s._populate_up()
 	assert_true(s._furniture.size() > 0, "furniture was placed")
-	# no-overlap: every piece owns a distinct registered cell (the occupancy dict also
-	# holds small-floor starter cells + manifested-prop footprints, so compare per-piece).
+	# no-overlap: every piece owns a distinct registered cell (the grid also holds
+	# small-floor starter cells + manifested-prop footprints, so compare per-piece).
+	# a(3)-lite port: occupancy moved from a string-keyed dict + a "cell_key" sprite meta
+	# to per-floor RenderGrid instances keyed by the sprite's instance id.
+	var grid: RenderGrid = s._grid_for(s._floor)
 	var seen := {}
 	for spr in s._furniture:
-		var key := String(spr.get_meta("cell_key", ""))
-		assert_ne(key, "", "furniture piece carries its occupancy cell key")
-		assert_false(seen.has(key), "no two furniture share a grid cell (%s)" % key)
-		assert_true(s._occupied_cells.has(key), "furniture cell registered occupied")
-		seen[key] = true
+		var held: Array = grid.cells_of(spr.get_instance_id())
+		assert_eq(held.size(), 1, "furniture piece owns exactly one grid cell")
+		if held.is_empty():
+			continue
+		var held_cell: Vector2i = held[0]
+		assert_false(seen.has(held_cell), "no two furniture share a grid cell (%s)" % held_cell)
+		assert_true(grid.is_occupied(held_cell), "furniture cell registered occupied")
+		seen[held_cell] = true
 	# wall-affinity: every piece sits within one grid cell of a wall
 	var b: Rect2 = s._floor_bounds()
 	for spr in s._furniture:

--- a/godot/tests/unit/test_render_grid.gd
+++ b/godot/tests/unit/test_render_grid.gd
@@ -1,0 +1,290 @@
+extends GutTest
+## Guards RenderGrid (scripts/ui/office_floor/render_grid.gd), the a(3)-lite
+## render-layer grid approved by the ADR-0018 amendment (2026-07-27).
+##
+## What is actually at risk here, and so what these tests pin:
+##   - conversion ROUND-TRIPS: cell_at(cell_centre(c)) == c and
+##     cell_at(cell_origin(c)) == c, for positive AND negative cells;
+##   - NEGATIVE coordinates: the old hack used floor() on a screen-origin
+##     lattice; integer truncation would fold -1..+1 into column 0, so the
+##     floor-division behaviour is pinned explicitly;
+##   - SNAP EDGES: a point exactly on a cell boundary belongs to the cell it
+##     starts, not the one it ends -- half-open cells are what stops two
+##     edge-to-edge props claiming the same cell;
+##   - FOOTPRINT occupancy: claims skip (never steal) already-held cells, and
+##     release() frees exactly what an owner held;
+##   - row-major ENUMERATION order, which the sandbox's seeded furniture draw
+##     depends on for determinism (ADR-0006 discipline).
+##
+## Headless by construction: RenderGrid has no scene tree, no autoload, and no
+## sim dependency (the ADR-0018 arrow rule), so it needs no doubles.
+
+const CELL := 32.0
+
+
+func _grid(cell: Variant = CELL, origin: Vector2 = Vector2.ZERO) -> RenderGrid:
+	return RenderGrid.new(cell, origin)
+
+
+# --- Conversion round-trips ---------------------------------------------------
+func test_centre_and_origin_round_trip_through_cell_at() -> void:
+	var g := _grid()
+	for c in [Vector2i(0, 0), Vector2i(1, 0), Vector2i(7, 3), Vector2i(120, 45)]:
+		assert_eq(g.cell_at(g.cell_centre(c)), c, "centre round-trip for %s" % c)
+		assert_eq(g.cell_at(g.cell_origin(c)), c, "origin round-trip for %s" % c)
+
+
+func test_round_trip_holds_for_negative_cells() -> void:
+	var g := _grid()
+	for c in [Vector2i(-1, -1), Vector2i(-4, 2), Vector2i(3, -9), Vector2i(-31, -31)]:
+		assert_eq(g.cell_at(g.cell_centre(c)), c, "centre round-trip for %s" % c)
+		assert_eq(g.cell_at(g.cell_origin(c)), c, "origin round-trip for %s" % c)
+
+
+func test_round_trip_holds_with_a_shifted_origin() -> void:
+	# The sandbox anchors each floor's lattice at its inner bounds (16, 16).
+	var g := _grid(CELL, Vector2(16, 16))
+	assert_eq(g.cell_at(Vector2(16, 16)), Vector2i(0, 0))
+	assert_eq(g.cell_at(Vector2(15.9, 16)), Vector2i(-1, 0))
+	assert_eq(g.cell_centre(Vector2i(0, 0)), Vector2(32, 32))
+	for c in [Vector2i(0, 0), Vector2i(2, 5), Vector2i(-3, -1)]:
+		assert_eq(g.cell_at(g.cell_centre(c)), c, "shifted-origin round-trip %s" % c)
+
+
+func test_non_square_cells_convert_per_axis() -> void:
+	var g := _grid(Vector2(64, 16))
+	assert_eq(g.cell_at(Vector2(65, 17)), Vector2i(1, 1))
+	assert_eq(g.cell_centre(Vector2i(0, 0)), Vector2(32, 8))
+	assert_eq(g.cell_rect(Vector2i(1, 2)), Rect2(Vector2(64, 32), Vector2(64, 16)))
+
+
+func test_degenerate_cell_size_is_clamped_not_divided_by_zero() -> void:
+	var g := _grid(0.0)
+	assert_gt(g.cell_size.x, 0.0, "zero cell size must clamp, not divide by zero")
+	assert_eq(g.cell_at(Vector2(0, 0)), Vector2i(0, 0))
+
+
+# --- Negative coordinates -----------------------------------------------------
+func test_negative_world_points_use_floor_division_not_truncation() -> void:
+	var g := _grid()
+	# Truncation would put all four of these in column/row 0.
+	assert_eq(g.cell_at(Vector2(-1, -1)), Vector2i(-1, -1))
+	assert_eq(g.cell_at(Vector2(-0.001, -0.001)), Vector2i(-1, -1))
+	assert_eq(g.cell_at(Vector2(-32, -32)), Vector2i(-1, -1))
+	assert_eq(g.cell_at(Vector2(-33, -33)), Vector2i(-2, -2))
+	assert_eq(g.cell_at(Vector2(0, 0)), Vector2i(0, 0))
+
+
+func test_snap_is_continuous_across_the_origin() -> void:
+	var g := _grid()
+	assert_eq(g.snap(Vector2(-1, -1)), Vector2(-16, -16))
+	assert_eq(g.snap(Vector2(1, 1)), Vector2(16, 16))
+	assert_eq(g.snap(Vector2(-33, 5)), Vector2(-48, 16))
+
+
+# --- Snap edges ---------------------------------------------------------------
+func test_snap_edges_are_half_open() -> void:
+	var g := _grid()
+	# Exactly on a boundary belongs to the cell STARTING there.
+	assert_eq(g.cell_at(Vector2(32, 32)), Vector2i(1, 1))
+	assert_eq(g.cell_at(Vector2(31.999, 31.999)), Vector2i(0, 0))
+	assert_eq(g.snap(Vector2(32, 32)), Vector2(48, 48))
+	assert_eq(g.snap(Vector2(31.999, 0)), Vector2(16, 16))
+	# Both ends of a cell snap to the same centre.
+	assert_eq(g.snap(Vector2(0, 0)), g.snap(Vector2(31.5, 31.5)))
+
+
+func test_snap_to_corner_returns_the_cell_origin() -> void:
+	var g := _grid(CELL, Vector2(16, 16))
+	assert_eq(g.snap_to_corner(Vector2(50, 50)), Vector2(48, 48))
+	assert_eq(g.snap_to_corner(Vector2(16, 16)), Vector2(16, 16))
+
+
+# --- Footprints ---------------------------------------------------------------
+func test_footprint_cells_is_row_major_and_clamps_to_at_least_one_cell() -> void:
+	var g := _grid()
+	var cells := g.footprint_cells(Vector2i(2, 3), Vector2i(3, 2))
+	assert_eq(cells.size(), 6)
+	assert_eq(cells[0], Vector2i(2, 3))
+	assert_eq(cells[2], Vector2i(4, 3))
+	assert_eq(cells[3], Vector2i(2, 4), "row-major: 4th entry starts the next row")
+	assert_eq(cells[5], Vector2i(4, 4))
+	assert_eq(g.footprint_cells(Vector2i(0, 0), Vector2i(0, -5)).size(), 1,
+		"a non-positive footprint still occupies its own cell")
+
+
+func test_cells_in_rect_covers_touched_cells_without_bleeding_past_a_flush_edge() -> void:
+	var g := _grid()
+	assert_eq(g.cells_in_rect(Rect2(Vector2(0, 0), Vector2(32, 32))).size(), 1,
+		"a rect exactly one cell wide occupies one cell")
+	assert_eq(g.cells_in_rect(Rect2(Vector2(0, 0), Vector2(64, 32))).size(), 2)
+	assert_eq(g.cells_in_rect(Rect2(Vector2(16, 16), Vector2(32, 32))).size(), 4,
+		"a straddling rect touches four cells")
+	assert_eq(g.cells_in_rect(Rect2(Vector2(5, 5), Vector2.ZERO)),
+		[Vector2i(0, 0)] as Array[Vector2i], "a zero-size rect is one cell")
+	# Edge-to-edge rects must not overlap.
+	var a := g.cells_in_rect(Rect2(Vector2(0, 0), Vector2(32, 32)))
+	var b := g.cells_in_rect(Rect2(Vector2(32, 0), Vector2(32, 32)))
+	assert_false(a.has(b[0]), "flush neighbours claim disjoint cells")
+
+
+func test_cells_in_rect_handles_negative_space() -> void:
+	var g := _grid()
+	# -40 .. +8 spans cells -2, -1 and 0 on both axes.
+	var cells := g.cells_in_rect(Rect2(Vector2(-40, -40), Vector2(48, 48)))
+	assert_eq(cells.size(), 9)
+	assert_eq(cells[0], Vector2i(-2, -2), "row-major starts at the top-left cell")
+	assert_true(cells.has(Vector2i(-1, -1)))
+	assert_true(cells.has(Vector2i(0, 0)), "the far edge reaches 8px into cell 0")
+	assert_false(cells.has(Vector2i(1, 0)), "and stops there")
+
+
+# --- Occupancy ----------------------------------------------------------------
+func test_occupancy_claim_and_release_round_trip() -> void:
+	var g := _grid()
+	var cells := g.footprint_cells(Vector2i(1, 1), Vector2i(2, 2))
+	assert_eq(g.occupy(cells, "desk").size(), 4)
+	assert_true(g.is_occupied(Vector2i(2, 2)))
+	assert_eq(g.owner_of(Vector2i(2, 2)), "desk")
+	assert_eq(g.occupied_count(), 4)
+	assert_eq(g.cells_of("desk").size(), 4)
+	assert_eq(g.release("desk"), 4)
+	assert_eq(g.occupied_count(), 0)
+	assert_false(g.is_occupied(Vector2i(2, 2)))
+	assert_null(g.owner_of(Vector2i(2, 2)), "a free cell has no owner")
+
+
+func test_claims_skip_occupied_cells_instead_of_stealing_them() -> void:
+	var g := _grid()
+	g.occupy_cell(Vector2i(1, 1), "desk")
+	var claimed := g.occupy(g.footprint_cells(Vector2i(1, 1), Vector2i(2, 1)), "plant")
+	assert_eq(claimed, [Vector2i(2, 1)] as Array[Vector2i], "only the free cell is claimed")
+	assert_eq(g.owner_of(Vector2i(1, 1)), "desk", "an existing claim is never stolen")
+	# Releasing the loser must not free the winner's cell.
+	g.release("plant")
+	assert_true(g.is_occupied(Vector2i(1, 1)))
+	assert_false(g.is_occupied(Vector2i(2, 1)))
+
+
+func test_release_of_an_unknown_owner_is_a_no_op() -> void:
+	var g := _grid()
+	g.occupy_cell(Vector2i(0, 0), 7)
+	assert_eq(g.release(999), 0, "defensive teardown releases must be harmless")
+	assert_eq(g.occupied_count(), 1)
+
+
+func test_release_cell_drops_the_owner_when_its_last_cell_goes() -> void:
+	var g := _grid()
+	g.occupy(g.footprint_cells(Vector2i(0, 0), Vector2i(2, 1)), "server")
+	g.release_cell(Vector2i(0, 0))
+	assert_eq(g.cells_of("server"), [Vector2i(1, 0)] as Array[Vector2i])
+	g.release_cell(Vector2i(1, 0))
+	assert_eq(g.cells_of("server").size(), 0)
+	assert_eq(g.occupied_count(), 0)
+
+
+func test_clear_wipes_every_claim() -> void:
+	var g := _grid()
+	g.occupy_cell(Vector2i(0, 0), "a")
+	g.occupy_cell(Vector2i(9, 9), "b")
+	g.clear()
+	assert_eq(g.occupied_count(), 0)
+	assert_eq(g.cells_of("a").size(), 0)
+
+
+func test_two_grids_do_not_share_occupancy() -> void:
+	# This is the whole point of retiring the "a|"/"b|" string-key prefix: the two
+	# compare-view floors used to collide on identical local coordinates.
+	var a := _grid()
+	var b := _grid()
+	a.occupy_cell(Vector2i(3, 3), "desk")
+	assert_false(b.is_occupied(Vector2i(3, 3)), "grids are independent lattices")
+
+
+# --- Bounds, neighbours, enumeration ------------------------------------------
+func test_set_bounds_anchors_the_origin_and_counts_whole_cells_only() -> void:
+	var g := _grid()
+	g.set_bounds(Rect2(Vector2(16, 16), Vector2(200, 100)))
+	assert_eq(g.origin, Vector2(16, 16))
+	assert_eq(g.cols(), 6, "200/32 = 6 whole columns, the trailing 8px is unaddressable")
+	assert_eq(g.rows(), 3)
+	assert_true(g.has_bounds())
+	assert_eq(g.bounds_rect(), Rect2(Vector2(16, 16), Vector2(192, 96)))
+	assert_eq(g.cell_at(Vector2(16, 16)), Vector2i(0, 0))
+
+
+func test_unbounded_grid_contains_everything_and_enumerates_nothing() -> void:
+	var g := _grid()
+	assert_false(g.has_bounds())
+	assert_true(g.contains(Vector2i(-500, 900)), "an unbounded lattice is infinite")
+	assert_false(g.is_edge_cell(Vector2i(0, 0)), "no bounds means no perimeter")
+	assert_eq(g.all_cells().size(), 0, "enumerating an infinite lattice returns nothing")
+
+
+func test_containment_and_edge_detection_on_a_bounded_grid() -> void:
+	var g := _grid()
+	g.set_bounds(Rect2(Vector2.ZERO, Vector2(128, 96)))   # 4 x 3
+	assert_true(g.contains(Vector2i(3, 2)))
+	assert_false(g.contains(Vector2i(4, 2)))
+	assert_false(g.contains(Vector2i(-1, 0)))
+	assert_true(g.is_edge_cell(Vector2i(0, 1)))
+	assert_true(g.is_edge_cell(Vector2i(3, 1)))
+	assert_false(g.is_edge_cell(Vector2i(1, 1)), "the only interior cells are (1,1) and (2,1)")
+
+
+func test_enumeration_is_row_major_and_partitions_edge_from_interior() -> void:
+	var g := _grid()
+	g.set_bounds(Rect2(Vector2.ZERO, Vector2(128, 96)))   # 4 x 3 = 12 cells
+	var all := g.all_cells()
+	assert_eq(all.size(), 12)
+	assert_eq(all[0], Vector2i(0, 0))
+	assert_eq(all[3], Vector2i(3, 0))
+	assert_eq(all[4], Vector2i(0, 1), "row-major wrap")
+	assert_eq(g.edge_cells().size(), 10)
+	assert_eq(g.interior_cells(), [Vector2i(1, 1), Vector2i(2, 1)] as Array[Vector2i])
+	assert_eq(g.edge_cells().size() + g.interior_cells().size(), all.size(),
+		"edge and interior partition the grid")
+
+
+func test_free_filters_drop_occupied_cells() -> void:
+	var g := _grid()
+	g.set_bounds(Rect2(Vector2.ZERO, Vector2(128, 96)))
+	g.occupy_cell(Vector2i(0, 0), "desk")
+	g.occupy_cell(Vector2i(1, 1), "plant")
+	assert_eq(g.free_cells().size(), 10)
+	assert_eq(g.edge_cells(true).size(), 9)
+	assert_eq(g.interior_cells(true), [Vector2i(2, 1)] as Array[Vector2i])
+
+
+func test_neighbours_are_clipped_to_bounds_and_ordered() -> void:
+	var g := _grid()
+	g.set_bounds(Rect2(Vector2.ZERO, Vector2(128, 96)))
+	assert_eq(g.neighbours4(Vector2i(1, 1)),
+		[Vector2i(1, 0), Vector2i(0, 1), Vector2i(2, 1), Vector2i(1, 2)] as Array[Vector2i])
+	assert_eq(g.neighbours4(Vector2i(0, 0)),
+		[Vector2i(1, 0), Vector2i(0, 1)] as Array[Vector2i], "corner drops out-of-bounds")
+	assert_eq(g.neighbours8(Vector2i(1, 1)).size(), 8)
+	assert_eq(g.neighbours8(Vector2i(0, 0)).size(), 3)
+
+
+func test_unbounded_neighbours_keep_negative_cells() -> void:
+	var g := _grid()
+	assert_eq(g.neighbours4(Vector2i(0, 0)).size(), 4)
+	assert_true(g.neighbours4(Vector2i(0, 0)).has(Vector2i(-1, 0)))
+
+
+func test_free_neighbours_skip_claimed_cells() -> void:
+	var g := _grid()
+	g.set_bounds(Rect2(Vector2.ZERO, Vector2(128, 96)))
+	g.occupy_cell(Vector2i(1, 0), "desk")
+	var free := g.free_neighbours4(Vector2i(1, 1))
+	assert_false(free.has(Vector2i(1, 0)))
+	assert_eq(free.size(), 3)
+
+
+func test_no_cell_sentinel_cannot_collide_with_a_real_cell() -> void:
+	var g := _grid()
+	g.set_bounds(Rect2(Vector2.ZERO, Vector2(128, 96)))
+	assert_false(g.contains(RenderGrid.NO_CELL))
+	assert_ne(g.cell_at(Vector2(-1e6, -1e6)), RenderGrid.NO_CELL,
+		"the sentinel must sit outside any plausible lattice")

--- a/godot/tests/unit/test_render_grid.gd.uid
+++ b/godot/tests/unit/test_render_grid.gd.uid
@@ -1,0 +1,1 @@
+uid://c7c7f6vr6s4wk


### PR DESCRIPTION
## What

Builds the **a(3)-lite** grid Pip ruled for at 2026-07-27 1143, under the
**ADR-0018 amendment merged today**: a first-class integer grid type "is
approved as **RENDER-LAYER INFRASTRUCTURE**", with the non-negotiable scope
guard that it is "explicitly **not** a pathfinding or simulation grid; nothing
sim-side may read cell state".

## New: `godot/scripts/ui/office_floor/render_grid.gd`

`class_name RenderGrid extends RefCounted`. **Zero project dependencies by
construction** -- no `GameState`, nothing from `scripts/core`, no signals out.
That is the ADR-0018 arrow rule made structural (*the sim owns counts and
quantities; the render owns coordinates*), and it is also why the type is
headless unit-testable with no scene tree and no doubles.

| group | methods |
|---|---|
| conversion | `cell_at` `cell_origin` `cell_centre` `cell_rect` `snap` `snap_to_corner` |
| footprints | `footprint_cells(anchor, size)` `cells_in_rect(rect)` |
| occupancy | `occupy` `occupy_cell` `release` `release_cell` `is_occupied` `owner_of` `cells_of` `occupied_count` `clear` |
| bounds | `set_bounds` `clear_bounds` `has_bounds` `cols` `rows` `bounds_rect` `contains` `is_edge_cell` |
| neighbours | `neighbours4` `neighbours8` `free_neighbours4` |
| enumeration | `all_cells` `free_cells` `edge_cells` `interior_cells` |
| sentinel | `RenderGrid.NO_CELL` |

Semantics worth knowing before reviewing the port:

- **Floor division, not truncation** -- negative coordinates round-trip
  (`cell_at(cell_centre(c)) == c` for negative `c`; truncation would fold
  `-1..+1` into column 0).
- **Cells are half-open on the far edge** -- two rects laid edge-to-edge claim
  disjoint cell sets.
- **Claims skip, never steal** -- `occupy()` returns only the cells actually
  taken, leaving existing owners alone. This reproduces the sandbox's prior
  behaviour exactly.
- **Every enumerator is row-major**, so a seeded-RNG draw over the result is
  independent of `Dictionary` iteration order (same discipline as
  `PropCatalogue.ids()` for ADR-0006).
- Non-square cells supported; a zero/negative cell edge clamps rather than
  dividing by zero.

## Retired from `office_sandbox.gd`

The ad hoc string-keyed 32px snap-hack, in full:

- `_snap_to_grid()`, `_cell_of()`, `_cell_key()`
- the sprite metas `"cell_key"` and `"occupied_keys"`
- `_occupied_cells: Dictionary` -- a `String -> true` map keyed by
  **stringified cell centres**, whose `"a|"` / `"b|"` prefix existed *only* to
  stop the two compare-view floors colliding on identical local coordinates

Replaced by **one `RenderGrid` per floor** (`_grid` / `_grid_b`, re-anchored to
that floor's inner bounds on every access so a compare relayout cannot leave
the lattice behind), occupancy keyed by sprite `get_instance_id()`, plus a
screen-origin `_snap_grid` for the free-placement snap.

**Behaviour is intentionally unchanged.** Same two lattices, same row-major
enumeration (so the seeded furniture draw picks the same cells in the same
order), same skip-do-not-steal occupancy. One thing became *explicit* rather
than changed: the free-placement snap lattice and the occupancy lattice have
always been **16px out of phase** (`_bounds_of()` insets by 16). Unifying them
would visibly shift every manual placement, which is out of scope for a port
that must look identical -- so it is preserved and now documented at the
declaration.

`office_floor.gd` (the shipped continuous-placement view) is **untouched**.

## Seam note for Wednesday's W2 decorating block

Recorded in `render_grid.gd`'s header **and** at `_occupy_prop_footprint`,
restating ADR-0018 verbatim in intent:

> Decor value keys off **ownership + tier + spend** (sim-side counts); **placement is expression.**

Occupancy in this file exists so props do not overlap and walkers do not stand
inside furniture -- picture-correctness. The moment a decor bonus is priced by
*which cell* a prop sits in, a spatial fact has become a gameplay input and the
doctrine is breached through the back door.

## Tests

New `godot/tests/unit/test_render_grid.gd` -- 24 cases: conversion round-trips
(positive, negative, shifted-origin, non-square), floor-division vs truncation,
half-open snap edges, footprint + rect coverage incl. negative space,
occupancy claim/skip/release/clear, **per-grid isolation** (the test that pins
why the `"a|"`/`"b|"` prefix is gone), bounds/edge/interior partition,
neighbour clipping, `NO_CELL` sentinel safety.

`test_office_sandbox_v3.gd`'s occupancy assertion ported to the grid API (it
asserted on the now-retired `"cell_key"` meta).

**Fast gate: 836 tests, 0 failures, 86/86 files collected.**

---

Follows ADR-0018 (render-only office doctrine) + its a(3)-lite amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
