### PR TITLE
feat(0014): conference rhythm-break shell -- commit, travel+away exposure, auto-resolve, backlog return (flavor yields)

### DIFF
--- a/godot/data/actions/travel.json
+++ b/godot/data/actions/travel.json
@@ -22,6 +22,14 @@
 			"is_stub": true
 		},
 		{
+			"id": "attend_conference_trip",
+			"name": "Attend Conference (trip)",
+			"description": "Leave for a few days. Travel cash up front, ALL your remaining Attention for the window, and the world keeps running while you are gone -- you come home to a backlog.",
+			"costs": {},
+			"category": "travel",
+			"_seam": "ADR-0014 rhythm-break SHELL (scripts/core/conference_trip.gd). Costs are {} on purpose: travel cash and Attention are consumed by ConferenceTrip at commit time, not by the plan queue, because the trip resolves synchronously instead of queueing. The legacy instant attend_conference (#468/#469) above is untouched -- the two merge when adoption-v1 lands."
+		},
+		{
 			"id": "send_delegation",
 			"name": "Send Delegation",
 			"description": "[Coming Soon] Send researchers to attend on your behalf",

--- a/godot/data/events/conferences.json
+++ b/godot/data/events/conferences.json
@@ -1,0 +1,65 @@
+{
+	"_description": "Conference RHYTHM-BREAK shell catalogue (ADR-0014, Pip ruling 2026-07-27). Tempo data ONLY: how long the founder is away and what the trip reads like. Deliberately tiny (3 entries) -- this is the placeholder that turns the travel menu's '[Coming Soon]' into something shippable.",
+	"_grain": "duration_turns and travel_days are DAY TICKS (GameState.turn is the workday tick beneath the plan month, ADR-0009). away window = travel_days + duration_turns + travel_days.",
+	"_seam_catalogue": "The richer #468 catalogue lives in scripts/core/conferences.gd (prestige, submission deadlines, acceptance rolls). Ids here MATCH its ids so the two merge cleanly once adoption-v1 lands and this shell stops being flavor-only. Do NOT duplicate yield numbers into this file.",
+	"_seam_yields": "flavor_reputation and contacts are FIRST-PASS PLACEHOLDERS. Real adoption-accelerant multipliers and contacts-as-receivables (ADR-0014 point 3, Ledger counterparty slot) attach at ConferenceTrip._apply_flavor_yields -- swap the function body, not this schema.",
+	"conferences": [
+		{
+			"id": "safety_retreat",
+			"name": "Safety Research Retreat",
+			"duration_turns": 3,
+			"travel_days": 1,
+			"travel_cost": 900,
+			"flavor_reputation": 1.0,
+			"blurb": "A converted farmhouse, no wifi in the barn, forty people who all read the same preprint last week.",
+			"vignette": [
+				"The shuttle drops you at a farmhouse that has been a conference venue for exactly four years and a working farm for two hundred.",
+				"There is no wifi in the barn. This is presented as a feature. By the second afternoon you agree.",
+				"Someone sketches an argument on the back of a feed-store receipt. You keep the receipt."
+			],
+			"contacts": [
+				"a postdoc who runs the whiteboard",
+				"the organiser who never sits down",
+				"a funder's analyst, off the record"
+			]
+		},
+		{
+			"id": "facct",
+			"name": "FAccT",
+			"duration_turns": 3,
+			"travel_days": 1,
+			"travel_cost": 2200,
+			"flavor_reputation": 1.5,
+			"blurb": "Hotel ballroom, four parallel tracks, and the hallway is louder than any of them.",
+			"vignette": [
+				"Badge, lanyard, tote bag, a program you will not open. The ballroom carpet has a pattern designed to hide spills.",
+				"You attend one session in full and three in the hallway outside it. The hallway ones go better.",
+				"A policy person hands you a card and says 'send me the thing' without specifying which thing."
+			],
+			"contacts": [
+				"a policy staffer with a card and no title",
+				"an auditor who wants your incident log",
+				"a journalist pretending not to take notes"
+			]
+		},
+		{
+			"id": "neurips",
+			"name": "NeurIPS",
+			"duration_turns": 5,
+			"travel_days": 2,
+			"travel_cost": 5400,
+			"flavor_reputation": 2.5,
+			"blurb": "Convention-centre scale. Eighteen thousand people and a poster hall you could land a plane in.",
+			"vignette": [
+				"The poster hall is a hangar. You walk it once end to end to establish that walking it is not a plan.",
+				"Your inbox is a country you have emigrated from. The time zone helps. Nothing else does.",
+				"At a party in a rented warehouse someone from a rival lab is very friendly and asks nothing at all about your work."
+			],
+			"contacts": [
+				"a rival's engineer, unguarded at hour eleven",
+				"a lab director's chief of staff",
+				"a hardware vendor who owes someone a favour"
+			]
+		}
+	]
+}

--- a/godot/data/icon_mapping.json
+++ b/godot/data/icon_mapping.json
@@ -143,6 +143,11 @@
       "status": "mapped",
       "note": "#768 interim: reused international-cooperation icon (travel/conference theme)"
     },
