### PR TITLE
feat(0011-T3): workstream substrate core -- objects, backlog, assignment, topic accrual, compute intensity

### DIFF
--- a/godot/data/balance/defaults.json
+++ b/godot/data/balance/defaults.json
@@ -130,6 +130,18 @@
 		"_description": "AP economy: per-turn AP = difficulty base + per_staff * total staff.",
 		"per_staff": 0.5
 	},
+	"workstreams": {
+		"_description": "ADR-0011 s3/s4 workstream substrate (workstream.gd + the turn_manager accrual hook). turns_per_month re-denominates the per-MONTH quotes below onto the workday tick. effort_per_turn_scale converts one researcher's effective productivity into effort units. compute_starved_effort_multiplier is what an assigned researcher gets done when the fleet cannot cover their workstream's compute_intensity that tick (they are not idle, just slower). FIRST PASS -- priced by hand, not by sweep; re-price after the first assignment playtest (review-by 2026-08-31).",
+		"turns_per_month": 22,
+		"effort_per_turn_scale": 1.0,
+		"compute_starved_effort_multiplier": 0.5,
+		"self_direction": {
+			"_description": "Unassigned staff self-direct on their agenda (ADR-0011 s3: idle staff don't exist). effort_multiplier is the tax for nobody steering: unsteered work is real work, just less of it lands where it was needed. optimism_min/optimism_span set the OVER-CLAIM band for self-reported progress -- deterministic per person (Researcher.self_report_optimism, seeded off their stable key, never rng). FIRST-PASS GENTLE by ruling (2026-07-27): an audit should surface a nagging discrepancy, not a fraud. Audits ground-truth reported vs actual in a later lane; nothing consumes the reported figure yet.",
+			"effort_multiplier": 0.8,
+			"optimism_min": 1.05,
+			"optimism_span": 0.3
+		}
+	},
 	"rivals": {
 		"_description": "Rival lab coefficients (rivals.gd). ADR-0015: rivals no longer emit doom literals -- capability_overhang_doom_per_progress and per_tick_doom_scale (the pre-L1 shim) are RETIRED (Legacy #7/#12). Rival capability_progress IS the actor's frontier_capability slice, converted by the DoomSystem overhang stream; panic_per_capability_action feeds global_panic when a rival makes a reckless capability move.",
 		"panic_per_capability_action": 0.05,

--- a/godot/data/workstreams/backlog.json
+++ b/godot/data/workstreams/backlog.json
@@ -1,0 +1,78 @@
+{
+  "_description": "ADR-0011 s3 workstream BACKLOG -- the standing list of directed work the founder can commit people to. 'There's always a backlog': this file is the thing that makes idle staff impossible. Each entry mints a Workstream (scripts/core/workstream.gd) when started. effort_target is in effort units (one average researcher contributes ~1.0/workday tick); duration_months is design INTENT (the target is the actual gate). compute_intensity is compute units per assigned researcher per MONTH -- the A7 dial: heavy empirical work drains the fleet, theory does not.",
+  "_review": "First-pass content, priced by hand not by sweep. Re-price after the first assignment playtest (review-by 2026-08-31).",
+  "workstreams": [
+    {
+      "id": "eval_harness",
+      "title": "Build an internal eval harness",
+      "topic": "safety",
+      "effort_target": 60.0,
+      "duration_months": 2,
+      "compute_intensity": 2.0,
+      "description": "Measure the thing before claiming it. Cheap in people, hungry for compute."
+    },
+    {
+      "id": "reward_hacking_study",
+      "title": "Reward-hacking case study",
+      "topic": "alignment",
+      "effort_target": 90.0,
+      "duration_months": 3,
+      "compute_intensity": 1.5,
+      "description": "Chase a concrete misgeneralization until it is legible to outsiders."
+    },
+    {
+      "id": "circuit_atlas",
+      "title": "Circuit atlas for a small model",
+      "topic": "interpretability",
+      "effort_target": 140.0,
+      "duration_months": 5,
+      "compute_intensity": 1.0,
+      "description": "Slow, unglamorous, and the only thing that makes later claims checkable."
+    },
+    {
+      "id": "scaling_probe",
+      "title": "Scaling probe on the house model",
+      "topic": "capabilities",
+      "effort_target": 80.0,
+      "duration_months": 2,
+      "compute_intensity": 4.0,
+      "description": "Fast prestige, heavy fleet burn, and it moves the frontier you claim to fear."
+    },
+    {
+      "id": "incident_taxonomy",
+      "title": "Incident taxonomy for the field",
+      "topic": "governance",
+      "effort_target": 70.0,
+      "duration_months": 3,
+      "compute_intensity": 0.0,
+      "description": "Pen and paper. Costs no compute and buys standing with people who write rules."
+    },
+    {
+      "id": "red_team_program",
+      "title": "Standing red-team program",
+      "topic": "safety",
+      "effort_target": 110.0,
+      "duration_months": 4,
+      "compute_intensity": 2.5,
+      "description": "A program, not a paper: it keeps finding things for as long as you staff it."
+    },
+    {
+      "id": "corrigibility_theory",
+      "title": "Corrigibility theory push",
+      "topic": "alignment",
+      "effort_target": 160.0,
+      "duration_months": 6,
+      "compute_intensity": 0.5,
+      "description": "A long theory bet. Nothing to show for months, then possibly everything."
+    },
+    {
+      "id": "compute_governance_brief",
+      "title": "Compute-governance briefing pack",
+      "topic": "governance",
+      "effort_target": 50.0,
+      "duration_months": 2,
+      "compute_intensity": 0.0,
+      "description": "Short, political, and it expires: the brief nobody reads twice."
+    }
+  ]
+}

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -162,6 +162,28 @@ var candidate_pool: Array[Researcher] = []
 const MAX_CANDIDATES: int = 6  # Maximum candidates in pool
 var pending_hire_queue: Array[Researcher] = []  # Queue of candidates selected for hiring (FIFO)
 
+# ============================================================================
+# WORKSTREAM SUBSTRATE (ADR-0011 s3/s4, lane T1 / issue #613)
+# The directed-work layer the month plan was pointing at (month_plan.gd:21). Workstreams
+# are started off the data-driven backlog (WorkstreamBacklog), researchers are committed
+# to them at plan speed, and effort accrues per person per tick (turn_manager
+# _step_workstream_accrual). Everything here is INERT until the player starts a
+# workstream: with an empty list the accrual hook only records self-directed effort and
+# bills no compute, so an untouched run is byte-identical to the pre-substrate build.
+#
+# NOT in this lane: AP-pool deletion / Attention migration, founder-hour typing, manager
+# shields. Nothing below reads action_points.
+# ============================================================================
+var workstreams: Array = []                          # Array[Workstream], live + finished
+var workstream_backlog_taken: Array[String] = []     # backlog entry ids already started
+var workstream_serial: int = 0                       # pure counter for workstream ids (no rng)
+var researcher_id_serial: int = 0                    # pure counter for minted staff ids
+# Self-directed effort tally by topic key -> {"actual": float, "reported": float}. The
+# REPORTED half is the optimistic claim (Researcher.self_report_optimism); audits
+# ground-truth reported vs actual in a later lane (ruled 2026-07-27, review-by
+# 2026-08-31). Nothing consumes "reported" today -- it only serializes and displays.
+var self_directed_progress: Dictionary = {}
+
 # Purchased upgrades (one-time purchases)
 var purchased_upgrades: Array[String] = []
 
@@ -331,6 +353,13 @@ func reset():
 	candidate_pool.clear()
 	pending_hire_queue.clear()
 	researchers.clear()
+
+	# Workstream substrate: a new run starts with an empty board and the full backlog.
+	workstreams.clear()
+	workstream_backlog_taken.clear()
+	workstream_serial = 0
+	researcher_id_serial = 0
+	self_directed_progress.clear()
 
 	# Initialize with 2-3 starting candidates (low quality)
 	_populate_initial_candidates()
@@ -769,6 +798,142 @@ func remove_researcher(researcher: Researcher):
 			"interpretability", "alignment":
 				safety_researchers = max(0, safety_researchers - 1)
 
+		# A departing person stops accruing, but what they already contributed STAYS on the
+		# workstream (contributions feed later authorship). Losing your lead is supposed to
+		# hurt as a slowdown, not as a retroactive erasure.
+		release_from_workstreams(researcher)
+
+# ============================================================================
+# WORKSTREAM SUBSTRATE -- BACKLOG, ASSIGNMENT, READOUT (ADR-0011 s3/s4, #613)
+# Assignment is PLAYER INPUT, so it replays for free (ADR-0006); every function below is
+# deterministic and rng-free. Single source of truth for "who is on what" is
+# Workstream.assigned_ids -- the Researcher does NOT carry a back-pointer, so the two
+# cannot drift.
+# ============================================================================
+
+func researcher_id(researcher: Researcher) -> String:
+	"""The stable id used in workstream assignment lists, MINTING one if this person has
+	none (direct/legacy hires are created without a pipeline id). Pure counter, no rng;
+	the 'staff_' prefix cannot collide with the pipeline's 'cand_'/'job_' serials."""
+	if researcher == null:
+		return ""
+	if researcher.candidate_id == "":
+		researcher_id_serial += 1
+		researcher.candidate_id = "staff_%d" % researcher_id_serial
+	return researcher.candidate_id
+
+
+func available_backlog() -> Array[Dictionary]:
+	"""Backlog entries not yet started this run (id-sorted, like WorkstreamBacklog)."""
+	var out: Array[Dictionary] = []
+	for e in WorkstreamBacklog.entries():
+		if not workstream_backlog_taken.has(String(e.get("id", ""))):
+			out.append(e)
+	return out
+
+
+func start_workstream(backlog_id: String):
+	"""Commit the lab to a backlog item. Returns the new Workstream, or null if the id is
+	unknown or already running. Costs nothing here: pricing the START against founder
+	Attention is the plan-screen lane's call, not the substrate's."""
+	if not WorkstreamBacklog.has(backlog_id):
+		return null
+	if workstream_backlog_taken.has(backlog_id):
+		return null
+	var entry := WorkstreamBacklog.get_entry(backlog_id)
+	workstream_serial += 1
+	var ws := Workstream.make("ws_%d" % workstream_serial, entry, turn)
+	workstreams.append(ws)
+	workstream_backlog_taken.append(backlog_id)
+	return ws
+
+
+func get_workstream(workstream_id: String):
+	for ws in workstreams:
+		if ws.id == workstream_id:
+			return ws
+	return null
+
+
+func active_workstreams() -> Array:
+	var out: Array = []
+	for ws in workstreams:
+		if ws.status == Workstream.Status.ACTIVE:
+			out.append(ws)
+	return out
+
+
+func workstream_for_researcher(researcher: Researcher):
+	"""The ACTIVE workstream this person is committed to, or null if they self-direct.
+	A researcher is on at most one workstream at a time (assign_to_workstream enforces it):
+	splitting one person across bets is exactly the fungible-scalar move ADR-0011 kills."""
+	if researcher == null or researcher.candidate_id == "":
+		return null
+	for ws in workstreams:
+		if ws.status == Workstream.Status.ACTIVE and ws.is_assigned(researcher.candidate_id):
+			return ws
+	return null
+
+
+func assign_to_workstream(researcher: Researcher, workstream_id: String) -> bool:
+	"""Commit a researcher to a workstream at plan speed. Pulls them off any other one
+	first. Returns false if the workstream is unknown/finished or they were already there."""
+	var ws = get_workstream(workstream_id)
+	if ws == null or ws.status != Workstream.Status.ACTIVE:
+		return false
+	var rid := researcher_id(researcher)
+	if rid == "":
+		return false
+	if ws.is_assigned(rid):
+		return false
+	release_from_workstreams(researcher)
+	return ws.assign(rid)
+
+
+func release_from_workstreams(researcher: Researcher) -> bool:
+	"""Take a person off whatever they are on (back to self-directing). Their accrued
+	contribution stays recorded on the workstream."""
+	if researcher == null or researcher.candidate_id == "":
+		return false
+	var released := false
+	for ws in workstreams:
+		if ws.unassign(researcher.candidate_id):
+			released = true
+	return released
+
+
+func record_self_directed(topic_key: String, actual: float, reported: float) -> void:
+	"""Tally self-directed work by topic. TWO figures by ruling (2026-07-27): `actual` is
+	the deterministic truth, `reported` is what the unsupervised researcher claims.
+	SEAM: audits ground-truth reported vs actual (a later lane) -- nothing reads
+	`reported` yet. Review-by 2026-08-31."""
+	var bucket: Dictionary = self_directed_progress.get(topic_key, {"actual": 0.0, "reported": 0.0})
+	# Snapped at the accumulator so live == saved (DoomSystem.SAVE_QUANTUM; see the note in
+	# Workstream.accrue -- an unsnapped live tally forks a loaded run from an unsaved one).
+	bucket["actual"] = DoomSystem._snap(float(bucket.get("actual", 0.0)) + actual)
+	bucket["reported"] = DoomSystem._snap(float(bucket.get("reported", 0.0)) + reported)
+	self_directed_progress[topic_key] = bucket
+
+
+func workstream_readout() -> Array[String]:
+	"""Minimal ASCII debug readout for this lane (the plan-screen assignment verb is a
+	separate UI carve). Lists running workstreams, then the self-directed drift with the
+	claimed-vs-true gap the audit hour will eventually reconcile."""
+	var lines: Array[String] = []
+	if workstreams.is_empty():
+		lines.append("[workstreams] none started -- all staff self-directing")
+	for ws in workstreams:
+		lines.append("[workstreams] " + ws.readout_line())
+	var topics: Array = self_directed_progress.keys()
+	topics.sort()  # order-stable readout regardless of Dictionary iteration order
+	for t in topics:
+		var b: Dictionary = self_directed_progress[t]
+		lines.append("[self-directed] %s: %.1f actual / %.1f reported (gap %.1f)" % [
+			String(t), float(b.get("actual", 0.0)), float(b.get("reported", 0.0)),
+			float(b.get("reported", 0.0)) - float(b.get("actual", 0.0)),
+		])
+	return lines
+
 func add_candidate(candidate: Researcher):
 	"""Add a candidate to the hiring pool"""
 	# Phase B: stamp a stable id (+ deterministic visa flag) so the pipeline can reference
@@ -1100,6 +1265,19 @@ func to_dict() -> Dictionary:
 	for paper in paper_submissions:
 		paper_dicts.append(paper.to_dict())
 
+	# Serialize workstreams (ADR-0011 substrate). Self-directed tallies are float pairs, so
+	# they get the same serialization-boundary snap as every other sim float.
+	var workstream_dicts = []
+	for ws in workstreams:
+		workstream_dicts.append(ws.to_dict())
+	var self_directed_out := {}
+	for t in self_directed_progress.keys():
+		var b: Dictionary = self_directed_progress[t]
+		self_directed_out[String(t)] = {
+			"actual": DoomSystem._snap(float(b.get("actual", 0.0))),
+			"reported": DoomSystem._snap(float(b.get("reported", 0.0))),
+		}
+
 	return {
 		"money": money,
 		"compute": compute,
@@ -1199,7 +1377,14 @@ func to_dict() -> Dictionary:
 		"start_month": start_month,
 		"start_day": start_day,
 		"pending_hire_queue": pending_hire_dicts,
-		"rival_labs_full": rival_full_dicts  # "rival_labs" stays display summaries for the UI
+		"rival_labs_full": rival_full_dicts,  # "rival_labs" stays display summaries for the UI
+		# --- Workstream substrate (ADR-0011 s3/s4, #613). ADDITIVE top-level keys, one per
+		# concern (convention rule 2); a pre-substrate save loads with an empty board. ---
+		"workstreams": workstream_dicts,
+		"workstream_backlog_taken": workstream_backlog_taken.duplicate(),
+		"workstream_serial": workstream_serial,
+		"researcher_id_serial": researcher_id_serial,
+		"self_directed_progress": self_directed_out
 	}
 
 
@@ -1393,3 +1578,25 @@ func from_dict(data: Dictionary) -> void:
 		for paper_data in data["paper_submissions"]:
 			var paper = PaperSubmissions.PaperSubmission.from_dict(paper_data)
 			paper_submissions.append(paper)
+
+	# Restore the workstream substrate (ADR-0011 s3/s4, #613). Every key is optional: a
+	# pre-substrate save restores to an empty board with the full backlog available.
+	workstreams.clear()
+	for ws_data in data.get("workstreams", []):
+		if ws_data is Dictionary:
+			workstreams.append(Workstream.from_dict(ws_data))
+	workstream_backlog_taken.clear()
+	for bid in data.get("workstream_backlog_taken", []):
+		workstream_backlog_taken.append(String(bid))
+	workstream_serial = int(data.get("workstream_serial", 0))
+	researcher_id_serial = int(data.get("researcher_id_serial", 0))
+	self_directed_progress.clear()
+	var sd_data = data.get("self_directed_progress", {})
+	if sd_data is Dictionary:
+		for t in sd_data.keys():
+			var b = sd_data[t]
+			if b is Dictionary:
+				self_directed_progress[String(t)] = {
+					"actual": DoomSystem._snap(float(b.get("actual", 0.0))),
+					"reported": DoomSystem._snap(float(b.get("reported", 0.0))),
+				}

--- a/godot/scripts/core/paper_submissions.gd
+++ b/godot/scripts/core/paper_submissions.gd
@@ -45,6 +45,13 @@ class PaperSubmission:
 	var research_invested: float = 0.0
 	var lead_researcher_name: String = ""  # Track by name since Researcher refs may change
 	var co_author_names: Array[String] = []
+	# The workstream this paper came out of ("" = no workstream, the legacy path).
+	# ADR-0011 s4: workstreams "produce artifacts (papers, systems, campaigns)". This is the
+	# idea-carrying seam -- a paper stops being a decontextualized counter++ and points back
+	# at the multi-month bet that generated it. Emission itself (progress threshold -> paper,
+	# contributors -> authors) is a LATER lane; this lane only opens the ref where the struct
+	# already serializes, so no save migration is owed when emission lands.
+	var source_workstream: String = ""
 
 	# ADR-0010 B8 -- PER-THING reputation: the standing this specific paper carries.
 	# Rises when the paper is adopted by a named lab/body (the Wednesday adoption
@@ -99,7 +106,8 @@ class PaperSubmission:
 			"lead_researcher_name": lead_researcher_name,
 			"co_author_names": co_author_names,
 			# ADR-0010 B8 -- NEW KEY ONLY (snapped, same grid as the rest of the save).
-			"standing": DoomSystem._snap(standing)
+			"standing": DoomSystem._snap(standing),
+			"source_workstream": source_workstream  # ADR-0011 s4 idea-carrying seam ("" = legacy path)
 		}
 
 	static func from_dict(data: Dictionary) -> PaperSubmission:
