### PR TITLE
docs(runsheet): Tuesday morning wall -- carry Monday's hanging actions forward

### DIFF
--- a/docs/game-design/RUNSHEET_2026-07-27_to_29.md
+++ b/docs/game-design/RUNSHEET_2026-07-27_to_29.md
@@ -96,6 +96,48 @@ orchestrates; Pip's involvement is CEO chunks + three short drive-by windows.
 Orchestration per the standing lessons: push-per-step, narrow fan-out, tier
 the model.
 
+### 0. MORNING WALL -- hanging actions carried in from Monday (added 2026-07-28 0915, session handoff)
+
+Reconcile note: Monday's evening fleet pulled MOST of the anticipated build
+queue below forward -- already MERGED: workstream substrate (#981, ~lane 1),
+early-game decisions (#982, lane 4), RenderGrid (#977, lane 5), conference
+shell (#979), stream pricing (#974), typed rep (#975), doom-strip S-ticket
+(#985, lane 3's S-cut; M-ticket is #986), day-log/seeds/ADR amendments
+(#989), changelog (#988), perf-log flake fix (#990, issue #976 closed), F7
+UI-evolution capture rail (#991). Read the queue below through that lens;
+the detailed replacement plan is
+`G:/tmp/pdoom1-tuesday-handoff-2026-07-28/TUESDAY_PLAN_2026-07-28.md`.
+
+Pip actions, roughly in order:
+
+1. **Manifund post** (~20 min): staged draft + freshness notes (one FLOOR
+   paragraph edit) + payout email, all in
+   `G:/tmp/pdoom1-tuesday-handoff-2026-07-28/`. Post page first, send
+   payout email second, same sitting. NOT yet posted -- do not re-record
+   as done until it is.
+2. **Set OPENAI_API_KEY** (30 sec): unblocks the vignette vanguard image
+   gen (~$1-2; 30 specs live in `docs/game-design/SEED_VIGNETTE_SPECS.md`).
+3. **Version bump + tag**: one bump covers the whole merged Monday batch;
+   changelog entry (#988) rides it; tag -> CI -> website sync channel.
+4. **#985 balance eyeball**: doom-strip uplift scale factors were agent
+   judgment -- eyeball the numbers in a normal run.
+5. **Doom-sheet 55-cell blitz**: export verdicts ->
+   `docs/game-design/doom_strip_verdicts.json` (sheet has bulk-select).
+6. **bodies.json tone pass** (#975 follow-up) + **names hybridization
+   round 2**: seeds committed in `docs/game-design/
+   SEED_GOVERNANCE_BODIES_NAMES.md` + `SEED_GOVERNANCE_NAMES_YESAND.md`.
+7. **Website handoff paste**:
+   `G:/tmp/pdoom1-tuesday-handoff-2026-07-28/WEBSITE_HANDOFF_BRIEF.md`.
+8. **4 art-sheet triages** (worker round2 / cat west picks / prop rebase /
+   t6 diagonals+cats) + commit the loose `art_source/*_verdicts.json`.
+
+Build centerpiece once the wall clears: **T2 AP->Attention migration**
+(owns `actions.gd`; prerequisites all merged), then hour-typing 4-way +
+#980 planning-vs-operating, quirk balance sweep, workstream pacing
+feel-check. Fleet ops rules for the day: never `git stash` in worktree
+agents; commit-first-then-rebase; sequential finishers; foreground gates
+with explicit timeouts.
+
 ### Schedule
 
 | Time | Block |


### PR DESCRIPTION
Per Pip's 0912 ask: all hanging actions from Monday move to the FRONT of the Tuesday runsheet section, with a reconcile note listing what the evening fleet already pulled forward and merged (so the anticipated build queue reads correctly against reality).

Ordered wall: Manifund post -> OPENAI_API_KEY -> version bump/tag -> #985 balance eyeball -> doom-sheet blitz -> bodies.json tone pass + names round 2 -> website handoff paste -> art triages. Then the T2 AP->Attention centerpiece.

Handoff artifacts (Tuesday plan, Manifund staging, website brief) copied durable to `G:/tmp/pdoom1-tuesday-handoff-2026-07-28/` -- the session scratchpad dies with the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)