+    "attend_conference_trip": {
+      "icon": "res://assets/icons/actions_policies/action_policy_international_cooperation_64.png",
+      "status": "mapped",
+      "note": "ADR-0014 rhythm-break shell: shares the attend_conference icon until the two attendance paths merge (post adoption-v1)"
+    },
     "send_delegation": {
       "icon": "res://assets/icons/actions/action_publicity_network_64.png",
       "status": "mapped",

--- a/godot/scenes/ui/conference_vignette.tscn
+++ b/godot/scenes/ui/conference_vignette.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://c0nfvign3tte01x"]
+
+[ext_resource type="Script" path="res://scripts/ui/conference_vignette.gd" id="1_confvig"]
+
+[node name="ConferenceVignette" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_confvig")

--- a/godot/scripts/core/conference_trip.gd
+++ b/godot/scripts/core/conference_trip.gd
@@ -1,0 +1,378 @@
+class_name ConferenceTrip
+extends RefCounted
+## The conference RHYTHM-BREAK shell (ADR-0014; Pip's 2026-07-27 rulings).
+##
+## WHAT THIS IS: the player voluntarily leaves the normal turn rhythm. Committing to a
+## conference consumes ALL of the founder's remaining Attention for the away window (Pip,
+## 2026-07-27 1555), pays travel cash up front, and hands the next N day-ticks to the
+## standing plan. The world keeps running while the founder is gone -- events fire, salaries
+## bill, the ledger compounds -- and everything that happened comes home as a BACKLOG the
+## player reads on return. The HoMM analogy: opt into the pocket, the map resolves, the
+## outcome is carried back.
+##
+## WHAT THIS IS NOT: the yields. Reputation and the named contact below are FLAVOR-ONLY
+## first-pass placeholders. See the SEAM banners.
+##
+## MODEL (A) -- SKIP-TURNS, per the design seed's recommendation. The away window is real
+## day-ticks driven through the EXISTING MonthController.advance_tick() path, in the existing
+## order, drawing from the existing state.rng. No new RNG source, no new turn loop, no
+## reordering of TurnManager's load-bearing steps (turn_manager.gd start_turn docstring:
+## "STEP ORDER IS LOAD-BEARING"). Determinism is therefore free by construction: an away
+## window is a pure function of (state, rng position, conference), so a replay re-simulates
+## it identically.
+##
+## THE ANTI-FREE-BUTTON PROPERTY (seed section 2 -- protect this in any future edit): the
+## trip must never be strictly dominant. Three real costs are wired in here:
+##   1. travel cash leaves immediately (spiky cash flow, ADR-0012);
+##   2. the founder's remaining Attention for the window is consumed and each fresh month
+##      that opens while away is drained again -- nothing can be planned from the road;
+##   3. with no Attention and no reserve, response windows that fire while away auto-resolve
+##      as IGNORE (the documented default, seed section 1) and cost the nonresponse
+##      reputation penalty. An UNIGNORABLE window CUTS THE TRIP SHORT and comes home still
+##      queued for the player to answer.
+## If a later edit removes all three, the framing collapses into a free button.
+##
+## FEED-CHANNEL DISCIPLINE (seed section 1, FRESH_EYES item 9, #877 modal-stacking history):
+## this file produces ONE ordered backlog array. It never opens a dialog and never surfaces
+## anything itself. main_ui renders it as a SINGLE dismissible panel on return; the deferred
+## window (if any) is listed at the TOP and is only surfaced as a real dialog AFTER that
+## panel is closed -- one surface at a time, never a stack of N modals for N missed ticks.
+
+const Definitions = preload("res://scripts/data/definition_loader.gd")
+
+const CATALOGUE_PATH := "res://data/events/conferences.json"
+
+# Runaway guard for the window-drain inner loop. A tick cannot legitimately queue this many
+# windows; if it ever does, we cut the trip short rather than spin.
+const WINDOW_DRAIN_GUARD := 64
+
+static var _catalogue: Array = []
+
+
+# ---------------------------------------------------------------------------
+# Catalogue
+# ---------------------------------------------------------------------------
+static func catalogue() -> Array:
+	"""The shell catalogue (data/events/conferences.json), cached after first load."""
+	if _catalogue.is_empty():
+		var data := Definitions.load_object(CATALOGUE_PATH, "ConferenceTrip")
+		var out: Array = []
+		for entry in data.get("conferences", []):
+			if entry is Dictionary:
+				out.append(entry)
+		_catalogue = out
+	return _catalogue
+
+
+static func reload_catalogue() -> void:
+	"""Drop the cache (tests / data tuning) -- mirrors GameActions.reload_definitions()."""
+	_catalogue = []
+
+
+static func by_id(conf_id: String) -> Dictionary:
+	for conf in catalogue():
+		if String(conf.get("id", "")) == conf_id:
+			return conf
+	return {}
+
+
+static func away_ticks(conf: Dictionary) -> int:
+	"""The exposed window in day-ticks: travel out + the conference + travel back.
+	Pip's 2026-07-27 ruling -- travel days are part of the away window, not free."""
+	var travel: int = max(0, int(conf.get("travel_days", 0)))
+	var duration: int = max(1, int(conf.get("duration_turns", 1)))
+	return travel + duration + travel
+
+
+static func can_commit(state: GameState, conf_id: String) -> Dictionary:
+	"""Gate the commit. Returns {ok: bool, reason: String}."""
+	if state == null:
+		return {"ok": false, "reason": "no game state"}
+	if state.game_over:
+		return {"ok": false, "reason": "the run is over"}
+	var conf := by_id(conf_id)
+	if conf.is_empty():
+		return {"ok": false, "reason": "Conference not found: %s" % conf_id}
+	if state.has_attended_conference(conf_id):
+		return {"ok": false, "reason": "Already attended %s this year" % String(conf.get("name", conf_id))}
+	var cost: int = int(conf.get("travel_cost", 0))
+	if cost > 0 and not state.can_afford({"money": cost}):
+		return {"ok": false, "reason": "Cannot afford travel: %s" % GameConfig.format_money(cost)}
+	return {"ok": true, "reason": ""}
+
+
+# ---------------------------------------------------------------------------
+# The trip
+# ---------------------------------------------------------------------------
+static func run_trip(state: GameState, controller, conf_id: String) -> Dictionary:
+	"""Commit to a conference and resolve the whole away window SYNCHRONOUSLY.
+
+	`controller` is the live MonthController (untyped, matching MonthController's own
+	turn_manager field, so tests can drive this without class load-order coupling).
+
+	Synchronous on purpose: the sim outcome is fully determined at commit time, so the
+	presentation layer (fade -> vignette -> fade) is pure theatre over an already-decided
+	result. Nothing about the mini-scene can influence the simulation -- the same one-way
+	arrow ADR-0018 draws for the office render surface.
+
+	Returns the trip record consumed by the vignette scene and the return backlog panel."""
+	var gate := can_commit(state, conf_id)
+	if not bool(gate.get("ok", false)):
+		return {"success": false, "message": String(gate.get("reason", "cannot attend")), "backlog": []}
+
+	var conf := by_id(conf_id)
+	var ticks := away_ticks(conf)
+	var backlog: Array = []
+	var trip := {
+		"success": true,
+		"conference_id": conf_id,
+		"conference": conf.duplicate(true),
+		"away_ticks": ticks,
+		"ticks_resolved": 0,
+		"cut_short": false,
+		"cut_short_reason": "",
+		"attention_consumed": 0,
+		"travel_cost": int(conf.get("travel_cost", 0)),
+		"start_turn": state.turn,
+		"end_turn": state.turn,
+		"backlog": backlog,
+		"memento": {},
+	}
+
+	# --- Book it. Travel cash leaves NOW (cost #1 of the anti-free-button property). ---
+	var cost: int = int(conf.get("travel_cost", 0))
+	if cost > 0:
+		state.spend_resources({"money": cost})
+	state.mark_conference_attended(conf_id)
+
+	# --- Commit the OPEN plan turn with whatever the player already queued. That queue IS
+	# the standing plan for the departure tick; an empty one routes through the canonical
+	# pass, exactly as GameManager.end_month() does for an empty month. ---
+	_commit_open_turn(state, controller)
+	trip["attention_consumed"] = int(trip["attention_consumed"]) + _consume_founder_capacity(state)
+
+	# --- The away window. ---
+	for _i in ticks:
+		if state.game_over:
+			trip["cut_short"] = true
+			trip["cut_short_reason"] = "The run ended while you were away."
+			break
+		if controller == null:
+			break
+
+		var tick_result: Dictionary = controller.advance_tick()
+		trip["ticks_resolved"] = int(trip["ticks_resolved"]) + 1
+		collect_tick(backlog, state.turn, tick_result)
+
+		if String(tick_result.get("status", "")) == "paused_on_window":
+			var drain := _drain_windows_while_away(state, controller, backlog)
+			if not bool(drain.get("ok", false)):
+				trip["cut_short"] = true
+				trip["cut_short_reason"] = String(drain.get("reason", ""))
+				break
+
+		# A fresh month opened mid-trip: the boundary tick is HELD OPEN as that month's plan
+		# phase (MonthController.month_open_pending). The founder is not there to plan it, so
+		# the standing plan commits it and the new Attention grant is consumed immediately --
+		# nothing can be planned from the road (cost #2).
+		if bool(controller.month_open_pending):
+			_commit_open_turn(state, controller)
+			trip["attention_consumed"] = int(trip["attention_consumed"]) + _consume_founder_capacity(state)
+
+	trip["end_turn"] = state.turn
+
+	# --- Home. Flavor yields + the stamped memento. ---
+	trip["memento"] = _apply_flavor_yields(state, conf, trip)
+	return trip
+
+
+static func collect_tick(backlog: Array, turn: int, tick_result: Dictionary) -> void:
+	"""Fold ONE MonthController.advance_tick() result into the return backlog, in surfaced
+	order. Kept a separate static so it is unit-testable against a synthetic tick result
+	without running a whole sim.
+
+	Entries are plain data: {kind, turn, ...}. kind is one of
+	  "feed"               -- a readable feed line that accrued while away
+	  "month_opened"       -- a plan month began with nobody home to plan it
+	  "strategic_released" -- queued strategic WIP whose duration elapsed
+	  "window_auto_ignored"-- a response window fired and auto-resolved to the IGNORE default
+	  "window_deferred"    -- an unignorable window that cut the trip short (rendered FIRST)"""
+	for item in tick_result.get("feed", []):
+		if not (item is Dictionary):
+			continue
+		var ev: Dictionary = item.get("event", {})
+		if not (ev is Dictionary):
+			ev = {}
+		backlog.append({
+			"kind": "feed",
+			"turn": turn,
+			"source_id": String(item.get("source_id", "?")),
+			"id": String(ev.get("id", "")),
+			"name": String(ev.get("name", ev.get("id", "update"))),
+			"message": String(ev.get("message", "")),
+			"channel": String(ev.get("channel", "normal")),
+		})
+
+	if bool(tick_result.get("month_opened", false)):
+		backlog.append({
+			"kind": "month_opened",
+			"turn": turn,
+			"name": "A new month opened while you were away",
+			"message": "The month's Attention grant went unplanned -- you were not there to spend it.",
+		})
+
+	for released in tick_result.get("released", []):
+		if not (released is Dictionary):
+			continue
+		backlog.append({
+			"kind": "strategic_released",
+			"turn": turn,
+			"name": "Strategic work landed: %s" % String(released.get("action_id", "?")),
+			"message": "Queued before you left; its duration elapsed while you were gone.",
+		})
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+static func _commit_open_turn(state: GameState, controller) -> void:
+	"""Run the currently-open plan turn's consequence phase with the standing plan.
+
+	Mirrors the head of GameManager.end_month() deliberately: an empty queue routes through
+	GameActions.PASS_ACTION_ID (the canonical, cost-0, determinism-safe no-op) rather than
+	erroring, and the open turn is executed via TurnManager.execute_turn(). We do NOT
+	duplicate end_month()'s implicit-reserve line -- the founder is away, so there is no
+	reserve to hold; _consume_founder_capacity takes the remainder instead."""
+	if state.game_over:
+		return
+	if state.queued_actions.is_empty():
+		state.queued_actions.append(GameActions.PASS_ACTION_ID)
+	if controller != null and controller.turn_manager != null:
+		controller.turn_manager.execute_turn()
+
+
+static func _consume_founder_capacity(state: GameState) -> int:
+	"""Pip's 2026-07-27 1555 ruling: attending consumes ALL the founder's remaining
+	attention/action capacity for the away window.
+
+	==== SEAM: ATTENTION MIGRATION ====
+	This is the ONLY place this lane touches the founder currency, and it spends through the
+	EXISTING mechanism (MonthPlan.spend_attention) rather than migrating anything. When L2
+	deletes the legacy AP pool and re-homes cost dicts onto Attention/staff (month_plan.gd
+	class docstring), this one function is the entire surface that has to move. Do not spread
+	capacity arithmetic through the trip loop.
+	Returns the Attention actually consumed (for the return panel's honesty about the cost)."""
+	if state.month_plan == null:
+		return 0
+	var free: int = state.month_plan.available()
+	if free <= 0:
+		return 0
+	state.month_plan.spend_attention(free)
+	return free
+
+
+static func _drain_windows_while_away(state: GameState, controller, backlog: Array) -> Dictionary:
+	"""Resolve response windows that fired with nobody home.
+
+	Seed section 1: "No response-window items should accrue while away (a response window
+	demands presence by definition). An event that WOULD have opened one either auto-resolves
+	to a documented default, or defers to the founder's first turn back."
+	Both halves are implemented:
+	  * ignorable window -> MonthController.skip_current_window() = the documented default
+	    (auto-resolve as IGNORE + the mild nonresponse reputation penalty). Uses state.rng
+	    through the same WindowResolver path normal play uses -- no new stream.
+	  * UNIGNORABLE window -> refuses to be skipped by construction, so it stays queued and
+	    the trip is CUT SHORT. It comes home with the player and is answered on return. This
+	    is also the soft-lock guard: we never force-resolve a window the engine says must be
+	    handled, and we never spin waiting for one.
+	Returns {ok: bool, reason: String}. ok=false means cut the trip short."""
+	var guard := 0
+	while controller.is_paused() and not controller.window_queue.is_empty():
+		guard += 1
+		if guard > WINDOW_DRAIN_GUARD:
+			return {"ok": false, "reason": "Too many demands at once -- you came home early."}
+		var window: Dictionary = controller.window_queue[0]
+		var label := String(window.get("name", window.get("id", "something")))
+
+		if EventTiers.is_unignorable(window):
+			backlog.push_front({
+				"kind": "window_deferred",
+				"turn": state.turn,
+				"id": String(window.get("id", "")),
+				"name": label,
+				"message": "This could not wait. You came home early; it is still open.",
+			})
+			return {"ok": false, "reason": "%s demanded your presence." % label}
+
+		var result: Dictionary = controller.skip_current_window()
+		if not bool(result.get("success", false)):
+			# The engine refused the skip for some other reason -- do not spin, do not
+			# force-resolve. Leave it queued and come home to it.
+			backlog.push_front({
+				"kind": "window_deferred",
+				"turn": state.turn,
+				"id": String(window.get("id", "")),
+				"name": label,
+				"message": String(result.get("message", "Still open on your return.")),
+			})
+			return {"ok": false, "reason": "%s could not be left unanswered." % label}
+
+		backlog.append({
+			"kind": "window_auto_ignored",
+			"turn": state.turn,
+			"id": String(window.get("id", "")),
+			"name": label,
+			"message": String(result.get("message", "Went unanswered while you were away.")),
+		})
+	return {"ok": true, "reason": ""}
+
+
+static func _apply_flavor_yields(state: GameState, conf: Dictionary, trip: Dictionary) -> Dictionary:
+	"""==== SEAM: REAL YIELDS ATTACH HERE ====
+	FIRST PASS, FLAVOR ONLY -- deliberately, per the design seed's shell-vs-yields split.
+
+	What lands today: a small reputation nudge and ONE named contact breadcrumb with no
+	receivable behavior whatsoever.
+
+	What replaces it AFTER adoption-v1 (ADR-0014 point 3, WS3_FINISH_OR_DROP sequencing):
+	  * the adoption-accelerant multiplier on the player's published work;
+	  * contacts minted as real receivables into the Ledger's counterparty slot
+	    (ledger.gd counterparty field, DQ-9);
+	  * delegate-vs-founder yield scaling (ADR-0014 point 2).
+	Swap THIS FUNCTION BODY. The UX above it -- commit, fade, vignette, away window, backlog
+	panel -- does not care whether its yield hook is a stub or a real accelerant call, and
+	must not be re-opened to wire the real numbers.
+
+	The contact pick is the trip's only NEW rng draw. It comes from state.rng (the one
+	deterministic stream, ADR-0006) and is recorded to the verification artifact like every
+	other draw, so replays stay self-consistent. It is drawn only when a trip happens, so
+	no pre-existing replay is disturbed."""
+	var rep_gain: float = float(conf.get("flavor_reputation", 1.0))
+	if rep_gain > 0.0:
+		state.add_resources({"reputation": rep_gain})
+
+	var contact: Dictionary = {}
+	var pool: Array = conf.get("contacts", [])
+	if not pool.is_empty():
+		var idx: int = int(state.rng.randi() % pool.size())
+		VerificationTracker.record_rng_outcome("conference_contact_pick", float(idx), state.turn)
+		contact = {
+			"name": String(pool[idx]),
+			"met_at": String(conf.get("name", "")),
+			"met_on_turn": state.turn,
+			"receivable": null,   # SEAM: becomes a Ledger counterparty entry post adoption-v1
+			"first_pass": true,
+		}
+
+	var name := String(conf.get("name", "the conference"))
+	var line := "Back from %s after %d days." % [name, int(trip.get("ticks_resolved", 0))]
+	if bool(trip.get("cut_short", false)):
+		line = "Back from %s early -- %s" % [name, String(trip.get("cut_short_reason", ""))]
+
+	return {
+		"first_pass": true,   # honest label: these are placeholder yields, not the real ones
+		"line": line,
+		"reputation_gain": rep_gain,
+		"contact": contact,
+		"keepsake": "Lanyard from %s, kept." % name,
+	}

--- a/godot/scripts/core/conference_trip.gd.uid
+++ b/godot/scripts/core/conference_trip.gd.uid
@@ -1,0 +1,1 @@
+uid://ijnpxep67iy0

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -29,6 +29,17 @@ var _rival_cap_snapshot: Dictionary = {}
 # Synthetic month-review dialog id -- intercepted by resolve_event before any engine path.
 const MONTH_REVIEW_EVENT_ID := "__month_review__"
 
+# --- Conference rhythm break (ADR-0014 shell; scripts/core/conference_trip.gd) ---
+# One-shot handoff flag: main.tscn is LEFT for the conference mini-scene and re-entered
+# afterwards. main_ui._boot_game() would otherwise start_new_game() and destroy the live run,
+# so re-entry checks this and resumes in place instead. Set by the vignette on its way out,
+# cleared by resume_in_place(). Deliberately NOT serialized -- it is a scene-handoff flag,
+# never simulation state.
+var pending_resume: bool = false
+# The most recent resolved trip record (ConferenceTrip.run_trip). Read by the vignette scene
+# and by the return backlog panel. Display data only; the sim already consumed its effects.
+var last_conference_trip: Dictionary = {}
+
 func _ready():
 	print("[GameManager] Pure GDScript version ready")
 
@@ -543,6 +554,63 @@ func start_next_turn():
 #   month boundary -> review dialog -> next plan phase (boundary tick held open).
 # Guard rule (sacred): no routine decision hangs on a day tick -- only windows pause.
 # ============================================================================
+
+func attend_conference_trip(conf_id: String) -> Dictionary:
+	"""Commit to a conference and resolve the whole away window (ADR-0014 rhythm-break shell).
+
+	The SIM half runs here and finishes before the player sees anything: ConferenceTrip
+	drives real day-ticks through the existing MonthController, so the outcome is fully
+	determined at commit time and replays identically. The PRESENTATION half (fade ->
+	vignette scene -> fade -> return backlog panel) is theatre over an already-decided
+	result -- the caller navigates after this returns success.
+
+	Returns the trip record (see ConferenceTrip.run_trip), or {success:false, message} if
+	the commit was refused."""
+	if not is_initialized:
+		error_occurred.emit("Cannot attend: Game not initialized")
+		return {"success": false, "message": "Game not initialized"}
+	# Stop any in-flight timer-driven month playback first: the away window advances the same
+	# ticks synchronously, and two drivers on one MonthController would interleave.
+	month_playback_active = false
+	var trip: Dictionary = ConferenceTrip.run_trip(state, month_controller, conf_id)
+	if not bool(trip.get("success", false)):
+		error_occurred.emit(String(trip.get("message", "Cannot attend that conference")))
+		return trip
+	last_conference_trip = trip
+	print("[GameManager] Conference trip resolved: %s, turns %d..%d, %d backlog items%s" % [
+		conf_id, int(trip.get("start_turn", 0)), int(trip.get("end_turn", 0)),
+		(trip.get("backlog", []) as Array).size(),
+		" (CUT SHORT)" if bool(trip.get("cut_short", false)) else ""])
+	game_state_updated.emit(state.to_dict())
+	return trip
+
+
+func resume_in_place() -> void:
+	"""Re-attach a freshly-loaded main.tscn to the ALREADY-RUNNING game (conference return).
+
+	Mirrors the tail of load_saved_game() minus the loading: push state and the action list
+	to the new view. It deliberately does NOT surface pending events -- the return backlog
+	panel is the single surface on arrival (feed-channel discipline / the #877 modal-stacking
+	lesson). The caller surfaces events afterwards via surface_pending_events()."""
+	pending_resume = false
+	if not is_initialized or state == null:
+		return
+	MusicManager.play_context(MusicManager.MusicContext.GAMEPLAY)
+	game_state_updated.emit(state.to_dict())
+	turn_phase_changed.emit("action_selection")
+	actions_available.emit(turn_manager.get_available_actions())
+
+
+func surface_pending_events() -> void:
+	"""Open any window that came home still unanswered (a trip cut short by an unignorable
+	event). Called AFTER the return backlog panel is dismissed, so the player never faces a
+	panel and a dialog at the same time."""
+	if not is_initialized or state == null or state.pending_events.is_empty():
+		return
+	turn_phase_changed.emit("turn_start")
+	for event in state.pending_events:
+		event_triggered.emit(WindowResolver.strip_ap(event))
+
 
 func end_month():
 	"""Commit the queued actions as this month's plan and play the month out day by day."""

--- a/godot/scripts/ui/conference_vignette.gd
+++ b/godot/scripts/ui/conference_vignette.gd
@@ -1,0 +1,241 @@
+extends Control
+## The conference mini-scene -- the tempo pocket (ADR-0014 shell, Pip ruling 2026-07-27).
+##
+## FIDELITY: option 1 from the design seed (text vignette), chosen for this pass. The seed
+## recommends option 2 (an illustrated tableau with 2-4 hotspots) as the sweet spot -- the
+## visual context-switch IS the break. This scene is deliberately structured so that upgrade
+## is a re-skin: BEATS below drives a generic staged reveal, so a tableau backdrop and
+## hotspots can be layered in without touching the sim seam or the navigation contract.
+##
+## SAFETY / SCOPE (the same contract cold_open_sequence.gd keeps, and ADR-0018's arrow):
+##  * PURE PRESENTATION. The away window was ALREADY resolved synchronously by
+##    ConferenceTrip.run_trip() before this scene loaded. Nothing here reads or writes the
+##    simulation, draws RNG, or can influence the outcome -- it renders a decided result.
+##  * ALL navigation goes through the SceneTransition autoload (the v0.11.0 segfault rule,
+##    enforced by tools/check_scene_nav.py). Never change_scene_to_file.
+##  * The return backlog is NOT shown here. It belongs to the office, on return, as ONE
+##    panel (feed-channel discipline; see main_ui._show_conference_backlog).
+
+const MAIN_SCENE := "res://scenes/main.tscn"
+
+# --- Timing dials (seconds) -- Pip edits pacing here, in one place. ---
+const LINE_FADE_IN := 0.7
+const LINE_HOLD := 2.6
+const HEADER_FADE_IN := 0.9
+const OPENING_BLACK_HOLD := 0.4
+
+var _trip: Dictionary = {}
+var _lines: Array = []
+var _line_index: int = 0
+var _finished_reveal: bool = false
+var _leaving: bool = false
+
+var _body: VBoxContainer
+var _lines_box: VBoxContainer
+var _return_button: Button
+var _skip_hint: Label
+var _active_tween: Tween
+
+
+func _ready() -> void:
+	set_anchors_preset(Control.PRESET_FULL_RECT)
+	_trip = _read_trip()
+	_build_ui()
+	set_process_unhandled_input(true)
+	await get_tree().create_timer(OPENING_BLACK_HOLD).timeout
+	_reveal_next_line()
+
+
+func _read_trip() -> Dictionary:
+	"""The trip record produced at commit time. Read-only handoff -- if it is missing (scene
+	opened directly, e.g. from the editor), fall back to an empty record and still offer the
+	way back, so this scene can never trap a player."""
+	var gm := get_node_or_null("/root/GameManager")
+	if gm != null and gm.get("last_conference_trip") != null:
+		var t = gm.last_conference_trip
+		if t is Dictionary:
+			return t
+	return {}
+
+
+func _conference() -> Dictionary:
+	var conf = _trip.get("conference", {})
+	return conf if conf is Dictionary else {}
+
+
+func _build_ui() -> void:
+	var bg := ColorRect.new()
+	bg.color = Color(0.04, 0.05, 0.06)
+	bg.set_anchors_preset(Control.PRESET_FULL_RECT)
+	bg.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(bg)
+
+	var margin := MarginContainer.new()
+	margin.set_anchors_preset(Control.PRESET_FULL_RECT)
+	margin.add_theme_constant_override("margin_left", 120)
+	margin.add_theme_constant_override("margin_right", 120)
+	margin.add_theme_constant_override("margin_top", 90)
+	margin.add_theme_constant_override("margin_bottom", 70)
+	add_child(margin)
+
+	_body = VBoxContainer.new()
+	_body.add_theme_constant_override("separation", 18)
+	_body.alignment = BoxContainer.ALIGNMENT_CENTER
+	margin.add_child(_body)
+
+	var conf := _conference()
+	var title := Label.new()
+	title.text = String(conf.get("name", "Away"))
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	title.add_theme_font_size_override("font_size", 34)
+	title.add_theme_color_override("font_color", Color(0.85, 0.72, 0.35))
+	title.modulate.a = 0.0
+	_body.add_child(title)
+
+	var subtitle := Label.new()
+	subtitle.text = _away_summary()
+	subtitle.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	subtitle.add_theme_font_size_override("font_size", 15)
+	subtitle.add_theme_color_override("font_color", Color(0.55, 0.58, 0.6))
+	subtitle.modulate.a = 0.0
+	_body.add_child(subtitle)
+
+	var rule := HSeparator.new()
+	_body.add_child(rule)
+
+	_lines_box = VBoxContainer.new()
+	_lines_box.add_theme_constant_override("separation", 22)
+	_body.add_child(_lines_box)
+
+	_skip_hint = Label.new()
+	_skip_hint.text = "[ click or press any key to skip ahead ]"
+	_skip_hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_skip_hint.add_theme_font_size_override("font_size", 12)
+	_skip_hint.add_theme_color_override("font_color", Color(0.35, 0.37, 0.4))
+	_body.add_child(_skip_hint)
+
+	_return_button = Button.new()
+	_return_button.text = "Return to the office  >>"
+	_return_button.custom_minimum_size = Vector2(280, 44)
+	_return_button.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+	_return_button.visible = false
+	_return_button.pressed.connect(_leave)
+	_body.add_child(_return_button)
+
+	_lines = _collect_lines(conf)
+
+	_fade_in_control(title, HEADER_FADE_IN)
+	_fade_in_control(subtitle, HEADER_FADE_IN)
+
+
+func _collect_lines(conf: Dictionary) -> Array:
+	var out: Array = []
+	var blurb := String(conf.get("blurb", ""))
+	if not blurb.is_empty():
+		out.append(blurb)
+	for line in conf.get("vignette", []):
+		out.append(String(line))
+	# The one line that must SURPRISE (seed section 5: a boring auto-resolve turns the break
+	# into a wait-state). Cut-short trips say so here rather than silently ending early.
+	if bool(_trip.get("cut_short", false)):
+		out.append("Then the phone goes. %s You are on the next flight home."
+			% String(_trip.get("cut_short_reason", "Something at the lab could not wait.")))
+	var memento = _trip.get("memento", {})
+	if memento is Dictionary:
+		var contact = memento.get("contact", {})
+		if contact is Dictionary and not contact.is_empty():
+			out.append("You leave with a name you did not have on the way out: %s."
+				% String(contact.get("name", "someone")))
+	if out.is_empty():
+		out.append("A few days elsewhere. The work waits.")
+	return out
+
+
+func _away_summary() -> String:
+	var resolved := int(_trip.get("ticks_resolved", 0))
+	var attention := int(_trip.get("attention_consumed", 0))
+	if resolved <= 0:
+		return "Away."
+	return "%d days away  |  %d Attention consumed  |  the lab runs on the standing plan" % [
+		resolved, attention]
+
+
+# ---------------------------------------------------------------------------
+# Staged reveal
+# ---------------------------------------------------------------------------
+func _reveal_next_line() -> void:
+	if _leaving:
+		return
+	if _line_index >= _lines.size():
+		_finish_reveal()
+		return
+	var label := Label.new()
+	label.text = String(_lines[_line_index])
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	label.add_theme_font_size_override("font_size", 19)
+	label.add_theme_color_override("font_color", Color(0.82, 0.84, 0.86))
+	label.modulate.a = 0.0
+	_lines_box.add_child(label)
+	_line_index += 1
+	_fade_in_control(label, LINE_FADE_IN)
+	await get_tree().create_timer(LINE_FADE_IN + LINE_HOLD).timeout
+	_reveal_next_line()
+
+
+func _reveal_all_now() -> void:
+	"""Skip: dump every remaining line at once, then offer the way back."""
+	while _line_index < _lines.size():
+		var label := Label.new()
+		label.text = String(_lines[_line_index])
+		label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		label.add_theme_font_size_override("font_size", 19)
+		label.add_theme_color_override("font_color", Color(0.82, 0.84, 0.86))
+		_lines_box.add_child(label)
+		_line_index += 1
+	_finish_reveal()
+
+
+func _finish_reveal() -> void:
+	if _finished_reveal:
+		return
+	_finished_reveal = true
+	_skip_hint.visible = false
+	_return_button.visible = true
+	_return_button.grab_focus()
+
+
+func _fade_in_control(node: CanvasItem, duration: float) -> void:
+	var tween := create_tween()
+	tween.tween_property(node, "modulate:a", 1.0, duration)
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if _leaving:
+		return
+	var pressed: bool = (event is InputEventKey and event.pressed and not event.echo) \
+		or (event is InputEventMouseButton and event.pressed)
+	if not pressed:
+		return
+	if _finished_reveal:
+		_leave()
+	else:
+		_reveal_all_now()
+	get_viewport().set_input_as_handled()
+
+
+# ---------------------------------------------------------------------------
+# Exit -- ALWAYS through SceneTransition (never change_scene_to_file; v0.11.0 rule)
+# ---------------------------------------------------------------------------
+func _leave() -> void:
+	if _leaving:
+		return
+	_leaving = true
+	# Tell main.tscn to RESUME the live run instead of booting a new one. Without this flag
+	# main_ui._boot_game() would start_new_game() and destroy the run on re-entry.
+	var gm := get_node_or_null("/root/GameManager")
+	if gm != null:
+		gm.pending_resume = true
+	print("[ConferenceVignette] returning to the office (turn %d)" % int(_trip.get("end_turn", 0)))
+	SceneTransition.go_to(MAIN_SCENE, true)

--- a/godot/scripts/ui/conference_vignette.gd.uid
+++ b/godot/scripts/ui/conference_vignette.gd.uid
@@ -1,0 +1,1 @@
+uid://2kh5auv6us0i

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -693,6 +693,13 @@ func _apply_balance_tooltips() -> void:
 func _boot_game():
 	# Was _on_init_button_pressed (wired to a vestigial "Init" button that has been
 	# removed, #715); the game auto-boots from _ready. Loads a queued save or starts fresh.
+	# ADR-0014 rhythm break: main.tscn was LEFT for the conference mini-scene and is now being
+	# re-entered with the run still live in the GameManager autoload. Resume it -- booting a
+	# new game here would silently destroy the run. One-shot flag, cleared by resume_in_place.
+	if game_manager.pending_resume and game_manager.is_initialized:
+		game_manager.resume_in_place()
+		_show_conference_backlog(game_manager.last_conference_trip)
+		return
 	# L7 (#618): if the welcome screen queued a saved game, boot into it instead
 	# of starting a new run. The flag is one-shot.
 	if GameConfig.pending_load_path != "":
@@ -707,6 +714,120 @@ func _boot_game():
 	# GameConfig.game_seed was ignored. Empty arg -> GameManager falls back to
 	# GameConfig.get_display_seed() (player's configured seed, else the weekly seed).
 	game_manager.start_new_game()
+
+func _show_conference_backlog(trip: Dictionary) -> void:
+	"""The return burst -- ONE surface (ADR-0014 shell; design-seed section 1).
+
+	FEED-CHANNEL DISCIPLINE, the load-bearing constraint here: the fade-in must NOT land the
+	player in a stack of N modals for N missed ticks. That is the #877 modal-stacking failure
+	and the FRESH_EYES item-9 complaint about auto-jumping month-review modals. So:
+	  * exactly one dismissible, SCROLLABLE panel, never auto-advancing;
+	  * the conference's own outcome headlines it, routine accrual reads as compressed feed
+	    lines underneath -- not separate interrupts;
+	  * a window that came home unanswered (a cut-short trip) is listed FIRST here, and is
+	    only surfaced as a real dialog AFTER this panel is closed
+	    (game_manager.surface_pending_events on the close path). One surface at a time."""
+	if trip.is_empty() or not bool(trip.get("success", false)):
+		return
+	var conf: Dictionary = trip.get("conference", {})
+	var conf_name := String(conf.get("name", "the conference"))
+	var backlog: Array = trip.get("backlog", [])
+	var memento: Dictionary = trip.get("memento", {})
+
+	var dialog := Panel.new()
+	dialog.custom_minimum_size = Vector2(620, 520)
+	dialog.size = Vector2(620, 520)
+	dialog.position = Vector2(80, 50)
+
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 18)
+	margin.add_theme_constant_override("margin_right", 18)
+	margin.add_theme_constant_override("margin_top", 16)
+	margin.add_theme_constant_override("margin_bottom", 16)
+	dialog.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 8)
+	margin.add_child(vbox)
+
+	var header := Label.new()
+	header.text = "WHILE YOU WERE AWAY"
+	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	header.add_theme_font_size_override("font_size", 15)
+	header.add_theme_color_override("font_color", Color(0.85, 0.72, 0.35))
+	vbox.add_child(header)
+
+	var body := RichTextLabel.new()
+	body.bbcode_enabled = true
+	body.fit_content = false
+	body.scroll_active = true
+	body.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	body.custom_minimum_size = Vector2(0, 380)
+	vbox.add_child(body)
+
+	var lines: Array[String] = []
+
+	# --- Headline: the trip's own outcome + its FIRST-PASS flavor yields. ---
+	lines.append("[b]%s[/b]  --  days %d to %d" % [
+		conf_name, int(trip.get("start_turn", 0)), int(trip.get("end_turn", 0))])
+	lines.append("[color=gray]%s  |  %d Attention consumed  |  %s travel[/color]" % [
+		("Cut short" if bool(trip.get("cut_short", false)) else "Full trip"),
+		int(trip.get("attention_consumed", 0)),
+		GameConfig.format_money(int(trip.get("travel_cost", 0)))])
+	if not memento.is_empty():
+		lines.append("")
+		lines.append("[color=#c8b98a]%s[/color]" % String(memento.get("line", "")))
+		var contact: Dictionary = memento.get("contact", {})
+		if not contact.is_empty():
+			lines.append("[color=#c8b98a]New contact: %s (met at %s).[/color]" % [
+				String(contact.get("name", "someone")), String(contact.get("met_at", conf_name))])
+		lines.append("[color=gray][i]First-pass yields -- reputation and the contact are placeholders "
+			+ "until the adoption pipeline lands.[/i][/color]")
+
+	# --- Compressed accrual, in surfaced order. Deferred windows sort FIRST by construction. ---
+	lines.append("")
+	if backlog.is_empty():
+		lines.append("[color=gray]Nothing stacked up. The lab held.[/color]")
+	else:
+		lines.append("[b]%d things stacked up:[/b]" % backlog.size())
+		for entry in backlog:
+			if not (entry is Dictionary):
+				continue
+			var kind := String(entry.get("kind", ""))
+			var turn := int(entry.get("turn", 0))
+			var name := String(entry.get("name", entry.get("id", "update")))
+			match kind:
+				"window_deferred":
+					lines.append("[color=#ff8080][!] day %d -- %s -- STILL OPEN: %s[/color]" % [
+						turn, name, String(entry.get("message", ""))])
+				"window_auto_ignored":
+					lines.append("[color=#e0b060][ ] day %d -- %s -- went unanswered[/color]" % [turn, name])
+				"month_opened":
+					lines.append("[color=#8090c0][M] day %d -- %s[/color]" % [turn, name])
+				"strategic_released":
+					lines.append("[color=#80c090][>] day %d -- %s[/color]" % [turn, name])
+				_:
+					lines.append("[color=gray]day %d -- %s -- %s[/color]" % [
+						turn, String(entry.get("source_id", "feed")), name])
+
+	body.text = "\n".join(lines)
+
+	var close_btn := Button.new()
+	close_btn.text = "Back to work  >>"
+	close_btn.custom_minimum_size = Vector2(220, 38)
+	close_btn.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+	close_btn.pressed.connect(func():
+		dialog.queue_free()
+		active_dialog = null
+		# Only NOW may a real dialog open -- never stacked on top of this panel.
+		game_manager.surface_pending_events())
+	vbox.add_child(close_btn)
+
+	_present_modal_dialog(dialog)
+	active_dialog = dialog
+	# One compressed feed line is the persistent record; the panel is the readable surface.
+	log_message("[color=#c8b98a]Back from %s -- %d items waiting.[/color]" % [conf_name, backlog.size()])
+
 
 func _on_reserve_ap_button_pressed():
 	"""Reserve 1 AP for event responses"""