@@ -119,6 +127,7 @@ class PaperSubmission:
 		paper.lead_researcher_name = String(data.get("lead_researcher_name", ""))
 		# ADR-0010 B8: absent on pre-typing saves -> the paper loads with no standing.
 		paper.standing = DoomSystem._snap(float(data.get("standing", 0.0)))
+		paper.source_workstream = String(data.get("source_workstream", ""))  # "" for pre-substrate saves
 		paper.co_author_names.clear()
 		for n in data.get("co_author_names", []):
 			paper.co_author_names.append(String(n))

--- a/godot/scripts/core/researcher.gd
+++ b/godot/scripts/core/researcher.gd
@@ -118,6 +118,27 @@ var quirk_known: bool = false              # true once an exposure event surface
 var loyalty_risk: float = 0.0              # 0..1 hidden flight predisposition (NOT live loyalty)
 
 # ============================================================================
+# DIRECTION -- FOCUS TOPIC + SELF-DIRECTED WORK (ADR-0011 s3, lane T1 / issue #613)
+# The topic this person is pointed at. -1 = UNSET, in which case their lane picks for
+# them (Workstream.agenda_topic). Values are PaperSubmissions.Topic enum members, shared
+# with papers on purpose so a workstream's output needs no topic translation.
+#
+# The two self-directed tallies below are the ADR-0011 delegation lesson made cheap: a
+# researcher nobody assigned still works -- on their own agenda, at their own topic --
+# and they report that work OPTIMISTICALLY. `self_directed_effort` is the deterministic
+# TRUTH; `self_directed_reported` is what the person claims on the plan screen.
+#
+# SEAM (ruled 2026-07-27, review-by 2026-08-31): AUDITS ground-truth reported vs actual.
+# The audit founder-hour type is a LATER lane -- nothing consumes self_directed_reported
+# yet. It exists now so the distortion source and its record are in the save format
+# before the mechanic that reads them lands. ASSIGNED (planned) workstream progress stays
+# single-valued and truthful: only self-direction misreports, first pass.
+# ============================================================================
+var focus_topic: int = -1                  # PaperSubmissions.Topic value, or -1 = unset
+var self_directed_effort: float = 0.0      # ACTUAL self-directed effort (the truth)
+var self_directed_reported: float = 0.0    # what this person CLAIMS (optimism-inflated)
+
+# ============================================================================
 # SPECIALIZATIONS
 # ============================================================================
 
