### PR TITLE
fix(tests): make perf_log line-shape test hermetic via private log path (#976)

### DIFF
--- a/godot/autoload/perf_log.gd
+++ b/godot/autoload/perf_log.gd
@@ -63,6 +63,8 @@ var _thresholds: Dictionary = {}
 var _enabled_override = null
 ## File logging can be disabled (e.g. by tests) to stay hermetic; on by default in dev.
 var _file_logging := true
+## Test hook: null => write to LOG_PATH; non-null => redirect writes to this path instead.
+var _log_path_override = null
 
 
 ## Manual stopwatch for scoped timing without matching begin/end names. Cheap RefCounted;
@@ -182,6 +184,35 @@ func set_file_logging(enabled: bool) -> void:
 	_file_logging = enabled
 
 
+## Test hook: redirect file writes to a private path (null => the real LOG_PATH).
+## Exists because turn_manager.gd/office_floor.gd/event_service.gd call PerfLog with NO
+## test gating of their own (by design -- they're production call sites), so whenever a test
+## suite run exercises them the real LOG_PATH gets real writes for the whole suite. A test
+## that wants to inspect the actual written-line shape needs a path nothing else touches,
+## rather than fighting that shared, suite-wide traffic (issue #976).
+func set_log_path_override(path) -> void:
+	_log_path_override = path
+
+
+## Effective file-trail path: the override when a test set one, else the real LOG_PATH.
+func get_log_path() -> String:
+	return _log_path_override if _log_path_override != null else LOG_PATH
+
+
+## Test-only: reset ALL shared singleton state in one call (dev/test hook, unused in a
+## release cut). Covers what before_each/after_each need so a test can't leak ring-buffer
+## entries, warnings, open sections, threshold overrides, the enabled/file-logging gates, or
+## a log-path override into the next test -- see issue #976.
+func reset_for_tests() -> void:
+	_entries.clear()
+	_warnings.clear()
+	_open.clear()
+	_thresholds.clear()
+	_enabled_override = null
+	_file_logging = true
+	_log_path_override = null
+
+
 ## --- Introspection (for the dev overlay / tests) ---------------------------
 
 func get_entries() -> Array:
@@ -266,15 +297,16 @@ func _write_line(type: String, body: String) -> void:
 	var dir := DirAccess.open("user://")
 	if dir != null and not dir.dir_exists("logs"):
 		dir.make_dir("logs")
-	_rotate_if_needed()
+	var log_path := get_log_path()
+	_rotate_if_needed(log_path)
 	var line := "%s %s %s" % [_timestamp(), type, body]
 	var f: FileAccess
-	if FileAccess.file_exists(LOG_PATH):
-		f = FileAccess.open(LOG_PATH, FileAccess.READ_WRITE)
+	if FileAccess.file_exists(log_path):
+		f = FileAccess.open(log_path, FileAccess.READ_WRITE)
 		if f != null:
 			f.seek_end()
 	else:
-		f = FileAccess.open(LOG_PATH, FileAccess.WRITE)
+		f = FileAccess.open(log_path, FileAccess.WRITE)
 	if f != null:
 		f.store_line(line)
 		f.close()
@@ -293,8 +325,12 @@ static func should_rotate(current_size_bytes: int, threshold_bytes: int = MAX_LO
 
 ## Size-based rotation: when perf.log has reached MAX_LOG_BYTES, move it to perf.log.1
 ## (clobbering any prior rotation) so the next write starts a fresh perf.log. Runs at the
-## top of every file write; a no-op on a small/missing log (the common case).
-func _rotate_if_needed() -> void:
+## top of every file write; a no-op on a small/missing log (the common case). Rotation is
+## defined only for the real LOG_PATH -- a test-only log_path_override (issue #976) never
+## rotates, since it is a throwaway path a single test owns.
+func _rotate_if_needed(log_path: String = LOG_PATH) -> void:
+	if log_path != LOG_PATH:
+		return
 	if not FileAccess.file_exists(LOG_PATH):
 		return
 	var f := FileAccess.open(LOG_PATH, FileAccess.READ)

--- a/godot/tests/unit/test_perf_log.gd
+++ b/godot/tests/unit/test_perf_log.gd
@@ -9,21 +9,26 @@ extends GutTest
 ##
 ## Hermetic: file logging is disabled and the override forces the gate, so the suite does
 ## not depend on the DEV_BUILD const nor write to user://.
+##
+## #976: PerfLog is a shared autoload singleton with NO test gating of its own callers --
+## turn_manager.gd/office_floor.gd/event_service.gd call it unconditionally, so across a
+## full-suite run they write real lines to the real LOG_PATH the entire time (DEV_BUILD is a
+## hardcoded true const). reset_for_tests() below resets every piece of shared state
+## (including the _thresholds map, which before_each/after_each never used to touch) so
+## nothing this file sets can leak into another test file, in either direction.
 
 var _anomaly_count := 0
 
 
 func before_each() -> void:
-	PerfLog.clear()
+	PerfLog.reset_for_tests()
 	PerfLog.set_file_logging(false)
 	PerfLog.set_enabled_override(true)  # force-active regardless of DEV_BUILD
 	_anomaly_count = 0
 
 
 func after_each() -> void:
-	PerfLog.clear()
-	PerfLog.set_enabled_override(null)  # restore the dev-build default
-	PerfLog.set_file_logging(true)
+	PerfLog.reset_for_tests()
 
 
 func _on_anomaly(_msg: String) -> void:
@@ -192,23 +197,33 @@ func test_should_rotate_false_under_threshold():
 # --- File line shape ---------------------------------------------------------
 # Enables real file logging briefly to check the written line shape, then removes the file
 # and restores hermetic settings -- the only test in this suite that touches user://.
+#
+# #976: writes to a private log_path_override rather than the real PerfLog.LOG_PATH.
+# turn_manager.gd/office_floor.gd/event_service.gd write real, unguarded lines to the real
+# LOG_PATH throughout a full-suite run (nothing gates their PerfLog calls), so sharing that
+# path here raced this test's delete-then-4-writes-then-read against that outside traffic --
+# an order-dependent flake that passed 18/18 in isolation and failed intermittently in the
+# full fast gate. A path nothing else ever touches makes that race structurally impossible.
+const _TEST_LOG_PATH := "user://logs/perf_log_line_shape_test.log"
 
 func test_written_line_has_timestamp_and_type_fields():
 	var re := RegEx.new()
 	re.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z (BEGIN|END|MARK|GAUGE|WARN|ITER) ")
 
+	PerfLog.set_log_path_override(_TEST_LOG_PATH)
 	PerfLog.set_file_logging(true)
-	if FileAccess.file_exists(PerfLog.LOG_PATH):
-		DirAccess.remove_absolute(PerfLog.LOG_PATH)
+	if FileAccess.file_exists(_TEST_LOG_PATH):
+		DirAccess.remove_absolute(_TEST_LOG_PATH)
 	PerfLog.begin("line_shape_section", {"turn": 1})
 	PerfLog.end("line_shape_section")
 	PerfLog.mark("line_shape_mark")
 	PerfLog.gauge("line_shape_gauge", 5)
 	PerfLog.set_file_logging(false)
 
-	var f := FileAccess.open(PerfLog.LOG_PATH, FileAccess.READ)
-	assert_not_null(f, "perf.log should exist after a real write")
+	var f := FileAccess.open(_TEST_LOG_PATH, FileAccess.READ)
+	assert_not_null(f, "perf log should exist after a real write")
 	if f == null:
+		PerfLog.set_log_path_override(null)
 		return
 	var lines: Array = []
 	while not f.eof_reached():
@@ -216,7 +231,8 @@ func test_written_line_has_timestamp_and_type_fields():
 		if not line.is_empty():
 			lines.append(line)
 	f.close()
-	DirAccess.remove_absolute(PerfLog.LOG_PATH)
+	DirAccess.remove_absolute(_TEST_LOG_PATH)
+	PerfLog.set_log_path_override(null)
 
 	assert_gte(lines.size(), 4, "begin+end+mark+gauge should write at least 4 lines")
 	for line in lines:


### PR DESCRIPTION
## Root cause (issue #976)

`test_written_line_has_timestamp_and_type_fields` deleted, wrote, and re-read the REAL `PerfLog.LOG_PATH` -- but `turn_manager.gd` / `office_floor.gd` / `event_service.gd` call PerfLog with no test gating of their own (by design: they are production call sites, and DEV_BUILD is a hardcoded const). Across a full-suite run those callers write real lines to that same path the whole time, so the test raced outside traffic: green 18/18 in isolation, intermittent in the full fast gate. Order-dependence, not a wrong assertion.

## Fix

- `set_log_path_override()` test hook: the one real-write test now uses a private path (`user://logs/perf_log_line_shape_test.log`) that nothing else ever touches, making the race structurally impossible. Rotation is defined only for the real LOG_PATH and never runs on an override path.
- `reset_for_tests()` resets ALL shared singleton state (entries, warnings, open sections, thresholds, enabled override, file-logging gate, path override) in `before_each`/`after_each` -- the old cleanup never touched `_thresholds`, so threshold overrides could leak across test files in either direction.
- Assertions unchanged at full strength (regex line-shape check, >=4-line count).

## Evidence

Fast gate run 3x post-fix in a rebased worktree: **932 tests / 0 failures, all three runs.**

## Note for merger

Squash merges do NOT fire closes-keywords in this repo -- close #976 manually after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)