--- a/godot/scripts/ui/travel_panel_controller.gd
+++ b/godot/scripts/ui/travel_panel_controller.gd
@@ -304,6 +304,127 @@ func _on_travel_option_selected(action_id: String, action_name: String, dialog: 
 	elif action_id == "attend_conference":
 		_show_conference_attendance_dialog()
 		return
+	elif action_id == "attend_conference_trip":
+		_show_conference_trip_dialog()
+		return
+
+
+func _show_conference_trip_dialog() -> void:
+	"""The rhythm-break commit surface (ADR-0014 shell; Pip ruling 2026-07-27).
+
+	Deliberately blunt about the cost BEFORE the player commits -- the whole point of the
+	tempo break is that it is a legible-cost / fuzzy-payoff call ("is this worth the blackout
+	window"). If this dialog ever stops showing the days away, the cash, and the
+	all-your-Attention line, the decision degenerates into a free button.
+
+	PURE VIEW: it reads the ConferenceTrip catalogue and the live state payload, then hands
+	the whole commit to GameManager.attend_conference_trip(). No sim work happens here."""
+	var dialog := Panel.new()
+	dialog.custom_minimum_size = Vector2(560, 460)
+	dialog.size = Vector2(560, 460)
+	dialog.position = Vector2(90, 60)
+
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 18)
+	margin.add_theme_constant_override("margin_right", 18)
+	margin.add_theme_constant_override("margin_top", 16)
+	margin.add_theme_constant_override("margin_bottom", 16)
+	dialog.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 10)
+	margin.add_child(vbox)
+
+	var header := Label.new()
+	header.text = "LEAVE FOR A CONFERENCE"
+	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	header.add_theme_font_size_override("font_size", 15)
+	header.add_theme_color_override("font_color", Color(0.85, 0.72, 0.35))
+	vbox.add_child(header)
+
+	var warning := Label.new()
+	warning.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	warning.text = "You are gone for the whole window, travel days included. The lab runs on " \
+		+ "whatever you have already queued -- your remaining Attention goes with you, and " \
+		+ "anything that happens while you are away waits for you on your desk."
+	warning.add_theme_font_size_override("font_size", 12)
+	warning.add_theme_color_override("font_color", Color(0.62, 0.64, 0.66))
+	vbox.add_child(warning)
+
+	vbox.add_child(HSeparator.new())
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	vbox.add_child(scroll)
+
+	var list := VBoxContainer.new()
+	list.add_theme_constant_override("separation", 12)
+	list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(list)
+
+	var current_state: Dictionary = host.game_manager.get_game_state()
+	var money: float = float(current_state.get("money", 0))
+
+	for conf in ConferenceTrip.catalogue():
+		var conf_id := String(conf.get("id", ""))
+		var away: int = ConferenceTrip.away_ticks(conf)
+		var cost: int = int(conf.get("travel_cost", 0))
+
+		var row := VBoxContainer.new()
+		row.add_theme_constant_override("separation", 3)
+		list.add_child(row)
+
+		var title := Label.new()
+		title.text = "%s -- %d days away (%d travel)" % [
+			String(conf.get("name", conf_id)), away, int(conf.get("travel_days", 0)) * 2]
+		title.add_theme_font_size_override("font_size", 13)
+		row.add_child(title)
+
+		var blurb := Label.new()
+		blurb.text = String(conf.get("blurb", ""))
+		blurb.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		blurb.add_theme_font_size_override("font_size", 11)
+		blurb.add_theme_color_override("font_color", Color(0.55, 0.57, 0.6))
+		row.add_child(blurb)
+
+		var gate: Dictionary = ConferenceTrip.can_commit(host.game_manager.state, conf_id)
+		var go_btn := Button.new()
+		go_btn.text = "Commit -- %s + all remaining Attention" % GameConfig.format_money(cost)
+		go_btn.disabled = not bool(gate.get("ok", false)) or money < float(cost)
+		if go_btn.disabled:
+			go_btn.tooltip_text = String(gate.get("reason", "Unavailable"))
+			go_btn.modulate = Color(0.5, 0.5, 0.5)
+		go_btn.pressed.connect(_on_conference_trip_committed.bind(conf_id, dialog))
+		row.add_child(go_btn)
+
+	var cancel := Button.new()
+	cancel.text = "Stay home"
+	cancel.pressed.connect(func():
+		dialog.queue_free()
+		host.active_dialog = null)
+	vbox.add_child(cancel)
+
+	host._present_modal_dialog(dialog)
+	host.active_dialog = dialog
+
+
+func _on_conference_trip_committed(conf_id: String, dialog: Control) -> void:
+	"""Commit -> resolve the away window -> fade out to the mini-scene.
+
+	Navigation goes through SceneTransition (the v0.11.0 rule); use_fade=true IS the
+	fade-out half of the tempo pocket. The fade back in happens on the vignette's exit."""
+	dialog.queue_free()
+	host.active_dialog = null
+	host.active_dialog_buttons = []
+
+	var trip: Dictionary = host.game_manager.attend_conference_trip(conf_id)
+	if not bool(trip.get("success", false)):
+		host.log_message("[color=yellow]%s[/color]" % String(trip.get("message", "Cannot attend.")))
+		return
+
+	host.log_message("[color=cyan]Leaving for %s...[/color]" % String(
+		trip.get("conference", {}).get("name", "a conference")))
+	SceneTransition.go_to("res://scenes/ui/conference_vignette.tscn", true)
 
 func _show_paper_submission_dialog():
 	"""Show dialog for submitting a paper to a conference"""

