### PR TITLE
feat(0015): S-ticket -- event doom effects rerouted to the doom engine + 46 uplifts + guard tests

### DIFF
--- a/godot/data/events/balancing/variable_mapping.json
+++ b/godot/data/events/balancing/variable_mapping.json
@@ -37,8 +37,7 @@
     },
     "legendary": {
       "research": 20,
-      "reputation": 10,
-      "doom": 5
+      "reputation": 10
     }
   }
 }

--- a/godot/data/events/core_events.json
+++ b/godot/data/events/core_events.json
@@ -62,10 +62,9 @@
 						"action_points": 1
 					},
 					"effects": {
-						"safety_researchers": 1,
-						"doom": -3
+						"safety_researchers": 1
 					},
-					"message": "Fast-tracked hiring process! (+1 safety researcher, -3 doom)"
+					"message": "Fast-tracked hiring process! (+1 safety researcher)"
 				},
 				{
 					"id": "hire_discounted",
@@ -74,10 +73,9 @@
 						"money": 25000
 					},
 					"effects": {
-						"safety_researchers": 1,
-						"doom": -2
+						"safety_researchers": 1
 					},
-					"message": "Hired talented researcher at discount! (+1 safety researcher, -2 doom)"
+					"message": "Hired talented researcher at discount! (+1 safety researcher)"
 				},
 				{
 					"id": "decline",
@@ -104,20 +102,20 @@
 					"id": "publish_open",
 					"text": "Publish Openly",
 					"effects": {
-						"doom": 5,
+						"general_capability": 5,
 						"reputation": 10,
 						"research": 20
 					},
-					"message": "Published breakthrough! (+5 doom, +10 reputation, +20 research)"
+					"message": "Published breakthrough! (+capability diffusion, +10 reputation, +20 research)"
 				},
 				{
 					"id": "keep_proprietary",
 					"text": "Keep Proprietary",
 					"effects": {
-						"doom": 2,
+						"frontier_capability": 20,
 						"research": 30
 					},
-					"message": "Kept research proprietary (+2 doom, +30 research)"
+					"message": "Kept research proprietary (+frontier capability, +30 research)"
 				},
 				{
 					"id": "safety_review",
@@ -127,11 +125,10 @@
 						"money": 20000
 					},
 					"effects": {
-						"doom": 1,
 						"research": 15,
 						"reputation": 5
 					},
-					"message": "Safety review complete (+1 doom, +15 research, +5 reputation)"
+					"message": "Safety review complete (+15 research, +5 reputation)"
 				}
 			]
 		},
@@ -222,10 +219,9 @@
 						"action_points": 2
 					},
 					"effects": {
-						"reputation": 8,
-						"doom": -5
+						"reputation": 8
 					},
-					"message": "Personal intervention prevented resignations! (+8 reputation, -5 doom)"
+					"message": "Personal intervention prevented resignations! (+8 reputation)"
 				},
 				{
 					"id": "team_retreat",
@@ -234,10 +230,9 @@
 						"money": 30000
 					},
 					"effects": {
-						"reputation": 5,
-						"doom": -2
+						"reputation": 5
 					},
-					"message": "Team retreat restored morale (+5 reputation, -2 doom)"
+					"message": "Team retreat restored morale (+5 reputation)"
 				},
 				{
 					"id": "salary_raise",
@@ -255,10 +250,9 @@
 					"text": "Push Through (costs trust -- affected researchers lose loyalty)",
 					"costs": {},
 					"effects": {
-						"doom": 3,
 						"loyalty_hit": 15
 					},
-					"message": "Nobody quit, but pushing through cost trust -- the most burned-out researchers lose loyalty. (+3 doom)"
+					"message": "Nobody quit, but pushing through cost trust -- the most burned-out researchers lose loyalty."
 				}
 			]
 		},
@@ -343,27 +337,27 @@
 						"action_points": 1
 					},
 					"effects": {
-						"doom": -10,
+						"global_alarm": 20,
 						"reputation": 15
 					},
-					"message": "Regulation passed! Global safety improved (-10 doom, +15 reputation)"
+					"message": "Regulation passed! The world is paying attention (+global alarm, +15 reputation)"
 				},
 				{
 					"id": "oppose_regulation",
 					"text": "Oppose (Stay Competitive)",
 					"effects": {
-						"doom": 5,
+						"global_alarm": -10,
 						"reputation": -5
 					},
-					"message": "Regulation weakened (+5 doom, -5 reputation)"
+					"message": "Regulation weakened; public concern deflated (-global alarm, -5 reputation)"
 				},
 				{
 					"id": "stay_neutral",
 					"text": "Remain Neutral",
 					"effects": {
-						"doom": 2
+						"global_alarm": -4
 					},
-					"message": "Stayed neutral as doom increased (+2 doom)"
+					"message": "Stayed neutral while the debate moved on (-global alarm)"
 				}
 			]
 		},
@@ -429,10 +423,9 @@
 						"money": 500
 					},
 					"effects": {
-						"has_cat": 1,
-						"doom": -1
+						"has_cat": 1
 					},
-					"message": "Cat adopted! Your researchers' morale improves slightly. The cat has claimed its spot in the lab. (-1 doom)"
+					"message": "Cat adopted! Your researchers' morale improves slightly. The cat has claimed its spot in the lab."
 				},
 				{
 					"id": "feed_and_release",
@@ -446,10 +439,8 @@
 				{
 					"id": "shoo_away",
 					"text": "Shoo It Away",
-					"effects": {
-						"doom": 1
-					},
-					"message": "The cat leaves, disappointed. Your researchers seem a bit sad. (+1 doom for being heartless)"
+					"effects": {},
+					"message": "The cat leaves, disappointed. Your researchers seem a bit sad."
 				}
 			]
 		},
