### PR TITLE
data(office): prop-heights re-measure -- rebase triage still pending, all 5 props blocked

### DIFF
--- a/godot/data/office/props_manifest.json
+++ b/godot/data/office/props_manifest.json
@@ -28,7 +28,7 @@
       "style_tags": ["decent"],
       "sockets": [],
       "review": true,
-      "notes": "Footprint: subject is 52px wide = 1.6 tiles, rounded up to 2x1, but a filing cabinet may be intended as 1x1 -- Pip to rule. Height 3.125 rounded up to 3.25 (exact tie). Tier inferred as decent (no tier-variant art exists); Pip to confirm in the next review sweep."
+      "notes": "Footprint: subject is 52px wide = 1.6 tiles, rounded up to 2x1, but a filing cabinet may be intended as 1x1 -- Pip to rule. Height 3.125 rounded up to 3.25 (exact tie). Tier inferred as decent (no tier-variant art exists); Pip to confirm in the next review sweep. REBASE PENDING TRIAGE (2026-07-28): art_source/pixellab_2026-07-27_prop_rebase/native/ has 4 un-triaged candidates (filing_cabinet_decent_r1/r2, filing_cabinet_scummy_r1/r2) at a much smaller native canvas (40x52 vs 72x112 above) -- no prop_rebase_verdicts.json exists yet, so Pip's r1-vs-r2 pick has not happened. Measured candidate subject heights (PIL alpha bbox): decent_r1=49px, decent_r2=47px, scummy_r1=49px, scummy_r2=49px. Height/canvas/art NOT changed here -- do not promote a specific roll without a verdict."
     },
     "server_cluster": {
       "art": "res://assets/office_floor/props/server_cluster.png",
@@ -40,7 +40,7 @@
       "style_tags": ["decent"],
       "sockets": [],
       "review": true,
-      "notes": "Footprint: 118px wide = 3.7 tiles -> 4 wide; depth set to 1 but a server rack cluster plausibly occupies 2 tiles deep -- Pip to rule. Tier inferred as decent (no tier-variant art exists); Pip to confirm in the next review sweep."
+      "notes": "Footprint: 118px wide = 3.7 tiles -> 4 wide; depth set to 1 but a server rack cluster plausibly occupies 2 tiles deep -- Pip to rule. Tier inferred as decent (no tier-variant art exists); Pip to confirm in the next review sweep. REBASE PENDING TRIAGE (2026-07-28): art_source/pixellab_2026-07-27_prop_rebase/native/ has 2 un-triaged candidates (server_cluster_r1, server_cluster_r2) at a much smaller native canvas (112x80 vs 128x120 above) -- no prop_rebase_verdicts.json exists yet. Measured candidate subject heights (PIL alpha bbox): r1=72px (90px wide), r2=71px (62px wide) -- the two rolls differ enough in composition, not just noise, that picking one is a real Pip call. Height/canvas/art NOT changed here -- do not promote a specific roll without a verdict."
     },
     "water_cooler": {
       "art": "res://assets/office_floor/props/water_cooler.png",
@@ -53,7 +53,7 @@
       "style_tags": ["decent"],
       "sockets": [],
       "review": true,
-      "notes": "Tier inferred as decent (no tier-variant art exists); Pip to confirm in the next review sweep. Footprint confident (37px subject fits one 32px tile). approach_px: left/right side slots ~26 source px (~1.4x subject half-width) from the anchor, 2px front-biased -- walkers queue at the cooler's sides instead of standing in front (Pip, 2026-07-26)."
+      "notes": "Tier inferred as decent (no tier-variant art exists); Pip to confirm in the next review sweep. Footprint confident (37px subject fits one 32px tile). approach_px: left/right side slots ~26 source px (~1.4x subject half-width) from the anchor, 2px front-biased -- walkers queue at the cooler's sides instead of standing in front (Pip, 2026-07-26). REBASE PENDING TRIAGE (2026-07-28): art_source/pixellab_2026-07-27_prop_rebase/native/ has 4 un-triaged candidates (water_cooler_decent_r1/r2, water_cooler_scummy_r1/r2) at a much smaller native canvas (40x48 vs 64x120 above) -- no prop_rebase_verdicts.json exists yet. Measured candidate subject heights (PIL alpha bbox): decent_r1=48px, decent_r2=46px, scummy_r1=46px, scummy_r2=48px. Height/canvas/art NOT changed here -- do not promote a specific roll without a verdict."
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #948/#978 (native-grain prop re-base, `art_source/pixellab_2026-07-27_prop_rebase/`). Job was: re-measure `godot/data/office/props_manifest.json` heights against the re-based sprites (PIL alpha-channel bounding box, per `docs/art/PROP_MANIFEST.md`).

**Finding: this is currently blocked for all 5 props in the catalog.** No `prop_rebase_verdicts.json` exists anywhere in `art_source/` for the 2026-07-27 batch (checked `art_source/*verdicts*.json` and `docs/game-design/WS3A_DAYLOG_2026-07-27.md`) -- Pip's sheet triage (`art_generated/prop_rebase_sheet.html`, built by `tools/art_review/build_prop_rebase_sheet.py`) has not run yet. The 2026-07-26 vanguard ruling that's on record (`prop_grain_verdicts.json`, daylog "PROP RULING (build-gating): NATIVE GRAIN WINS") only green-lit the *style/process* for this re-base generation run -- it does not pick between the r1/r2 rolls the run actually produced.

Every prop has 2+ un-triaged candidate rolls, and measuring them confirms this isn't just noise -- the candidates genuinely differ in subject height and (for server_cluster especially) composition. Per the task's own escape hatch ("where ambiguous, leave the manifest entry alone rather than guessing"), **no `canvas_px`/`subject_px`/`anchor_px`/`footprint_tiles`/`art` field was changed.**

What this PR does instead: annotates the 3 existing manifest entries with a `REBASE PENDING TRIAGE` note recording the measured candidate heights, so Pip's eventual triage pass has the numbers already on hand. `desk` and `door` are net-new (not yet manifest entries at all) and are out of scope for a height re-measure until Pip also rules on their tier/footprint questions.

## Changed heights

None. Table below is candidate data only -- nothing has been promoted/selected.

| prop | old height (subject_px h) | old canvas_px | rebase candidates (native canvas) | candidate heights (PIL alpha bbox) |
|---|---|---|---|---|
| water_cooler | 109px | 64x120 | decent_r1, decent_r2, scummy_r1, scummy_r2 (40x48) | decent_r1=48, decent_r2=46, scummy_r1=46, scummy_r2=48 |
| filing_cabinet | 100px | 72x112 | decent_r1, decent_r2, scummy_r1, scummy_r2 (40x52) | decent_r1=49, decent_r2=47, scummy_r1=49, scummy_r2=49 |
| server_cluster | 113px | 128x120 | r1, r2 (112x80, single tier) | r1=72 (90 wide), r2=71 (62 wide -- meaningfully different composition, not just noise) |

Note the rebase native canvases are roughly half the linear size of the currently-shipped art across the board -- this is a real re-proportioning against the 64px-worker standard, not just a style refresh, which is one more reason not to guess a pick.

## Pending triage (all 5 props)

- **water_cooler** -- 4 candidates (decent x2, scummy x2), no verdict data
- **filing_cabinet** -- 4 candidates (decent x2, scummy x2), no verdict data
- **server_cluster** -- 2 candidates (single tier), no verdict data
- **desk** -- 4 D-queue candidates (decent x2, scummy x2) + 4 E-queue facing-pilot variants (front/side x scummy/decent, explicitly an evidence probe per `MANIFEST.md`, not to be wired into the manifest schema until Pip rules on the Wednesday decorating-math question); net-new prop, not yet in the manifest
- **door** -- 2 candidates (1 roll each of decent/scummy -- unambiguous by roll count, but still net-new and needs tier/footprint authorship, not just a height copy, before it belongs in the manifest)

Unblocking this fully needs: (1) `python tools/art_review/build_prop_rebase_sheet.py` run + Pip's pick per prop-tier, exported as `art_source/prop_rebase_verdicts.json` (or similar); (2) for desk/door specifically, Pip's ruling on footprint/tier questions per the `MANIFEST.md` follow-up hooks, since those are genuinely new manifest entries, not a height copy onto an existing one.

## Test plan

- [x] `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -- green, 940 tests, 0 failures, 93/93 files collected
- [x] `props_manifest.json` re-validated as JSON + ASCII-only after edit
- [x] Throwaway measurement script kept in local scratchpad only (not committed -- no natural `tools/` home for a one-off PIL bbox dump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)