--- a/godot/tests/unit/test_conference_trip.gd
+++ b/godot/tests/unit/test_conference_trip.gd
@@ -1,0 +1,199 @@
+extends GutTest
+## ConferenceTrip -- the ADR-0014 rhythm-break shell (Pip rulings 2026-07-27).
+##
+## The two properties this lane must not lose:
+##   1. an away window auto-resolves DETERMINISTICALLY (model A skip-turns rides the existing
+##      seeded stream through MonthController.advance_tick -- no new RNG source), so a
+##      recorded replay re-simulates the blackout window identically;
+##   2. everything that fired while the founder was away lands in the return BACKLOG rather
+##      than vanishing or ambushing the player as a stack of modals.
+
+var state: GameState
+var turn_manager: TurnManager
+var controller: MonthController
+var _saved_historical_events := []
+
+
+func before_each():
+	# Test isolation (#534): unit tests must NOT load the live ~1194-event historical timeline
+	# into pending_events -- it hangs the headless suite. Same guard as test_turn_manager.gd.
+	if EventService:
+		_saved_historical_events = EventService.transformed_events.duplicate()
+		EventService.transformed_events.clear()
+	ConferenceTrip.reload_catalogue()
+	state = GameState.new("conference-trip-seed")
+	turn_manager = TurnManager.new(state)
+	controller = MonthController.new(state, turn_manager)
+	turn_manager.start_turn()  # open turn 1, matching the plan phase GameManager boots into
+
+
+func after_each():
+	if EventService:
+		EventService.transformed_events = _saved_historical_events
+
+
+func _fresh_run(game_seed: String) -> Dictionary:
+	"""Stand up an independent run on `game_seed` and take the same trip on it."""
+	var s := GameState.new(game_seed)
+	var tm := TurnManager.new(s)
+	var mc := MonthController.new(s, tm)
+	tm.start_turn()
+	var trip: Dictionary = ConferenceTrip.run_trip(s, mc, "safety_retreat")
+	return {"state": s, "trip": trip}
+
+
+func _fingerprint(s: GameState, trip: Dictionary) -> String:
+	"""Everything an away window is allowed to move, plus the backlog it produced. Compared as
+	one JSON blob so a divergence anywhere shows up as a failed string equality."""
+	return JSON.stringify({
+		"turn": s.turn,
+		"money": s.money,
+		"reputation": s.reputation,
+		"doom": s.doom,
+		"rng_state": str(s.rng.state),
+		"attended": s.attended_conferences,
+		"backlog": trip.get("backlog", []),
+		"memento": trip.get("memento", {}),
+		"ticks_resolved": trip.get("ticks_resolved", 0),
+		"attention_consumed": trip.get("attention_consumed", 0),
+		"cut_short": trip.get("cut_short", false),
+	})
+
+
+# ---------------------------------------------------------------------------
+# Catalogue + the away-window arithmetic (Pip's travel ruling)
+# ---------------------------------------------------------------------------
+func test_catalogue_loads_the_shell_entries():
+	var all: Array = ConferenceTrip.catalogue()
+	assert_gt(all.size(), 0, "conferences.json loaded at least one entry")
+	assert_between(all.size(), 2, 4, "the shell catalogue stays tiny (2-3 entries by design)")
+	for conf in all:
+		assert_true(conf.has("id"), "every entry has an id")
+		assert_gt(int(conf.get("duration_turns", 0)), 0, "every entry has a positive duration")
+
+
+func test_away_window_includes_travel_on_both_sides():
+	# Pip 2026-07-27 1555: attending consumes the away window PLUS roughly a day either side
+	# for travel -- travel days are exposed time, not free.
+	var conf := {"duration_turns": 3, "travel_days": 1}
+	assert_eq(ConferenceTrip.away_ticks(conf), 5, "3 days away + 1 travel day each side")
+	var big := {"duration_turns": 5, "travel_days": 2}
+	assert_eq(ConferenceTrip.away_ticks(big), 9, "5 days away + 2 travel days each side")
+
+
+# ---------------------------------------------------------------------------
+# Determinism -- the load-bearing property
+# ---------------------------------------------------------------------------
+func test_away_window_resolves_deterministically():
+	var a := _fresh_run("conference-determinism-probe")
+	var b := _fresh_run("conference-determinism-probe")
+	assert_true(bool(a["trip"].get("success", false)), "run A committed")
+	assert_true(bool(b["trip"].get("success", false)), "run B committed")
+	var fa := _fingerprint(a["state"], a["trip"])
+	var fb := _fingerprint(b["state"], b["trip"])
+	if fa != fb:
+		gut.p("[conference-determinism] A: " + fa)
+		gut.p("[conference-determinism] B: " + fb)
+	assert_eq(fa, fb, "the same seed must resolve the same away window, backlog included")
+
+
+func test_away_window_advances_exactly_the_expected_ticks():
+	# Non-vacuity guard for the determinism test above: the window must actually run turns.
+	var start := state.turn
+	var trip: Dictionary = ConferenceTrip.run_trip(state, controller, "safety_retreat")
+	assert_true(bool(trip.get("success", false)), "committed to the retreat")
+	var expected: int = ConferenceTrip.away_ticks(ConferenceTrip.by_id("safety_retreat"))
+	if not bool(trip.get("cut_short", false)):
+		assert_eq(int(trip.get("ticks_resolved", 0)), expected, "resolved the whole away window")
+		assert_eq(state.turn - start, expected, "state.turn advanced by exactly the away window")
+	assert_gt(int(trip.get("ticks_resolved", 0)), 0, "the trip is not a no-op")
+
+
+# ---------------------------------------------------------------------------
+# The backlog captures what fired while away
+# ---------------------------------------------------------------------------
+func test_backlog_captures_fired_feed_events():
+	# Against a synthetic advance_tick() result, so the assertion is about the collector's
+	# contract rather than about whichever events a given seed happens to roll.
+	var backlog: Array = []
+	ConferenceTrip.collect_tick(backlog, 12, {
+		"status": "ready",
+		"month_opened": false,
+		"feed": [
+			{"source_id": "rivals", "event": {"id": "rival_move", "name": "A rival moved", "channel": "rivals"}},
+			{"source_id": "hiring", "event": {"id": "advertise_hit", "name": "Applicant responded"}},
+		],
+		"released": [],
+	})
+	assert_eq(backlog.size(), 2, "both fired feed events landed in the backlog")
+	assert_eq(String(backlog[0].get("kind", "")), "feed", "captured as feed items")
+	assert_eq(int(backlog[0].get("turn", 0)), 12, "stamped with the turn they fired on")
+	assert_eq(String(backlog[0].get("name", "")), "A rival moved", "keeps the event's own name")
+	assert_eq(String(backlog[0].get("channel", "")), "rivals", "carries the feed channel through")
+
+
+func test_backlog_captures_month_boundaries_and_released_work():
+	var backlog: Array = []
+	ConferenceTrip.collect_tick(backlog, 30, {
+		"status": "month_open",
+		"month_opened": true,
+		"feed": [],
+		"released": [{"action_id": "research_basic", "attention_cost": 2}],
+	})
+	var kinds: Array = []
+	for entry in backlog:
+		kinds.append(String(entry.get("kind", "")))
+	assert_has(kinds, "month_opened", "a month opening with nobody home is reported")
+	assert_has(kinds, "strategic_released", "strategic WIP that landed while away is reported")
+
+
+func test_real_away_window_produces_a_readable_backlog():
+	var trip: Dictionary = ConferenceTrip.run_trip(state, controller, "neurips")
+	if not bool(trip.get("success", false)):
+		# Not affordable on this seed's opening cash -- the gate is itself the behaviour.
+		assert_string_contains(String(trip.get("message", "")), "afford", "refused for an honest reason")
+		return
+	var backlog: Array = trip.get("backlog", [])
+	for entry in backlog:
+		assert_true(entry is Dictionary, "backlog entries are plain data")
+		assert_true(entry.has("kind"), "every entry declares its kind")
+		assert_true(entry.has("turn"), "every entry is stamped with when it happened")
+
+
+# ---------------------------------------------------------------------------
+# The costs that keep this from being a free button
+# ---------------------------------------------------------------------------
+func test_trip_consumes_all_remaining_founder_attention():
+	var before: int = state.month_plan.available()
+	assert_gt(before, 0, "the founder starts the month with Attention to lose")
+	var trip: Dictionary = ConferenceTrip.run_trip(state, controller, "safety_retreat")
+	assert_true(bool(trip.get("success", false)), "committed")
+	assert_eq(state.month_plan.available(), 0,
+		"no Attention is left to plan with from the road (Pip ruling 2026-07-27 1555)")
+	assert_gt(int(trip.get("attention_consumed", 0)), 0, "the cost is reported back to the player")
+
+
+func test_travel_cash_leaves_up_front():
+	var conf := ConferenceTrip.by_id("safety_retreat")
+	var cost: int = int(conf.get("travel_cost", 0))
+	assert_gt(cost, 0, "the retreat costs real travel cash")
+	var money_before: float = state.money
+	var trip: Dictionary = ConferenceTrip.run_trip(state, controller, "safety_retreat")
+	assert_true(bool(trip.get("success", false)), "committed")
+	# Salaries and the ledger also bill during the away window, so cash must be at least the
+	# travel cost lower -- the point is that the travel cash is not free.
+	assert_lt(state.money, money_before - float(cost) + 1.0, "travel cash left the account")
+
+
+func test_cannot_attend_the_same_conference_twice_in_a_year():
+	var first: Dictionary = ConferenceTrip.run_trip(state, controller, "safety_retreat")
+	assert_true(bool(first.get("success", false)), "first trip committed")
+	var gate: Dictionary = ConferenceTrip.can_commit(state, "safety_retreat")
+	assert_false(bool(gate.get("ok", true)), "a second trip this year is refused")
+	assert_string_contains(String(gate.get("reason", "")), "Already attended", "with a legible reason")
+
+
+func test_unknown_conference_is_refused_cleanly():
+	var trip: Dictionary = ConferenceTrip.run_trip(state, controller, "not_a_conference")
+	assert_false(bool(trip.get("success", true)), "refused")
+	assert_eq((trip.get("backlog", []) as Array).size(), 0, "and produces no backlog")