@@ -472,10 +463,9 @@
 						"action_points": 1
 					},
 					"effects": {
-						"reputation": 3,
-						"doom": -1
+						"reputation": 3
 					},
-					"message": "Successful mediation! Team cohesion improved (+3 reputation, -1 doom)"
+					"message": "Successful mediation! Team cohesion improved (+3 reputation)"
 				},
 				{
 					"id": "hire_mediator",
@@ -492,10 +482,9 @@
 					"id": "ignore_conflict",
 					"text": "Let Them Work It Out",
 					"effects": {
-						"reputation": -3,
-						"doom": 2
+						"reputation": -3
 					},
-					"message": "Conflict festered and spread (-3 reputation, +2 doom)"
+					"message": "Conflict festered and spread (-3 reputation)"
 				}
 			]
 		},
@@ -538,10 +527,9 @@
 					"id": "minimize_issue",
 					"text": "Minimize the Issue",
 					"effects": {
-						"reputation": -10,
-						"doom": 3
+						"reputation": -10
 					},
-					"message": "Poor handling damaged lab culture (-10 reputation, +3 doom)"
+					"message": "Poor handling damaged lab culture (-10 reputation)"
 				}
 			]
 		},
@@ -565,10 +553,9 @@
 						"money": 60000
 					},
 					"effects": {
-						"reputation": 10,
-						"doom": -2
+						"reputation": 10
 					},
-					"message": "Salary audit complete, adjustments made (+10 reputation, -2 doom)"
+					"message": "Salary audit complete, adjustments made (+10 reputation)"
 				},
 				{
 					"id": "explain_structure",
@@ -585,10 +572,9 @@
 					"id": "ignore_concerns",
 					"text": "Dismiss Concerns",
 					"effects": {
-						"reputation": -5,
-						"doom": 1
+						"reputation": -5
 					},
-					"message": "Ignored concerns bred resentment (-5 reputation, +1 doom)"
+					"message": "Ignored concerns bred resentment (-5 reputation)"
 				}
 			]
 		},
@@ -611,10 +597,9 @@
 						"money": 30000
 					},
 					"effects": {
-						"reputation": 8,
-						"doom": -3
+						"reputation": 8
 					},
-					"message": "Provided full support. Team sees you care (+8 reputation, -3 doom)"
+					"message": "Provided full support. Team sees you care (+8 reputation)"
 				},
 				{
 					"id": "partial_leave",
@@ -629,10 +614,9 @@
 					"id": "deny_leave",
 					"text": "Deny Request (Too Busy)",
 					"effects": {
-						"reputation": -8,
-						"doom": 5
+						"reputation": -8
 					},
-					"message": "Denial caused serious damage to culture (-8 reputation, +5 doom)"
+					"message": "Denial caused serious damage to culture (-8 reputation)"
 				}
 			]
 		},
@@ -716,10 +700,9 @@
 					"id": "sweep_under_rug",
 					"text": "Ignore It (They're Valuable)",
 					"effects": {
-						"reputation": -6,
-						"doom": 2
+						"reputation": -6
 					},
-					"message": "Favoritism damaged morale (-6 reputation, +2 doom)"
+					"message": "Favoritism damaged morale (-6 reputation)"
 				}
 			]
 		},
@@ -743,10 +726,10 @@
 						"money": 30000
 					},
 					"effects": {
-						"doom": 3,
+						"general_capability": 3,
 						"reputation": 5
 					},
-					"message": "Found and addressed the leak, but damage done (+3 doom, +5 reputation)"
+					"message": "Found and addressed the leak, but the work is already spreading (+capability diffusion, +5 reputation)"
 				},
 				{
 					"id": "publish_immediately",
@@ -757,18 +740,18 @@
 					"effects": {
 						"papers": 1,
 						"reputation": 8,
-						"doom": 5
+						"general_capability": 5
 					},
-					"message": "Published to get credit, but all labs benefit (+1 paper, +8 rep, +5 doom)"
+					"message": "Published to get credit, but all labs benefit (+1 paper, +8 reputation, +capability diffusion)"
 				},
 				{
 					"id": "accept_leak",
 					"text": "Accept the Loss",
 					"effects": {
-						"doom": 8,
+						"general_capability": 8,
 						"reputation": -3
 					},
-					"message": "Competitor gained significant advantage (+8 doom, -3 reputation)"
+					"message": "Competitor gained significant advantage (+capability diffusion, -3 reputation)"
 				}
 			]
 		},
@@ -790,10 +773,10 @@
 						"money": 20000
 					},
 					"effects": {
-						"doom": -5,
+						"safety_absorption": 50,
 						"reputation": -8
 					},
-					"message": "Used intel to counter their work (-5 doom, -8 reputation for ethics)"
+					"message": "Used the intel to harden your own safety work (+safety absorption, -8 reputation for ethics)"
 				},
 				{
 					"id": "report_intel",
@@ -803,9 +786,9 @@
 					},
 					"effects": {
 						"reputation": 10,
-						"doom": -3
+						"global_alarm": 6
 					},
