### PR TITLE
docs(changelog): 2026-07-27 build day entry (rides next version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 2026-07-27 build day (rides the next version bump)
+
+#### Added
+- **The early game has a real first fifteen minutes** (#791, #811, #982): you
+  start in a free bedroom/basement (2-hire cap), then choose one of three
+  first offices -- a cheap-in/cheap-out co-working corner, a balanced
+  second-floor walk-up, or a bigger university annex sublet -- each with its
+  own deposit, monthly rent, desk count, lease term, and break fee. You're
+  locked into the pick mechanically for now (moving costs are architected but
+  not live yet). New scouting actions let you find your next hire, including
+  a deliberately loud strategic-shitposting option.
+- **Conference trips are a real commit, not a menu skip** (#468, #979): the
+  Travel submenu can now send you to one of 3 shell conferences. Going costs
+  real travel cash and drains all your remaining Attention for the trip; the
+  world keeps running while you're away (events and developments still
+  fire), and you come home to a single "while you were away" digest instead
+  of a stack of missed-turn popups.
+- **Publishing and safety-research actions now genuinely move the doom
+  engine** (#971, #974): `publish_paper`'s alarm bump and `safety_research`'s
+  absorption effect were silently wired to 0.0 since the doom-stream
+  migration -- they read as working in the UI but did nothing. They're
+  priced now and actually fire, along with `audit_safety`'s scrutiny effect
+  and the lobbying/rival/opensource doom streams.
+- **Four new office workers, with mood states** (#947, #969): a Black man
+  with idle/working/stressed mood art plus a full 8-direction walk cycle, and
+  three more fully-walking hires (wheelchair-accessible, glasses-and-badge,
+  and hijab-wearing) join the office rotation.
+- **Office floor groundwork**: a first-class render-layer grid replaces the
+  sandbox's old string-keyed hack (#977) -- render-only, purely cosmetic for
+  now; and dev-build performance logging gained mark/gauge instrumentation
+  across save/load, scene transitions, and office-roster rebuilds (#973), in
+  preparation for surfacing real load-time and scaling data later.
+
+#### Fixed
+- **Hire candidates could silently vanish** (#952, #960): if your cash
+  dropped between queuing a hire and it executing later the same turn, the
+  candidate was removed from the pool but never actually hired -- gone for
+  good, with no message. Stranded hires now return to the pool (or a
+  walk-away line if the pool had refilled), including self-healing existing
+  saves.
+
+#### Dev / data (no visible gameplay change yet)
+- Typed reputation dimensions -- org / operator / employee -- landed
+  additively behind `rep_for()`/`rep_dims()`; the legacy scalar
+  `GameState.reputation` stays authoritative and is still what every
+  existing write site touches (#975). Ships alongside a first governance-body
+  roster (`godot/data/bodies.json`).
+- Workstream substrate core -- the object model, backlog, per-person
+  assignment, and topic-tagged effort accrual that the Attention-economy
+  migration builds on -- landed with a `reported` vs `actual` progress seam
+  for self-directed researchers (deterministic per-person optimism, no new
+  RNG); nothing consumes `reported` yet (#981).
+- Balance-key coverage guard test so a doom-stream key silently falling back
+  to a call-site default can't ship unnoticed again (#974).
+- ~500 art files (worker round 2, cat west-walk variants, prop re-base, tier-6
+  diagonals) made durable from the day's generation runs, plus shared
+  bulk-select/mass-tag triage tooling across the art review sheets (#965,
+  #966, #972, #978).
+- `ladder_version` bumped 2 -> 3 for the day's core/ changes.
+- ADR-0018 drafted: render-only office doctrine (no spatial fact becomes a
+  gameplay input) (#968).
+
+---
+
 ### Added
 - **Research Quality System** (#500): Rushed / Standard / Thorough quality toggle for research
   - **Rushed**: faster research, but accumulates technical debt and raises risk


### PR DESCRIPTION
## Summary
Adds an Unreleased/next-version CHANGELOG entry for 2026-07-27's merged build day: early-game office lease decision, conference rhythm-break shell, the doom-stream key pricing fix (publishing/safety-research actions now actually fire), four newly wired office workers, plus a terse dev/data section (typed rep dims, workstream substrate w/ reported-vs-actual seam, PerfLog instrumentation, guard tests, ~500 art files, ladder 2->3).

Player-facing language leads; only effects that actually fire are claimed (matches the day's own silent-promise audit findings -- e.g. typed rep is explicitly called out as additive with no reader wired yet).

Sources: PRs #960, #965, #966, #968, #969, #972, #973, #974, #975, #977, #978, #979, #981, #982; `docs/game-design/WS3A_DAYLOG_2026-07-27.md`.

## Test plan
- [x] Docs-only change, no code touched
- [x] Pre-commit hooks passed (ASCII/emoji gate, trailing whitespace, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)