@@ -598,6 +619,53 @@ func has_quirk() -> bool:
 	"""True if this person actually carries a quirk (regardless of whether it is known)."""
 	return quirk != ""
 
+# ============================================================================
+# DIRECTION -- SELF-DIRECTED ACCRUAL + OPTIMISTIC SELF-REPORT
+# ============================================================================
+
+func stable_key() -> String:
+	"""A handle that survives save/load and is stable for one person across a run. The
+	pipeline id when there is one (direct/legacy hires have none), else the name."""
+	return candidate_id if candidate_id != "" else researcher_name
+
+
+func self_report_optimism() -> float:
+	"""This person's habitual over-claim factor, >= 1.0. DETERMINISTIC and seeded off their
+	own stable key -- NOT an rng draw (ADR-0006: adding an rng source here would fork every
+	recorded replay). Same person, same run, same factor, every tick.
+
+	First-pass GENTLE per the 2026-07-27 ruling: the band is small enough that an audit
+	finds a nagging discrepancy, not a fraud. Constants live in
+	balance/defaults.json workstreams.self_direction.*."""
+	var lo: float = Balance.num("workstreams.self_direction.optimism_min", 1.05)
+	var span: float = maxf(0.0, Balance.num("workstreams.self_direction.optimism_span", 0.30))
+	var key := stable_key()
+	if key == "":
+		return DoomSystem._snap(lo)
+	# abs(hash) % 1000 -> a stable 0..1 position inside the band. String hashing is a pure
+	# function of the characters, so this replays identically.
+	var pos: float = float(abs(hash(key)) % 1000) / 999.0
+	return DoomSystem._snap(lo + span * pos)
+
+
+func accrue_self_directed(amount: float) -> Dictionary:
+	"""Record `amount` of self-directed effort. Returns {actual, reported} for this tick.
+	The reported figure is the inflated claim; the actual is the truth. Audits (later lane)
+	are what reconcile them -- nothing reads `reported` today."""
+	if amount <= 0.0:
+		return {"actual": 0.0, "reported": 0.0}
+	# Snapped at the accumulator (not just at to_dict) so the live value and the saved value
+	# sit on the same grid -- see DoomSystem.SAVE_QUANTUM and the note in Workstream.accrue.
+	var claimed: float = amount * self_report_optimism()
+	self_directed_effort = DoomSystem._snap(self_directed_effort + amount)
+	self_directed_reported = DoomSystem._snap(self_directed_reported + claimed)
+	return {"actual": amount, "reported": claimed}
+
+
+func self_report_gap() -> float:
+	"""Claimed minus actual self-directed effort -- what an audit would surface."""
+	return self_directed_reported - self_directed_effort
+
 # --- Hire-state lifecycle (guarded transitions) ---
 
 func can_transition_to(new_state: int) -> bool:
@@ -749,6 +817,11 @@ func to_dict() -> Dictionary:
 		"meet_people_done": meet_people_done,
 		"mentoring_done": mentoring_done,
 		"mentoring_skipped": mentoring_skipped,
+		# --- Direction (ADR-0011 workstream substrate). ADDITIVE keys: a pre-substrate
+		# save simply loads with focus unset and zero self-directed effort. ---
+		"focus_topic": focus_topic,
+		"self_directed_effort": DoomSystem._snap(self_directed_effort),
+		"self_directed_reported": DoomSystem._snap(self_directed_reported),
 	}
 
 func from_dict(data: Dictionary):
@@ -804,3 +877,9 @@ func from_dict(data: Dictionary):
 	meet_people_done = bool(data.get("meet_people_done", false))
 	mentoring_done = bool(data.get("mentoring_done", false))
 	mentoring_skipped = bool(data.get("mentoring_skipped", false))
+
+	# --- Direction (ADR-0011 workstream substrate). Missing keys = pre-substrate save:
+	# focus unset (-1, lane decides) and no self-directed history. ---
+	focus_topic = int(data.get("focus_topic", -1))
+	self_directed_effort = DoomSystem._snap(float(data.get("self_directed_effort", 0.0)))
+	self_directed_reported = DoomSystem._snap(float(data.get("self_directed_reported", 0.0)))

--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -35,9 +35,11 @@ func start_turn() -> Dictionary:
 	var lifecycle_notes: Array = _step_process_researcher_lifecycles()
 	var staff_salaries: float = _step_pay_salaries(total_staff)
 	var prod: Dictionary = _step_researcher_productivity()
+	var workstream_notes: Array = _step_workstream_accrual()
 	var stationery: Dictionary = _step_consume_stationery()
 	var messages: Array = _build_start_turn_messages(max_ap, total_staff, staff_salaries, prod, stationery, ledger_result)
 	messages.append_array(lifecycle_notes)
+	messages.append_array(workstream_notes)
 	var triggered_events: Array[Dictionary] = _step_check_events(messages)
 
 	return {
@@ -297,6 +299,66 @@ func _step_researcher_productivity() -> Dictionary:
 		"unmanaged_employees": unmanaged_employees,
 		"total_unproductive": total_unproductive,
 	}