-					"message": "Reported concerns, triggering investigation (+10 reputation, -3 doom)"
+					"message": "Reported concerns, triggering investigation (+10 reputation, +global alarm)"
 				},
 				{
 					"id": "refuse_intel",
@@ -837,10 +820,10 @@
 						"money": 50000
 					},
 					"effects": {
-						"doom": -15,
+						"global_alarm": 30,
 						"reputation": 20
 					},
-					"message": "Major expose! Industry-wide safety improvements (-15 doom, +20 reputation)"
+					"message": "Major expose! Industry-wide alarm rises (+global alarm, +20 reputation)"
 				},
 				{
 					"id": "anonymous_support",
@@ -849,10 +832,10 @@
 						"money": 25000
 					},
 					"effects": {
-						"doom": -8,
+						"global_alarm": 16,
 						"reputation": 5
 					},
-					"message": "Quietly helped expose dangers (-8 doom, +5 reputation)"
+					"message": "Quietly helped expose dangers (+global alarm, +5 reputation)"
 				},
 				{
 					"id": "hire_whistleblower",
@@ -862,10 +845,9 @@
 						"action_points": 1
 					},
 					"effects": {
-						"safety_researchers": 1,
-						"doom": -3
+						"safety_researchers": 1
 					},
-					"message": "Hired the concerned researcher (+1 safety researcher, -3 doom)"
+					"message": "Hired the concerned researcher (+1 safety researcher)"
 				},
 				{
 					"id": "decline_involvement",
@@ -897,9 +879,9 @@
 					},
 					"effects": {
 						"reputation": 8,
-						"doom": -2
+						"global_alarm": 4
 					},
-					"message": "Transparent discussion improved practices (+8 reputation, -2 doom)"
+					"message": "Transparent discussion improved practices (+global alarm, +8 reputation)"
 				},
 				{
 					"id": "private_resolution",
@@ -917,9 +899,9 @@
 					"text": "Suppress the Issue",
 					"effects": {
 						"reputation": -15,
-						"doom": 5
+						"global_alarm": -10
 					},
-					"message": "Suppression backfired badly (-15 reputation, +5 doom)"
+					"message": "Suppression backfired badly (-global alarm, -15 reputation)"
 				}
 			]
 		},
@@ -941,10 +923,10 @@
 						"action_points": 1
 					},
 					"effects": {
-						"doom": -10,
+						"safety_absorption": 100,
 						"reputation": -15
 					},
-					"message": "Source planted, early warnings enabled -- but word of your methods spreads (-10 doom, -15 reputation)"
+					"message": "Source planted, early warnings enabled -- but word of your methods spreads (+safety absorption, -15 reputation)"
 				},
 				{
 					"id": "legitimate_partnership",
@@ -954,10 +936,10 @@
 						"money": 40000
 					},
 					"effects": {
-						"doom": -5,
+						"safety_absorption": 50,
 						"reputation": 8
 					},
-					"message": "Established safety information sharing (-5 doom, +8 reputation)"
+					"message": "Established safety information sharing (+safety absorption, +8 reputation)"
 				},
 				{
 					"id": "decline_espionage",
@@ -988,9 +970,9 @@
 					},
 					"effects": {
 						"reputation": 15,
-						"doom": -3
+						"safety_absorption": 30
 					},
-					"message": "Proactive security audit boosted confidence (+15 reputation, -3 doom)"
+					"message": "Proactive security audit boosted confidence (+safety absorption, +15 reputation)"
 				},
 				{
 					"id": "offer_help",
@@ -1008,9 +990,9 @@
 					"text": "Stay Silent",
 					"effects": {
 						"reputation": -5,
-						"doom": 2
+						"global_panic": 4
 					},
-					"message": "Silence perceived as indifference (-5 reputation, +2 doom)"
+					"message": "Silence perceived as indifference (+global panic, -5 reputation)"
 				},
 				{
 					"id": "exploit_weakness",
@@ -1021,9 +1003,9 @@
 					"effects": {
 						"money": 50000,
 						"reputation": -10,
-						"doom": 3
+						"global_panic": 6
 					},
-					"message": "Gained clients but damaged reputation (+$50k, -10 rep, +3 doom)"
+					"message": "Gained clients but damaged reputation (+$50k, -10 reputation, +global panic)"
 				}
 			]
 		},
@@ -1047,9 +1029,9 @@
 					},
 					"effects": {
 						"reputation": 8,
-						"doom": -5
+						"safety_absorption": 50
 					},
-					"message": "Comprehensive security upgrade complete (+8 reputation, -5 doom)"
+					"message": "Comprehensive security upgrade complete (+safety absorption, +8 reputation)"
 				},
 				{
 					"id": "patch_critical",
@@ -1059,17 +1041,17 @@
 					},
 					"effects": {
 						"reputation": 3,
-						"doom": -2
+						"safety_absorption": 20
 					},
-					"message": "Critical vulnerabilities patched (+3 reputation, -2 doom)"
+					"message": "Critical vulnerabilities patched (+safety absorption, +3 reputation)"
 				},
 				{
 					"id": "defer_security",
 					"text": "Defer (We're Too Busy)",
 					"effects": {
-						"doom": 5
+						"safety_absorption": -50
 					},
-					"message": "Security risks remain (+5 doom)"
+					"message": "Security risks remain; your safety posture erodes (-safety absorption)"
 				}
 			]
 		},
@@ -1112,10 +1094,9 @@
 					"id": "let_them_go",
 					"text": "Let Them Leave",
 					"effects": {
-						"lose_researcher": 1,
-						"doom": 3
+						"lose_researcher": 1
 					},