--- a/godot/tests/unit/test_conference_trip.gd.uid
+++ b/godot/tests/unit/test_conference_trip.gd.uid
@@ -1,0 +1,1 @@
+uid://doqtfxbv5xllq


### PR DESCRIPTION
Builds the ADR-0014 conference **rhythm break** as a shippable placeholder: the player
chooses to leave the normal turn rhythm, the world keeps running without them, and they
come home to a backlog. Authorized by Pip's 2026-07-27 rulings (the rhythm-break ruling +
the 1555 travel ruling).

**Shell only.** Yields are flavour first-pass by design (design seed section 3): real
adoption-accelerant numbers and contacts-as-receivables wire in after adoption-v1.

## What ships

1. **Commit surface** -- `Attend Conference (trip)` in the TRAVEL submenu opens a dialog
   listing the 3 shell conferences (`godot/data/events/conferences.json`) with days away,
   travel cash, and a blunt "all your remaining Attention" line. Blunt on purpose: the
   tempo break is only interesting as a legible-cost / fuzzy-payoff call.
2. **Tempo pocket** -- fade out (`SceneTransition.go_to(..., use_fade=true)`) to a text
   vignette mini-scene (`scenes/ui/conference_vignette.tscn`), staged line reveal,
   skip-ahead, then fade back to the office.