+
+func _step_workstream_accrual() -> Array:
+	"""=== WORKSTREAM ACCRUAL (ADR-0011 s3/s4, lane T1 / issue #613) ===
+	Every employed researcher's effort lands SOMEWHERE this tick:
+	  - assigned to an active workstream -> effort accrues into that multi-month bet, and
+	    the workstream's compute_intensity is billed per head against the fleet (atom A7);
+	  - assigned to nothing -> they SELF-DIRECT on their agenda topic (ADR-0011 s3, 'idle
+	    staff don't exist; unmanaged staff do'). That work is real but unsteered, and they
+	    report it OPTIMISTICALLY -- state.record_self_directed keeps the true and the
+	    claimed figure side by side.
+
+	SEAM (ruled 2026-07-27, review-by 2026-08-31): AUDITS ground-truth reported vs actual.
+	The audit founder-hour is a later lane; nothing consumes the reported figure yet.
+
+	DETERMINISM (ADR-0006): this step makes ZERO rng draws, so inserting it does not shift
+	the seeded stream -- recorded replays from before the substrate stay valid. It is also
+	INERT on an untouched run: with no workstreams started, nothing is billed to compute
+	and only bookkeeping tallies move.
+
+	Returns feed lines for COMPLETIONS only (feed discipline: per-tick effort trickle is a
+	readout, not news)."""
+	var notes: Array = []
+	if state.researchers.is_empty():
+		return notes
+	var scale: float = Balance.num("workstreams.effort_per_turn_scale", 1.0)
+	var self_mult: float = Balance.num("workstreams.self_direction.effort_multiplier", 0.8)
+	var starved_mult: float = Balance.num("workstreams.compute_starved_effort_multiplier", 0.5)
+
+	for researcher in state.researchers:
+		# get_effective_productivity() already folds burnout, jet lag, quirk and onboarding
+		# in -- effort is the SAME quantity the research roll is scaled by, just not gambled.
+		var effort: float = researcher.get_effective_productivity() * scale
+		if effort <= 0.0:
+			continue
+		var ws = state.workstream_for_researcher(researcher)
+		if ws == null:
+			# Unassigned: self-direct on the agenda topic (explicit focus_topic, else lane).
+			var topic: int = Workstream.agenda_topic(researcher.specialization, researcher.focus_topic)
+			var rec: Dictionary = researcher.accrue_self_directed(effort * self_mult)
+			state.record_self_directed(Workstream.topic_key(topic),
+				float(rec["actual"]), float(rec["reported"]))
+			continue
+		# Assigned: bill this workstream's compute intensity for this head, then accrue.
+		# A fleet that cannot cover the charge does not idle the person -- it slows them
+		# (they queue for runs). The charge is skipped entirely when it cannot be paid, so
+		# compute never goes negative on this path.
+		var charge: float = DoomSystem._snap(ws.compute_demand_per_turn_per_head())
+		if charge > 0.0:
+			if state.compute >= charge:
+				# Snapped: compute is a saved scalar, and an unsnapped decrement would leave
+				# the live value 1 ulp off what the save writes (DoomSystem.SAVE_QUANTUM).
+				state.compute = DoomSystem._snap(state.compute - charge)
+			else:
+				effort *= starved_mult
+		var was_complete: bool = ws.is_complete()
+		ws.accrue(state.researcher_id(researcher), effort, state.turn)
+		if ws.is_complete() and not was_complete:
+			notes.append("[workstream] '%s' reached its target (%s, lead: %s)" % [
+				ws.title, Workstream.topic_key(ws.topic), ws.lead_contributor()])
+	return notes
 
 func _step_consume_stationery() -> Dictionary:
 	"""=== STATIONERY SYSTEM === Staff consume stationery each turn; running out

--- a/godot/scripts/core/workstream.gd
+++ b/godot/scripts/core/workstream.gd
@@ -1,0 +1,295 @@
+extends RefCounted
+class_name Workstream
+## A multi-month unit of directed work (ADR-0011 s3/s4, build lane L2 / issue #613).
+##
+## This is the substrate the month plan was always pointing at: `month_plan.gd:21` calls
+## staff effort + strategic WIP "the seam L2 workstreams extend". A Workstream is world
+## state, not a trophy: it carries a TOPIC, the people committed to it, the effort they
+## have poured in, and the compute that work demands. Artifacts (papers, systems,
+## campaigns) are emitted off it by later lanes -- this object only owns the accounting.
+##
+## DETERMINISM (ADR-0006): every method here is a pure function of its inputs plus the
+## object's own state. There is NO rng in this file and none is wanted -- effort accrual
+## must replay byte-identically, and assignment is player input, which replays for free.
+## Floats that cross the save boundary are snapped to DoomSystem.SAVE_QUANTUM (Godot's
+## JSON parse is not correctly-rounded; see the SERIALIZATION block in game_state.gd).
+##
+## SCOPE NOTE (lane T1, 2026-07-27): objects + backlog + assignment + topic accrual +
+## compute intensity only. AP-pool deletion and the Attention migration are lane T2;
+## founder-hour typing (doors/approvals/audits/reserve) and manager shields are later
+## rungs. Nothing here reads or writes action_points.
+
+# Topic vocabulary is SHARED with papers on purpose (RESEARCH_IDEA_PAPER_PIPELINE_GAP
+# "Add a per-researcher focus_topic (reuse the PaperSubmissions.Topic enum)") -- a
+# workstream that emits a paper must not have to translate its topic on the way out.
+const TOPIC_KEYS := {
+	PaperSubmissions.Topic.SAFETY: "safety",
+	PaperSubmissions.Topic.ALIGNMENT: "alignment",
+	PaperSubmissions.Topic.INTERPRETABILITY: "interpretability",
+	PaperSubmissions.Topic.CAPABILITIES: "capabilities",
+	PaperSubmissions.Topic.GOVERNANCE: "governance",
+}
+
+# Researcher specialization -> the topic they self-direct toward when nobody has assigned
+# them anything (ADR-0011 s3: "idle staff don't exist; unmanaged staff do"). A researcher
+# with an explicit focus_topic overrides this; the map is only the fallback agenda.
+const SPECIALIZATION_TOPIC := {
+	"safety": PaperSubmissions.Topic.SAFETY,
+	"alignment": PaperSubmissions.Topic.ALIGNMENT,
+	"interpretability": PaperSubmissions.Topic.INTERPRETABILITY,
+	"capabilities": PaperSubmissions.Topic.CAPABILITIES,
+	"governance": PaperSubmissions.Topic.GOVERNANCE,
+}
+
+# Accrual cadence. A turn is one WORKDAY (Clock.TURNS_PER_WEEK = 5); a plan-month is the
+# decision cadence above it. compute_intensity is quoted PER ASSIGNED RESEARCHER PER
+# MONTH (the readable unit), so the per-turn charge divides by this. Balance-tunable
+# ("workstreams.turns_per_month"); the const is the fallback.
+const TURNS_PER_MONTH := 22
+
+enum Status {
+	PROPOSED,   # sitting on the backlog / created but not started
+	ACTIVE,     # running: assigned people accrue into it each tick
+	COMPLETE,   # effort_target reached
+	ABANDONED,  # dropped by the player (terminal; kept for the ledger/readout)
+}
+
+var id: String = ""
+var backlog_id: String = ""          # which backlog entry minted this (may be "" for ad-hoc)
+var title: String = ""
+var topic: int = PaperSubmissions.Topic.SAFETY
+var status: int = Status.PROPOSED
+
+# --- Effort accounting (the multi-month bet) ---
+var effort_accrued: float = 0.0      # total effort poured in
+var effort_target: float = 100.0     # effort at which the workstream completes
+var duration_months: int = 3         # PLANNED span (design intent; the target is the gate)
+var assigned_ids: Array[String] = [] # stable researcher ids (GameState mints these)
+var contributions: Dictionary = {}   # researcher_id -> float effort contributed
+var started_on_turn: int = -1
+var completed_on_turn: int = -1
+var turns_active: int = 0            # ticks on which this workstream accrued anything
+
+# --- Compute intensity (atom A7, the nested streams-proposal dial) ---
+# Compute units this workstream demands PER ASSIGNED RESEARCHER PER MONTH, on top of the
+# flat per-researcher burn in turn_manager. 0.0 = a pen-and-paper workstream. This is one
+# field and one consumption hook by design: no influence stocks, no compute market yet.
+var compute_intensity: float = 1.0
+
+
+static func topic_key(topic_value: int) -> String:
+	"""Lowercase stable key for a topic enum value (used by balance lookups + readouts)."""
+	return String(TOPIC_KEYS.get(topic_value, "general"))
+
+
+static func topic_from_key(key: String, default_topic: int = PaperSubmissions.Topic.SAFETY) -> int:
+	"""Parse a lowercase topic key (as written in data/workstreams/backlog.json)."""
+	for t in TOPIC_KEYS.keys():
+		if TOPIC_KEYS[t] == key:
+			return int(t)
+	return default_topic
+
+
+static func agenda_topic(specialization: String, focus_topic: int) -> int:
+	"""The topic a researcher works toward when self-directing. An explicitly-set
+	focus_topic (>= 0) wins; otherwise their lane picks for them. Pure lookup, no rng --
+	self-direction is a RULE, not a dice roll (ADR-0006)."""
+	if focus_topic >= 0:
+		return focus_topic
+	return int(SPECIALIZATION_TOPIC.get(specialization, PaperSubmissions.Topic.SAFETY))
+
+
+static func make(new_id: String, entry: Dictionary, current_turn: int) -> Workstream:
+	"""Build a workstream from a backlog entry dict (see WorkstreamBacklog)."""
+	var ws := Workstream.new()
+	ws.id = new_id
+	ws.backlog_id = String(entry.get("id", ""))
+	ws.title = String(entry.get("title", new_id))
+	ws.topic = Workstream.topic_from_key(String(entry.get("topic", "safety")))
+	ws.effort_target = maxf(1.0, float(entry.get("effort_target", 100.0)))
+	ws.duration_months = maxi(1, int(entry.get("duration_months", 3)))
+	ws.compute_intensity = maxf(0.0, float(entry.get("compute_intensity", 1.0)))
+	ws.status = Status.ACTIVE
+	ws.started_on_turn = current_turn
+	return ws
+
+
+# --- Assignment ---
+
+func assign(researcher_id: String) -> bool:
+	"""Commit a researcher to this workstream. Idempotent-false on a double-assign so the
+	caller can tell 'already here' from 'newly committed'."""
+	if researcher_id == "" or assigned_ids.has(researcher_id):
+		return false
+	if status == Status.COMPLETE or status == Status.ABANDONED:
+		return false
+	assigned_ids.append(researcher_id)
+	# Sorted so serialization, readouts and lead-contributor tie-breaks are order-stable
+	# regardless of the order the player clicked people in.
+	assigned_ids.sort()
+	return true
+
+
+func unassign(researcher_id: String) -> bool:
+	"""Pull a researcher off. Their accrued CONTRIBUTION stays -- effort already spent is
+	spent, and later lanes read contributions for authorship."""
+	var idx := assigned_ids.find(researcher_id)
+	if idx < 0:
+		return false
+	assigned_ids.remove_at(idx)
+	return true
+
+
+func is_assigned(researcher_id: String) -> bool:
+	return assigned_ids.has(researcher_id)
+
+
+func assigned_count() -> int:
+	return assigned_ids.size()
+
+
+# --- Accrual ---
+
+func accrue(researcher_id: String, amount: float, current_turn: int) -> float:
+	"""Pour `amount` effort in on behalf of `researcher_id`. Returns the effort actually
+	accepted (0.0 once complete/abandoned). Deterministic: no rng, no clock reads."""
+	if amount <= 0.0:
+		return 0.0
+	if status != Status.ACTIVE:
+		return 0.0
+	# SNAP AT THE ACCUMULATOR, not just at to_dict: the LIVE value has to sit on the same
+	# binary-exact grid the save writes, or a loaded run continues from a 1-ulp-different
+	# base and diverges from an unsaved continuation (the doom-intermediary lesson,
+	# DoomSystem.SAVE_QUANTUM ~1e-6 -- gameplay-invisible, replay-critical).
+	var accepted: float = amount
+	effort_accrued = DoomSystem._snap(effort_accrued + accepted)
+	contributions[researcher_id] = DoomSystem._snap(
+		float(contributions.get(researcher_id, 0.0)) + accepted)
+	turns_active += 1
+	if effort_accrued >= effort_target:
+		status = Status.COMPLETE
+		completed_on_turn = current_turn
+	return accepted
+
+
+func progress() -> float:
+	"""0.0 .. 1.0 fraction of the effort target reached."""
+	if effort_target <= 0.0:
+		return 1.0
+	return clampf(effort_accrued / effort_target, 0.0, 1.0)
+
+
+func is_complete() -> bool:
+	return status == Status.COMPLETE
+
+
+func abandon() -> void:
+	"""Drop the workstream. Terminal; the accrued effort and contributions are kept so the
+	readout (and any later ledger entry) can show what was sunk into it."""
+	if status == Status.ACTIVE or status == Status.PROPOSED:
+		status = Status.ABANDONED
+
+
+func lead_contributor() -> String:
+	"""The researcher id with the most effort in this workstream ("" if none). Ties break
+	on the lower id string, so the answer never depends on Dictionary iteration order."""
+	var best_id: String = ""
+	var best: float = -1.0
+	var keys: Array = contributions.keys()
+	keys.sort()
+	for k in keys:
+		var v := float(contributions[k])
+		if v > best:
+			best = v
+			best_id = String(k)
+	return best_id
+
+
+# --- Compute intensity (A7) ---
+
+static func turns_per_month() -> int:
+	return maxi(1, Balance.inum("workstreams.turns_per_month", TURNS_PER_MONTH))
+
+
+func compute_demand_per_month() -> float:
+	"""Compute units this workstream wants for a whole plan-month at its current staffing."""
+	return compute_intensity * float(assigned_ids.size())
+
+
+func compute_demand_per_turn() -> float:
+	"""The per-workday slice of the monthly demand (what the accrual hook actually bills)."""
+	return compute_demand_per_turn_per_head() * float(assigned_ids.size())
+
+
+func compute_demand_per_turn_per_head() -> float:
+	"""Per-assigned-researcher, per-turn compute charge. The consumption hook bills this
+	per person so a partly-starved fleet degrades person-by-person, not all-or-nothing."""
+	return compute_intensity / float(Workstream.turns_per_month())
+
+
+# --- Readout (minimal UI for this lane; the plan-screen verb is a separate CARVE lane) ---
+
+func status_text() -> String:
+	match status:
+		Status.PROPOSED: return "Proposed"
+		Status.ACTIVE: return "Active"
+		Status.COMPLETE: return "Complete"
+		Status.ABANDONED: return "Abandoned"
+	return "Unknown"
+
+
+func readout_line() -> String:
+	"""One ASCII line for the debug readout: no emoji, house chrome only."""
+	return "[%s] %s (%s) %d%% -- %d assigned, %.1f/%.1f effort, compute %.2f/mo" % [
+		status_text(), title, Workstream.topic_key(topic),
+		int(round(progress() * 100.0)), assigned_ids.size(),
+		effort_accrued, effort_target, compute_demand_per_month(),
+	]
+
+
+# --- Serialization (game_state.gd SERIALIZATION CONVENTION rule 1) ---
+
+func to_dict() -> Dictionary:
+	return {
+		"id": id,
+		"backlog_id": backlog_id,
+		"title": title,
+		"topic": topic,
+		"status": status,
+		"effort_accrued": DoomSystem._snap(effort_accrued),
+		"effort_target": DoomSystem._snap(effort_target),
+		"duration_months": duration_months,
+		"assigned_ids": assigned_ids.duplicate(),
+		"contributions": DoomSystem._snap_dict(contributions),
+		"started_on_turn": started_on_turn,
+		"completed_on_turn": completed_on_turn,
+		"turns_active": turns_active,
+		"compute_intensity": DoomSystem._snap(compute_intensity),
+	}
+
+
+static func from_dict(data: Dictionary) -> Workstream:
+	"""Rebuild from a save dict. Explicit casts throughout: JSON hands every number back
+	as a float and every array back untyped (#618)."""
+	var ws := Workstream.new()
+	ws.id = String(data.get("id", ""))
+	ws.backlog_id = String(data.get("backlog_id", ""))
+	ws.title = String(data.get("title", ""))
+	ws.topic = int(data.get("topic", PaperSubmissions.Topic.SAFETY))
+	ws.status = int(data.get("status", Status.PROPOSED))
+	ws.effort_accrued = DoomSystem._snap(float(data.get("effort_accrued", 0.0)))
+	ws.effort_target = DoomSystem._snap(float(data.get("effort_target", 100.0)))
+	ws.duration_months = int(data.get("duration_months", 3))
+	ws.assigned_ids.clear()
+	for rid in data.get("assigned_ids", []):
+		ws.assigned_ids.append(String(rid))
+	ws.contributions = {}
+	var contrib = data.get("contributions", {})
+	if contrib is Dictionary:
+		for k in contrib.keys():
+			ws.contributions[String(k)] = DoomSystem._snap(float(contrib[k]))
+	ws.started_on_turn = int(data.get("started_on_turn", -1))
+	ws.completed_on_turn = int(data.get("completed_on_turn", -1))
+	ws.turns_active = int(data.get("turns_active", 0))
+	ws.compute_intensity = DoomSystem._snap(float(data.get("compute_intensity", 1.0)))
+	return ws

--- a/godot/scripts/core/workstream.gd.uid
+++ b/godot/scripts/core/workstream.gd.uid
@@ -1,0 +1,1 @@
+uid://4siormdwhceo

--- a/godot/scripts/core/workstream_backlog.gd
+++ b/godot/scripts/core/workstream_backlog.gd
@@ -1,0 +1,87 @@
+extends RefCounted
+class_name WorkstreamBacklog
+## The standing backlog of directed work (ADR-0011 s3: "idle staff don't exist"). Loads
+## res://data/workstreams/backlog.json once and exposes a read-only API GameState uses to
+## mint Workstream objects. Same shape as QuirkCatalogue -- data over hardcoding.
+##
+## DETERMINISM (ADR-0006): entries() returns the list SORTED BY ID, never in JSON/parse
+## order, so any code that indexes or iterates the backlog is order-stable across
+## platforms and reloads. There is no rng here: which workstream starts is player input.
+
+const Definitions = preload("res://scripts/data/definition_loader.gd")
+const BACKLOG_PATH := "res://data/workstreams/backlog.json"
+
+static var _loaded: bool = false
+static var _entries: Array[Dictionary] = []
+static var _by_id: Dictionary = {}
+
+
+static func _ensure_loaded() -> void:
+	if _loaded:
+		return
+	_loaded = true
+	var data := Definitions.load_object(BACKLOG_PATH, "WorkstreamBacklog")
+	var raw = data.get("workstreams", [])
+	var collected: Array[Dictionary] = []
+	if raw is Array:
+		for e in raw:
+			if e is Dictionary and String(e.get("id", "")) != "":
+				collected.append((e as Dictionary).duplicate(true))
+	collected.sort_custom(func(a, b): return String(a.get("id", "")) < String(b.get("id", "")))
+	_entries = collected
+	_by_id = {}
+	for e in _entries:
+		_by_id[String(e.get("id", ""))] = e
+	if _entries.is_empty():
+		push_error("[WorkstreamBacklog] No workstreams loaded from %s" % BACKLOG_PATH)
+
+
+static func reload() -> void:
+	"""Force a re-read (tests + the balance reload path)."""
+	_loaded = false
+	_entries = []
+	_by_id = {}
+	_ensure_loaded()
+
+
+static func entries() -> Array[Dictionary]:
+	"""All backlog entries, id-sorted. Copies out -- callers must not mutate the cache."""
+	_ensure_loaded()
+	var out: Array[Dictionary] = []
+	for e in _entries:
+		out.append(e.duplicate(true))
+	return out
+
+
+static func size() -> int:
+	_ensure_loaded()
+	return _entries.size()
+
+
+static func has(entry_id: String) -> bool:
+	_ensure_loaded()
+	return _by_id.has(entry_id)
+
+
+static func get_entry(entry_id: String) -> Dictionary:
+	"""One backlog entry by id, or {} if unknown."""
+	_ensure_loaded()
+	var e = _by_id.get(entry_id, {})
+	return (e as Dictionary).duplicate(true) if e is Dictionary else {}
+
+
+static func ids() -> Array[String]:
+	_ensure_loaded()
+	var out: Array[String] = []
+	for e in _entries:
+		out.append(String(e.get("id", "")))
+	return out
+
+
+static func entries_for_topic(topic_key: String) -> Array[Dictionary]:
+	"""Backlog entries on one topic (id-sorted, like entries())."""
+	var out: Array[Dictionary] = []
+	for e in entries():
+		if String(e.get("topic", "")) == topic_key:
+			out.append(e)
+	return out

--- a/godot/scripts/core/workstream_backlog.gd.uid
+++ b/godot/scripts/core/workstream_backlog.gd.uid
@@ -1,0 +1,1 @@
+uid://cdhjyd6bi4we5

--- a/godot/tests/unit/test_workstream.gd
+++ b/godot/tests/unit/test_workstream.gd
@@ -1,0 +1,416 @@
+extends GutTest
+## ADR-0011 s3/s4 WORKSTREAM SUBSTRATE (lane T1 / issue #613).
+##
+## Covers the substrate atoms this lane owns:
+##  1. Workstream object -- effort accrual, completion, lead contributor, compute intensity.
+##  2. Backlog + per-person assignment (one person, one bet).
+##  3. Topic-tagged accrual through the turn hook; unassigned staff self-direct on their
+##     agenda and REPORT optimistically (actual vs reported; audits reconcile them later).
+##  4. compute_intensity (atom A7) billed per assigned head against the compute resource.
+##  5. Serialization round-trip (Workstream, GameState keys, PaperSubmission.source_workstream).
+##
+## DETERMINISM (ADR-0006) is the load-bearing property: accrual makes no rng draws, so the
+## same seed + same inputs must produce byte-identical tallies. Tests 3/5 pin that.
+##
+## NOT covered here (other lanes): AP-pool deletion, founder-hour typing, manager shields,
+## artifact emission from a completed workstream, the plan-screen assignment UI.
+
+
+func _new_state(seed_str: String) -> GameState:
+	var s := GameState.new(seed_str)
+	s.turn = 1
+	return s
+
+
+func _employ(state: GameState, spec: String, name: String, skill: int = 5) -> Researcher:
+	var r := Researcher.new(spec, name)
+	r.researcher_name = name
+	r.skill_level = skill
+	r.base_productivity = 0.5 + skill * 0.1
+	state.add_researcher(r)
+	return r
+
+
+func _entry(id_str: String = "t_ws", topic: String = "safety", target: float = 10.0,
+		intensity: float = 1.0) -> Dictionary:
+	return {
+		"id": id_str,
+		"title": "Test workstream",
+		"topic": topic,
+		"effort_target": target,
+		"duration_months": 2,
+		"compute_intensity": intensity,
+	}
+
+
+# ============================================================================
+# 1. The Workstream object
+# ============================================================================
+
+func test_make_reads_the_backlog_entry():
+	var ws := Workstream.make("ws_1", _entry("eval", "interpretability", 40.0, 2.5), 7)
+	assert_eq(ws.id, "ws_1")
+	assert_eq(ws.backlog_id, "eval")
+	assert_eq(ws.topic, PaperSubmissions.Topic.INTERPRETABILITY, "topic key parses to the shared paper enum")
+	assert_eq(ws.effort_target, 40.0)
+	assert_eq(ws.compute_intensity, 2.5)
+	assert_eq(ws.status, Workstream.Status.ACTIVE, "a started workstream is active at once")
+	assert_eq(ws.started_on_turn, 7)
+
+
+func test_accrual_accumulates_and_completes_at_target():
+	var ws := Workstream.make("ws_1", _entry("t", "safety", 10.0, 0.0), 0)
+	ws.assign("staff_1")
+	ws.accrue("staff_1", 4.0, 1)
+	assert_almost_eq(ws.progress(), 0.4, 0.0001, "progress is effort over target")
+	assert_false(ws.is_complete(), "not done yet")
+	ws.accrue("staff_1", 6.0, 2)
+	assert_true(ws.is_complete(), "hitting the target completes it")
+	assert_eq(ws.completed_on_turn, 2, "completion stamps the turn it landed")
+
+
+func test_completed_workstream_accepts_no_more_effort():
+	var ws := Workstream.make("ws_1", _entry("t", "safety", 5.0, 0.0), 0)
+	ws.accrue("staff_1", 5.0, 1)
+	assert_eq(ws.accrue("staff_1", 5.0, 2), 0.0, "a finished bet is a closed account")
+	assert_almost_eq(ws.effort_accrued, 5.0, 0.0001)
+
+
+func test_lead_contributor_is_the_biggest_contributor_and_ties_break_stably():
+	var ws := Workstream.make("ws_1", _entry("t", "safety", 1000.0, 0.0), 0)
+	ws.accrue("staff_2", 3.0, 1)
+	ws.accrue("staff_1", 9.0, 1)
+	assert_eq(ws.lead_contributor(), "staff_1", "most effort leads")
+	var tied := Workstream.make("ws_2", _entry("t2", "safety", 1000.0, 0.0), 0)
+	tied.accrue("staff_9", 5.0, 1)
+	tied.accrue("staff_3", 5.0, 1)
+	assert_eq(tied.lead_contributor(), "staff_3", "ties break on the lower id, never on dict order")
+
+
+func test_agenda_topic_prefers_explicit_focus_over_lane():
+	assert_eq(Workstream.agenda_topic("capabilities", -1), PaperSubmissions.Topic.CAPABILITIES,
+		"unset focus falls back to the researcher's lane")
+	assert_eq(Workstream.agenda_topic("capabilities", PaperSubmissions.Topic.GOVERNANCE),
+		PaperSubmissions.Topic.GOVERNANCE, "an explicitly-set focus_topic wins")
+
+
+# ============================================================================
+# 2. Backlog + assignment
+# ============================================================================
+
+func test_backlog_loads_and_is_id_sorted():
+	var ids := WorkstreamBacklog.ids()
+	assert_gt(ids.size(), 0, "the backlog data file loads")
+	var sorted_ids := ids.duplicate()
+	sorted_ids.sort()
+	assert_eq(ids, sorted_ids, "entries come back id-sorted (order-stable across platforms)")
+
+
+func test_start_workstream_consumes_the_backlog_entry():
+	var s := _new_state("ws_start")
+	var backlog_id: String = WorkstreamBacklog.ids()[0]
+	var before := s.available_backlog().size()
+	var ws = s.start_workstream(backlog_id)
+	assert_not_null(ws, "a known backlog id starts")
+	assert_eq(s.workstreams.size(), 1)
+	assert_eq(s.available_backlog().size(), before - 1, "the entry leaves the available list")
+	assert_null(s.start_workstream(backlog_id), "starting the same entry twice is refused")
+	assert_null(s.start_workstream("no_such_entry"), "an unknown id is refused")
+
+
+func test_assignment_is_exclusive_one_person_one_workstream():
+	var s := _new_state("ws_assign")
+	var r := _employ(s, "safety", "Assignee One")
+	var ids := WorkstreamBacklog.ids()
+	var a = s.start_workstream(ids[0])
+	var b = s.start_workstream(ids[1])
+	assert_true(s.assign_to_workstream(r, a.id), "first assignment lands")
+	assert_eq(s.workstream_for_researcher(r).id, a.id)
+	assert_true(s.assign_to_workstream(r, b.id), "re-assigning moves them")
+	assert_eq(s.workstream_for_researcher(r).id, b.id, "they are on the new bet")
+	assert_eq(a.assigned_count(), 0, "and off the old one -- no splitting a person across bets")
+	assert_false(s.assign_to_workstream(r, b.id), "assigning where they already are is a no-op")
+
+
+func test_release_keeps_the_contribution():
+	var s := _new_state("ws_release")
+	var r := _employ(s, "safety", "Departing Person")
+	var ws = s.start_workstream(WorkstreamBacklog.ids()[0])
+	s.assign_to_workstream(r, ws.id)
+	ws.accrue(r.candidate_id, 7.0, 1)
+	assert_true(s.release_from_workstreams(r), "they come off the workstream")
+	assert_eq(ws.assigned_count(), 0)
+	assert_almost_eq(float(ws.contributions.get(r.candidate_id, 0.0)), 7.0, 0.0001,
+		"effort already spent stays on the record (authorship reads it later)")
+
+
+func test_removing_a_researcher_releases_them():
+	var s := _new_state("ws_remove")
+	var r := _employ(s, "safety", "Quitter")
+	var ws = s.start_workstream(WorkstreamBacklog.ids()[0])
+	s.assign_to_workstream(r, ws.id)
+	s.remove_researcher(r)
+	assert_eq(ws.assigned_count(), 0, "a departing person stops accruing")
+
+
+func test_researcher_ids_are_stable_and_unique():
+	var s := _new_state("ws_ids")
+	var a := _employ(s, "safety", "Person A")
+	var b := _employ(s, "safety", "Person B")
+	var id_a := s.researcher_id(a)
+	assert_ne(id_a, "", "an employed person always resolves to an id")
+	assert_eq(s.researcher_id(a), id_a, "resolving is idempotent for the same person")
+	assert_ne(s.researcher_id(b), id_a, "and unique across people")
+
+
+func test_ids_are_minted_only_for_people_who_have_none():
+	# add_researcher already stamps a pipeline 'cand_N' id; minting is the fallback for
+	# people who never went through it (legacy/loaded records).
+	var s := _new_state("ws_mint")
+	var stamped := _employ(s, "safety", "Stamped Person")
+	assert_true(stamped.candidate_id.begins_with("cand_"), "the pipeline id is left alone")
+	var orphan := Researcher.new("safety", "Orphan Record")
+	var minted := s.researcher_id(orphan)
+	assert_true(minted.begins_with("staff_"), "a minted id cannot collide with 'cand_' serials")
+	assert_eq(s.researcher_id(orphan), minted, "and it sticks to that person")
+
+
+# ============================================================================
+# 3. Topic-tagged accrual through the turn hook
+# ============================================================================
+
+func _run_accrual(state: GameState, ticks: int) -> void:
+	var tm := TurnManager.new(state)
+	for i in range(ticks):
+		tm._step_workstream_accrual()
+
+
+func test_assigned_effort_lands_on_the_workstream():
+	var s := _new_state("ws_accrue")
+	var r := _employ(s, "safety", "Worker")
+	var ws = s.start_workstream("incident_taxonomy")  # compute_intensity 0.0: isolates effort
+	s.assign_to_workstream(r, ws.id)
+	_run_accrual(s, 3)
+	assert_gt(ws.effort_accrued, 0.0, "assigned work accrues into the bet")
+	assert_almost_eq(ws.effort_accrued, r.get_effective_productivity() * 3.0, 0.0001,
+		"three ticks of one person's effective productivity, ungambled")
+	assert_almost_eq(r.self_directed_effort, 0.0, 0.0001, "an assigned person self-directs nothing")
+
+
+func test_unassigned_staff_self_direct_on_their_lane():
+	var s := _new_state("ws_selfdirect")
+	var r := _employ(s, "interpretability", "Unsteered Person")
+	_run_accrual(s, 2)
+	assert_gt(r.self_directed_effort, 0.0, "idle staff don't exist -- they work on their own agenda")
+	assert_true(s.self_directed_progress.has("interpretability"),
+		"the tally is tagged with their lane's topic")
+	assert_false(s.self_directed_progress.has("safety"), "and not with anyone else's")
+
+
+func test_focus_topic_redirects_self_directed_work():
+	var s := _new_state("ws_focus")
+	var r := _employ(s, "capabilities", "Redirected Person")
+	r.focus_topic = PaperSubmissions.Topic.GOVERNANCE
+	_run_accrual(s, 1)
+	assert_true(s.self_directed_progress.has("governance"),
+		"an explicit focus_topic beats the lane default")
+
+
+func test_self_reported_progress_is_optimistic_and_deterministic():
+	var s := _new_state("ws_optimism")
+	var r := _employ(s, "safety", "Optimistic Person")
+	_run_accrual(s, 4)
+	assert_gt(r.self_directed_reported, r.self_directed_effort,
+		"unsupervised progress is over-claimed (the audit seam)")
+	var factor := r.self_report_optimism()
+	assert_gte(factor, 1.0, "the optimism factor never under-claims")
+	assert_lte(factor, 1.05 + 0.3 + 0.0001, "and stays inside the first-pass gentle band")
+	assert_eq(r.self_report_optimism(), factor, "the factor is stable for one person")
+	assert_almost_eq(r.self_report_gap(), r.self_directed_reported - r.self_directed_effort, 0.0001)
+
+
+func test_assigned_progress_stays_single_valued_and_truthful():
+	# By ruling (2026-07-27): only SELF-DIRECTED work misreports, first pass. A planned
+	# workstream's progress is the truth, full stop.
+	var s := _new_state("ws_truthful")
+	var r := _employ(s, "safety", "Steered Person")
+	var ws = s.start_workstream("incident_taxonomy")
+	s.assign_to_workstream(r, ws.id)
+	_run_accrual(s, 3)
+	assert_eq(s.self_directed_progress.size(), 0, "assigned work leaves no self-directed tally")
+	assert_almost_eq(r.self_directed_reported, 0.0, 0.0001, "and nothing to over-claim")
+
+
+func test_accrual_is_deterministic_for_the_same_seed():
+	# THE replay-safety property: no rng in the accrual path, so two identical runs must
+	# produce identical tallies down to the float.
+	var results: Array = []
+	for run in range(2):
+		var s := _new_state("ws_determinism")
+		var a := _employ(s, "safety", "Alpha", 6)
+		var b := _employ(s, "capabilities", "Beta", 4)
+		var ws = s.start_workstream("eval_harness")
+		s.assign_to_workstream(a, ws.id)
+		_run_accrual(s, 5)
+		results.append({
+			"effort": ws.effort_accrued,
+			"compute": s.compute,
+			"self_actual": b.self_directed_effort,
+			"self_reported": b.self_directed_reported,
+			"tally": s.self_directed_progress.duplicate(true),
+		})
+	assert_eq(results[0], results[1], "same seed, same inputs -> byte-identical accrual")
+
+
+func test_accrual_draws_no_rng():
+	var s := _new_state("ws_no_rng")
+	_employ(s, "safety", "Person")
+	var before := s.rng.state
+	_run_accrual(s, 5)
+	assert_eq(s.rng.state, before, "the accrual hook must not move the seeded stream")
+
+
+# ============================================================================
+# 4. compute_intensity (atom A7)
+# ============================================================================
+
+func test_compute_intensity_is_billed_per_assigned_head():
+	var s := _new_state("ws_compute")
+	var r := _employ(s, "safety", "Compute Hog")
+	var ws = s.start_workstream("scaling_probe")  # compute_intensity 4.0/month
+	s.assign_to_workstream(r, ws.id)
+	var before := s.compute
+	_run_accrual(s, 1)
+	var expected := 4.0 / float(Workstream.turns_per_month())
+	assert_almost_eq(before - s.compute, expected, 0.0001,
+		"one tick bills one month's intensity divided by the month's ticks, per head")
+
+
+func test_zero_intensity_workstreams_bill_nothing():
+	var s := _new_state("ws_pen_and_paper")
+	var r := _employ(s, "governance", "Policy Person")
+	var ws = s.start_workstream("incident_taxonomy")  # compute_intensity 0.0
+	s.assign_to_workstream(r, ws.id)
+	var before := s.compute
+	_run_accrual(s, 3)
+	assert_almost_eq(s.compute, before, 0.0001, "pen-and-paper work costs no compute")
+
+
+func test_compute_starvation_slows_but_does_not_idle():
+	var s := _new_state("ws_starved")
+	var r := _employ(s, "safety", "Queued Person")
+	var ws = s.start_workstream("scaling_probe")
+	s.assign_to_workstream(r, ws.id)
+	s.compute = 0.0
+	_run_accrual(s, 1)
+	assert_almost_eq(s.compute, 0.0, 0.0001, "an unpayable charge is skipped, never overdrawn")
+	assert_gt(ws.effort_accrued, 0.0, "a starved researcher is slowed, not idled")
+	assert_lt(ws.effort_accrued, r.get_effective_productivity(),
+		"but they get less done than a researcher whose runs never queue")
+
+
+func test_monthly_demand_scales_with_staffing():
+	var ws := Workstream.make("ws_1", _entry("t", "safety", 100.0, 2.0), 0)
+	assert_almost_eq(ws.compute_demand_per_month(), 0.0, 0.0001, "an unstaffed bet demands nothing")
+	ws.assign("staff_1")
+	ws.assign("staff_2")
+	assert_almost_eq(ws.compute_demand_per_month(), 4.0, 0.0001, "two heads at intensity 2.0")
+
+
+# ============================================================================
+# 5. Serialization
+# ============================================================================
+
+func _json_hop(d: Dictionary) -> Dictionary:
+	return JSON.parse_string(JSON.stringify(d)) as Dictionary
+
+
+func test_workstream_round_trips_through_json():
+	var ws := Workstream.make("ws_7", _entry("eval", "alignment", 55.0, 1.5), 3)
+	ws.assign("staff_2")
+	ws.assign("staff_1")
+	ws.accrue("staff_1", 12.5, 4)
+	var restored := Workstream.from_dict(_json_hop(ws.to_dict()))
+	assert_eq(restored.to_dict(), ws.to_dict(), "a workstream survives the JSON hop intact")
+	assert_eq(restored.assigned_ids, ["staff_1", "staff_2"], "assignment order is stable (sorted)")
+	assert_almost_eq(float(restored.contributions.get("staff_1", 0.0)), 12.5, 0.0001)
+
+
+func test_game_state_round_trips_the_substrate():
+	var s := _new_state("ws_save")
+	var r := _employ(s, "safety", "Saved Person")
+	var idle := _employ(s, "alignment", "Idle Person")
+	var ws = s.start_workstream("red_team_program")
+	s.assign_to_workstream(r, ws.id)
+	_run_accrual(s, 3)
+
+	var restored := GameState.new("ws_save")
+	restored.from_dict(_json_hop(s.to_dict()))
+	assert_eq(restored.workstreams.size(), 1, "workstreams restore")
+	assert_eq(restored.workstreams[0].id, ws.id)
+	assert_almost_eq(restored.workstreams[0].effort_accrued, ws.effort_accrued, 0.0001)
+	assert_eq(restored.workstream_backlog_taken, s.workstream_backlog_taken, "taken backlog ids restore")
+	assert_eq(restored.workstream_serial, s.workstream_serial)
+	assert_eq(restored.researcher_id_serial, s.researcher_id_serial)
+	assert_eq(restored.self_directed_progress, s.self_directed_progress,
+		"the actual/reported self-direction tally restores as a pair")
+	assert_eq(restored.to_dict()["workstreams"], s.to_dict()["workstreams"],
+		"and the whole substrate re-serializes deep-equal")
+	assert_eq(idle.focus_topic, -1, "an unset focus stays unset")
+
+
+func test_researcher_direction_fields_round_trip():
+	var r := Researcher.new("safety", "Round Tripper")
+	r.candidate_id = "cand_3"
+	r.focus_topic = PaperSubmissions.Topic.GOVERNANCE
+	r.accrue_self_directed(4.0)
+	var restored := Researcher.new()
+	restored.from_dict(_json_hop(r.to_dict()))
+	assert_eq(restored.focus_topic, PaperSubmissions.Topic.GOVERNANCE)
+	assert_almost_eq(restored.self_directed_effort, r.self_directed_effort, 0.0001)
+	assert_almost_eq(restored.self_directed_reported, r.self_directed_reported, 0.0001)
+
+
+func test_pre_substrate_saves_load_with_an_empty_board():
+	# Additive-keys guarantee: a save written before this lane has none of the new keys.
+	var s := _new_state("ws_legacy")
+	var legacy := s.to_dict()
+	legacy.erase("workstreams")
+	legacy.erase("workstream_backlog_taken")
+	legacy.erase("workstream_serial")
+	legacy.erase("researcher_id_serial")
+	legacy.erase("self_directed_progress")
+	var restored := GameState.new("ws_legacy")
+	restored.from_dict(_json_hop(legacy))
+	assert_eq(restored.workstreams.size(), 0, "old saves load with an empty board")
+	assert_eq(restored.workstream_backlog_taken.size(), 0)
+	assert_eq(restored.self_directed_progress.size(), 0)
+
+
+func test_paper_carries_its_source_workstream():
+	var paper := PaperSubmissions.PaperSubmission.new()
+	paper.title = "Toward Safe Something"
+	paper.source_workstream = "ws_4"
+	var restored := PaperSubmissions.PaperSubmission.from_dict(_json_hop(paper.to_dict()))
+	assert_eq(restored.source_workstream, "ws_4", "the idea-carrying ref survives the save hop")
+	var legacy_dict := paper.to_dict()
+	legacy_dict.erase("source_workstream")
+	var legacy := PaperSubmissions.PaperSubmission.from_dict(legacy_dict)
+	assert_eq(legacy.source_workstream, "", "a pre-substrate paper loads with no workstream")
+
+
+func test_readout_lists_workstreams_and_the_self_report_gap():
+	var s := _new_state("ws_readout")
+	assert_true("none started" in s.workstream_readout()[0], "an empty board says so")
+	var r := _employ(s, "safety", "Readout Person")
+	var idle := _employ(s, "governance", "Drifting Person")
+	var ws = s.start_workstream("incident_taxonomy")
+	s.assign_to_workstream(r, ws.id)
+	_run_accrual(s, 2)
+	var lines := s.workstream_readout()
+	assert_gt(lines.size(), 1, "the readout lists the workstream and the drift")
+	var joined := "\n".join(lines)
+	assert_true("[workstreams]" in joined, "workstream lines are tagged")
+	assert_true("[self-directed]" in joined, "so is the unsteered drift")
+	assert_true("gap" in joined, "and the claimed-vs-true gap the audit hour will reconcile")
+	assert_not_null(idle)

--- a/godot/tests/unit/test_workstream.gd.uid
+++ b/godot/tests/unit/test_workstream.gd.uid
@@ -1,0 +1,1 @@
+uid://ck3pdv1wkjr0x


### PR DESCRIPTION
Lane T1 of the ADR-0011 **T3 rung** ("the substrate lands and AP dies", ruled 2026-07-27 1240). This PR is the **substrate core only** -- atoms A4/A5/A6 + A7 + the A2 seam. Explicitly out of scope and owned by other lanes: **AP-pool deletion + Attention migration (T2, owns actions.gd)**, founder-hour typing, manager shields (T4).

Authority: `docs/game-design/decisions/ADR-0011-effort-economy.md` s3/s4, `docs/game-design/RESEARCH_IDEA_PAPER_PIPELINE_GAP.md` (the focus_topic -> Workstream seam), issue #613.

## What lands

1. **`Workstream` object** (`godot/scripts/core/workstream.gd`) on the `month_plan.gd:21` seam -- topic, effort accrued vs target, duration_months, assignees, per-person contributions, lead contributor, status lifecycle, `compute_intensity`, full serialization.
2. **Backlog + per-person assignment** -- data-driven `godot/data/workstreams/backlog.json` (8 first-pass entries across the five topics) behind `WorkstreamBacklog`, plus GameState wiring: `start_workstream` / `assign_to_workstream` / `release_from_workstreams` / `workstream_for_researcher` / `available_backlog` / `workstream_readout`. A researcher is on **at most one** workstream (splitting a person across bets is the fungible-scalar move ADR-0011 exists to kill). A departing researcher is released but their contribution stays on the record.
3. **Topic-tagged accrual** (`turn_manager._step_workstream_accrual`) -- assigned effort accrues into the bet; **unassigned researchers self-direct** on their agenda topic (explicit `focus_topic`, else their lane) per ADR-0011 s3 "idle staff don't exist; unmanaged staff do". Effort is `get_effective_productivity()` -- the same quantity the research roll scales, just not gambled.
4. **Idea-carrying papers seam** -- `PaperSubmission.source_workstream` added where the struct already serializes. Emission (threshold -> paper, contributors -> authors) is a later lane; opening the ref now means no save migration is owed then.
5. **`compute_intensity` per topic (atom A7)** -- a 0..N float on the workstream, quoted per assigned researcher per **month**, billed per head per tick against the existing compute resource. A fleet that cannot cover the charge **slows** the researcher (`compute_starved_effort_multiplier`) rather than idling them, and the unpayable charge is skipped so compute never goes negative. One field, one consumption hook; no influence stocks.

## Mid-flight ruling addition (flagged per instruction)

Pip's four-way founder-hour ruling (2026-07-27) makes **unassigned self-directing researchers the audit target**, so this PR builds the distortion source now:

- Self-directed work carries **two** figures: `actual` (deterministic truth) and `reported` (what the researcher claims). Both live on the `Researcher` and in `GameState.self_directed_progress` per topic.
- The optimism factor is **deterministic per person**, seeded off their stable key (`Researcher.self_report_optimism`) -- **no new rng source**, so recorded replays are untouched. First-pass gentle band: `optimism_min` 1.05 + `optimism_span` 0.30, both in `defaults.json` and marked first-pass.
- **Assigned/planned progress stays single-valued and truthful** -- only self-direction misreports, first pass.
- **Nothing consumes `reported` yet.** It serializes additively and shows in the debug readout. Seam named in comments at every site: *audits ground-truth reported vs actual (ruled 2026-07-27, review-by 2026-08-31)*.

## Determinism + save format

- The accrual hook makes **zero rng draws**, so the seeded stream is unshifted and pre-substrate replays stay valid (there is a test pinning `rng.state`).
- Every accumulator snaps to `DoomSystem.SAVE_QUANTUM` **at the accumulator**, not only at `to_dict` -- an unsnapped live value forks a loaded run from an unsaved continuation (this is what the L7 round-trip test caught mid-build).
- Save keys are **additive only**: `workstreams`, `workstream_backlog_taken`, `workstream_serial`, `researcher_id_serial`, `self_directed_progress` at the top level, plus additive `Researcher` (`focus_topic`, `self_directed_effort`, `self_directed_reported`) and `PaperSubmission` (`source_workstream`) keys. **No existing key was restructured**, so the rep-key lane landing this week merges clean. Pre-substrate saves load with an empty board (tested).
- The whole substrate is **inert until a workstream is started**: an untouched run bills no compute and only moves bookkeeping tallies.

## UI

Minimal by design -- `GameState.workstream_readout()` emits ASCII debug lines (`[workstreams] ...` / `[self-directed] ... (gap N)`), and a completion note goes to the turn feed. The plan-screen assignment verb is the separate CARVE lane.

## Verification

- **Fast gate: 838 tests, 0 failures** (`--quick --ci-mode --min-tests 300`), 29 of them new in `tests/unit/test_workstream.gd` covering accrual determinism (same seed -> byte-identical), the no-rng property, exclusive assignment, compute billing + starvation, optimism band + stability, and three serialization round-trips (Workstream, GameState substrate, PaperSubmission) plus a pre-substrate-save load.
- **Simulation tier**: `test_engine_determinism`, `test_property_determinism` and `test_replay_verification` run directly and **all 13 pass**. The full `--simulation` runner hit its own 15-minute cap on this machine (those three files alone take 5.5 min here) -- a machine-speed timeout, not a regression.

Closes part of #613 (substrate atoms only; AP death and founder-hour typing remain open on that issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