-					"message": "Researcher departed for competitor (+3 doom, lost valuable team member)"
+					"message": "Researcher departed for competitor (lost a valuable team member)"
 				}
 			]
 		}

--- a/godot/data/events/overrides/example.json
+++ b/godot/data/events/overrides/example.json
@@ -1,22 +1,20 @@
 {
   "_description": "Example override file showing how to tune pdoom-data events for game balance",
   "_note": "Only include fields you want to override - unspecified fields keep base values",
+  "_adr_0015": "NEVER add a literal 'doom' impact here. The doom LEVEL is single-authority (DoomSystem); content writes a world-state INTERMEDIARY instead (global_alarm / global_panic / safety_absorption / frontier_capability / general_capability). The doom impacts this template used to demonstrate were inert no-ops AND the worst copy-me trap in the tree.",
 
   "ftx_future_fund_collapse_2022": {
     "_reason": "The FTX collapse was a massive blow to AI safety funding - making it legendary and high-impact",
     "rarity": "legendary",
     "impacts": [
-      {"variable": "money", "change": -80},
-      {"variable": "doom", "change": 15}
-    ],
-    "pdoom_impact": 15
+      {"variable": "money", "change": -80}
+    ]
   },
 
   "openai_founded": {
     "_reason": "Founding of OpenAI is a pivotal moment in AI history - legendary rarity",
     "rarity": "legendary",
     "impacts": [
-      {"variable": "doom", "change": 5},
       {"variable": "reputation", "change": 10}
     ]
   },
@@ -25,7 +23,6 @@
     "_reason": "ChatGPT mainstreamed AI - legendary event with mixed impacts",
     "rarity": "legendary",
     "impacts": [
-      {"variable": "doom", "change": 10},
       {"variable": "reputation", "change": 5}
     ]
   }

