### PR TITLE
fix(scenes): re-entry run-killer family -- start_new_game self-guard, dev-overlay return path, Play Again check, reentry regression test

### DIFF
--- a/godot/scripts/debug/debug_overlay.gd
+++ b/godot/scripts/debug/debug_overlay.gd
@@ -429,4 +429,6 @@ func _on_reset_game_button_pressed():
 	var gm = _live_gm()
 	if gm:
 		ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Debug: Reset game requested", {})
-		gm.start_new_game()
+		# Deliberate reset over a live run -- force=true declares that intent explicitly
+		# (start_new_game's self-guard otherwise refuses, scene-reentry run-killer family).
+		gm.start_new_game("", true)

--- a/godot/scripts/debug/dev_mode_overlay.gd
+++ b/godot/scripts/debug/dev_mode_overlay.gd
@@ -305,10 +305,16 @@ func _jump_employee() -> void:
 
 
 func _jump_leaderboard() -> void:
+	# Scene-reentry run-killer family (sibling of #979): this used to leave a live main.tscn
+	# behind with no handoff -- leaderboard_screen's Back only ever went to welcome, whence
+	# Launch Lab / Load Game silently clobbered the run. leaderboard_screen._live_run_active()
+	# now detects the still-live GameManager autoload directly (is_initialized && not
+	# game_over) and offers "[BACK TO GAME]" instead, so no flag needs setting here.
 	SceneTransition.go_to("res://scenes/leaderboard_screen.tscn")
 
 
 func _jump_settings() -> void:
+	# See _jump_leaderboard() above -- settings_menu._live_run_active() does the same check.
 	SceneTransition.go_to("res://scenes/settings_menu.tscn")
 
 

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -43,8 +43,21 @@ var last_conference_trip: Dictionary = {}
 func _ready():
 	print("[GameManager] Pure GDScript version ready")
 
-func start_new_game(game_seed: String = ""):
-	"""Initialize new game - pure GDScript - FIX #418: Handle initial events"""
+func start_new_game(game_seed: String = "", force: bool = false):
+	"""Initialize new game - pure GDScript - FIX #418: Handle initial events.
+
+	Self-guard (scene-reentry run-killer family, sibling of #979): this used to
+	unconditionally replace `state`, so every caller had to remember its own guard --
+	the dev-overlay leaderboard/settings jump forgot, and silently destroyed a live run.
+	Refuses to run when a game is already live unless the caller passes force=true.
+	Legitimate fresh-start callers (welcome/config_confirmation Launch-Lab chain via
+	main_ui._boot_game's fresh-boot branch, the debug "Reset Game" button) pass
+	force=true explicitly -- that is the caller declaring "yes, I mean to end the
+	current run"."""
+	if is_initialized and not force:
+		push_warning("[GameManager] start_new_game() REFUSED: a game is already live (is_initialized=true) and force=false would silently destroy it. Pass force=true if this is a deliberate reset/new-game.")
+		PerfLog.mark("start_new_game_refused", {"turn": state.turn if state != null else -1})
+		return
 	# Get config from GameConfig singleton if seed not provided
 	if game_seed.is_empty():
 		game_seed = GameConfig.get_display_seed()
@@ -789,9 +802,18 @@ func save_game(path: String = SaveLoad.QUICKSAVE_PATH) -> bool:
 	action_executed.emit({"success": true, "message": "Game saved (turn %d)" % state.turn})
 	return true
 