3. **Exposure while away** -- travel days count on **both** sides of the conference. Events
   and developments fire normally into a return **backlog**.
4. **Return** -- ONE dismissible, scrollable "WHILE YOU WERE AWAY" panel plus a single
   compressed feed line. Never a stack of N modals for N missed ticks.

## How the away window works (model A, skip-turns)

`ConferenceTrip.run_trip()` drives real day-ticks through the **existing**
`MonthController.advance_tick()` path, in the existing order, on the existing `state.rng`.
No new RNG source, no new turn loop, no reordering of `TurnManager`'s load-bearing steps.
Determinism therefore comes for free by construction, and is asserted directly
(`test_away_window_resolves_deterministically` fingerprints turn / money / reputation /
doom / rng state / backlog / memento across two identical runs).

The sim half resolves **synchronously at commit time**, before the vignette scene loads --
so the mini-scene is pure theatre over an already-decided result and cannot influence the
simulation. Same one-way arrow ADR-0018 draws for the office render surface.

## The anti-free-button property (please protect in review)

If attending is ever strictly dominant the HoMM framing collapses. Three real costs:

- travel cash leaves up front (spiky cash flow, ADR-0012);
- **all** remaining founder Attention is consumed, and every fresh month that opens while
  away is drained again -- nothing can be planned from the road (Pip's 1555 ruling);
- with no Attention and no reserve, response windows that fire while away auto-resolve as
  IGNORE + the nonresponse reputation penalty (the documented default from the seed). An
  **unignorable** window refuses to be skipped, so the trip is **cut short** and the window
  comes home still queued -- which is also the soft-lock guard: nothing is ever
  force-resolved and the drain loop cannot spin.

## Feed-channel discipline

Per the design seed and the #877 modal-stacking history: the deferred window is listed
FIRST in the panel and only opens as a real dialog **after** the panel is dismissed
(`GameManager.surface_pending_events()`). One surface at a time.

## Seams left for later lanes

| Seam | Where | For |
|---|---|---|
| Real yields | `ConferenceTrip._apply_flavor_yields` | adoption accelerant + contacts-as-receivables into the Ledger counterparty slot. Swap the function body, not the UX. |
| Attention migration | `ConferenceTrip._consume_founder_capacity` | the ONLY place this lane touches the founder currency; spends through the existing `MonthPlan.spend_attention`, so L2's AP->Attention migration has exactly one surface to move. |
| Catalogue merge | `godot/data/events/conferences.json` | ids match `scripts/core/conferences.gd` (#468) so the two attendance paths merge cleanly. The legacy instant `attend_conference` is untouched. |
| Fidelity upgrade | `conference_vignette.gd` BEATS/reveal structure | seed option 2 (illustrated tableau + hotspots) is a re-skin, not a rewrite. |

## Scene-leave safety

Leaving `main.tscn` and returning would have hit `_boot_game()` -> `start_new_game()` and
destroyed the live run. Added a one-shot `GameManager.pending_resume` handoff +
`resume_in_place()` (mirrors the tail of `load_saved_game`). Not serialized -- it is a
scene-handoff flag, never simulation state.

## Verification

`python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`
-> **820 tests, 0 failures, 86/86 files collected** (11 new in
`godot/tests/unit/test_conference_trip.gd`).

Scene-nav gate and no-emoji gate both pass.

## Open questions for Pip (from the seed, section 6)

- Fidelity: this ships option 1 (text vignette). The seed recommends option 2 (tableau).
  Upgrade now or after playtest?
- Should a glimpsed-rival beat go in the flavour yields, or does that jump ahead of WS-3's
  Developments/Sightings ruling?
- Delegate attendance (`send_delegation`) is still the #411 stub -- deliberately untouched.

Refs ADR-0014, ADR-0018, ADR-0009, ADR-0006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
