### PR TITLE
feat(debug): UI evolution capture rail -- F7 screenshot + context manifest (dev builds)

### DIFF
--- a/docs/content/UI_EVOLUTION_CAPTURE.md
+++ b/docs/content/UI_EVOLUTION_CAPTURE.md
@@ -1,0 +1,104 @@
+# UI evolution capture -- the "it went from this... to this..." rail
+
+> Authorized: Pip's UI-evolution capture ask, 2026-07-27 0800. Purpose:
+> programmatically capture UI states as visual lanes land, so a later
+> devblog/anniversary/grantmaker montage can be assembled from a real timeline
+> instead of hunting through Win+PrtScn screenshots by hand.
+
+## The three pieces
+
+1. **In-game hotkey (F7)** -- `godot/scripts/debug/ui_evolution_recorder.gd`,
+   wired through `KeybindManager.ui_evolution_shot_requested`. One silent
+   press drops a screenshot + a one-line context entry (scene name, version,
+   turn) into `user://ui_evolution/<version>/manifest.jsonl`. Dev-build only
+   (`BuildInfo.is_dev_build()`), same gate as the flight recorder (F6) and the
+   DEV MODE overlay -- zero cost in release builds.
+2. **Collector** -- `tools/collect_ui_evolution.py`. Resolves the real Windows
+   path for `user://` (`%APPDATA%/Godot/app_userdata/P(Doom)/`), sweeps
+   `ui_evolution/` for a date range, optionally also sweeps
+   `Pictures\Screenshots` (the existing manual Win+PrtScn rail -- timestamped
+   automatically by Windows), and copies everything into
+   `G:/tmp/pdoom1-ui-evolution/<date>/` with normalized names plus an ASCII
+   `index.md` timeline table.
+3. **This doc** -- the convention: when to press F7, where things land, how
+   the timeline gets mined later.
+
+## Why F7 is a *silent* capture, unlike the flight recorder (F6)
+
+The flight recorder (F6, `godot/scripts/debug/flight_recorder.gd`) is a deep
+playtest tool: screenshot + full `GameState.to_dict()` snapshot + a note popup
+that pauses for input. UI evolution capture is a much lighter ask -- "grab
+what this screen looks like right now" -- so F7 does not open a popup, does
+not dump game state, and does not block input. It reuses the flight
+recorder's *shape* (session directory under `user://`, append-only
+`manifest.jsonl`, zero-padded sortable filenames) rather than inventing a
+third capture layout, but it is deliberately cheaper per press.
+
+## When to capture
+
+- **Before and after every visual-lane merge** (theme changes, panel
+  redesigns, new screens, art passes that touch UI chrome). Press F7 once on
+  the pre-merge build, once on the post-merge build, same scene/screen if
+  possible.
+- **On version bumps**, if a lane spans several versions -- one shot per
+  `version.txt` bump keeps the timeline resolvable by version even without
+  precise dates.
+- Ad hoc, whenever something looks worth remembering for a "look how far this
+  has come" narrative later. Cheap enough to over-capture; the collector's
+  date filtering makes cleanup a non-issue.
+
+## Where things land
+
+- **In-game (per machine, per project):**
+  `user://ui_evolution/<version>/` -->
+  `%APPDATA%/Godot/app_userdata/P(Doom)/ui_evolution/<version>/` on Windows
+  (macOS/Linux equivalents in `tools/collect_ui_evolution.py::resolve_user_dir`).
+  Each version directory holds `NNNN_<timestamp>.png` screenshots plus one
+  `manifest.jsonl` (one JSON line per shot: `index`, `timestamp`, `version`,
+  `scene`, `turn`, `screenshot`).
+- **After collection:** `G:/tmp/pdoom1-ui-evolution/<date>/` (or a
+  `--dest` override) -- **outside the repo**, same doctrine as
+  `docs/art/ART_MASTERS_POLICY.md` masters staging (`G:/tmp/pdoom1-art-masters/`):
+  Godot packs the entire `godot/` tree into the `.pck`, and this capture set
+  accumulates indefinitely, so it must never live under `godot/` and should
+  not be committed to git.
+
+Run the collector after a capture session:
+
+```
+python tools/collect_ui_evolution.py                        # today's captures
+python tools/collect_ui_evolution.py --since 2026-07-20 --until 2026-07-27
+python tools/collect_ui_evolution.py --no-manual             # skip Pictures\Screenshots
+python tools/collect_ui_evolution.py --dry-run               # preview only
+```
+
+## How the timeline gets mined later
+
+`index.md` in each dated staging directory is the join point: a plain ASCII
+table of `Version | Timestamp | Scene | Turn | Source | File`, sorted
+chronologically. For a montage/devblog pass:
+
+1. Pick the version/scene pairs that bracket the change being told (e.g.
+   "the office floor before/after the sprite re-base").
+2. Cross-reference by timestamp against the perf story: `UIEvolutionRecorder`
+   calls `PerfLog.mark("ui_evolution", {"index":..., "version":..., "scene":...})`
+   on every capture (`godot/autoload/perf_log.gd`, merged in PR #973's
+   story-mining hooks). If `PerfLog` is active for that session, the same
+   moment shows up as a `MARK ui_evolution` line in the perf trail, so the
+   visual story and the performance story can be joined by timestamp without
+   a second manual log.
+3. Assemble the before/after pairs into whatever the output needs (devblog
+   screenshots, anniversary retrospective, grantmaker deck) -- the staged
+   files are already normalized and dated, so no further hunting through
+   Pictures\Screenshots is needed.
+
+## Gotchas
+
+- F7 does nothing in a release build (`BuildInfo.is_dev_build()` gates it) --
+  this is by design, not a bug to fix.
+- The collector's `--since`/`--until` filter reads the `timestamp` field
+  written by the recorder, not filesystem mtimes, for the F7 rail (mtimes are
+  used only for the manual `Pictures\Screenshots` sweep, since Windows
+  doesn't tag those with in-game metadata).
+- If `user://ui_evolution/` doesn't exist yet, the collector reports "nothing
+  found" rather than erroring -- press F7 at least once first.

--- a/godot/autoload/keybind_manager.gd
+++ b/godot/autoload/keybind_manager.gd
@@ -28,6 +28,11 @@ var keybinds: Dictionary = {
 	# FlightRecorder itself, same pattern as dev_mode. Rebound from F9 to F6 (Pip playtest:
 	# F9 collides with his Nvidia overlay hotkey). F6 is otherwise unused.
 	"flight_recorder": {"key": KEY_F6, "category": Category.DEBUG, "description": "Flight Recorder Capture (screenshot + state + note)"},
+	# UI evolution capture rail (Pip's "it went from this... to this..." ask, 2026-07-27):
+	# one silent press drops a screenshot + one-line context (scene/version/turn) for later
+	# devblog/anniversary montages. Gated on BuildInfo.is_dev_build() by UIEvolutionRecorder
+	# itself, same pattern as flight_recorder. F7 is otherwise unused.
+	"ui_evolution_shot": {"key": KEY_F7, "category": Category.DEBUG, "description": "UI Evolution Capture (screenshot + context line)"},
 	"admin_mode": {"key": KEY_BRACKETRIGHT, "category": Category.ADMIN, "description": "Toggle Admin Mode"},
 
 	# Gameplay
@@ -85,6 +90,7 @@ signal admin_mode_toggled
 signal debug_overlay_toggled
 signal dev_mode_toggled
 signal flight_recorder_requested
+signal ui_evolution_shot_requested
 
 func _ready():
 	load_keybinds()
@@ -305,6 +311,12 @@ func _input(event: InputEvent):
 	# (dev builds only; FlightRecorder itself gates on BuildInfo.is_dev_build()).
 	elif is_action_pressed(event, "flight_recorder"):
 		flight_recorder_requested.emit()
+		get_viewport().set_input_as_handled()
+
+	# UI evolution capture (F7) -- screenshot + one-line context, no popup
+	# (dev builds only; UIEvolutionRecorder itself gates on BuildInfo.is_dev_build()).
+	elif is_action_pressed(event, "ui_evolution_shot"):
+		ui_evolution_shot_requested.emit()
 		get_viewport().set_input_as_handled()
 
 	# Admin mode

--- a/godot/scripts/debug/ui_evolution_recorder.gd
+++ b/godot/scripts/debug/ui_evolution_recorder.gd
@@ -1,0 +1,154 @@
+extends CanvasLayer
+class_name UIEvolutionRecorder
+## UI evolution capture rail -- Pip's "it went from this... to this..." ask
+## (2026-07-27): a lightweight way to programmatically snapshot visual state as UI
+## lanes land, so a later devblog/anniversary/grantmaker montage can be assembled
+## from a timeline instead of hunting through Win+PrtScn screenshots by hand.
+##
+## One press of F7 drops a screenshot + one-line context (scene name, version,
+## turn) into user://ui_evolution/<version>/manifest.jsonl. Deliberately reuses
+## flight_recorder.gd's shape -- session directory under user://, append-only
+## manifest.jsonl, zero-padded sortable filenames -- rather than inventing a third
+## capture layout. Unlike the flight recorder this is a single silent keypress: no
+## note popup, no full GameState.to_dict() dump, because the ask is "before/after
+## this visual change", not a deep playtest replay.
+##
+## Dev-build only (BuildInfo.is_dev_build(), same gate as FlightRecorder and
+## DevModeOverlay); zero effect on normal play when gated off. Registered the same
+## way: a signal on KeybindManager, connected here, built in code (no .tscn).
+##
+## tools/collect_ui_evolution.py sweeps user://ui_evolution/ (plus optionally
+## Windows' Pictures\Screenshots, the manual Win+PrtScn rail) into
+## G:/tmp/pdoom1-ui-evolution/<date>/ -- OUTSIDE the repo, per
+## docs/art/ART_MASTERS_POLICY.md (the .pck packs the whole godot/ tree, and
+## these captures accumulate indefinitely).
+
+const ROOT := "user://ui_evolution"
+
+## Reference to the MainUI node so the live GameManager/state can be resolved
+## the same way FlightRecorder/DevModeOverlay do (main_ui.gd wires this at
+## instantiation).
+var main_ui: Node = null
+
+var _built := false
+var _shot_count := 0
+
+
+# --- Live-manager resolution (mirrors flight_recorder.gd's _live_gm) -------
+
+func _live_gm() -> Node:
+	if main_ui != null:
+		var gm = main_ui.get("game_manager")
+		if gm != null:
+			return gm
+	return GameManager
+
+
+func _ready() -> void:
+	# Below FlightRecorder's note popup (180) and the DEV BUILD badge (200); this
+	# recorder has no visible UI of its own, so exact layering barely matters.
+	layer = 170
+	if not BuildInfo.is_dev_build():
+		visible = false
+		return
+	_built = true
+	if is_instance_valid(KeybindManager):
+		KeybindManager.ui_evolution_shot_requested.connect(_on_capture_requested)
+
+
+# --- Pure helpers (unit-tested without a live viewport/GameManager) --------
+
+static func session_dir(version: String) -> String:
+	return ROOT.path_join(version)
+
+
+## Zero-padded index + timestamp so shots within one version sort chronologically
+## by filename -- same convention as flight_recorder.gd's marker_prefix.
+static func shot_filename(index: int, timestamp: Dictionary) -> String:
+	return "%04d_%04d%02d%02d_%02d%02d%02d.png" % [
+		index,
+		int(timestamp.get("year", 0)), int(timestamp.get("month", 0)), int(timestamp.get("day", 0)),
+		int(timestamp.get("hour", 0)), int(timestamp.get("minute", 0)), int(timestamp.get("second", 0)),
+	]
+
+
+static func iso_timestamp(timestamp: Dictionary) -> String:
+	return "%04d-%02d-%02d %02d:%02d:%02d" % [
+		int(timestamp.get("year", 0)), int(timestamp.get("month", 0)), int(timestamp.get("day", 0)),
+		int(timestamp.get("hour", 0)), int(timestamp.get("minute", 0)), int(timestamp.get("second", 0)),
+	]
+
+
+static func manifest_entry(index: int, timestamp: Dictionary, version: String, scene_name: String, turn: int, screenshot: String) -> Dictionary:
+	return {
+		"index": index,
+		"timestamp": iso_timestamp(timestamp),
+		"version": version,
+		"scene": scene_name,
+		"turn": turn,
+		"screenshot": screenshot,
+	}
+
+
+# --- Capture flow ------------------------------------------------------------
+
+func _on_capture_requested() -> void:
+	if not _built:
+		return
+	_capture()
+
+
+func _capture() -> void:
+	var version: String = GameConfig.CURRENT_VERSION if is_instance_valid(GameConfig) else "unknown"
+	var dir := session_dir(version)
+	DirAccess.make_dir_recursive_absolute(dir)
+
+	_shot_count += 1
+	var timestamp := Time.get_datetime_dict_from_system()
+	var filename := shot_filename(_shot_count, timestamp)
+
+	# (a) Screenshot
+	var image := get_viewport().get_texture().get_image()
+	var shot_path := dir.path_join(filename)
+	var shot_err := image.save_png(shot_path)
+	if shot_err != OK:
+		push_error("[UIEvolutionRecorder] Failed to save screenshot: %s" % shot_err)
+
+	# (b) One-line context: scene name, version, turn (if a run is live).
+	var scene_name := "unknown"
+	var scene := get_tree().current_scene
+	if scene != null:
+		scene_name = scene.name
+
+	var turn := -1
+	var gm := _live_gm()
+	if gm != null and gm.get("state") != null:
+		turn = gm.get("state").turn
+
+	var entry := manifest_entry(_shot_count, timestamp, version, scene_name, turn, filename)
+	_append_manifest(dir, entry)
+
+	# Cross-reference hook: the perf story and the visual story can be joined by
+	# timestamp later (PerfLog.mark is a no-op when PerfLog isn't active).
+	if is_instance_valid(PerfLog):
+		PerfLog.mark("ui_evolution", {"index": _shot_count, "version": version, "scene": scene_name})
+
+	if is_instance_valid(NotificationManager) and NotificationManager.has_method("info"):
+		NotificationManager.info("UI evolution shot %d captured" % _shot_count)
+
+	var abs_path := OS.get_user_data_dir().path_join("ui_evolution").path_join(version)
+	print("[UIEvolutionRecorder] Captured %s -> %s" % [filename, abs_path])
+
+
+func _append_manifest(dir: String, entry: Dictionary) -> void:
+	var path := dir.path_join("manifest.jsonl")
+	var existing := ""
+	if FileAccess.file_exists(path):
+		var rf := FileAccess.open(path, FileAccess.READ)
+		if rf != null:
+			existing = rf.get_as_text()
+			rf.close()
+	var wf := FileAccess.open(path, FileAccess.WRITE)
+	if wf != null:
+		wf.store_string(existing + JSON.stringify(entry) + "\n")
+		wf.close()

--- a/godot/scripts/debug/ui_evolution_recorder.gd.uid
+++ b/godot/scripts/debug/ui_evolution_recorder.gd.uid
@@ -1,0 +1,1 @@
+uid://devuhowjyao35

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -324,6 +324,13 @@ func _ready():
 	flight_recorder.main_ui = self
 	add_child(flight_recorder)
 
+	# UI evolution capture rail (F7) -- screenshot + one-line context, no popup.
+	# Same wiring pattern as the flight recorder above (WORKSHOP capture tooling,
+	# Pip's "it went from this... to this..." ask, 2026-07-27).
+	var ui_evolution_recorder := UIEvolutionRecorder.new()
+	ui_evolution_recorder.main_ui = self
+	add_child(ui_evolution_recorder)
+
 	# Enable input processing for keyboard shortcuts
 	set_process_input(true)
 	set_process_unhandled_input(true)

--- a/godot/tests/unit/test_ui_evolution_recorder.gd
+++ b/godot/tests/unit/test_ui_evolution_recorder.gd
@@ -1,0 +1,65 @@
+extends GutTest
+## Tests for the UI evolution capture rail (F7) -- Pip's "it went from this...
+## to this..." ask (2026-07-27). Covers keybind registration and the pure
+## filename/manifest helpers; the actual screenshot (get_viewport().get_texture())
+## needs a live rendered viewport, same caveat as test_flight_recorder.gd.
+
+
+func test_ui_evolution_shot_keybind_registered_on_f7():
+	assert_true(KeybindManager.keybinds.has("ui_evolution_shot"),
+		"ui_evolution_shot action must be registered as a named keybind")
+	assert_eq(KeybindManager.keybinds["ui_evolution_shot"]["key"], KEY_F7,
+		"ui_evolution_shot should default to F7")
+
+
+func test_f7_emits_ui_evolution_shot_requested():
+	var ev := InputEventKey.new()
+	ev.keycode = KEY_F7
+	ev.pressed = true
+	watch_signals(KeybindManager)
+	KeybindManager._input(ev)
+	assert_signal_emitted(KeybindManager, "ui_evolution_shot_requested",
+		"Pressing F7 should fire ui_evolution_shot_requested")
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers -- filenames, session dir, manifest entry shape.
+# ---------------------------------------------------------------------------
+
+func test_session_dir_is_scoped_by_version():
+	assert_eq(UIEvolutionRecorder.session_dir("0.13.1"), "user://ui_evolution/0.13.1")
+
+
+func test_shot_filename_is_zero_padded_and_sortable():
+	var ts := {"year": 2026, "month": 7, "day": 27, "hour": 9, "minute": 5, "second": 3}
+	var name1 := UIEvolutionRecorder.shot_filename(1, ts)
+	assert_eq(name1, "0001_20260727_090503.png")
+
+	var name10 := UIEvolutionRecorder.shot_filename(10, ts)
+	assert_true(name1 < name10, "Shot 0001 sorts before shot 0010 (zero-padded)")
+
+
+func test_iso_timestamp_format():
+	var ts := {"year": 2026, "month": 7, "day": 27, "hour": 9, "minute": 5, "second": 3}
+	assert_eq(UIEvolutionRecorder.iso_timestamp(ts), "2026-07-27 09:05:03")
+
+
+func test_manifest_entry_shape():
+	var ts := {"year": 2026, "month": 7, "day": 27, "hour": 9, "minute": 5, "second": 3}
+	var entry := UIEvolutionRecorder.manifest_entry(3, ts, "0.13.1", "MainUI", 5, "0003_20260727_090503.png")
+
+	assert_eq(entry["index"], 3)
+	assert_eq(entry["timestamp"], "2026-07-27 09:05:03")
+	assert_eq(entry["version"], "0.13.1")
+	assert_eq(entry["scene"], "MainUI")
+	assert_eq(entry["turn"], 5)
+	assert_eq(entry["screenshot"], "0003_20260727_090503.png")
+
+
+func test_manifest_entry_is_json_round_trippable():
+	var ts := {"year": 2026, "month": 7, "day": 27, "hour": 9, "minute": 5, "second": 3}
+	var entry := UIEvolutionRecorder.manifest_entry(1, ts, "0.13.1", "MainUI", -1, "0001_x.png")
+	var text := JSON.stringify(entry)
+	var parsed = JSON.parse_string(text)
+	assert_true(parsed is Dictionary, "Manifest entry round-trips through JSON as a Dictionary")
+	assert_eq(int(parsed.get("index", -1)), 1)

--- a/godot/tests/unit/test_ui_evolution_recorder.gd.uid
+++ b/godot/tests/unit/test_ui_evolution_recorder.gd.uid
@@ -1,0 +1,1 @@
+uid://c25vx2sp1rcm7

--- a/tools/collect_ui_evolution.py
+++ b/tools/collect_ui_evolution.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+UI evolution capture collector for P(Doom).
+
+Sweeps the in-game UI evolution capture rail's output -- the F7 hotkey wired in
+godot/scripts/debug/ui_evolution_recorder.gd, which drops screenshot +
+manifest.jsonl entries under user://ui_evolution/<version>/ -- plus, optionally,
+Windows' manual Win+PrtScn rail (Pictures\\Screenshots), and copies everything
+into a dated, OUTSIDE-the-repo staging directory with normalized names, next to
+an ASCII index.md timeline. See docs/content/UI_EVOLUTION_CAPTURE.md for the
+full convention (when to capture, where things land, how the timeline gets
+mined later).
+
+Usage:
+    python tools/collect_ui_evolution.py                       # today's captures
+    python tools/collect_ui_evolution.py --since 2026-07-20 --until 2026-07-27
+    python tools/collect_ui_evolution.py --no-manual           # skip Pictures\\Screenshots
+    python tools/collect_ui_evolution.py --dest G:/tmp/custom  # override staging dir
+    python tools/collect_ui_evolution.py --dry-run             # list what would copy
+
+Output (default G:/tmp/pdoom1-ui-evolution/<date>/ -- repo-external, per
+docs/art/ART_MASTERS_POLICY.md; big/accumulating binaries never go in git):
+    <version>_<index>_<scene>.png   -- from the in-game F7 rail
+    manual_<timestamp>.png          -- from Win+PrtScn, unless --no-manual
+    index.md                        -- ASCII timeline table
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+# The Godot project's actual app_userdata folder name, i.e. project.godot's
+# config/name ("P(Doom)"), NOT the repo/package name "pdoom1". Verified
+# empirically 2026-07-27 against %APPDATA%/Godot/app_userdata/P(Doom)/ --
+# tools/process_bug_reports.py assumes "pdoom1" and is stale; do not copy that
+# assumption here.
+PROJECT_NAME = "P(Doom)"
+
+UI_EVOLUTION_SUBDIR = "ui_evolution"
+
+
+def resolve_user_dir() -> Path:
+    """Resolve Godot's user:// root for this project, platform-aware."""
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA", "")) / "Godot" / "app_userdata" / PROJECT_NAME
+    elif sys.platform == "darwin":
+        base = (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Godot"
+            / "app_userdata"
+            / PROJECT_NAME
+        )
+    else:
+        base = Path.home() / ".local" / "share" / "godot" / "app_userdata" / PROJECT_NAME
+    return base
+
+
+def default_dest_root() -> Path:
+    """G:/tmp is Pip's convention (docs/art/ART_MASTERS_POLICY.md masters
+    staging); fall back to a home-relative dir on a machine without a G: drive."""
+    g_tmp = Path("G:/tmp/pdoom1-ui-evolution")
+    if g_tmp.drive and Path(g_tmp.drive + "\\").exists():
+        return g_tmp
+    return Path.home() / "pdoom1-ui-evolution"
+
+
+def default_screenshots_dir() -> Path:
+    return Path.home() / "Pictures" / "Screenshots"
+
+
+def parse_date(text: str) -> date:
+    return datetime.strptime(text, "%Y-%m-%d").date()
+
+
+def entry_date(timestamp: str) -> date:
+    # manifest timestamps are "YYYY-MM-DD HH:MM:SS" (UIEvolutionRecorder.iso_timestamp).
+    return datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S").date()
+
+
+def sweep_manifests(user_dir: Path, since: date, until: date):
+    """Yield (version, entry_dict, screenshot_path) for manifest entries whose
+    timestamp falls within [since, until] and whose screenshot file exists."""
+    root = user_dir / UI_EVOLUTION_SUBDIR
+    if not root.exists():
+        return
+    for version_dir in sorted(root.iterdir()):
+        if not version_dir.is_dir():
+            continue
+        manifest_path = version_dir / "manifest.jsonl"
+        if not manifest_path.exists():
+            continue
+        with open(manifest_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    print(f"  [!] Skipping malformed manifest line in {manifest_path}")
+                    continue
+                ts = entry.get("timestamp", "")
+                try:
+                    d = entry_date(ts)
+                except ValueError:
+                    print(f"  [!] Skipping entry with unparseable timestamp: {ts!r}")
+                    continue
+                if not (since <= d <= until):
+                    continue
+                shot_path = version_dir / str(entry.get("screenshot", ""))
+                if not shot_path.exists():
+                    print(f"  [!] Manifest references missing screenshot: {shot_path}")
+                    continue
+                yield version_dir.name, entry, shot_path
+
+
+def sweep_manual_screenshots(screenshots_dir: Path, since: date, until: date):
+    """Yield Path for any file in Pictures\\Screenshots whose mtime date falls
+    within [since, until]. Windows' Win+PrtScn rail has no metadata beyond the
+    filesystem timestamp, so mtime is the only signal available."""
+    if not screenshots_dir.exists():
+        return
+    for path in sorted(screenshots_dir.iterdir()):
+        if not path.is_file() or path.suffix.lower() not in (".png", ".jpg", ".jpeg"):
+            continue
+        mtime = datetime.fromtimestamp(path.stat().st_mtime).date()
+        if since <= mtime <= until:
+            yield path
+
+
+def safe_name(text: str) -> str:
+    keep = "".join(c if (c.isalnum() or c in "-_") else "_" for c in text)
+    return keep or "unknown"
+
+
+def collect(
+    since: date,
+    until: date,
+    dest_root: Path,
+    include_manual: bool,
+    screenshots_dir: Path,
+    dry_run: bool,
+) -> Path:
+    user_dir = resolve_user_dir()
+    print(f"[collect_ui_evolution] Godot user:// root: {user_dir}")
+
+    label = since.isoformat() if since == until else f"{since.isoformat()}_to_{until.isoformat()}"
+    dest = dest_root / label
+    if not dry_run:
+        dest.mkdir(parents=True, exist_ok=True)
+
+    rows = []  # (version, timestamp, scene, turn, source, relative_path)
+
+    for version, entry, shot_path in sweep_manifests(user_dir, since, until):
+        index = entry.get("index", 0)
+        scene = safe_name(str(entry.get("scene", "unknown")))
+        dest_name = f"{safe_name(version)}_{int(index):04d}_{scene}.png"
+        dest_path = dest / dest_name
+        print(f"  [rail] {shot_path} -> {dest_name}")
+        if not dry_run:
+            shutil.copy2(shot_path, dest_path)
+        rows.append(
+            (
+                version,
+                entry.get("timestamp", ""),
+                entry.get("scene", "unknown"),
+                entry.get("turn", -1),
+                "f7-rail",
+                dest_name,
+            )
+        )
+
+    if include_manual:
+        for shot_path in sweep_manual_screenshots(screenshots_dir, since, until):
+            mtime = datetime.fromtimestamp(shot_path.stat().st_mtime)
+            dest_name = f"manual_{mtime.strftime('%Y%m%d_%H%M%S')}_{safe_name(shot_path.stem)}{shot_path.suffix}"
+            dest_path = dest / dest_name
+            print(f"  [manual] {shot_path} -> {dest_name}")
+            if not dry_run:
+                shutil.copy2(shot_path, dest_path)
+            rows.append(
+                (
+                    "-",
+                    mtime.strftime("%Y-%m-%d %H:%M:%S"),
+                    "(manual capture)",
+                    "-",
+                    "win+prtscn",
+                    dest_name,
+                )
+            )
+
+    rows.sort(key=lambda r: r[1])  # chronological by timestamp
+
+    if not rows:
+        print("[collect_ui_evolution] Nothing found in the requested date range.")
+        return dest
+
+    index_lines = [
+        "# UI evolution capture index",
+        "",
+        f"Range: {since.isoformat()} to {until.isoformat()}",
+        f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+        "",
+        "| Version | Timestamp | Scene | Turn | Source | File |",
+        "|---|---|---|---|---|---|",
+    ]
+    for version, ts, scene, turn, source, dest_name in rows:
+        index_lines.append(f"| {version} | {ts} | {scene} | {turn} | {source} | {dest_name} |")
+    index_lines.append("")
+
+    index_path = dest / "index.md"
+    if not dry_run:
+        index_path.write_text("\n".join(index_lines), encoding="utf-8")
+    print(f"[collect_ui_evolution] {len(rows)} capture(s) -> {dest}")
+    if not dry_run:
+        print(f"[collect_ui_evolution] Index: {index_path}")
+    return dest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--since", type=parse_date, default=None, help="Start date YYYY-MM-DD (default: today)"
+    )
+    parser.add_argument(
+        "--until",
+        type=parse_date,
+        default=None,
+        help="End date YYYY-MM-DD (default: --since, or today)",
+    )
+    parser.add_argument(
+        "--dest", type=Path, default=None, help="Staging root (default: G:/tmp/pdoom1-ui-evolution)"
+    )
+    parser.add_argument(
+        "--no-manual", action="store_true", help="Skip the Pictures\\Screenshots (Win+PrtScn) sweep"
+    )
+    parser.add_argument(
+        "--screenshots-dir",
+        type=Path,
+        default=None,
+        help="Override the manual screenshots directory",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print what would be copied without touching disk"
+    )
+    args = parser.parse_args()
+
+    today = date.today()
+    since = args.since or today
+    until = args.until or since
+    if until < since:
+        parser.error("--until must not be before --since")
+
+    dest_root = args.dest or default_dest_root()
+    screenshots_dir = args.screenshots_dir or default_screenshots_dir()
+
+    collect(since, until, dest_root, not args.no_manual, screenshots_dir, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Pip's "it went from this... to this..." ask (2026-07-27): one silent **F7** press in a dev build drops a screenshot + one-line context (scene name, version, turn) into `user://ui_evolution/<version>/manifest.jsonl`. Devblog / anniversary / grantmaker before-after montages then assemble from a sortable timeline instead of hand-hunted Win+PrtScn screenshots.

## How

- `godot/scripts/debug/ui_evolution_recorder.gd` -- deliberately reuses `flight_recorder.gd`'s shape end-to-end: session dir under `user://`, append-only `manifest.jsonl`, zero-padded sortable filenames, `BuildInfo.is_dev_build()` gate, KeybindManager signal wiring, `main_ui.gd` instantiation pattern. No third capture layout invented. Unlike the flight recorder: single silent keypress, no popup, no state dump.
- **F7** was unused; registered as a DEBUG-category keybind (F6 = flight recorder, F9 avoided per the Nvidia-overlay collision).
- `tools/collect_ui_evolution.py` sweeps captures out to `G:/tmp/pdoom1-ui-evolution/<date>/` -- OUTSIDE `godot/`, per ART_MASTERS_POLICY (the .pck packs the whole tree; captures accumulate indefinitely).
- `docs/content/UI_EVOLUTION_CAPTURE.md` -- usage + sweep workflow.
- Zero effect on release builds (recorder no-ops when not a dev build).

## Tests

Keybind registration, F7 signal emission, and all pure helpers (session dir, zero-padded filename sorting, ISO timestamp, manifest entry shape + JSON round-trip). Screenshot capture itself needs a live viewport -- same caveat as `test_flight_recorder.gd`.

Fast gate: **939 tests, 0 failures.**

## Provenance note

This lane's original agent died pre-commit; work was salvaged intact from its worktree, sanity-read, gated, and shipped by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)