-func load_saved_game(path: String = SaveLoad.QUICKSAVE_PATH) -> bool:
+func load_saved_game(path: String = SaveLoad.QUICKSAVE_PATH, force: bool = false) -> bool:
 	"""Restore a saved game and resume exactly where it left off (phase, queued
-	actions, pending events, rng stream). Returns false if no/corrupt save."""
+	actions, pending events, rng stream). Returns false if no/corrupt save.
+
+	Self-guard (scene-reentry run-killer family, sibling of #979): same rule as
+	start_new_game -- refuses to clobber a live run unless force=true. The one
+	legitimate caller (main_ui._boot_game's queued-load branch) passes force=true;
+	it only fires straight off a fresh main.tscn boot, before any run exists."""
+	if is_initialized and not force:
+		push_warning("[GameManager] load_saved_game() REFUSED: a game is already live (is_initialized=true) and force=false would silently destroy it. Pass force=true if this is a deliberate load-over.")
+		PerfLog.mark("load_saved_game_refused", {"turn": state.turn if state != null else -1})
+		return false
 	var envelope := SaveLoad.load_envelope(path)
 	if envelope.is_empty():
 		error_occurred.emit("No save found to load")

--- a/godot/scripts/ui/config_confirmation.gd
+++ b/godot/scripts/ui/config_confirmation.gd
@@ -1,6 +1,13 @@
 extends Control
 ## Configuration Confirmation Screen - Shows locked-in game settings before launch
 ## Used for default pathway to show what options are configured
+##
+## ASSUMPTION (scene-reentry run-killer family, sibling of #979): this screen assumes a
+## pre-game context -- its Launch button drives main.tscn's fresh-boot path
+## (main_ui._boot_game -> GameManager.start_new_game(force=true)), which REPLACES any live
+## run. It must never be reachable mid-run without GameManager.pending_resume (or an
+## equivalent resume flag) set first. Before adding a new nav edge into this screen, check
+## that path can't be taken while a game is live.
 
 # UI References
 @onready var player_name_label = $Panel/VBox/FieldsContainer/PlayerNameRow/ValueLabel

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -535,7 +535,17 @@ func _on_copy_result_pressed() -> void:
 		copy_result_button.text = "Copied to clipboard"
 
 func _on_play_again_pressed():
-	"""Restart the game"""
+	"""Restart the game.
+
+	VERIFIED (scene-reentry run-killer family audit, sibling of #979): this looks like it
+	reloads the GAME-OVER SCREEN, not the game, but it doesn't -- GameOverScreen is never its
+	own current_scene. It only ever lives as a child of TabManager inside main.tscn
+	(godot/scenes/main.tscn, node "GameOverScreen"; see also test_endgame_score_isolation.gd /
+	test_game_over_remote_isolation.gd, which instantiate it standalone for isolated testing,
+	never as the live tree root). So get_tree().current_scene at this point IS main.tscn, and
+	SceneTransition.reload() reloads main.tscn -- re-running main_ui._boot_game(), whose
+	fresh-start branch calls GameManager.start_new_game("", true) (force=true: a real reset,
+	not a reentry bug). Play Again works correctly."""
 	print("[GameOverScreen] Play Again pressed")
 	# Reload the main scene to restart
 	SceneTransition.reload()

--- a/godot/scripts/ui/leaderboard_screen.gd
+++ b/godot/scripts/ui/leaderboard_screen.gd
@@ -46,6 +46,7 @@ var global_toggle_button: Button = null
 @onready var avg_score_label = $MarginContainer/VBoxContainer/Stats/AvgScore
 @onready var best_score_label = $MarginContainer/VBoxContainer/Stats/BestScore
 @onready var subtitle = $MarginContainer/VBoxContainer/Header/Subtitle
+@onready var back_button: Button = $MarginContainer/VBoxContainer/Buttons/BackButton
 
 func _ready():
 	ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Leaderboard screen opened", {})
@@ -56,6 +57,19 @@ func _ready():
 	_populate_seed_dropdown()
 	_setup_global_toggle()
 	_select_default_view()
+	# Scene-reentry run-killer family (sibling of #979): reached mid-run (dev-overlay jump,
+	# or any future nav) with the run still live and unfinished in the GameManager autoload.
+	# Relabel Back so it reads honestly -- it resumes the run instead of going to welcome,
+	# where Launch Lab / Load Game would silently clobber it.
+	if back_button != null and _live_run_active():
+		back_button.text = "[BACK TO GAME]"
+
+
+func _live_run_active() -> bool:
+	"""True when a real, unfinished run is sitting live in the GameManager autoload (not a
+	just-concluded game -- game_over_screen's own Back-to-leaderboard path must NOT offer
+	this; that run is over)."""
+	return GameManager.is_initialized and GameManager.state != null and not GameManager.state.game_over
 
 func _exit_tree():
 	# Cleanup guard: drop the working-set references the instant the screen leaves
@@ -683,8 +697,18 @@ func _on_back_button_pressed():
 	ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Exiting leaderboard screen", {})
 	# Try to go back to previous scene
 	if get_tree().current_scene.name == "LeaderboardScreen":
-		# If launched as main scene, go to welcome
-		SceneTransition.go_to("res://scenes/welcome.tscn")
+		if _live_run_active():
+			# Scene-reentry run-killer family (sibling of #979): a live, unfinished run is
+			# sitting in the GameManager autoload -- welcome's Launch Lab / Load Game would
+			# silently clobber it (main.tscn._boot_game has no idea it exists). Route back
+			# to main.tscn with the resume flag set instead, mirroring the conference
+			# rhythm-break's own exit (conference_vignette.gd).
+			GameManager.pending_resume = true
+			SceneTransition.go_to("res://scenes/main.tscn")
+		else:
+			# No live run (fresh session, or reached from the post-game-over leaderboard) --
+			# welcome is the correct destination.
+			SceneTransition.go_to("res://scenes/welcome.tscn")
 	else:
 		# Otherwise hide this overlay
 		queue_free()

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -706,14 +706,20 @@ func _boot_game():
 		var load_path: String = GameConfig.pending_load_path
 		GameConfig.pending_load_path = ""
 		log_message("[color=cyan]Loading saved game...[/color]")
-		if game_manager.load_saved_game(load_path):
+		# force=true: reaching here with no pending_resume flag means this really is a
+		# deliberate fresh boot of main.tscn (welcome's Load Game queued the path). The
+		# start_new_game/load_saved_game self-guard (scene-reentry run-killer family,
+		# sibling of #979) exists to catch callers that DON'T declare that intent.
+		if game_manager.load_saved_game(load_path, true):
 			return
 		log_message("[color=red]Load failed -- starting a new game instead.[/color]")
 	log_message("[color=cyan]Initializing game...[/color]")
 	# #617 debt: was hardcoded "test-seed" -- every boot ran the SAME timeline and
 	# GameConfig.game_seed was ignored. Empty arg -> GameManager falls back to
 	# GameConfig.get_display_seed() (player's configured seed, else the weekly seed).
-	game_manager.start_new_game()
+	# force=true: same reasoning as the load branch above -- no resume flag means this
+	# boot of main.tscn is a genuine fresh start (welcome/config_confirmation chain).
+	game_manager.start_new_game("", true)
 
 func _show_conference_backlog(trip: Dictionary) -> void:
 	"""The return burst -- ONE surface (ADR-0014 shell; design-seed section 1).

--- a/godot/scripts/ui/pregame_setup.gd
+++ b/godot/scripts/ui/pregame_setup.gd
@@ -1,5 +1,12 @@
 extends Control
 ## Pre-Game Setup Screen - Configure player name, lab name, seed, and difficulty using GameConfig
+##
+## ASSUMPTION (scene-reentry run-killer family, sibling of #979): this screen assumes a
+## pre-game context -- it only ever forwards to config_confirmation.tscn, whose Launch button
+## drives a fresh-boot (force=true) main.tscn that REPLACES any live run. It must never be
+## reachable mid-run without GameManager.pending_resume (or an equivalent resume flag) set
+## first. Before adding a new nav edge into this screen, check that path can't be taken while
+## a game is live.
 
 # UI References
 @onready var player_name_input = $Panel/VBox/FieldsContainer/PlayerNameRow/LineEdit

--- a/godot/scripts/ui/settings_menu.gd
+++ b/godot/scripts/ui/settings_menu.gd
@@ -33,12 +33,20 @@ var play_intros_checkbox: CheckButton = null
 @onready var ui_label = $VBox/Scroll/SettingsContainer/UISettings/UILabel
 @onready var accessibility_label = $VBox/Scroll/SettingsContainer/AccessibilitySettings/AccessibilityLabel
 @onready var keyboard_label = $VBox/Scroll/SettingsContainer/KeyboardShortcuts/KeyboardLabel
+@onready var back_button: Button = $VBox/ButtonRow/BackButton
 
 func _ready():
 	print("[SettingsMenu] Initializing...")
 
 	# Load settings from GameConfig singleton
 	update_ui_from_game_config()
+
+	# Scene-reentry run-killer family (sibling of #979): reached mid-run (dev-overlay jump,
+	# or any future nav) with the run still live and unfinished in the GameManager autoload.
+	# Relabel Back so it reads honestly -- it resumes the run instead of going to welcome,
+	# where Launch Lab / Load Game would silently clobber it.
+	if back_button != null and _live_run_active():
+		back_button.text = "[BACK TO GAME]"
 
 	# Add icons to section headers
 	_setup_section_icons()
@@ -322,13 +330,26 @@ func _on_apply_pressed():
 
 func _on_back_pressed():
 	"""Handle Back button press"""
-	print("[SettingsMenu] Returning to welcome screen...")
-
 	# Ask if user wants to save unsaved changes
 	# For now, just return (changes are applied in real-time anyway)
 
-	# Return to welcome screen
-	SceneTransition.go_to("res://scenes/welcome.tscn")
+	if _live_run_active():
+		# Scene-reentry run-killer family (sibling of #979): a live, unfinished run is
+		# sitting in the GameManager autoload -- welcome's Launch Lab / Load Game would
+		# silently clobber it (main.tscn._boot_game has no idea it exists). Route back
+		# to main.tscn with the resume flag set instead, mirroring the conference
+		# rhythm-break's own exit (conference_vignette.gd).
+		print("[SettingsMenu] Returning to the live game...")
+		GameManager.pending_resume = true
+		SceneTransition.go_to("res://scenes/main.tscn")
+	else:
+		print("[SettingsMenu] Returning to welcome screen...")
+		SceneTransition.go_to("res://scenes/welcome.tscn")
+
+
+func _live_run_active() -> bool:
+	"""True when a real, unfinished run is sitting live in the GameManager autoload."""
+	return GameManager.is_initialized and GameManager.state != null and not GameManager.state.game_over
 
 func _input(event: InputEvent):
 	"""Handle keyboard shortcuts"""

--- a/godot/tests/unit/test_game_lifecycle_hygiene.gd
+++ b/godot/tests/unit/test_game_lifecycle_hygiene.gd
@@ -25,7 +25,7 @@ func test_start_new_game_frees_prior_game_node_subsystems() -> void:
 	await get_tree().process_frame
 	var orphans_after_first: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
 
-	gm.start_new_game("hygiene-seed-2")
+	gm.start_new_game("hygiene-seed-2", true)  # force: deliberate reset over the first game
 	await get_tree().process_frame
 	await get_tree().process_frame
 	var orphans_after_second: int = Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)

--- a/godot/tests/unit/test_ui_scene_reentry_safety.gd
+++ b/godot/tests/unit/test_ui_scene_reentry_safety.gd
@@ -1,0 +1,131 @@
+extends GutTest
+## Regression guard for the scene-reentry run-killer family (sibling of #979, the conference
+## rhythm-break's own live-run clobber). Root cause: GameManager.start_new_game() /
+## load_saved_game() used to unconditionally replace `state`, so every caller had to remember
+## its own guard -- the dev-mode overlay's leaderboard/settings jump forgot, leaving main.tscn
+## live with no handoff, so Launch Lab / Load Game on the far side silently destroyed the run.
+##
+## This test drives the REAL main.tscn boot (matching test_game_start_actionable.gd), then:
+##  1. asserts start_new_game() WITHOUT force refuses to touch a live run;
+##  2. asserts the two now-fixed reentry surfaces (leaderboard_screen, settings_menu) detect
+##     the live run and relabel their Back button "[BACK TO GAME]";
+##  3. asserts the fixed _boot_game() resume path (GameManager.pending_resume) reattaches to
+##     the SAME state object rather than minting a new one -- the run survives.
+##
+## Real scene-tree navigation (SceneTransition.go_to swapping get_tree().current_scene) is
+## deliberately NOT exercised here -- no test in this suite swaps the root scene (it would
+## risk tearing down the GUT runner itself); main_ui._boot_game() is called directly instead,
+## which is exactly what a real reload would invoke.
+
+var _root: Node = null
+var _main_ui: Node = null
+var _gm: Node = null
+
+
+func before_each() -> void:
+	# Boot the real scene tree exactly as the game does (test_game_start_actionable.gd's
+	# pattern): main.tscn -> TabManager -> MainUI, whose _ready() auto-boots via _boot_game().
+	var scene: PackedScene = load("res://scenes/main.tscn")
+	_root = scene.instantiate()
+	add_child_autofree(_root)
+	_main_ui = _root.find_child("MainUI", true, false)
+	assert_not_null(_main_ui, "MainUI node must exist under the scene root")
+	_gm = _main_ui.get("game_manager")
+	assert_not_null(_gm, "MainUI must have created/bound a GameManager")
+
+
+func _wait_for_boot() -> void:
+	for _i in range(10):
+		await get_tree().process_frame
+
+
+func test_start_new_game_without_force_refuses_over_live_run() -> void:
+	await _wait_for_boot()
+	assert_true(_gm.is_initialized, "precondition: a game must be live before the refusal is meaningful")
+	var original_state = _gm.state
+	var original_seed: String = String(original_state.game_seed_str)
+
+	# No force: must be refused. State object identity and seed must be unchanged.
+	_gm.start_new_game("attempted-clobber-seed")
+
+	# The refusal push_warning()s LOUDLY on purpose (that's the fix) -- GUT counts an
+	# unhandled push_warning as a test failure by default. Mark it handled: we asserted
+	# the actual behavior (refusal) above/below; this just accepts the expected log line.
+	for e in get_errors():
+		e.handled = true
+
+	assert_eq(_gm.state, original_state,
+		"start_new_game() without force must NOT replace a live game's state object")
+	assert_eq(String(_gm.state.game_seed_str), original_seed,
+		"start_new_game() without force must NOT touch a live game's seed")
+	assert_true(_gm.is_initialized, "refused start_new_game() must leave is_initialized true")
+
+
+func test_start_new_game_with_force_replaces_live_run() -> void:
+	# Sanity check for the other half of the guard: force=true is a real, working escape
+	# hatch (the debug Reset Game button / genuine fresh-boot path rely on this).
+	await _wait_for_boot()
+	var original_state = _gm.state
+	_gm.start_new_game("deliberate-reset-seed", true)
+	assert_ne(_gm.state, original_state,
+		"start_new_game(force=true) must replace the state object (deliberate reset)")
+	assert_eq(String(_gm.state.game_seed_str), "deliberate-reset-seed")
+
+
+func test_leaderboard_screen_offers_back_to_game_over_a_live_run() -> void:
+	await _wait_for_boot()
+	assert_true(_gm.is_initialized and not _gm.state.game_over,
+		"precondition: a live, unfinished run must exist")
+
+	var packed: PackedScene = load("res://scenes/leaderboard_screen.tscn")
+	var inst: Control = packed.instantiate()
+	add_child_autofree(inst)
+	await get_tree().process_frame
+
+	assert_true(inst.call("_live_run_active"),
+		"leaderboard_screen must detect the live run via GameManager")
+	var back_btn: Button = inst.get("back_button")
+	assert_not_null(back_btn, "leaderboard_screen must expose its Back button")
+	assert_eq(back_btn.text, "[BACK TO GAME]",
+		"Back button must be relabeled when a live run is reachable behind this screen")
+
+
+func test_settings_menu_offers_back_to_game_over_a_live_run() -> void:
+	await _wait_for_boot()
+	assert_true(_gm.is_initialized and not _gm.state.game_over,
+		"precondition: a live, unfinished run must exist")
+
+	var packed: PackedScene = load("res://scenes/settings_menu.tscn")
+	var inst: Control = packed.instantiate()
+	add_child_autofree(inst)
+	await get_tree().process_frame
+
+	assert_true(inst.call("_live_run_active"),
+		"settings_menu must detect the live run via GameManager")
+	var back_btn: Button = inst.get("back_button")
+	assert_not_null(back_btn, "settings_menu must expose its Back button")
+	assert_eq(back_btn.text, "[BACK TO GAME]",
+		"Back button must be relabeled when a live run is reachable behind this screen")
+
+
+func test_reentry_resume_path_preserves_the_same_live_state() -> void:
+	# Simulates the fixed round trip: dev-overlay jump -> leaderboard/settings -> Back ->
+	# main.tscn re-boot. The Back handlers set GameManager.pending_resume=true before
+	# navigating; main_ui._boot_game() is the deferred-swap target's _ready path, so calling
+	# it again on the SAME live main.tscn instance exercises exactly the decision it makes
+	# on a real reload, without swapping get_tree().current_scene (untested/risky territory
+	# for this suite -- see file header).
+	await _wait_for_boot()
+	assert_true(_gm.is_initialized, "precondition: a game must be live")
+	var original_state = _gm.state
+	var original_turn: int = original_state.turn
+
+	_gm.pending_resume = true
+	_main_ui.call("_boot_game")
+	await get_tree().process_frame
+
+	assert_false(_gm.pending_resume, "resume_in_place() must consume the one-shot flag")
+	assert_eq(_gm.state, original_state,
+		"the resume path must reattach to the SAME state object, not mint a new one")
+	assert_eq(_gm.state.turn, original_turn, "the run's turn counter must be untouched by reentry")
+	assert_true(_gm.is_initialized, "the run must still be live after reentry")

--- a/godot/tests/unit/test_ui_scene_reentry_safety.gd.uid
+++ b/godot/tests/unit/test_ui_scene_reentry_safety.gd.uid
@@ -1,0 +1,1 @@
+uid://df3fi82shy7b


### PR DESCRIPTION
## Summary

Pre-Thursday-playtest fix for the scene-reentry run-killer family (sibling of the #979 conference-reentry bug). Root cause: `GameManager.start_new_game()` / `load_saved_game()` unconditionally replaced the live game state -- every caller had to remember its own guard. The dev-mode overlay's leaderboard/settings jump forgot, leaving `main.tscn` live with no handoff, so Launch Lab / Load Game on the far side silently destroyed the run.

- **Self-guard**: `start_new_game(game_seed, force=false)` / `load_saved_game(path, force=false)` now refuse to replace a live run unless `force=true`, with a loud `push_warning` + `PerfLog.mark` on refusal. `main_ui._boot_game()`'s fresh-boot/load branches and the debug "Reset Game" button now pass `force=true` explicitly.
- **Dev-overlay return path**: `leaderboard_screen.gd` and `settings_menu.gd` detect a live, unfinished run behind them (`GameManager.is_initialized && not state.game_over`) and relabel Back `[BACK TO GAME]`, routing to `main.tscn` with `pending_resume` set (reusing the #979 conference-reentry mechanism) instead of forcing through welcome.
- **Latent hole documented**: `config_confirmation.gd` / `pregame_setup.gd` get a one-line assumption comment -- pre-game-only, must never be reached mid-run without a resume flag.
- **Play Again verdict: works correctly.** `game_over_screen.gd` lives inside `main.tscn`'s TabManager, never as its own `current_scene`, so `SceneTransition.reload()` reloads `main.tscn` and correctly re-boots through the now-forced fresh-start path. Documented in place so this isn't re-litigated.
- **Regression test**: `test_ui_scene_reentry_safety.gd` boots `main.tscn` for real and asserts (1) `start_new_game()` without `force` refuses over a live run and leaves state/seed untouched, (2) `force=true` still works as a deliberate reset, (3) leaderboard/settings detect the live run and relabel Back, (4) the resume path reattaches to the *same* state object (run survives).

## Test plan

- [x] `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -- 875 tests, 0 failures (clean first run, no perf_log flake hit)
- [x] Pre-commit hooks passed clean on first commit (ASCII/no-emoji, scene-nav chokepoint check, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)