--- a/godot/data/historical_timeline/2017.json
+++ b/godot/data/historical_timeline/2017.json
@@ -11,7 +11,6 @@
       "description": "OpenAI announces bot that can beat amateur Dota 2 players in 1v1 matches",
       "detailed_description": "OpenAI's bot learned to play Dota 2 through self-play using a scaled-up version of Proximal Policy Optimization. This demonstrated the potential of reinforcement learning at scale and sparked discussions about AI capabilities advancement.",
       "game_effect": {
-        "doom_increase": 2.0,
         "capability_research_boost": 5,
         "media_attention": true,
         "reputation_change": -1
@@ -33,7 +32,6 @@
       "description": "DeepMind's AlphaGo Zero learns Go from scratch without human data, defeating previous versions 100-0",
       "detailed_description": "AlphaGo Zero achieved superhuman performance in Go using only self-play reinforcement learning, without any human game data. This milestone demonstrated that AI systems could surpass human knowledge entirely through self-learning.",
       "game_effect": {
-        "doom_increase": 3.0,
         "capability_research_boost": 10,
         "media_attention": true
       },
@@ -54,7 +52,6 @@
       "description": "Google researchers introduce the Transformer architecture, revolutionizing NLP",
       "detailed_description": "Vaswani et al. introduce the Transformer model architecture, which would become the foundation for GPT, BERT, and virtually all modern large language models. The self-attention mechanism proved more effective than recurrent architectures.",
       "game_effect": {
-        "doom_increase": 1.0,
         "capability_research_boost": 15,
         "unlocks_research_option": "transformer_architectures"
       },
@@ -89,7 +86,6 @@
       "description": "Safety researchers reference 'Concrete Problems in AI Safety' paper (published June 2016)",
       "detailed_description": "Amodei et al.'s 'Concrete Problems in AI Safety' paper from 2016 gains traction in the safety community during 2017, establishing a research agenda around reward misspecification, safe exploration, distributional shift, robustness, and interpretability.",
       "game_effect": {
-        "doom_decrease": -0.5,
         "reputation_boost": 3,
         "unlocks_research_option": "reward_modeling_basics"
       },
@@ -105,13 +101,13 @@
           "id": "study_paper",
           "text": "Assign researchers to study concrete safety problems",
           "costs": {"action_points": 1},
-          "effects": {"research": 10, "doom": -1.0, "reputation": 2}
+          "effects": {"research": 10, "safety_absorption": 10, "reputation": 2}
         },
         {
           "id": "organize_reading_group",
           "text": "Organize safety reading group (costs 2 AP)",
           "costs": {"action_points": 2, "money": 3000},
-          "effects": {"research": 20, "doom": -2.0, "reputation": 5}
+          "effects": {"research": 20, "safety_absorption": 20, "reputation": 5}
         },
         {
           "id": "ignore",
@@ -131,7 +127,6 @@
       "description": "Future of Life Institute publishes 23 principles for beneficial AI development",
       "detailed_description": "At the Asilomar conference, AI researchers and thought leaders agree on 23 principles for safe and beneficial AI development, covering research issues, ethics and values, and longer-term considerations. These become influential in AI governance discussions.",
       "game_effect": {
-        "doom_decrease": -1.0,
         "reputation_boost": 5,
         "governance_boost": 10
       },
@@ -146,13 +141,13 @@
           "id": "endorse_principles",
           "text": "Publicly endorse Asilomar Principles",
           "costs": {"action_points": 1},
-          "effects": {"reputation": 8, "doom": -0.5}
+          "effects": {"reputation": 8, "global_alarm": 1}
         },
         {
           "id": "integrate_principles",
           "text": "Integrate principles into lab policy (costs 2 AP, $10k)",
           "costs": {"action_points": 2, "money": 10000},
-          "effects": {"reputation": 15, "doom": -2.0}
+          "effects": {"reputation": 15, "safety_absorption": 20}
         },
         {
           "id": "ignore",

--- a/godot/data/scenarios/crisis.json
+++ b/godot/data/scenarios/crisis.json
@@ -29,8 +29,8 @@
           "id": "issue_statement",
           "text": "Issue a supporting statement",
           "costs": {},
-          "effects": {"reputation": 10, "doom": -2},
-          "message": "Your public support helps legitimize safety concerns."
+          "effects": {"reputation": 10, "global_alarm": 4},
+          "message": "Your public support helps legitimize safety concerns (+global alarm)."
         },
         {
           "id": "stay_quiet",
@@ -55,8 +55,8 @@
           "id": "compromise",
           "text": "Accept faster timelines",
           "costs": {},
-          "effects": {"money": 50000, "doom": 3},
-          "message": "Additional funding secured, but at what cost?"
+          "effects": {"money": 50000, "frontier_capability": 30},
+          "message": "Additional funding secured; the compressed timeline pushes your frontier ahead of your safety work (+frontier capability)."
         },
         {
           "id": "stand_firm",

--- a/godot/scripts/core/actions.gd
+++ b/godot/scripts/core/actions.gd
@@ -949,11 +949,12 @@ static func attend_conference_action(state: GameState, conf_id: String, travel_c
 
 		return {
 			"success": true,
-			"message": "Presented '%s' at %s! (+%.0f rep, -%.1f doom, cost: %s %s)%s" % [
+			# ADR-0015 S-ticket: the mechanic above was migrated to global_alarm but this
+			# string still printed "-N doom" -- a number the doom level never moved by.
+			"message": "Presented '%s' at %s! (+%.0f rep, +global alarm, cost: %s %s)%s" % [
 				presenting_paper.title,
 				conf.name,
 				rep_gain,
-				doom_reduction,
 				GameConfig.format_money(travel_cost.total),
 				travel_cost.class_name,
 				jet_lag_msg

--- a/godot/scripts/core/events.gd
+++ b/godot/scripts/core/events.gd
@@ -287,10 +287,51 @@ static func execute_event_choice(event: Dictionary, choice_id: String, state: Ga
 	for key in effects.keys():
 		var value = effects[key]
 
+		# ADR-0015 S-ticket (#967 Parent 1): a literal "doom" effect must NEVER reach
+		# Resources.add's `state.doom += v` sink -- that write is CLOBBERED at resolve by
+		# `state.doom = doom_system.current_doom` (turn_manager.gd:657), so every
+		# "(+/-N doom)" message in event content was a silent lie. Route it through the
+		# doom engine as a named stream input instead, exactly as the risk pools do
+		# (turn_manager.gd:691,717). Migrated CONTENT no longer carries this key at all
+		# (guarded by test_events.gd::test_no_authored_event_content_writes_literal_doom);
+		# this branch exists for RUNTIME-generated effects (event_service.gd pdoom-data
+		# events) and as a permanent trap so a re-introduced literal cannot go inert.
+		# Attributed to the `panic` stream -- an unmodelled event shock the world reacts
+		# to, the same stream add_event_doom() gives risk-pool shocks -- rather than
+		# add_event_doom's default `ledger` bucket, which would misattribute it in the
+		# L6 delta chips / death attribution.
+		if key == "doom":
+			if state.doom_system:
+				state.doom_system.add_stream_input("panic", float(value))
+			else:
+				# Direct-state unit contexts with no doom engine: keep the legacy write so
+				# those tests still observe a delta.
+				state.add_resources({"doom": value})
+			continue
+
 		if Resources.add(state, key, value):
 			continue
 
 		match key:
+			# --- ADR-0015 world-state intermediaries (the honest replacements for the
+			# retired literal "doom" content effect). These are real accumulating stocks
+			# read by DoomSystem._compute_streams; the doom LEVEL stays single-authority.
+			# NOTE political_pressure is deliberately absent: doom_system.gd:246
+			# REASSIGNS it every tick (global_alarm - global_panic), so an event write
+			# there would be the same inert-sink bug in a new costume.
+			"global_alarm":
+				state.global_alarm += float(value)
+			"global_panic":
+				state.global_panic += float(value)
+			"safety_absorption":
+				state.safety_absorption += float(value)
+			"general_capability":
+				state.general_capability += float(value)
+			"frontier_capability":
+				# Events address the PLAYER slice; rival slices are owned by the rival
+				# sim (doom_system.gd:215) and the event schema carries no actor id.
+				state.frontier_capability["player"] = \
+					float(state.frontier_capability.get("player", 0.0)) + float(value)
 			"safety_researchers":
 				_apply_staffing_effect(state, "safety", int(value), staffing_notes)
 			"capability_researchers":

--- a/godot/tests/unit/simulation/test_events.gd
+++ b/godot/tests/unit/simulation/test_events.gd
@@ -27,6 +27,106 @@ func test_all_events_have_required_fields():
 		assert_has(event, "trigger_type", "Event should have trigger_type")
 		assert_has(event, "options", "Event should have options")
 
+## --------------------------------------------------------------------------------------
+## ADR-0015 S-ticket CONTENT-SCAN GUARD (#967 Parent 1)
+##
+## Authored event CONTENT must never carry a literal `doom` effect again. Such a write went
+## to Resources.add's `state.doom += v` sink, which turn resolution clobbers -- so every
+## "(+/-N doom)" message in the data files was a promise the engine never kept. Content now
+## writes a world-state INTERMEDIARY (global_alarm / global_panic / safety_absorption /
+## frontier_capability / general_capability) and DoomSystem converts it into doom rate.
+##
+## This guard exists mainly to protect the ADR-0016 pack schema: the year packs are authored
+## by copying these files, so one surviving literal would breed.
+##
+## CARVE-OUTS (deliberate, both documented in ADR-0015):
+##  1. START CONFIG -- `starting_resources.doom` sets the initial LEVEL. That is a legitimate
+##     scenario dial, not an event effect, and is not scanned.
+##  2. risk_events.json -- its 20 pool `effects.doom` fields are LIVE (turn_manager routes
+##     them through doom_system.add_event_doom), so re-authoring them is a BALANCE change
+##     deferred to the ADR-0015 M-ticket. Budgeted below so the count can only shrink.
+## --------------------------------------------------------------------------------------
+
+const RISK_EVENTS_DOOM_BUDGET := 20  # M-ticket backlog; MUST only ever go down
+
+func _all_data_json_paths(dir_path: String, out: Array) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while entry != "":
+		var full := dir_path.path_join(entry)
+		if dir.current_is_dir():
+			_all_data_json_paths(full, out)
+		elif entry.ends_with(".json"):
+			out.append(full)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+func _parse_json(path: String):
+	var text := FileAccess.get_file_as_string(path)
+	assert_ne(text, "", "readable: " + path)
+	var parsed = JSON.parse_string(text)
+	assert_not_null(parsed, "parses as JSON: " + path)
+	return parsed
+
+func _scan_for_doom_effects(node, path: String, trail: String, hits: Array) -> void:
+	"""Walk a parsed data tree and record every place authored content still writes doom."""
+	if node is Array:
+		for i in range(node.size()):
+			_scan_for_doom_effects(node[i], path, "%s[%d]" % [trail, i], hits)
+		return
+	if not (node is Dictionary):
+		return
+	for key in node.keys():
+		var child = node[key]
+		var child_trail := "%s.%s" % [trail, key]
+		# (a) the event-choice / event effect schema
+		if key == "effects" and child is Dictionary and child.has("doom"):
+			hits.append("%s%s.doom" % [path, child_trail])
+		# (b) the pdoom-data override schema (impacts[].variable == "doom")
+		if key == "impacts" and child is Array:
+			for i in range(child.size()):
+				var imp = child[i]
+				if imp is Dictionary and str(imp.get("variable", "")) == "doom":
+					hits.append("%s%s[%d].variable=doom" % [path, child_trail, i])
+		# (c) the dead historical-timeline schema (game_effect.doom_increase/_decrease)
+		if key == "game_effect" and child is Dictionary:
+			for gk in child.keys():
+				if str(gk).begins_with("doom"):
+					hits.append("%s%s.%s" % [path, child_trail, gk])
+		# (d) rarity default effects (variable_mapping.json default_effects.*)
+		if key == "default_effects" and child is Dictionary:
+			for rk in child.keys():
+				var bucket = child[rk]
+				if bucket is Dictionary and bucket.has("doom"):
+					hits.append("%s%s.%s.doom" % [path, child_trail, rk])
+		_scan_for_doom_effects(child, path, child_trail, hits)
+
+func test_no_authored_event_content_writes_literal_doom():
+	var paths: Array = []
+	_all_data_json_paths("res://data", paths)
+	assert_gt(paths.size(), 10, "the data tree was found and walked")
+
+	var hits: Array = []
+	var risk_hits: Array = []
+	for path in paths:
+		var parsed = _parse_json(path)
+		var found: Array = []
+		_scan_for_doom_effects(parsed, path, "", found)
+		if path.ends_with("risk_events.json"):
+			risk_hits.append_array(found)
+		else:
+			hits.append_array(found)
+
+	assert_eq(hits.size(), 0,
+		"authored content must write an intermediary, never a literal doom effect. Offenders: "
+		+ ", ".join(PackedStringArray(hits)))
+	assert_lte(risk_hits.size(), RISK_EVENTS_DOOM_BUDGET,
+		"the risk_events.json carve-out may only shrink (ADR-0015 M-ticket); found %d"
+		% risk_hits.size())
+
 func test_event_count():
 	# Test that we have a substantial number of events
 	var events = GameEvents.get_all_events()
@@ -305,15 +405,18 @@ func test_multi_resource_effects():
 	var events = GameEvents.get_all_events()
 	var ai_breakthrough = _find_event_by_id(events, "ai_breakthrough")
 
-	var initial_doom = state.doom
+	var initial_general_capability = state.general_capability
 	var initial_reputation = state.reputation
 	var initial_research = state.research
 
-	# Choose publish openly (affects doom, reputation, research)
+	# Choose publish openly. ADR-0015 S-ticket: the hazard arm is no longer a literal
+	# "doom" write (that was clobbered at resolve) -- publishing openly commoditizes the
+	# capability, which is the general_capability intermediary behind the diffusion stream.
 	var result = GameEvents.execute_event_choice(ai_breakthrough, "publish_open", state)
 
 	assert_true(result["success"], "Choice should succeed")
-	assert_ne(state.doom, initial_doom, "Doom should change")
+	assert_ne(state.general_capability, initial_general_capability,
+		"Publishing openly raises general_capability (diffusion stream), not a printed doom number")
 	assert_ne(state.reputation, initial_reputation, "Reputation should change")
 	assert_ne(state.research, initial_research, "Research should change")
 
@@ -451,7 +554,13 @@ func test_remove_researchers_safe_noop_when_empty():
 # Every effect key execute_event_choice actually applies (scalars via
 # ResourceAccessor.add + the non-scalar match arms in events.gd).
 const HANDLED_EFFECT_KEYS := [
-	"money", "compute", "research", "papers", "reputation", "doom",
+	"money", "compute", "research", "papers", "reputation",
+	"doom",  # routed to doom_system.add_event_doom (ADR-0015 S-ticket); authored content no
+	         # longer uses it (see test_no_authored_event_content_writes_literal_doom) but the
+	         # runtime pdoom-data path in event_service.gd still emits it.
+	# ADR-0015 world-state intermediaries -- the honest replacements for literal doom.
+	"global_alarm", "global_panic", "safety_absorption",
+	"general_capability", "frontier_capability",
 	"compute_engineers",  # scalar legacy count (ResourceAccessor.add)
 	"safety_researchers", "capability_researchers",  # staffing arms
 	"has_cat", "lose_researcher",
@@ -503,7 +612,10 @@ func test_push_through_burnout_docks_loyalty_least_loyal_first_no_removal():
 
 	assert_true(result["success"], "Push Through should succeed")
 	assert_eq(state.researchers.size(), before_count, "Push Through removes nobody (interim: loyalty-hit only)")
-	assert_eq(state.doom, before_doom + 3.0, "Doom still applies as flavor states")
+	# ADR-0015 S-ticket: the old "+3 doom" was a clobbered no-op AND a category error --
+	# team morale is not a printed doom write (same ruling as actions.gd team_building).
+	# The loyalty hit below is now the whole teeth of Push Through.
+	assert_eq(state.doom, before_doom, "Burnout is a morale outcome, not a doom write")
 
 	# The two least-loyal researchers (Weary Wade 10, Frayed Fiona 20) take the hit;
 	# the most-loyal (Steady Sam 80) is untouched.

--- a/godot/tests/unit/test_game_state.gd
+++ b/godot/tests/unit/test_game_state.gd
@@ -86,6 +86,32 @@ func test_add_resources_clamps_doom():
 	state.add_resources({"doom": -20})
 	assert_eq(state.doom, 0.0, "Doom should be clamped to 0")
 
+func test_add_resources_doom_write_is_clobbered_by_the_doom_engine():
+	## ADR-0015 S-ticket CLOBBER GUARD (#967 Parent 1).
+	## `add_resources({"doom": N})` still moves `state.doom` in a direct-state context (the
+	## test above depends on that), which is exactly why the bug was invisible for so long:
+	## turn resolution REASSIGNS `state.doom = doom_system.current_doom`
+	## (turn_manager.gd _step_resolve_doom), so the parallel write never survives a real turn.
+	## This test PINS the clobber. It must stay red-if-removed, because the wrong fix is to
+	## make the parallel write stick -- the doom LEVEL is single-authority (DoomSystem), and
+	## content that wants to move it writes a world-state INTERMEDIARY instead
+	## (events.gd effect loop -> add_event_doom / global_alarm / safety_absorption / ...).
+	var state = GameState.new("clobber_guard_seed")
+	assert_not_null(state.doom_system, "GameState owns a DoomSystem")
+	state.doom_system.current_doom = 42.0
+	state.doom = 42.0
+
+	state.add_resources({"doom": 25.0})
+	assert_eq(state.doom, 67.0, "the raw sink does move state.doom before resolution")
+
+	var tm: TurnManager = autofree(TurnManager.new(state))
+	tm.execute_turn()
+
+	assert_eq(state.doom, state.doom_system.current_doom,
+		"after resolution the doom level is whatever DoomSystem says -- single authority")
+	assert_lt(state.doom, 67.0,
+		"the +25 parallel write was discarded, not coincidentally preserved")
+
 func test_get_total_staff_counts_all_types():
 	# Test get_total_staff sums all staff types
 	var state = GameState.new("test_seed")


### PR DESCRIPTION
ADR-0015 S-ticket. Collapses silent-promise Parent 1 (#967): every `effects.doom`
in authored event content flowed to `Resources.add`'s `state.doom += v` sink, which
turn resolution CLOBBERS (`state.doom = doom_system.current_doom`,
turn_manager.gd `_step_resolve_doom`). Result: ~46 "(+/-N doom)" strings the engine
never honoured.

## Disposition authority

`docs/game-design/doom_strip_verdicts.json` **does not exist on origin/main** (checked),
so the authority used is the **scout-default pattern table** in the lane brief
(`ADR0015_STRIP_INVENTORY.md` "Key disposition patterns for the S ticket"):
morale/flavor -> drop; publishing/capability -> overhang/frontier; regulation /
transparency / whistleblower -> global_alarm; security -> safety_absorption;
`ai_breakthrough/safety_review` "+1 doom" contradiction -> drop.

**Two deviations from a literal transcription of that table, both deliberate:**

1. **"rival intel/sabotage -> rival frontier delay" has no landing zone.** The generic
   event-effects schema carries no rival id, and inventing rival-targeting plumbing was
   explicitly out of lane. Substituted **`global_panic`** for the hazard-direction
   rival fields, mirroring `actions.gd` `sabotage_competitor`'s own caught-branch
   precedent (`state.global_panic += ...`). Two rival-adjacent fields point the OTHER
   way (they were doom *reductions* -- "used intel to counter their work", "planted
   source, early warnings enabled"); panic would flip their sign, so those went to
   `safety_absorption` instead.
2. **`political_pressure` is NOT used anywhere**, even though the table lists it as a
   route for the regulation family. `doom_system.gd` `_advance_intermediaries`
   REASSIGNS it every tick (`= _snap(global_alarm - global_panic)`), so an event write
   there is the same inert-sink bug in a new costume (silent-promise audit Parent 2).
   The regulation family routes to `global_alarm` only, and `events.gd` documents the
   omission so a future author does not reintroduce it.

## 1. Plumbing (the one change that collapses the parent)

`events.gd` effect loop now intercepts `"doom"` BEFORE `Resources.add` and dispatches
`state.doom_system.add_stream_input("panic", value)` -- the same named-stream route the
risk pools take (`turn_manager.gd:691,717`). Attributed to `panic` explicitly rather
than via `add_event_doom()`, whose shim buckets any non-`risk*` reason into `ledger`,
which would misattribute an event shock in the L6 delta chips / death attribution.
Kept as a permanent trap: migrated content no longer carries the key, but
`event_service.gd` still synthesizes `doom` effects for pdoom-data events at runtime,
and those were silently inert too.

Same loop gained five world-state intermediary arms: `global_alarm`, `global_panic`,
`safety_absorption`, `general_capability`, `frontier_capability` (player slice).

## 2. Content uplift -- 46 inert fields

Scale conversions from the retired literal |doom| N (derived from the live
`doom.streams.*` coefficients so the re-authored magnitudes land in the same
per-day rate family as the existing `actions.gd` migrations):

| intermediary | factor | why |
|---|---|---|
| `global_alarm` / `global_panic` | N x 2 | `W_alarm` = `W_panic` = 0.02 |
| `safety_absorption` / `frontier_capability` | N x 10 | they subtract inside `overhang`, so they MUST share a scale |
| `general_capability` | N x 1 | `W_general` = 0.0005, ~13x per unit vs frontier |

| file | fields | re-authored | dropped |
|---|---|---|---|
| `godot/data/events/core_events.json` | 40 | 22 | 18 |
| `godot/data/historical_timeline/2017.json` (dormant) | 4 | 4 | 0 |
| `godot/data/scenarios/crisis.json` | 2 | 2 | 0 |

Every touched `message` string was reworded -- no `"(+/-N doom)"` survives in authored
content. Also fixed `actions.gd` conference presentation, whose mechanic was migrated
to `global_alarm` in the original ADR-0015 pass but whose string still printed
`-%.1f doom`.

## 3. Dead schema deleted (the ADR-0016 copy-paste trap)

- `godot/data/events/overrides/example.json` -- 3 `impacts[].variable == "doom"` +
  1 `pdoom_impact`. Loaded by nothing, but it is the explicit copy-me template. Replaced
  with an `_adr_0015` note stating the rule.
- `godot/data/historical_timeline/2017.json` -- 5 orphaned
  `game_effect.doom_increase` / `doom_decrease` fields (read nowhere; would have been
  copied into every future year pack).
- `godot/data/events/balancing/variable_mapping.json` -- `default_effects.legendary.doom`.

## 4. Guard tests (both)

- `tests/unit/test_game_state.gd::test_add_resources_doom_write_is_clobbered_by_the_doom_engine`
  -- pins the clobber itself, so the WRONG fix (making the parallel write stick) fails.
- `tests/unit/simulation/test_events.gd::test_no_authored_event_content_writes_literal_doom`
  -- walks every JSON under `res://data` and fails on `effects.doom`,
  `impacts[].variable == "doom"`, `game_effect.doom*`, `default_effects.*.doom`.

Carve-outs, both documented in the test:
- **start config** (`starting_resources.doom`, incl. crisis.json's 65) is a scenario
  dial, not an event effect -- not scanned.
- **`risk_events.json`'s 20 pool fields are LIVE** (routed through `add_event_doom`
  already) and re-authoring them is a balance change deferred to the ADR-0015 M-ticket.
  Budgeted at `RISK_EVENTS_DOOM_BUDGET := 20` so the count can only shrink.

Three pre-existing simulation assertions encoded the bug and were corrected with the
reason inline: `test_multi_resource_effects` (now asserts `general_capability` moves),
the burnout "Doom still applies as flavor states" assertion (morale is not a doom
write -- same ruling as `actions.gd` `team_building`), and `HANDLED_EFFECT_KEYS`.

## Verification

- Fast gate on the rebased branch (`origin/main` @ 9abe20a7):
  **899 tests, 0 failures, 90/90 files collected -- fully green.**
- `tests/unit/simulation/test_events.gd` run on its own: **34/34 pass**, including the
  new content-scan guard.
- Simulation tier: not run to completion (non-blocking per CLAUDE.md). Checked that
  `test_replay_verification.gd` / `test_engine_determinism.gd` hold **no committed
  golden artifacts** -- they self-compare run-vs-run -- so the content uplift cannot
  shift a stored expectation. The only failures observed while it ran were in
  `test_adversarial_ui_state.gd` (dialog-stacking invariants, untouched by this diff).

## Out of scope (unchanged, by instruction)

- The 20 live `risk_events.json` doom fields (ADR-0015 M-ticket; needs a severity-curve
  calibration pass).
- `crisis.json` `starting_resources.doom` (start-config carve-out).
- `finance_engine.gd` `desperation_payroll` (the other live silent promise; M-ticket).

Refs #967, ADR-0015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
