### PR TITLE
feat(effort): T2 -- kill the AP pool, founder Attention + 2-way founder hours

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,7 +111,7 @@ re-authored** to intermediaries (the printed-delta ban isn't 100% true in data y
 ### Liability Ledger (every mitigation is a loan)
 A two-sided ledger (payables / receivables) of trades that pay now and bill later.
 **No new player-facing currency**  --  entries read/write only existing resources (money,
-reputation, governance, doom, AP). Compounding interest on unpaid payables is the
+reputation, governance, doom, Attention). Compounding interest on unpaid payables is the
 **mortality guarantee** (ADR-0002): debt grows unbounded until a bill you can't cover ends
 the run  --  and the death is attributable to specific entries. A defaulted money bill
 converts its shortfall to **capped** doom + reputation damage (doom residual rolls forward
@@ -142,15 +142,20 @@ rep / nonprofit); equity dilution + board seats mint **inert standing riders** (
 The founder currency is **Attention** (~N decisions/month; admin as painful overhead), held
 on `MonthPlan`. It splits into `available` (fund strategic work), `reserved` (crisp reserve
 for response windows  --  **evaporates** monthly), and `spent`. Strategic actions carry
-**durations** (nothing strategic resolves instantly). There is **no global AP pool** in the
-target design  --  staff get a separate per-person budget.
+**durations** (nothing strategic resolves instantly). There is **no global AP pool**  --
+staff get a separate per-person budget. Every Attention spend is typed into one of two
+**founder hour types** (2-way floor, T2): **planning** (planner mind  --  queuing strategic
+work, direction) or **operating** (presence  --  response windows, hiring, travel).
+Overflow is **asymmetric**: operating may eat planning hours, planning may never eat
+operating. The crisp reserve is deliberately untyped (it is the emergency channel).
 **Files:** [`month_plan.gd`](../godot/scripts/core/month_plan.gd) (`MonthPlan`);
 plan API on `GameManager` (`queue_strategic_action`, `set_attention_reserve`).
-**ADR:** ADR-0011, ADR-0009. **Status:** **Attention layer built**; the **legacy
-per-turn AP pool still co-exists** (`GameState.action_points`, `select_action`)  --  L1
-introduced Attention *alongside* AP; **L2 (#613) deletes AP and migrates costs**. This dual
-economy is the single most confusing live edge for a new dev (see section 7). The **staff effort
-economy (L2) is not built**  --  only spec inputs exist.
+**ADR:** ADR-0011 (amendments (a)-(g)), ADR-0009. **Status:** **Attention is the only
+founder currency.** T2 (2026-07-28) deleted the AP pool outright  --  no `action_points`
+field, no per-turn grant, no AP in any cost dict; the cost key everywhere is `attention`,
+read through `GameActions.attention_cost()` / `hour_type()`. The **4-way** hour split
+(doors / approvals / audits / reserve, ADR-0011 amendment (c)) subdivides the 2-way floor in
+a later lane. Workstream substrate is built (T1); manager shields are not.
 
 ### SA channels (situational awareness)
 "Spending buys sight": simulate everything, gate only the *view*; SA is **channels with
@@ -232,7 +237,7 @@ Gameplay numbers live in JSON, not code, via the **`Balance` autoload** (L9 #621
   `user://balance_overrides.json` **deep-merges on top**, so sweeps/tuning swap a file
   instead of editing code.
 - **Top-level keys in `defaults.json`:** `starting_resources`, `attention`, `doom`
-  (incl. `doom.streams.*`), `ledger`, `financing`, `salaries`, `action_points`, `rivals`,
+  (incl. `doom.streams.*`), `ledger`, `financing`, `salaries`, `rivals`,
   `risk`, `difficulty`, `events`, `papers`.
 - **Contract:** every consumer passes its inline literal as the fallback, so a missing/broken
   file *should* degrade to shipped behavior. [!] **This contract is currently violated for
@@ -242,8 +247,9 @@ Gameplay numbers live in JSON, not code, via the **`Balance` autoload** (L9 #621
   `data/scenarios/*.json` (bootstrap / crisis / sandbox).
 
 **What's tunable without code:** starting resources, doom stream coefficients, ledger
-escalation rates/fuses, financing rate curves & instruments, salaries, AP grants, rival
-pressure, difficulty modifiers, event budgets  --  all of it.
+escalation rates/fuses, financing rate curves & instruments, salaries, the monthly
+Attention grant and its planning/operating split (`attention.per_month`,
+`attention.planning_share`), rival pressure, difficulty modifiers, event budgets  --  all of it.
 
 ---
 
@@ -307,11 +313,18 @@ Where a new dev will hit live edges. Pulled from the ADRs, code TODOs, and
 [`WORKSHOP_2_BACKLOG.md`](game-design/WORKSHOP_2_BACKLOG.md) open DQs.
 
 **Half-built / transitional:**
-- **Dual currency (AP vs Attention).** L1 added Attention beside the legacy AP pool; both
-  are live. `select_action` still spends AP; windows spend Attention. **L2 (#613) deletes
-  AP.** Expect confusion until then.
-- **Staff effort economy (L2, #613): not built.** Only spec inputs exist (burnout debuffs,
-  typed delegation DQ-24).
+- **Dual currency (AP vs Attention): RESOLVED (T2, 2026-07-28).** The AP pool is deleted;
+  Attention is the only founder currency and it is typed 2-way (planning / operating).
+  Residual: `action_points` is still accepted as a READ-ONLY cost-key alias for content
+  that lags the code  --  in-repo data carries none, and a unit test pins that.
+- **Founder-hour typing is at the 2-way FLOOR.** ADR-0011 amendment (c) ruled a 4-way split
+  (doors / approvals / audits / reserve); only planning-vs-operating is built. The
+  subdivision points are `GameActions.hour_type()` and `GameState._cost_hour_type()`.
+- **Attention balance is un-swept.** `attention.planning_share` (0.6) is hand-set; the
+  planning pool is now a real cap on strategic cards per month. Re-price with the
+  exploit-finder (review-by 2026-08-31).
+- **Staff effort economy (L2, #613): substrate built (T1), consumption thin.** Workstreams,
+  backlog, assignment and reported-vs-actual accrual exist; manager shields do not.
 - **Ledger not player-facing** (BL-1). Engine + soak only; no action/UI to view or pay bills
   from the plan screen yet. Exposure not fired by rival/scheduled causes (BL-2);
   hire/departure don't create/flip riders (BL-3).

--- a/docs/game-design/decisions/ADR-0011-effort-economy.md
+++ b/docs/game-design/decisions/ADR-0011-effort-economy.md
@@ -132,3 +132,58 @@ breaks priced in, logged as lessons).
 Founder-hour-typing lane itself (the mechanism that spends the 4-way split)
 is scheduled **Tuesday** -- it consumes T1's merged substrate and was
 deliberately not parallelized with T1 the same night.
+
+## Amendment 2026-07-28 -- T2 landed: AP deleted in code, 2-way hours live
+
+Build record for the T2 lane. The Decision section above is unchanged; this
+records what shipped and the calls the lane had to make.
+
+**(d) The AP pool is DELETED in code**, closing amendment (a). Gone:
+`GameState.action_points` / `max_action_points` / `committed_ap` /
+`reserved_ap` / `used_event_ap` and their reserve methods;
+`turn_manager._step_grant_action_points` (there is now NO per-turn founder
+grant of any kind -- point 1's "the pool illusion dies" is now structural,
+not a convention); the Balance keys `starting_resources.action_points` and
+`action_points.per_staff`. The cost key in all action / event / scenario
+data is `attention` (72 keys, 13 files). `action_points` survives ONLY as a
+read-only alias in `GameActions.attention_cost()` for content that lags the
+code; nothing writes it. Difficulty now scales the monthly Attention grant
+(24 / 20 / 16) rather than a per-turn cap. Removing the grant step is
+RNG-safe -- it drew nothing from `state.rng`, so recorded replay streams are
+unchanged.
+
+**(e) 2-way founder hours shipped as the floor**, ahead of the 4-way split
+ruled in (c). Every Attention spend is **PLANNING** (planner mind: queuing
+strategic work, direction, approvals) or **OPERATING** (presence: response
+windows, hiring loop, travel, interviews). Typed pools are **additive
+accounting over the authoritative scalar** -- the shape N2 used for typed
+reputation -- so `attention_total`/`attention_spent` stay authoritative and
+every caller that only knows the aggregate still works. **Overflow is
+asymmetric**: operating may eat planning hours (a crisis costs you the month
+you meant to spend thinking), planning may never eat operating (you cannot
+retroactively have been in the room). The 4-way split subdivides these two
+in a later lane; `GameActions.hour_type()` and `GameState._cost_hour_type()`
+are the single points that lane changes.
+
+This also closes the seam **#980** named: conference travel drains OPERATING
+hours only, with overflow forbidden. Away costs operator presence, not
+planner mind.
+
+**(f) The crisp reserve is deliberately UNTYPED.** Gating `set_reserve` on
+the operating pool was built, then reverted: the reserve is the emergency
+channel, and an emergency is exactly where the type wall is allowed to break
+(cannibalizing already lets operating overflow into planning). Capping the
+pre-declared reserve at operating hours forbids at PLAN time what the
+overflow rule permits at CRISIS time, and it silently truncated the implicit
+end-of-month reserve #789's hiring flow depends on. Pinned by a test so the
+call cannot be reverted silently.
+
+**(g) `staff_rider` re-expressed.** The contractor action used to mint +2
+into the founder pool, which point 1 forbids outright. It now grants +2
+OPERATING hours for the month (point 6: ops/admin staff reduce the founder-
+price of routine work -- bought presence). It cannot buy planner mind.
+
+**Balance is knowingly disturbed** under the day's audacity ruling: the
+planning pool is a real cap on strategic cards per month, and
+`attention.planning_share` (0.6) is hand-set, not swept. Re-price with the
+exploit-finder before the ADR's own review date.

--- a/godot/autoload/event_service.gd
+++ b/godot/autoload/event_service.gd
@@ -601,7 +601,7 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 			{
 				"id": "collaborate",
 				"text": "Seek collaboration",
-				"costs": {"action_points": 1},
+				"costs": {"attention": 1},
 				"effects": {"reputation": rep_effect, "doom": -doom_effect},
 				"message": "Established collaborative relationship." + (_format_reaction(safety_reaction))
 			},
@@ -626,14 +626,14 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 			{
 				"id": "build_upon",
 				"text": "Build upon this research",
-				"costs": {"action_points": 1, "money": money_effect},
+				"costs": {"attention": 1, "money": money_effect},
 				"effects": {"research": rep_effect * 3, "doom": doom_effect / 2},
 				"message": "Advancing the research frontier." + (_format_reaction(safety_reaction))
 			},
 			{
 				"id": "safety_analysis",
 				"text": "Conduct safety analysis",
-				"costs": {"action_points": 1},
+				"costs": {"attention": 1},
 				"effects": {"research": rep_effect, "doom": -doom_effect, "reputation": rep_effect / 2},
 				"message": "Published safety analysis of the work."
 			},
@@ -651,14 +651,14 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 			{
 				"id": "support",
 				"text": "Publicly support",
-				"costs": {"action_points": 1},
+				"costs": {"attention": 1},
 				"effects": {"reputation": rep_effect, "doom": -doom_effect},
 				"message": "Your support strengthens the policy effort." + (_format_reaction(media_reaction))
 			},
 			{
 				"id": "critique",
 				"text": "Offer constructive critique",
-				"costs": {"action_points": 1},
+				"costs": {"attention": 1},
 				"effects": {"reputation": rep_effect / 2, "research": rep_effect},
 				"message": "Your expertise shapes the discussion."
 			},
@@ -676,14 +676,14 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 			{
 				"id": "respond_publicly",
 				"text": "Issue public response",
-				"costs": {"action_points": 1},
+				"costs": {"attention": 1},
 				"effects": {"reputation": rep_effect, "doom": -doom_effect / 2},
 				"message": "Your response shapes public understanding." + (_format_reaction(media_reaction))
 			},
 			{
 				"id": "internal_review",
 				"text": "Conduct internal review",
-				"costs": {"action_points": 1},
+				"costs": {"attention": 1},
 				"effects": {"research": rep_effect, "doom": -doom_effect},
 				"message": "Lessons learned improve your safety practices."
 			},
@@ -703,14 +703,14 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 			{
 				"id": "emergency_fundraise",
 				"text": "Emergency Fundraising",
-				"costs": {"action_points": 2},
+				"costs": {"attention": 2},
 				"effects": {"money": abs(money_impact) / 2, "reputation": -rep_effect / 2},
 				"message": "Launched emergency fundraising campaign." + (_format_reaction(safety_reaction))
 			},
 			{
 				"id": "diversify_funding",
 				"text": "Diversify Funding Sources",
-				"costs": {"action_points": 1},
+				"costs": {"attention": 1},
 				"effects": {"doom": -doom_effect / 2, "reputation": rep_effect / 2},
 				"message": "Reduced dependency on any single funder."
 			},
@@ -729,7 +729,7 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 			{
 				"id": "engage",
 				"text": "Engage with this development",
-				"costs": {"action_points": 1},
+				"costs": {"attention": 1},
 				"effects": {"reputation": rep_effect, "research": rep_effect / 2},
 				"message": "Engaging with the broader AI safety community."
 			},

--- a/godot/data/actions/core.json
+++ b/godot/data/actions/core.json
@@ -24,7 +24,7 @@
 			"description": "Conduct AI safety research",
 			"costs": {
 				"research": 10,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "research"
 		},
@@ -34,7 +34,7 @@
 			"description": "Advance AI capabilities",
 			"costs": {
 				"research": 10,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "research"
 		},
@@ -44,7 +44,7 @@
 			"description": "Publish research to raise global alarm (adopted safety concern)",
 			"costs": {
 				"research": 20,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "research"
 		},
@@ -70,7 +70,7 @@
 			"description": "Improve morale",
 			"costs": {
 				"money": 10000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "management",
 			"unlock_conditions": {
@@ -83,7 +83,7 @@
 			"description": "Comprehensive safety review",
 			"costs": {
 				"money": 40000,
-				"action_points": 2
+				"attention": 2
 			},
 			"category": "research",
 			"unlock_conditions": {

--- a/godot/data/actions/financing.json
+++ b/godot/data/actions/financing.json
@@ -6,7 +6,7 @@
 			"name": "Take Loan",
 			"description": "+$50k now; a balloon repayment (~$60k) bills in 4 turns and compounds until paid.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "financing"
 		},
@@ -15,7 +15,7 @@
 			"name": "Funding (Strings)",
 			"description": "+$40k now; a governance obligation bills in 6 turns.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "financing"
 		},
@@ -24,7 +24,7 @@
 			"name": "Desperation Lever",
 			"description": "Suppress doom now; plants a SECRET, compounding governance liability that rivals can expose.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "financing"
 		},
@@ -34,7 +34,7 @@
 			"description": "+2 action points now; a small governance rider bills later.",
 			"costs": {
 				"money": 15000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "financing"
 		},
@@ -43,7 +43,7 @@
 			"name": "Seek Financing",
 			"description": "Run a raise (ADR-0013): the cost-of-debt engine quotes 2-3 concurrent offers priced by org type, counterparty, reputation and leverage. Offers stand until they expire; accept at plan speed.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "financing"
 		},
@@ -52,7 +52,7 @@
 			"name": "Accept Offer",
 			"description": "Accept a standing financing offer by id (from Seek Financing) -- cash now, its quoted terms mint a ledger entry.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "financing"
 		},
@@ -61,7 +61,7 @@
 			"name": "Pay the Bill",
 			"description": "Settle the soonest-due affordable loan early from cash (#566), retiring its balloon before it bills.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "financing"
 		}

--- a/godot/data/actions/fundraising.json
+++ b/godot/data/actions/fundraising.json
@@ -6,7 +6,7 @@
 			"name": "Modest Funding Round",
 			"description": "Conservative fundraising - lower amounts, lower risk, always available",
 			"costs": {
-				"action_points": 1,
+				"attention": 1,
 				"reputation": 2
 			},
 			"gains": {
@@ -20,7 +20,7 @@
 			"name": "Major Funding Round",
 			"description": "Aggressive funding - higher amounts but requires strong reputation",
 			"costs": {
-				"action_points": 2,
+				"attention": 2,
 				"reputation": 8
 			},
 			"gains": {
@@ -34,7 +34,7 @@
 			"name": "Business Loan",
 			"description": "Immediate funds via debt - creates future repayment obligation",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"gains": {
 				"money": 75000,
@@ -47,7 +47,7 @@
 			"name": "Research Grant",
 			"description": "Government/foundation funding - requires published papers",
 			"costs": {
-				"action_points": 1,
+				"attention": 1,
 				"papers": 1
 			},
 			"gains": {

--- a/godot/data/actions/hiring.json
+++ b/godot/data/actions/hiring.json
@@ -7,7 +7,7 @@
 			"description": "Focused on AI safety and alignment research",
 			"costs": {
 				"money": 60000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "hiring"
 		},
@@ -17,7 +17,7 @@
 			"description": "Advances AI capabilities (increases doom!)",
 			"costs": {
 				"money": 60000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "hiring"
 		},
@@ -27,7 +27,7 @@
 			"description": "Improves compute efficiency",
 			"costs": {
 				"money": 50000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "hiring"
 		},
@@ -37,7 +37,7 @@
 			"description": "Oversees a team of up to 8 researchers",
 			"costs": {
 				"money": 80000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "hiring"
 		},
@@ -47,7 +47,7 @@
 			"description": "Add philosophical perspective to research (+5 reputation)",
 			"costs": {
 				"money": 70000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "hiring"
 		},
@@ -57,7 +57,7 @@
 			"description": "Probes how models work internally (safety-aligned research)",
 			"costs": {
 				"money": 60000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "hiring"
 		},
@@ -67,7 +67,7 @@
 			"description": "Aligns AI goals with human values (safety-aligned research)",
 			"costs": {
 				"money": 60000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "hiring"
 		}

--- a/godot/data/actions/office.json
+++ b/godot/data/actions/office.json
@@ -6,7 +6,7 @@
 			"name": "Tour Offices",
 			"description": "Go and look at what is on the market. Three landlords will quote you terms; the offers stand for a while.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "office"
 		},
@@ -15,7 +15,7 @@
 			"name": "Sign: Co-working corner",
 			"description": "Cheap in, cheap out, low ceiling. Requires a current quote (tour first).",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "office"
 		},
@@ -24,7 +24,7 @@
 			"name": "Sign: Walk-up office",
 			"description": "Middle of everything -- more desks, more rent, a year on the term. Requires a current quote.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "office"
 		},
@@ -33,7 +33,7 @@
 			"name": "Sign: University annex",
 			"description": "The cheapest desk in town if you last two years. Big deposit. Requires a current quote.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "office"
 		}

--- a/godot/data/actions/operations.json
+++ b/godot/data/actions/operations.json
@@ -7,7 +7,7 @@
 			"description": "Restock stationery (+50 supplies). Staff consume supplies each turn.",
 			"costs": {
 				"money": 2000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "operations"
 		},
@@ -17,7 +17,7 @@
 			"description": "Routine repairs and cleaning. Improves morale slightly.",
 			"costs": {
 				"money": 5000,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "operations"
 		}

--- a/godot/data/actions/publicity.json
+++ b/godot/data/actions/publicity.json
@@ -6,7 +6,7 @@
 			"name": "Networking",
 			"description": "Build relationships and connections in the AI safety community",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "influence"
 		},
@@ -16,7 +16,7 @@
 			"description": "Public outreach through press and social media",
 			"costs": {
 				"money": 30000,
-				"action_points": 2
+				"attention": 2
 			},
 			"category": "influence"
 		},
@@ -26,7 +26,7 @@
 			"description": "Advocate for AI safety regulation (costly but impactful)",
 			"costs": {
 				"money": 80000,
-				"action_points": 2
+				"attention": 2
 			},
 			"category": "influence"
 		},
@@ -35,7 +35,7 @@
 			"name": "Public Warning",
 			"description": "Warn public about AI risks - risky but high impact",
 			"costs": {
-				"action_points": 2,
+				"attention": 2,
 				"reputation": 15
 			},
 			"category": "influence"
@@ -46,7 +46,7 @@
 			"description": "Release safety research publicly for community benefit",
 			"costs": {
 				"papers": 3,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "influence"
 		}

--- a/godot/data/actions/scouting.json
+++ b/godot/data/actions/scouting.json
@@ -6,7 +6,7 @@
 			"name": "Read the Literature",
 			"description": "Sit down with the arxiv firehose. Slow, free, and the only scouting that makes you better at the actual work.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "scouting"
 		},
@@ -15,7 +15,7 @@
 			"name": "Go to Meetups",
 			"description": "Drinks, badges, a talk you half-listen to. People remember you, and sometimes one of them is looking for a job.",
 			"costs": {
-				"action_points": 1,
+				"attention": 1,
 				"money": 300
 			},
 			"category": "scouting"
@@ -25,7 +25,7 @@
 			"name": "Post Online",
 			"description": "Be loud. Hype is not respect -- it buys you attention from people who fund things and costs you standing with people who read things.",
 			"costs": {
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "scouting"
 		}

--- a/godot/data/actions/strategic.json
+++ b/godot/data/actions/strategic.json
@@ -7,7 +7,7 @@
 			"description": "Buy struggling AI startup for talent and compute",
 			"costs": {
 				"money": 150000,
-				"action_points": 2
+				"attention": 2
 			},
 			"category": "strategic"
 		},
@@ -17,7 +17,7 @@
 			"description": "Slow down competitors (unethical, risky)",
 			"costs": {
 				"money": 100000,
-				"action_points": 3,
+				"attention": 3,
 				"reputation": 20
 			},
 			"category": "strategic"
@@ -28,7 +28,7 @@
 			"description": "Convert capability researchers to safety focus",
 			"costs": {
 				"money": 50000,
-				"action_points": 2
+				"attention": 2
 			},
 			"category": "strategic"
 		},
@@ -37,7 +37,7 @@
 			"name": "Grant Proposal",
 			"description": "Apply for government/foundation funding",
 			"costs": {
-				"action_points": 1,
+				"attention": 1,
 				"papers": 1
 			},
 			"category": "strategic"

--- a/godot/data/actions/travel.json
+++ b/godot/data/actions/travel.json
@@ -7,7 +7,7 @@
 			"description": "Submit research paper to a conference (multi-turn review process)",
 			"costs": {
 				"research": 15,
-				"action_points": 1
+				"attention": 1
 			},
 			"category": "travel"
 		},
@@ -16,7 +16,7 @@
 			"name": "Attend Conference",
 			"description": "[Coming Soon] Travel to present accepted paper or network at a conference -- day-bound scheduling is not available yet",
 			"costs": {
-				"action_points": 2
+				"attention": 2
 			},
 			"category": "travel",
 			"is_stub": true

--- a/godot/data/balance/defaults.json
+++ b/godot/data/balance/defaults.json
@@ -12,8 +12,9 @@
 		"default_event_class": "deferrable"
 	},
 	"attention": {
-		"_description": "Founder currency (workshop#3 addendum #5 / ADR-0011): ~N decisions per PLAN MONTH; admin is painful overhead spent here. Staff spend a SEPARATE per-person 'actions' currency -- there is no global pool (L2 deletes the legacy AP pool; L1 introduces Attention alongside it). Unspent reserve evaporates at month end (ADR-0009 S4 -- no banking).",
-		"per_month": 20
+		"_description": "Founder currency (workshop#3 addendum #5 / ADR-0011): ~N decisions per PLAN MONTH; admin is painful overhead spent here. Staff spend a SEPARATE per-person 'actions' currency -- there is no global pool, and as of T2 (2026-07-28) no legacy AP pool either: Attention is the ONLY founder currency. Unspent reserve evaporates at month end (ADR-0009 S4 -- no banking). planning_share splits the monthly grant into PLANNING vs OPERATING founder hours (the 2-way T3-rung floor); the remainder goes to operating. TUNING DIAL, HAND-SET, NOT SWEPT: planning hours bound how many strategic cards a month can hold, operating hours bound presence work (response windows, hiring loop, travel, interviews). Overflow is asymmetric -- operating may eat planning hours, planning may never eat operating. Re-price after the first playtest (review-by 2026-08-31).",
+		"per_month": 20,
+		"planning_share": 0.6
 	},
 	"papers": {
 		"_description": "Paper-decision pacing (#630 stopgap): at most max_decisions_per_turn paper accept/reject decisions surface per turn; clustered decision_turns otherwise flood a click-through wall. Surplus stays UNDER_REVIEW and resolves on later turns (never dropped). 0 = unlimited (pre-#630). Superseded by ADR-0009/0012/0014 response windows. research_per_paper/reputation_per_paper drive the auto-publish step (turn_manager._step_publish_papers) AND the Research/Papers HUD tooltips (main_ui) -- single source so the tooltip cannot drift from the mechanic.",
@@ -121,14 +122,9 @@
 		"papers": 0.0,
 		"reputation": 50.0,
 		"doom": 20.0,
-		"action_points": 3,
 		"stationery": 100.0,
 		"governance": 50.0,
 		"hype": 0.0
-	},
-	"action_points": {
-		"_description": "AP economy: per-turn AP = difficulty base + per_staff * total staff.",
-		"per_staff": 0.5
 	},
 	"workstreams": {
 		"_description": "ADR-0011 s3/s4 workstream substrate (workstream.gd + the turn_manager accrual hook). turns_per_month re-denominates the per-MONTH quotes below onto the workday tick. effort_per_turn_scale converts one researcher's effective productivity into effort units. compute_starved_effort_multiplier is what an assigned researcher gets done when the fleet cannot cover their workstream's compute_intensity that tick (they are not idle, just slower). FIRST PASS -- priced by hand, not by sweep; re-price after the first assignment playtest (review-by 2026-08-31).",
@@ -155,9 +151,9 @@
 	},
 	"difficulty": {
 		"_description": "Difficulty modifiers applied by game_manager._apply_difficulty_settings (indices: 0=easy, 1=standard, 2=hard). Replaces the dormant data/events/balancing/difficulty.json (deleted this lane).",
-		"easy": { "money_multiplier": 1.5, "max_action_points": 4 },
-		"standard": { "money_multiplier": 1.0, "max_action_points": 3 },
-		"hard": { "money_multiplier": 0.75, "max_action_points": 2 }
+		"easy": { "money_multiplier": 1.5, "attention_per_month": 24 },
+		"standard": { "money_multiplier": 1.0, "attention_per_month": 20 },
+		"hard": { "money_multiplier": 0.75, "attention_per_month": 16 }
 	},
 	"scouting": {
 		"_description": "Scouting action stubs (#811 item 1): read / meetups / shitpost. FIRST-PASS magnitudes -- deliberately small, and every one of them is actually applied and named in the action's message (no silent promises). hype feeds FinanceEngine pricing (vc_equity gates on min_hype 25), so ~7 shitposts opens that door.",

--- a/godot/data/events/core_events.json
+++ b/godot/data/events/core_events.json
@@ -15,7 +15,7 @@
 					"id": "emergency_fundraise",
 					"text": "Emergency Fundraising",
 					"costs": {
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"money": 75000
@@ -26,7 +26,7 @@
 					"id": "sell_assets",
 					"text": "Sell Lab Equipment",
 					"costs": {
-						"action_points": 2
+						"attention": 2
 					},
 					"effects": {
 						"money": 120000,
@@ -59,7 +59,7 @@
 					"text": "Fast-Track Hiring",
 					"costs": {
 						"money": 25000,
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"safety_researchers": 1
@@ -121,7 +121,7 @@
 					"id": "safety_review",
 					"text": "Conduct Safety Review First",
 					"costs": {
-						"action_points": 1,
+						"attention": 1,
 						"money": 20000
 					},
 					"effects": {
@@ -216,7 +216,7 @@
 					"text": "Emergency Intervention",
 					"costs": {
 						"money": 30000,
-						"action_points": 2
+						"attention": 2
 					},
 					"effects": {
 						"reputation": 8
@@ -334,7 +334,7 @@
 					"text": "Publicly Support",
 					"costs": {
 						"money": 50000,
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"global_alarm": 20,
@@ -460,7 +460,7 @@
 					"id": "mediate_personally",
 					"text": "Mediate Personally",
 					"costs": {
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"reputation": 3
@@ -504,7 +504,7 @@
 					"id": "thorough_investigation",
 					"text": "Full Investigation",
 					"costs": {
-						"action_points": 2,
+						"attention": 2,
 						"money": 25000
 					},
 					"effects": {
@@ -561,7 +561,7 @@
 					"id": "explain_structure",
 					"text": "Explain Compensation Structure",
 					"costs": {
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"reputation": 2
@@ -647,7 +647,7 @@
 					"id": "team_meeting",
 					"text": "Address at Team Meeting",
 					"costs": {
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"reputation": 2
@@ -681,7 +681,7 @@
 					"id": "formal_discipline",
 					"text": "Formal Disciplinary Action",
 					"costs": {
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"reputation": 5
@@ -722,7 +722,7 @@
 					"id": "investigate_leak",
 					"text": "Full Investigation",
 					"costs": {
-						"action_points": 2,
+						"attention": 2,
 						"money": 30000
 					},
 					"effects": {
@@ -735,7 +735,7 @@
 					"id": "publish_immediately",
 					"text": "Publish Research Publicly",
 					"costs": {
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"papers": 1,
@@ -782,7 +782,7 @@
 					"id": "report_intel",
 					"text": "Report to Authorities",
 					"costs": {
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"reputation": 10,
@@ -816,7 +816,7 @@
 					"id": "full_support",
 					"text": "Fully Support & Publicize",
 					"costs": {
-						"action_points": 2,
+						"attention": 2,
 						"money": 50000
 					},
 					"effects": {
@@ -842,7 +842,7 @@
 					"text": "Hire Them Instead",
 					"costs": {
 						"money": 60000,
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"safety_researchers": 1
@@ -875,7 +875,7 @@
 					"id": "address_concerns",
 					"text": "Open Forum Discussion",
 					"costs": {
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"reputation": 8,
@@ -920,7 +920,7 @@
 					"text": "Plant a Source",
 					"costs": {
 						"money": 80000,
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"safety_absorption": 100,
@@ -932,7 +932,7 @@
 					"id": "legitimate_partnership",
 					"text": "Propose Legitimate Partnership",
 					"costs": {
-						"action_points": 1,
+						"attention": 1,
 						"money": 40000
 					},
 					"effects": {
@@ -966,7 +966,7 @@
 					"text": "Announce Public Security Audit",
 					"costs": {
 						"money": 40000,
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"reputation": 15,
@@ -998,7 +998,7 @@
 					"id": "exploit_weakness",
 					"text": "Exploit Their Weakness (Poach Clients)",
 					"costs": {
-						"action_points": 1
+						"attention": 1
 					},
 					"effects": {
 						"money": 50000,
@@ -1025,7 +1025,7 @@
 					"text": "Full Security Overhaul",
 					"costs": {
 						"money": 60000,
-						"action_points": 2
+						"attention": 2
 					},
 					"effects": {
 						"reputation": 8,
@@ -1082,7 +1082,7 @@
 					"id": "counter_promotion",
 					"text": "Counter with Promotion",
 					"costs": {
-						"action_points": 1,
+						"attention": 1,
 						"money": 30000
 					},
 					"effects": {

--- a/godot/data/historical_timeline/2017.json
+++ b/godot/data/historical_timeline/2017.json
@@ -65,7 +65,7 @@
         {
           "id": "study_transformers",
           "text": "Assign researchers to study transformer architecture",
-          "costs": {"action_points": 1, "money": 5000},
+          "costs": {"attention": 1, "money": 5000},
           "effects": {"research": 15, "compute": 10}
         },
         {
@@ -100,13 +100,13 @@
         {
           "id": "study_paper",
           "text": "Assign researchers to study concrete safety problems",
-          "costs": {"action_points": 1},
+          "costs": {"attention": 1},
           "effects": {"research": 10, "safety_absorption": 10, "reputation": 2}
         },
         {
           "id": "organize_reading_group",
           "text": "Organize safety reading group (costs 2 AP)",
-          "costs": {"action_points": 2, "money": 3000},
+          "costs": {"attention": 2, "money": 3000},
           "effects": {"research": 20, "safety_absorption": 20, "reputation": 5}
         },
         {
@@ -140,13 +140,13 @@
         {
           "id": "endorse_principles",
           "text": "Publicly endorse Asilomar Principles",
-          "costs": {"action_points": 1},
+          "costs": {"attention": 1},
           "effects": {"reputation": 8, "global_alarm": 1}
         },
         {
           "id": "integrate_principles",
           "text": "Integrate principles into lab policy (costs 2 AP, $10k)",
-          "costs": {"action_points": 2, "money": 10000},
+          "costs": {"attention": 2, "money": 10000},
           "effects": {"reputation": 15, "safety_absorption": 20}
         },
         {

--- a/godot/data/icon_mapping.json
+++ b/godot/data/icon_mapping.json
@@ -222,7 +222,7 @@
     "research": "res://assets/icons/resources/resource_research_points_64.png",
     "papers": "res://assets/icons/actions_research/action_research_formal_verification_64.png",
     "reputation": "res://assets/icons/resources/resource_reputation_64.png",
-    "action_points": "res://assets/icons/resources/resource_action_points_64.png"
+    "attention": "res://assets/icons/resources/resource_action_points_64.png"
   },
   "decorative": {
     "corner_top_left": "res://assets/icons/decorative_corners/ui_corner_top_left_64.png",

--- a/godot/data/scenarios/sandbox.json
+++ b/godot/data/scenarios/sandbox.json
@@ -10,7 +10,7 @@
     "papers": 10,
     "reputation": 80,
     "doom": 30,
-    "action_points": 5,
+    "attention_per_month": 40,
     "stationery": 1000
   },
   "config": {

--- a/godot/scripts/core/actions.gd
+++ b/godot/scripts/core/actions.gd
@@ -19,6 +19,34 @@ class_name GameActions
 # execute_action, so replays recorded before the collapse still verify.
 const PASS_ACTION_ID := "pass"
 
+# --- Founder Attention cost API (T2 / ADR-0011 amendment (a)) -------------------------------
+# The AP pool is DELETED. An action's founder cost is `costs.attention`, and it bills one of
+# the two founder HOUR TYPES (2-way floor: planning / operating). Every consumer -- the plan
+# queue, the cost preview, the submenu tooltips -- reads these two statics, so the later
+# 4-way lane (doors / approvals / audits / reserve) changes ONE file, not forty call sites.
+#
+# `action_points` is accepted as a READ-ONLY legacy alias. In-repo data is fully migrated; the
+# alias exists because action defs are content (scenario packs, historical timeline, saved
+# mods) and content lags a code migration. Nothing WRITES it.
+
+static func attention_cost(action: Dictionary) -> int:
+	"""Founder Attention an action costs to queue. 0 when free or when `action` is empty."""
+	var costs: Dictionary = action.get("costs", {})
+	if costs.has("attention"):
+		return int(costs["attention"])
+	return int(costs.get("action_points", 0))
+
+
+static func hour_type(action: Dictionary) -> String:
+	"""Which founder hour type an action bills. Data may declare `costs.hour_type`; the
+	DEFAULT for a queued strategic action is PLANNING -- picking what the org does next is
+	planner mind, not presence (the #980 seam: that is exactly the part you keep while
+	away). Actions that are inherently presence work declare "operating" in their data."""
+	var declared: String = String(action.get("costs", {}).get("hour_type", MonthPlan.HOUR_PLANNING))
+	if declared == MonthPlan.HOUR_OPERATING:
+		return MonthPlan.HOUR_OPERATING
+	return MonthPlan.HOUR_PLANNING
+
 
 ## Check if an action is unlocked based on game state
 static func is_action_unlocked(action: Dictionary, state: Dictionary) -> bool:
@@ -225,8 +253,9 @@ static func get_pass_action() -> Dictionary:
 
 static func execute_action(action_id: String, state: GameState) -> Dictionary:
 	"""Execute an action, modify state, return result
-	Note: AP costs are handled by the commit system in game_manager.gd (committed_ap).
-	Only non-AP costs (money, research, etc.) are spent here."""
+	Note: the founder ATTENTION cost was already debited from the month plan when the action
+	was queued (game_manager.select_action). Only the non-Attention costs (money, research,
+	...) are spent here -- charging attention again would double-bill the month."""
 	# LEGACY replay-input alias (L0 #620): "pass_turn" was a twin "do nothing" id queued
 	# by the commit-plan path; new code queues PASS_ACTION_ID. Kept ONLY so replay
 	# artifacts recorded before the collapse still execute identically (no state, no RNG).
@@ -237,15 +266,17 @@ static func execute_action(action_id: String, state: GameState) -> Dictionary:
 	if action.is_empty():
 		return {"success": false, "message": "Unknown action: " + action_id}
 
-	# Build costs without AP (AP already deducted via committed_ap system)
+	# Build costs without Attention (already debited from the month plan at queue time)
 	var execution_costs = action["costs"].duplicate()
-	execution_costs.erase("action_points")
+	execution_costs.erase("attention")
+	execution_costs.erase("action_points")  # legacy alias, never billed here either
+	execution_costs.erase("hour_type")      # a type tag, not a resource
 
-	# Check affordability (non-AP costs only)
+	# Check affordability (non-Attention costs only)
 	if not state.can_afford(execution_costs):
 		return {"success": false, "message": "Cannot afford " + action["name"]}
 
-	# Spend non-AP costs
+	# Spend non-Attention costs
 	state.spend_resources(execution_costs)
 
 	# Apply effects based on action type
@@ -481,10 +512,15 @@ static func execute_action(action_id: String, state: GameState) -> Dictionary:
 			result["message"] = "Pulled a desperation lever (brief reprieve now; a SECRET liability is planted)"
 
 		"staff_rider":
-			state.action_points += 2
+			# T2 judgment call: this used to mint +2 AP into the founder pool, which ADR-0011
+			# point 1 explicitly forbids ("staff never add founder AP"). Re-expressed as
+			# ADR-0011 point 6 instead -- a contractor absorbs routine OPERATING load, buying
+			# back presence hours. It cannot buy planner mind.
+			if state.month_plan != null:
+				state.month_plan.grant_hours(2, MonthPlan.HOUR_OPERATING)
 			if state.ledger:
 				state.ledger.add(Ledger.staff_rider("Contractor"))
-			result["message"] = "Brought on a contractor (+2 AP; a governance rider bills later)"
+			result["message"] = "Brought on a contractor (+2 operating hours this month; a governance rider bills later)"
 
 		# --- ADR-0013 cost-of-debt engine (L5 #616): the raise-as-campaign flow ---
 		"seek_financing":
@@ -836,9 +872,10 @@ static func submit_paper_to_conference(state: GameState, conf_id: String, topic:
 	if state.research < research_amount:
 		return {"success": false, "message": "Not enough research points"}
 
-	# Check AP cost
-	if state.action_points < 1:
-		return {"success": false, "message": "Not enough action points"}
+	# Check the founder Attention cost. Submitting a paper is OPERATING work -- writing up,
+	# chasing co-authors, hitting the deadline; it is presence, not direction-setting.
+	if not state.can_afford({"attention": 1, "hour_type": MonthPlan.HOUR_OPERATING}):
+		return {"success": false, "message": "Not enough Attention (1 operating hour required)"}
 
 	# Calculate paper quality (media_savvy trait retired -> no press bonus for now)
 	var lead_skill = lead_researcher.skill_level if lead_researcher != null else 3
@@ -861,7 +898,11 @@ static func submit_paper_to_conference(state: GameState, conf_id: String, topic:
 	paper.title = PaperSubmissions.generate_paper_title(topic, state.rng)
 
 	# Spend resources
-	state.spend_resources({"research": research_amount, "action_points": 1})
+	state.spend_resources({
+		"research": research_amount,
+		"attention": 1,
+		"hour_type": MonthPlan.HOUR_OPERATING,
+	})
 
 	# Add to tracking
 	state.add_paper_submission(paper)
@@ -915,11 +956,18 @@ static func attend_conference_action(state: GameState, conf_id: String, travel_c
 	var travel_cost = get_travel_cost_with_class(conf, travel_class)
 
 	# Check affordability
-	if not state.can_afford({"money": travel_cost.total, "action_points": 2}):
-		return {"success": false, "message": "Cannot afford: %s + 2 AP required" % GameConfig.format_money(travel_cost.total)}
+	# Travel is OPERATING work by definition -- it is the loss of presence at home that the
+	# conference lane priced (#980: away costs operator presence, not planner mind).
+	var travel_costs := {
+		"money": travel_cost.total,
+		"attention": 2,
+		"hour_type": MonthPlan.HOUR_OPERATING,
+	}
+	if not state.can_afford(travel_costs):
+		return {"success": false, "message": "Cannot afford: %s + 2 operating hours required" % GameConfig.format_money(travel_cost.total)}
 
 	# Spend resources
-	state.spend_resources({"money": travel_cost.total, "action_points": 2})
+	state.spend_resources(travel_costs)
 	state.mark_conference_attended(conf_id)
 
 	# Apply jet lag to traveler if specified (Issue #469)

--- a/godot/scripts/core/conference_trip.gd
+++ b/godot/scripts/core/conference_trip.gd
@@ -252,22 +252,25 @@ static func _commit_open_turn(state: GameState, controller) -> void:
 
 
 static func _consume_founder_capacity(state: GameState) -> int:
-	"""Pip's 2026-07-27 1555 ruling: attending consumes ALL the founder's remaining
-	attention/action capacity for the away window.
+	"""Pip's 2026-07-27 1555 ruling: attending consumes the founder's remaining capacity for
+	the away window.
 
-	==== SEAM: ATTENTION MIGRATION ====
-	This is the ONLY place this lane touches the founder currency, and it spends through the
-	EXISTING mechanism (MonthPlan.spend_attention) rather than migrating anything. When L2
-	deletes the legacy AP pool and re-homes cost dicts onto Attention/staff (month_plan.gd
-	class docstring), this one function is the entire surface that has to move. Do not spread
-	capacity arithmetic through the trip loop.
+	==== SEAM CLOSED BY T2 (attention migration + 2-way founder hours) ====
+	Refined per Pip's #980 noticing: being away is a loss of OPERATOR PRESENCE, not of
+	PLANNER MIND. So the trip drains only the OPERATING pool, and drains it with overflow
+	FORBIDDEN -- travel must never eat the planning hours that let you decide next month's
+	direction from a hotel room. Everything else about the trip's cost model is unchanged.
 	Returns the Attention actually consumed (for the return panel's honesty about the cost)."""
 	if state.month_plan == null:
 		return 0
-	var free: int = state.month_plan.available()
+	# Cap the drain at whichever binds first: operating hours left, or un-reserved Attention.
+	var free: int = mini(
+		state.month_plan.hours_available(MonthPlan.HOUR_OPERATING),
+		state.month_plan.available()
+	)
 	if free <= 0:
 		return 0
-	state.month_plan.spend_attention(free)
+	state.month_plan.spend_attention(free, MonthPlan.HOUR_OPERATING)
 	return free
 
 

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -73,8 +73,12 @@ var player_frontier: float:
 	get:
 		return float(frontier_capability.get("player", 0.0))
 
-var action_points: int = 3
-var max_action_points: int = 3  # Per-turn AP cap; difficulty modifiers adjust this (game_manager._apply_difficulty_settings)
+# T2 / ADR-0011 amendment (a): the per-turn ACTION POINT pool is DELETED. There is no
+# `action_points` field, no per-turn grant, no AP in any cost dict. The founder currency is
+# ATTENTION, granted per PLAN MONTH and held by month_plan (MonthPlan), typed 2-way into
+# planning vs operating hours. `attention_per_month` is the grant size -- difficulty scales
+# THIS now (it used to scale max_action_points).
+var attention_per_month: int = 20
 var stationery: float = 100.0  # Office supplies, depletes with staff usage
 
 # Governance: institutional legitimacy the Liability Ledger bills against (ADR-0003).
@@ -143,10 +147,9 @@ var technical_debt: float = 0.0  # 0-100 scale
 const MAX_TECHNICAL_DEBT: float = 100.0
 const TECH_DEBT_DOOM_MULTIPLIER: float = 0.05  # 5% doom increase per debt point at high levels
 
-# AP Reserve System (for event responses)
-var committed_ap: int = 0      # AP spent on queued actions
-var reserved_ap: int = 0       # AP held back for events
-var used_event_ap: int = 0     # AP spent on event responses
+# (T2: the per-turn AP reserve trio -- committed_ap / reserved_ap / used_event_ap -- is
+# DELETED. Its job is done by MonthPlan's attention_spent / attention_reserved /
+# reserve_used, which are per PLAN MONTH and survive the day tick.)
 
 # Staff (legacy counts for backward compatibility)
 var safety_researchers: int = 0
@@ -171,8 +174,9 @@ var pending_hire_queue: Array[Researcher] = []  # Queue of candidates selected f
 # workstream: with an empty list the accrual hook only records self-directed effort and
 # bills no compute, so an untouched run is byte-identical to the pre-substrate build.
 #
-# NOT in this lane: AP-pool deletion / Attention migration, founder-hour typing, manager
-# shields. Nothing below reads action_points.
+# NOT in this lane: manager shields. (AP-pool deletion / Attention migration and the 2-way
+# founder-hour typing landed in T2; nothing below reads either -- workstream effort is a
+# STAFF currency, never founder Attention.)
 # ============================================================================
 var workstreams: Array = []                          # Array[Workstream], live + finished
 var workstream_backlog_taken: Array[String] = []     # backlog entry ids already started
@@ -308,7 +312,7 @@ func reset():
 	rep_org = {REP_KIND_SAFETY: 0.0, REP_KIND_CAPABILITY: 0.0}
 	rep_operator = {REP_KIND_SAFETY: 0.0, REP_KIND_CAPABILITY: 0.0}
 	doom = Balance.num("starting_resources.doom", 50.0)
-	action_points = Balance.inum("starting_resources.action_points", 3)
+	attention_per_month = Balance.inum("attention.per_month", 20)
 	stationery = Balance.num("starting_resources.stationery", 100.0)
 	governance = Balance.num("starting_resources.governance", 50.0)
 	hype = Balance.num("starting_resources.hype", 0.0)
@@ -320,7 +324,7 @@ func reset():
 	# L1/ADR-0009: fresh month plan, opened with the first month's Attention grant. The plan
 	# month ordinal is derived from the calendar (turn 0 -> ordinal 0).
 	month_plan = MonthPlan.new()
-	month_plan.begin_month(Balance.inum("attention.per_month", 20), 0)
+	month_plan.begin_month(attention_per_month, 0)
 	hiring = HiringPipeline.new()  # Phase B: fresh pipeline per game (created BEFORE candidates
 	                               # are populated so add_candidate can stamp their ids)
 	cause_log.clear()      # EE-8: fresh attribution trail per game
@@ -521,9 +525,24 @@ func can_afford(costs: Dictionary) -> bool:
 		return false
 	if costs.has("reputation") and reputation < costs["reputation"]:
 		return false
-	if costs.has("action_points") and action_points < costs["action_points"]:
-		return false
+	# T2: `attention` is the founder currency and lives on the month plan, not on a per-turn
+	# pool. An un-typed cost dict bills OPERATING hours (see MonthPlan.spend_attention).
+	if costs.has("attention"):
+		if month_plan == null:
+			return false
+		if not month_plan.can_spend_hours(int(costs["attention"]), _cost_hour_type(costs)):
+			return false
 	return true
+
+
+func _cost_hour_type(costs: Dictionary) -> String:
+	"""Which founder hour type a cost dict bills. Data may name it explicitly with an
+	`hour_type` key ("planning" | "operating"); anything else is OPERATING (presence work).
+	Kept in ONE place so the later 4-way lane subdivides here, not at 40 call sites."""
+	var declared: String = String(costs.get("hour_type", MonthPlan.HOUR_OPERATING))
+	if declared == MonthPlan.HOUR_PLANNING:
+		return MonthPlan.HOUR_PLANNING
+	return MonthPlan.HOUR_OPERATING
 
 func spend_resources(costs: Dictionary):
 	"""Spend resources (assumes can_afford was checked) (FIX #407: added reputation deduction)"""
@@ -540,7 +559,7 @@ func spend_resources(costs: Dictionary):
 					"research": research,
 					"papers": papers,
 					"reputation": reputation,
-					"action_points": action_points
+					"attention": get_available_attention()
 				}
 			}
 		)
@@ -572,10 +591,13 @@ func spend_resources(costs: Dictionary):
 		if reputation <= 0:
 			ErrorHandler.warning(ErrorHandler.Category.RESOURCES, "Reputation reached zero", {})
 
-	if costs.has("action_points"):
-		action_points -= costs["action_points"]
-		if action_points < 0:
-			ErrorHandler.warning(ErrorHandler.Category.RESOURCES, "Action points went negative", {"action_points": action_points})
+	if costs.has("attention") and month_plan != null:
+		if not month_plan.spend_attention(int(costs["attention"]), _cost_hour_type(costs)):
+			ErrorHandler.warning(
+				ErrorHandler.Category.RESOURCES,
+				"Attention spend rejected by the month plan",
+				{"cost": costs["attention"], "available": month_plan.available()}
+			)
 
 func add_resources(gains: Dictionary):
 	"""Add resources"""
@@ -1032,48 +1054,27 @@ func add_upgrade(upgrade_id: String):
 		if upgrade_id == "cat_adoption":
 			has_cat = true
 
-# AP Reserve System Methods
-func get_available_ap() -> int:
-	"""Founder Attention available for queuing actions this PLAN MONTH (L2 / ADR-0011).
-	The founder currency is the monthly Attention budget (month_plan), NOT the retired
-	per-turn AP pool. Named get_available_ap() for source compat -- every caller that used
-	to read the per-turn pool now reads the monthly Attention budget/spend/reserve. The
-	legacy action_points field survives only as a low-level resource primitive (paper/
-	conference costs, difficulty display); it no longer gates the plan queue."""
+# --- Founder Attention accessors (T2: the AP reserve system is gone; these read the plan) ---
+func get_available_attention() -> int:
+	"""Founder Attention free to fund new commitments this PLAN MONTH (ADR-0011 / T2).
+	Nets out what is already spent and what is explicitly reserved for response windows.
+	Zero when there is no month plan -- there is no fallback pool any more."""
 	if month_plan != null:
 		return month_plan.available()
-	return action_points - committed_ap - reserved_ap
+	return 0
 
-func get_event_ap() -> int:
-	"""AP available for event responses"""
-	return reserved_ap - used_event_ap
+func get_reserve_attention() -> int:
+	"""Attention still held in the crisp reserve for response windows (ADR-0009 S3)."""
+	if month_plan != null:
+		return month_plan.reserve_remaining()
+	return 0
 
-func reserve_ap_amount(amount: int) -> bool:
-	"""Reserve AP for events"""
-	if get_available_ap() >= amount:
-		reserved_ap += amount
-		return true
-	return false
-
-func commit_ap_amount(amount: int) -> bool:
-	"""Commit AP to queued action"""
-	if get_available_ap() >= amount:
-		committed_ap += amount
-		return true
-	return false
-
-func spend_event_ap(amount: int) -> bool:
-	"""Spend reserved AP on event response"""
-	if get_event_ap() >= amount:
-		used_event_ap += amount
-		return true
-	return false
-
-func reset_turn_ap():
-	"""Reset AP tracking for new turn"""
-	committed_ap = 0
-	reserved_ap = 0
-	used_event_ap = 0
+func get_available_hours(hour_type: String) -> int:
+	"""Founder hours of one TYPE still unspent this month (2-way floor: planning /
+	operating). The 4-way refinement subdivides these; it does not replace them."""
+	if month_plan != null:
+		return month_plan.hours_available(hour_type)
+	return 0
 
 # Paper Submission System Methods (Issue #468)
 func add_paper_submission(paper: PaperSubmissions.PaperSubmission):
@@ -1318,11 +1319,14 @@ func to_dict() -> Dictionary:
 		"sacred_chain_log": sacred_chain_log.duplicate(true),
 		"doom_system": doom_data,
 		"risk_system": risk_data,
-		"action_points": action_points,
-		"committed_ap": committed_ap,
-		"reserved_ap": reserved_ap,
-		"available_ap": get_available_ap(),
-		"event_ap": get_event_ap(),
+		# T2: founder currency in the state dict is ATTENTION. "attention" is what the HUD
+		# and every affordability readout wants (free-to-spend now); the pool breakdown
+		# rides month_plan (already serialized below).
+		"attention": get_available_attention(),
+		"attention_total": month_plan.attention_total if month_plan != null else 0,
+		"attention_reserved": get_reserve_attention(),
+		"planning_hours_left": get_available_hours(MonthPlan.HOUR_PLANNING),
+		"operating_hours_left": get_available_hours(MonthPlan.HOUR_OPERATING),
 		"stationery": stationery,
 		# Technical Debt System (Issue #416)
 		"technical_debt": technical_debt,
@@ -1370,8 +1374,7 @@ func to_dict() -> Dictionary:
 		"pending_events": pending_events.duplicate(true),  # event defs are pure-data dicts
 		"current_phase": current_phase,
 		"can_end_turn": can_end_turn,
-		"used_event_ap": used_event_ap,
-		"max_action_points": max_action_points,  # difficulty modifier -- next-turn AP base
+		"attention_per_month": attention_per_month,  # difficulty modifier -- next month's grant
 		"conference_year": conference_year,
 		"start_year": start_year,
 		"start_month": start_month,
@@ -1435,11 +1438,10 @@ func from_dict(data: Dictionary) -> void:
 	doom_dampers = (data.get("doom_dampers", []) as Array).duplicate(true)
 	doom_pulses = (data.get("doom_pulses", []) as Array).duplicate(true)
 	sacred_chain_log = (data.get("sacred_chain_log", []) as Array).duplicate(true)
-	action_points = int(data.get("action_points", 3))
-	max_action_points = int(data.get("max_action_points", 3))
-	committed_ap = int(data.get("committed_ap", 0))
-	reserved_ap = int(data.get("reserved_ap", 0))
-	used_event_ap = int(data.get("used_event_ap", 0))
+	# T2: pre-migration saves carry action_points / max_action_points / the *_ap trio. They
+	# are read for NOTHING -- the fields no longer exist. The founder budget restores from
+	# the serialized month_plan; only the grant size is carried here.
+	attention_per_month = int(data.get("attention_per_month", Balance.inum("attention.per_month", 20)))
 	stationery = float(data.get("stationery", 100.0))
 	technical_debt = float(data.get("technical_debt", 0.0))
 

--- a/godot/scripts/core/ledger.gd
+++ b/godot/scripts/core/ledger.gd
@@ -4,7 +4,7 @@ class_name Ledger
 ##
 ## A two-sided ledger of trades that pay now and bill later. There is NO new
 ## player-facing currency (ADR-0003 "no parallel economy"): every entry reads and
-## writes only existing resources -- money, reputation, governance, action_points,
+## writes only existing resources -- money, reputation, governance, attention,
 ## doom. Compounding interest on payables is the mortality guarantee (ADR-0002):
 ## an un-serviced debt grows without bound until a bill it cannot pay ends the run,
 ## and the death is attributable to specific entries.
@@ -21,7 +21,7 @@ enum Side { PAYABLE, RECEIVABLE }
 class Entry:
 	var id: String = ""
 	var source: String = ""            # the trade that created it ("loan", "payroll_coinflip", ...)
-	var currency: String = "money"     # money | reputation | governance | doom | action_points
+	var currency: String = "money"     # money | reputation | governance | doom | attention
 	var principal: float = 0.0         # current magnitude; grows by `interest` each turn while unsettled
 	var fuse: int = 0                  # turns until it bills (0 = due now)
 	var interest: float = 0.0          # per-turn compounding rate (0.0 = does not grow)
@@ -281,8 +281,11 @@ func _bill(e: Entry, state) -> void:
 			state.compute = max(0.0, state.compute - e.principal)
 			_note(state, "ledger_compute_bill", e.source, {"compute": -compute_paid})
 			_settle_promise(e, compute_covered, state)
-		"action_points":
-			state.action_points = max(0, state.action_points - int(e.principal))
+		"attention":
+			# T2: a liability denominated in founder time bills OPERATING hours -- somebody
+			# has to physically show up and deal with it. It cannot bill planner mind.
+			if state.month_plan != null:
+				state.month_plan.spend_attention(int(e.principal), MonthPlan.HOUR_OPERATING)
 		"equity", "board_seat", "agenda":
 			# Non-cash standing TERMS from the financing engine (ADR-0013 riders: equity
 			# dilution, board seat, agenda narrowing). Inert by design -- recorded, no resource

--- a/godot/scripts/core/media_system.gd
+++ b/godot/scripts/core/media_system.gd
@@ -231,18 +231,19 @@ func execute_press_release(game_state) -> Dictionary:
 
 func execute_exclusive_interview(game_state) -> Dictionary:
 	"""
-	Execute Exclusive Interview action (5 reputation, 1 AP)
+	Execute Exclusive Interview action (5 reputation, 1 operating hour)
 	High-impact story with small risk of backfire
 	"""
 	if game_state.reputation < 10.0:
 		return {"success": false, "message": "Requires 10+ reputation"}
 
-	if game_state.action_points < 1:
-		return {"success": false, "message": "Insufficient AP"}
+	# T2: an interview is OPERATING work -- you are in the room, on the record.
+	if game_state.month_plan == null or not game_state.month_plan.can_spend_hours(1, MonthPlan.HOUR_OPERATING):
+		return {"success": false, "message": "Insufficient Attention (1 operating hour)"}
 
-	# Costs reputation and AP
+	# Costs reputation and Attention
 	game_state.reputation -= 5.0
-	game_state.action_points -= 1
+	game_state.month_plan.spend_attention(1, MonthPlan.HOUR_OPERATING)
 
 	# Risk of backfire (10% chance)
 	var backfire = rng.randf() < 0.1

--- a/godot/scripts/core/month_controller.gd
+++ b/godot/scripts/core/month_controller.gd
@@ -288,7 +288,7 @@ func resolve_current_window_option(option_id: String, event: Dictionary = {}, al
 	if WindowResolver.window_config(window).has("option_verbs"):
 		return result
 	var option_present := false
-	for opt in WindowResolver.strip_ap(window).get("options", []):
+	for opt in WindowResolver.strip_attention(window).get("options", []):
 		if opt is Dictionary and String(opt.get("id", "")) == option_id:
 			option_present = true
 			break
@@ -392,7 +392,7 @@ func _open_plan_month(mi: int) -> void:
 	current_month_index = mi
 	windows_surfaced_this_month = 0
 	var ordinal := Clock.month_ordinal_since_start(state.turn, state.start_year, state.start_month, state.start_day)
-	state.month_plan.begin_month(Balance.inum("attention.per_month", 20), ordinal)
+	state.month_plan.begin_month(state.attention_per_month, ordinal)
 	# Office rent (#791): the predictable monthly cash sink, on the payroll rail (a direct
 	# deduction, not a compounding ledger payable -- see office.gd's rail decision). No-op
 	# for an unsigned run, so a bedroom-only game is economically unchanged.

--- a/godot/scripts/core/month_plan.gd
+++ b/godot/scripts/core/month_plan.gd
@@ -146,13 +146,15 @@ func set_reserve(amount: int) -> bool:
 	# The new reserve must fit within total minus what's spent on strategic work.
 	if amount > attention_total - attention_spent:
 		return false
-	# T2 (2-way hour typing): the crisp reserve is OPERATING capacity BY DEFINITION -- it
-	# exists to be present for response windows. You cannot hold back more firefighting
-	# capacity than you have operating hours left. (reserve_used deliberately does NOT book
-	# into hours_spent: the invariant kept here is sum(hours_spent) == attention_spent, and
-	# reserve draw is accounted by reserve_used against this operating-gated hold.)
-	if amount > hours_available(HOUR_OPERATING):
-		return false
+	# T2 DESIGN CALL: the crisp reserve is deliberately UNTYPED, and is NOT capped at the
+	# operating pool. Reason: the reserve is the emergency channel, and an emergency is
+	# precisely where the type wall is allowed to break -- pay_by_cannibalizing already lets
+	# OPERATING overflow into PLANNING hours. Capping the pre-declared reserve at operating
+	# hours would forbid at plan time exactly what the overflow rule permits at crisis time,
+	# which is incoherent (and would silently truncate the implicit end-of-month reserve).
+	# Consequence for the invariant: reserve_used does NOT book into hours_spent, so
+	# sum(hours_spent) == attention_spent continues to hold; the reserve is accounted
+	# separately by attention_reserved / reserve_used.
 	attention_reserved = amount
 	return true
 

--- a/godot/scripts/core/month_plan.gd
+++ b/godot/scripts/core/month_plan.gd
@@ -6,8 +6,9 @@ extends RefCounted
 ##
 ## Holds the founder currency **Attention** (workshop#3 addendum #5): ~N decisions/month,
 ## admin as painful overhead. Staff spend a SEPARATE per-person `actions` currency -- there
-## is no global pool here (this is NOT the legacy AP pool; L2 deletes that and migrates cost
-## dicts onto Attention/staff -- L1 introduces Attention alongside, seam left clean).
+## is no global pool here. **T2 (2026-07-28): the legacy AP pool is DELETED** -- Attention
+## is now the ONLY founder currency; action/event cost dicts carry an `attention` key and
+## nothing anywhere reads `action_points` (ADR-0011 amendment (a), ruled 2026-07-27 11:37).
 ##
 ## Attention splits three ways within a month:
 ##   available  -- free to fund queued strategic actions (plan speed)
@@ -17,14 +18,45 @@ extends RefCounted
 ## Unspent reserve EVAPORATES at month end (ADR-0009 S4 -- no banking, ever): begin_month()
 ## resets the pools, discarding any carry.
 ##
+## FOUNDER-HOUR TYPING (2-way, T3-rung FLOOR -- ADR-0011 point 2 / amendment (c)).
+## Every Attention spend is one of two HOUR TYPES:
+##   PLANNING  -- the planner mind: deciding direction, queuing strategic work, approvals.
+##                Does NOT require being in the building (this is the #980 seam: away at a
+##                conference you lose OPERATOR PRESENCE, not PLANNER MIND).
+##   OPERATING -- presence work: face-time, firefighting, response windows, running the
+##                hiring loop, being in the room.
+## The typed pools are ADDITIVE ACCOUNTING over an AUTHORITATIVE SCALAR -- the same shape
+## N2 used for typed reputation (ruled 2026-07-27). `attention_total`/`attention_spent`
+## stay the authoritative aggregate; `hours_total`/`hours_spent` type it. Every legacy
+## caller that only knows the aggregate keeps working unchanged.
+##
+## OVERFLOW IS ASYMMETRIC and that asymmetry is the whole design point:
+##   OPERATING may overflow into PLANNING hours -- a crisis eats the time you meant to
+##     spend thinking. (ADR-0011: "reserve -- instant-speed firefighting".)
+##   PLANNING may NOT overflow into OPERATING -- you cannot retroactively have been in the
+##     room. Running out of planner hours BLOCKS more strategic queuing this month.
+## The 4-way refinement (doors / approvals / audits / reserve, ADR-0011 amendment (c)) is a
+## LATER lane; it subdivides these two, it does not replace them.
+##
 ## Strategic actions carry DURATIONS (ADR-0009 S5 -- nothing strategic resolves instantly);
 ## queued items land on a future resolution tick. This is the seam L2 workstreams extend.
+
+# --- Founder hour types (2-way floor) ---
+const HOUR_PLANNING := "planning"
+const HOUR_OPERATING := "operating"
+const HOUR_TYPES := [HOUR_PLANNING, HOUR_OPERATING]
 
 # --- Attention accounting (all integer Attention units) ---
 var attention_total: int = 0        # granted this plan-month (Balance attention.per_month)
 var attention_spent: int = 0        # committed to queued strategic actions
 var attention_reserved: int = 0     # explicitly held for response windows (the crisp reserve)
 var reserve_used: int = 0           # reserve consumed by HANDLE-from-reserve this month
+
+# Typed founder hours (additive over the authoritative scalar above). hours_total sums to
+# attention_total by construction in begin_month; hours_spent sums to attention_spent for
+# every spend that goes through spend_attention/queue_strategic/the window payers.
+var hours_total: Dictionary = {HOUR_PLANNING: 0, HOUR_OPERATING: 0}
+var hours_spent: Dictionary = {HOUR_PLANNING: 0, HOUR_OPERATING: 0}
 
 # Which plan-month this is (0-based from run start) -- stamps the replay artifact (ADR-0016).
 var month_ordinal: int = 0
@@ -36,16 +68,63 @@ var month_ordinal: int = 0
 var queued_strategic: Array = []
 
 
-func begin_month(attention_per_month: int, ordinal: int) -> void:
+func begin_month(attention_per_month: int, ordinal: int, planning_share: float = -1.0) -> void:
 	"""Open a fresh plan phase. Crisp reserve evaporation happens HERE by construction:
-	the pools reset, so last month's unspent reserve is simply gone (ADR-0009 S4)."""
+	the pools reset, so last month's unspent reserve is simply gone (ADR-0009 S4).
+	`planning_share` splits the grant into PLANNING vs OPERATING hours; < 0 reads the
+	Balance dial (`attention.planning_share`). The remainder after integer division goes
+	to OPERATING, so an odd grant never silently loses an hour."""
 	attention_total = attention_per_month
 	attention_spent = 0
 	attention_reserved = 0
 	reserve_used = 0
 	month_ordinal = ordinal
+	var share: float = planning_share
+	if share < 0.0:
+		share = Balance.num("attention.planning_share", 0.6)
+	share = clampf(share, 0.0, 1.0)
+	var planning: int = int(floor(float(attention_per_month) * share))
+	planning = clampi(planning, 0, attention_per_month)
+	hours_total = {HOUR_PLANNING: planning, HOUR_OPERATING: attention_per_month - planning}
+	hours_spent = {HOUR_PLANNING: 0, HOUR_OPERATING: 0}
 	# In-flight strategic actions persist across the boundary (they have durations);
 	# resolved ones are pruned by the controller, not here.
+
+
+# --- Typed founder hours (2-way floor) ---
+
+func hours_available(hour_type: String) -> int:
+	"""Hours of `hour_type` not yet spent. This is the TYPE gate only -- a spend must also
+	fit inside the authoritative aggregate available() (which nets out the reserve)."""
+	return int(hours_total.get(hour_type, 0)) - int(hours_spent.get(hour_type, 0))
+
+
+func can_spend_hours(cost: int, hour_type: String) -> bool:
+	"""Would a `cost`-hour spend of `hour_type` be admissible right now? Applies both the
+	aggregate gate and the asymmetric-overflow type rule."""
+	if cost <= 0:
+		return true
+	if available() < cost:
+		return false
+	if hours_available(hour_type) >= cost:
+		return true
+	# OPERATING may eat PLANNING hours (a crisis costs you thinking time). PLANNING may not
+	# eat OPERATING hours -- you cannot retroactively have been in the room.
+	return hour_type == HOUR_OPERATING
+
+
+func _debit_hours(cost: int, hour_type: String) -> void:
+	"""Record `cost` hours against the typed pools, spilling into the other type per the
+	asymmetric-overflow rule. Callers gate with can_spend_hours() first; this only books."""
+	if cost <= 0:
+		return
+	var from_type: int = mini(cost, maxi(0, hours_available(hour_type)))
+	hours_spent[hour_type] = int(hours_spent.get(hour_type, 0)) + from_type
+	var spill: int = cost - from_type
+	if spill <= 0:
+		return
+	var other: String = HOUR_PLANNING if hour_type == HOUR_OPERATING else HOUR_OPERATING
+	hours_spent[other] = int(hours_spent.get(other, 0)) + spill
 
 
 func available() -> int:
@@ -67,6 +146,13 @@ func set_reserve(amount: int) -> bool:
 	# The new reserve must fit within total minus what's spent on strategic work.
 	if amount > attention_total - attention_spent:
 		return false
+	# T2 (2-way hour typing): the crisp reserve is OPERATING capacity BY DEFINITION -- it
+	# exists to be present for response windows. You cannot hold back more firefighting
+	# capacity than you have operating hours left. (reserve_used deliberately does NOT book
+	# into hours_spent: the invariant kept here is sum(hours_spent) == attention_spent, and
+	# reserve draw is accounted by reserve_used against this operating-gated hold.)
+	if amount > hours_available(HOUR_OPERATING):
+		return false
 	attention_reserved = amount
 	return true
 
@@ -75,28 +161,64 @@ func can_queue(attention_cost: int) -> bool:
 	return available() >= attention_cost
 
 
-func spend_attention(cost: int) -> bool:
+func spend_attention(cost: int, hour_type: String = HOUR_OPERATING) -> bool:
 	"""Spend `cost` Attention from the AVAILABLE (un-reserved) pool at plan speed, without
 	minting a queued-strategic WIP entry. This is the primitive the hiring pipeline (and
 	other duration subsystems that track their own jobs) use: the founder currency is still
 	debited here, but the duration/target bookkeeping lives in the subsystem. Returns false
-	(no charge) if the cost doesn't fit within available Attention."""
+	(no charge) if the cost doesn't fit within available Attention OR within the hour type
+	(PLANNING cannot borrow OPERATING hours -- see the header).
+
+	DEFAULT IS OPERATING: an un-typed spend is presence work. Callers that are genuinely
+	planner-mind work (queuing strategic direction) pass HOUR_PLANNING explicitly."""
 	if cost <= 0:
 		return true
-	if available() < cost:
+	if not can_spend_hours(cost, hour_type):
 		return false
 	attention_spent += cost
+	_debit_hours(cost, hour_type)
 	return true
+
+
+func grant_hours(amount: int, hour_type: String = HOUR_OPERATING) -> void:
+	"""Add `amount` hours of ONE type to this month's budget mid-month. This is ADR-0011
+	point 6 ("ops/admin staff reduce the founder-price of routine actions") -- bought
+	presence, e.g. a contractor absorbing routine operating load. It is deliberately NOT a
+	way for staff to top up the founder's PLANNING mind (ADR-0011 point 1: the pool illusion
+	is dead; staff never add founder capacity to think). Grants evaporate at month end like
+	everything else -- begin_month resets both pools."""
+	if amount <= 0:
+		return
+	hours_total[hour_type] = int(hours_total.get(hour_type, 0)) + amount
+	attention_total += amount
+
+
+func refund_attention(cost: int, hour_type: String = HOUR_OPERATING) -> void:
+	"""Give back `cost` Attention (queue clear / removed card / a subsystem rolling back).
+	Clamped at zero on both the aggregate and the typed pool so a mismatched refund can
+	never mint Attention out of nothing."""
+	if cost <= 0:
+		return
+	attention_spent = maxi(0, attention_spent - cost)
+	var booked: int = int(hours_spent.get(hour_type, 0))
+	var from_type: int = mini(cost, booked)
+	hours_spent[hour_type] = booked - from_type
+	var spill: int = cost - from_type
+	if spill > 0:
+		var other: String = HOUR_PLANNING if hour_type == HOUR_OPERATING else HOUR_OPERATING
+		hours_spent[other] = maxi(0, int(hours_spent.get(other, 0)) - spill)
 
 
 func queue_strategic(action_id: String, attention_cost: int, duration_ticks: int, current_turn: int) -> bool:
 	"""Queue a strategic action at plan speed. Spends Attention now; the EFFECT lands
 	`duration_ticks` resolution ticks later (ADR-0009 S5). duration_ticks <= 0 is coerced
-	to 1 -- nothing strategic resolves on the same tick it was queued."""
-	if not can_queue(attention_cost):
+	to 1 -- nothing strategic resolves on the same tick it was queued.
+	Queuing strategic work is PLANNER MIND -- it bills PLANNING hours (T2 2-way floor)."""
+	if not can_queue(attention_cost) or not can_spend_hours(attention_cost, HOUR_PLANNING):
 		return false
 	var ticks: int = max(1, duration_ticks)
 	attention_spent += attention_cost
+	_debit_hours(attention_cost, HOUR_PLANNING)
 	queued_strategic.append({
 		"action_id": action_id,
 		"attention_cost": attention_cost,
@@ -138,9 +260,12 @@ func pay_by_cannibalizing(cost: int) -> Dictionary:
 	var cancelled: Array = []
 	var free: int = available()
 	# Cancel most-recent queued strategic WIP until we can cover the cost from free Attention.
+	# Cancelled cards refund PLANNING hours (that is what queue_strategic billed); the window
+	# then bills OPERATING and overflows into those freed planning hours -- which IS the
+	# designed pain: the crisis you handled is the strategy month you did not get.
 	while free < cost and not queued_strategic.is_empty():
 		var victim: Dictionary = queued_strategic.pop_back()
-		attention_spent -= int(victim.get("attention_cost", 0))
+		refund_attention(int(victim.get("attention_cost", 0)), HOUR_PLANNING)
 		cancelled.append(String(victim.get("action_id", "")))
 		free = available()
 	if free < cost:
@@ -148,6 +273,7 @@ func pay_by_cannibalizing(cost: int) -> Dictionary:
 		# reflects the cancellations, which is correct -- cancelling WIP is a real refund.)
 		return {"paid": false, "cancelled": cancelled}
 	attention_spent += cost  # the window consumes this much of the freed/available capacity
+	_debit_hours(cost, HOUR_OPERATING)
 	return {"paid": true, "cancelled": cancelled}
 
 
@@ -160,6 +286,8 @@ func to_dict() -> Dictionary:
 		"attention_reserved": attention_reserved,
 		"reserve_used": reserve_used,
 		"month_ordinal": month_ordinal,
+		"hours_total": hours_total.duplicate(),
+		"hours_spent": hours_spent.duplicate(),
 		"queued_strategic": queued_strategic.duplicate(true),
 	}
 
@@ -170,6 +298,29 @@ func from_dict(data: Dictionary) -> void:
 	attention_reserved = int(data.get("attention_reserved", 0))
 	reserve_used = int(data.get("reserve_used", 0))
 	month_ordinal = int(data.get("month_ordinal", 0))
+	# Typed hours. A pre-T2 save has neither key: rebuild the split from the grant and book
+	# everything already spent as OPERATING (the un-typed default), so an old save loads
+	# into a legal, invariant-satisfying state rather than a zeroed one that would block
+	# every further spend.
+	var raw_total: Variant = data.get("hours_total", null)
+	if raw_total is Dictionary and not (raw_total as Dictionary).is_empty():
+		hours_total = {
+			HOUR_PLANNING: int((raw_total as Dictionary).get(HOUR_PLANNING, 0)),
+			HOUR_OPERATING: int((raw_total as Dictionary).get(HOUR_OPERATING, 0)),
+		}
+	else:
+		var planning: int = int(floor(float(attention_total) * clampf(Balance.num("attention.planning_share", 0.6), 0.0, 1.0)))
+		planning = clampi(planning, 0, attention_total)
+		hours_total = {HOUR_PLANNING: planning, HOUR_OPERATING: attention_total - planning}
+	var raw_spent: Variant = data.get("hours_spent", null)
+	if raw_spent is Dictionary and not (raw_spent as Dictionary).is_empty():
+		hours_spent = {
+			HOUR_PLANNING: int((raw_spent as Dictionary).get(HOUR_PLANNING, 0)),
+			HOUR_OPERATING: int((raw_spent as Dictionary).get(HOUR_OPERATING, 0)),
+		}
+	else:
+		hours_spent = {HOUR_PLANNING: 0, HOUR_OPERATING: 0}
+		_debit_hours(attention_spent, HOUR_OPERATING)
 	queued_strategic = []
 	for item in data.get("queued_strategic", []):
 		if item is Dictionary:

--- a/godot/scripts/core/resource_accessor.gd
+++ b/godot/scripts/core/resource_accessor.gd
@@ -14,7 +14,7 @@ static func has_readable(resource_name: String) -> bool:
 	names evaluate false, matching the old match's default arm)."""
 	return resource_name in [
 		"money", "compute", "research", "papers", "reputation", "doom",
-		"action_points", "safety_researchers", "capability_researchers",
+		"attention", "safety_researchers", "capability_researchers",
 		"compute_engineers", "managers", "researchers", "total_staff",
 	]
 
@@ -35,8 +35,10 @@ static func read(state, resource_name: String) -> float:
 			return state.reputation
 		"doom":
 			return state.doom
-		"action_points":
-			return float(state.action_points)
+		"attention":
+			# T2: the founder currency is the month plan's un-reserved Attention. Exposed to
+			# the exploit-finder / bot policy space under the name the design uses.
+			return float(state.get_available_attention())
 		"safety_researchers":
 			return float(state.safety_researchers)
 		"capability_researchers":

--- a/godot/scripts/core/turn_manager.gd
+++ b/godot/scripts/core/turn_manager.gd
@@ -31,13 +31,12 @@ func start_turn() -> Dictionary:
 	_step_apply_scheduled_causes()
 	var ledger_result: Dictionary = _step_ledger_tick_and_bill()
 	var total_staff: int = state.get_total_staff()
-	var max_ap: int = _step_grant_action_points(total_staff)
 	var lifecycle_notes: Array = _step_process_researcher_lifecycles()
 	var staff_salaries: float = _step_pay_salaries(total_staff)
 	var prod: Dictionary = _step_researcher_productivity()
 	var workstream_notes: Array = _step_workstream_accrual()
 	var stationery: Dictionary = _step_consume_stationery()
-	var messages: Array = _build_start_turn_messages(max_ap, total_staff, staff_salaries, prod, stationery, ledger_result)
+	var messages: Array = _build_start_turn_messages(total_staff, staff_salaries, prod, stationery, ledger_result)
 	messages.append_array(lifecycle_notes)
 	messages.append_array(workstream_notes)
 	var triggered_events: Array[Dictionary] = _step_check_events(messages)
@@ -82,17 +81,11 @@ func _step_ledger_tick_and_bill() -> Dictionary:
 		exposed_entries = state.ledger.check_exposures(state, Balance.num("ledger.exposure_chance_per_turn", 0.15))
 	return {"billed": billed_entries, "exposed": exposed_entries}
 
-func _step_grant_action_points(total_staff: int) -> int:
-	"""Grant this turn's AP: difficulty base + staff bonus (0.5 per staff member).
-	FIX #541: use state.max_action_points (set by difficulty: Easy=4, Standard=3,
-	Hard=2) as the base instead of a hardcoded 3, so difficulty actually changes AP.
-	Per-staff bonus sourced from Balance ("action_points.per_staff", L9 #621)."""
-	var max_ap = state.max_action_points + int(total_staff * Balance.num("action_points.per_staff", 0.5))
-	state.action_points = max_ap
-
-	# Reset AP tracking for new turn (reserve system)
-	state.reset_turn_ap()
-	return max_ap
+# T2 (ADR-0011 amendment (a)): _step_grant_action_points is DELETED. There is no per-turn
+# founder currency any more -- Attention is granted per PLAN MONTH by MonthController
+# (MonthPlan.begin_month), and staff never top up the founder's budget (ADR-0011 point 1:
+# "the pool illusion dies; staff never add founder AP"). Removing the step is RNG-safe:
+# it drew nothing from state.rng, so the recorded-replay stream is unchanged.
 
 func _step_process_researcher_lifecycles() -> Array:
 	"""=== RESEARCHER TURN PROCESSING ===
@@ -406,7 +399,7 @@ func _step_consume_stationery() -> Dictionary:
 		"supply_auto_ordered": supply_auto_ordered,
 	}
 
-func _build_start_turn_messages(max_ap: int, total_staff: int, staff_salaries: float, prod: Dictionary, stationery: Dictionary, ledger_result: Dictionary) -> Array:
+func _build_start_turn_messages(total_staff: int, staff_salaries: float, prod: Dictionary, stationery: Dictionary, ledger_result: Dictionary) -> Array:
 	"""Assemble the turn-start message list. Pure reads -- no sim mutation, no RNG."""
 	var billed_entries: Array = ledger_result.get("billed", [])
 	var exposed_entries: Array = ledger_result.get("exposed", [])
@@ -426,7 +419,12 @@ func _build_start_turn_messages(max_ap: int, total_staff: int, staff_salaries: f
 
 	var messages = [
 		"Turn %d started" % state.turn,
-		"Action Points: %d (base 3 + %d from %d staff)" % [max_ap, max_ap - 3, total_staff]
+		"Attention: %d free of %d this month (%d planning / %d operating hours left)" % [
+			state.get_available_attention(),
+			state.month_plan.attention_total if state.month_plan != null else 0,
+			state.get_available_hours(MonthPlan.HOUR_PLANNING),
+			state.get_available_hours(MonthPlan.HOUR_OPERATING),
+		]
 	]
 
 	# EE-7 (ADR-0012): the ledger's kill path must be LEGIBLE -- every bill, its

--- a/godot/scripts/core/window_resolver.gd
+++ b/godot/scripts/core/window_resolver.gd
@@ -168,9 +168,9 @@ static func resolve_chosen_option(state: GameState, plan: MonthPlan, event: Dict
 	if option_id == ignore_option_id(event) and not EventTiers.is_unignorable(event):
 		return resolve(state, plan, event, "ignore", rng)
 
-	# HANDLE with the chosen option. Check the option's own (AP-stripped) costs BEFORE
-	# drawing Attention, so a failed money check doesn't consume the reserve.
-	var cleaned := strip_ap(event)
+	# HANDLE with the chosen option. Check the option's own (Attention-stripped) costs
+	# BEFORE drawing Attention, so a failed money check doesn't consume the reserve.
+	var cleaned := strip_attention(event)
 	var chosen: Dictionary = {}
 	for opt in cleaned.get("options", []):
 		if opt is Dictionary and String(opt.get("id", "")) == option_id:
@@ -212,9 +212,10 @@ static func resolve_chosen_option(state: GameState, plan: MonthPlan, event: Dict
 
 
 static func _apply_option(state: GameState, event: Dictionary, option_id: String) -> Dictionary:
-	"""Apply an event option by id, STRIPPING any legacy action_point cost (windows spend
-	Attention, not AP). Returns the execute_event_choice result (or an empty success if the
-	option id is blank -- a no-op ignore)."""
+	"""Apply an event option by id, STRIPPING the option's own Attention cost -- the window's
+	Attention was already drawn from the reserve/cannibalize path above, so re-charging it
+	here would double-bill. Returns the execute_event_choice result (or an empty success if
+	the option id is blank -- a no-op ignore)."""
 	if option_id == "":
 		return {"success": true, "message": "No action", "deltas": {}}
 	# #789: hiring prompt cards mutate pipeline state (onboarding flags + money), not
@@ -222,17 +223,21 @@ static func _apply_option(state: GameState, event: Dictionary, option_id: String
 	# was already drawn before this call; the pipeline charges money only.
 	if String(event.get("kind", "")).begins_with("hiring_") and state.hiring != null:
 		return state.hiring.apply_prompt_option(state, event, option_id)
-	var cleaned := strip_ap(event)
+	var cleaned := strip_attention(event)
 	return Events.execute_event_choice(cleaned, option_id, state)
 
 
-static func strip_ap(event: Dictionary) -> Dictionary:
-	"""Clone an event with action_points removed from every option's costs. Public: month
-	playback presents windows through the event_dialog with AP already stripped, so the
-	dialog's affordability display matches what resolution will actually charge."""
+static func strip_attention(event: Dictionary) -> Dictionary:
+	"""Clone an event with the founder Attention cost removed from every option's costs.
+	Public: month playback presents windows through the event_dialog with Attention already
+	stripped, so the dialog's affordability display matches what resolution will actually
+	charge (the window Attention is drawn once, by resolve()).
+	T2: renamed from strip_ap and now erases `attention`; the legacy `action_points` key is
+	erased too so un-migrated content cannot resurrect a second founder charge."""
 	var clone := event.duplicate(true)
 	for opt in clone.get("options", []):
 		if opt is Dictionary and opt.has("costs") and opt["costs"] is Dictionary:
+			opt["costs"].erase("attention")
 			opt["costs"].erase("action_points")
 	return clone
 

--- a/godot/scripts/data/definition_loader.gd
+++ b/godot/scripts/data/definition_loader.gd
@@ -6,7 +6,7 @@ class_name DefinitionLoader
 ##
 ## JSON parses every number as float; whole-number floats are normalized back to
 ## int so definitions behave identically to the old in-code literals (typed
-## GameState fields such as action_points reject float assignment). Non-whole
+## int-typed cost fields such as attention reject float assignment). Non-whole
 ## floats (probabilities, weights) are preserved.
 
 

--- a/godot/scripts/debug/debug_overlay.gd
+++ b/godot/scripts/debug/debug_overlay.gd
@@ -97,7 +97,7 @@ func update_game_state():
 	lines.append("Research: %.1f" % state.research)
 	lines.append("Papers: %d" % state.papers)
 	lines.append("Reputation: %.1f" % state.reputation)
-	lines.append("Action Points: %d / %d" % [state.action_points, state.max_action_points if "max_action_points" in state else 3])
+	lines.append("Attention: %d free / %d granted" % [state.get_available_attention(), state.month_plan.attention_total if state.month_plan != null else 0])
 	lines.append("")
 
 	# Doom
@@ -341,7 +341,8 @@ func _on_add_money_button_pressed():
 func _on_add_ap_button_pressed():
 	var gm = _live_gm()
 	if gm and gm.state:
-		gm.state.action_points += 5
+		if gm.state.month_plan != null:
+			gm.state.month_plan.grant_hours(5, MonthPlan.HOUR_OPERATING)
 		gm.game_state_updated.emit(gm.state.to_dict())
 		ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Debug: Added 5 AP", {})
 

--- a/godot/scripts/debug/dev_mode_overlay.gd
+++ b/godot/scripts/debug/dev_mode_overlay.gd
@@ -329,8 +329,8 @@ func _advance_turn() -> void:
 	var gm := _live_gm()
 	if not is_instance_valid(gm) or gm.state == null or gm.turn_manager == null:
 		return
-	gm.state.action_points -= gm.state.committed_ap
-	gm.state.committed_ap = 0
+	# T2: there is no per-turn AP pool to un-commit. Queued cards already debited the
+	# month plan's Attention; GameManager.clear_action_queue does the refund.
 	gm.turn_manager.execute_turn()
 	gm.game_state_updated.emit(gm.state.to_dict())
 	if not gm.state.game_over:

--- a/godot/scripts/debug/dev_mode_readout.gd
+++ b/godot/scripts/debug/dev_mode_readout.gd
@@ -45,12 +45,12 @@ static func _resources_section(state) -> Dictionary:
 	lines.append("Stationery: %s" % _fnum(state.stationery))
 	lines.append("Tech debt:  %s" % _fnum(state.technical_debt))
 	var avail := 0
-	var reserved := int(state.reserved_ap)
-	var committed := int(state.committed_ap)
-	if state.has_method("get_available_ap"):
-		avail = int(state.get_available_ap())
+	var reserved := int(state.month_plan.attention_reserved) if state.month_plan != null else 0
+	var committed := int(state.month_plan.attention_spent) if state.month_plan != null else 0
+	if state.has_method("get_available_attention"):
+		avail = int(state.get_available_attention())
 	lines.append("AP: %d total | %d avail | %d committed | %d reserved" % [
-		int(state.action_points), avail, committed, reserved
+		int(state.month_plan.attention_total) if state.month_plan != null else 0, avail, committed, reserved
 	])
 	return {"title": "Resources", "lines": lines}
 

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -191,14 +191,16 @@ func select_action(action_id: String) -> bool:
 		error_occurred.emit("Action not found: " + action_id)
 		return false
 
-	# L2 (ADR-0011): the action's legacy `action_points` cost is now its ATTENTION cost --
-	# the founder spends the monthly Attention budget (month_plan), not a per-turn AP pool.
-	var attention_cost = action.get("costs", {}).get("action_points", 0)
+	# T2 (ADR-0011): the founder spends the monthly Attention budget (month_plan). Queuing a
+	# strategic action is PLANNER MIND -- it bills PLANNING hours (2-way founder-hour floor).
+	var attention_cost: int = GameActions.attention_cost(action)
+	var hour_type: String = GameActions.hour_type(action)
 
 	# Validation: Sufficient Attention this plan-month (checks REMAINING = total - spent -
 	# reserved, so an explicitly-held reserve is protected from over-queuing).
 	var available_attention = state.month_plan.available() if state.month_plan != null else 0
-	if available_attention < attention_cost:
+	var hours_ok: bool = state.month_plan != null and state.month_plan.can_spend_hours(attention_cost, hour_type)
+	if available_attention < attention_cost or not hours_ok:
 		var _err = ErrorHandler.warning(  # Underscore prefix indicates intentionally unused
 			ErrorHandler.Category.RESOURCES,
 			"Insufficient Attention",
@@ -211,14 +213,18 @@ func select_action(action_id: String) -> bool:
 				"attention_spent": state.month_plan.attention_spent if state.month_plan else 0
 			}
 		)
-		error_occurred.emit("Not enough Attention: %d needed, %d left this month" % [attention_cost, available_attention])
+		if available_attention >= attention_cost:
+			error_occurred.emit("Not enough %s hours: %d needed, %d left this month" % [
+				hour_type, attention_cost, state.get_available_hours(hour_type)])
+		else:
+			error_occurred.emit("Not enough Attention: %d needed, %d left this month" % [attention_cost, available_attention])
 		return false
 
-	# Validation: Can afford NON-Attention costs (money/compute/research/... ). The
-	# action_points key is the Attention cost, gated above -- strip it here so the legacy
-	# per-turn AP pool never blocks the plan queue (that duality was the L2 bug).
+	# Validation: Can afford NON-Attention costs (money/compute/research/... ). Attention is
+	# gated above against the month plan, so strip it here -- letting can_afford re-check it
+	# would double-gate the same budget.
 	var afford_costs = action.get("costs", {}).duplicate()
-	afford_costs.erase("action_points")
+	afford_costs.erase("attention")
 	if not state.can_afford(afford_costs):
 		var costs = action.get("costs", {})
 		var _err = ErrorHandler.warning(  # Underscore prefix indicates intentionally unused
@@ -390,7 +396,7 @@ func reserve_ap(amount: int):
 		# Emit updated state
 		game_state_updated.emit(state.to_dict())
 	else:
-		error_occurred.emit("Not enough Attention to reserve (need %d, have %d)" % [amount, state.get_available_ap()])
+		error_occurred.emit("Not enough Attention to reserve (need %d, have %d operating hours)" % [amount, state.get_available_hours(MonthPlan.HOUR_OPERATING)])
 
 func clear_action_queue():
 	"""Clear all queued actions and refund their committed Attention."""
@@ -400,7 +406,7 @@ func clear_action_queue():
 	var refunded := _queued_attention_cost()
 	state.queued_actions.clear()
 	if state.month_plan != null:
-		state.month_plan.attention_spent = max(0, state.month_plan.attention_spent - refunded)
+		state.month_plan.refund_attention(refunded, MonthPlan.HOUR_PLANNING)
 
 	print("[GameManager] Queue cleared, refunded %d Attention" % refunded)
 	game_state_updated.emit(state.to_dict())
@@ -408,10 +414,10 @@ func clear_action_queue():
 
 func _queued_attention_cost() -> int:
 	"""Sum the Attention cost of the currently queued founder actions (their legacy
-	action_points cost re-read as Attention). Used to refund on clear/remove."""
+	`attention` cost). Used to refund on clear/remove."""
 	var total := 0
 	for aid in state.queued_actions:
-		total += int(_get_action_by_id(aid).get("costs", {}).get("action_points", 0))
+		total += GameActions.attention_cost(_get_action_by_id(aid))
 	return total
 
 func set_research_quality(mode: String):
@@ -435,14 +441,14 @@ func remove_queued_action(action_id: String):
 			break
 
 	if removed_index >= 0:
-		# Get Attention cost before removing (legacy action_points cost = Attention cost)
+		# Get Attention cost before removing
 		var action = _get_action_by_id(action_id)
-		var attention_cost = action.get("costs", {}).get("action_points", 0)
+		var attention_cost: int = GameActions.attention_cost(action)
 
-		# Remove and refund Attention
+		# Remove and refund Attention (queued cards billed PLANNING hours)
 		state.queued_actions.remove_at(removed_index)
 		if state.month_plan != null:
-			state.month_plan.attention_spent = max(0, state.month_plan.attention_spent - attention_cost)
+			state.month_plan.refund_attention(attention_cost, GameActions.hour_type(action))
 
 		print("[GameManager] Removed %s from queue, refunded %d Attention (available: %d)" % [action_id, attention_cost, state.month_plan.available() if state.month_plan else 0])
 		game_state_updated.emit(state.to_dict())
@@ -622,7 +628,7 @@ func surface_pending_events() -> void:
 		return
 	turn_phase_changed.emit("turn_start")
 	for event in state.pending_events:
-		event_triggered.emit(WindowResolver.strip_ap(event))
+		event_triggered.emit(WindowResolver.strip_attention(event))
 
 
 func end_month():
@@ -710,7 +716,7 @@ func _run_month_playback() -> void:
 				for w in month_controller.window_queue:
 					# AP pre-stripped so the dialog's cost display matches what window
 					# resolution actually charges (Attention, not AP).
-					event_triggered.emit(WindowResolver.strip_ap(w))
+					event_triggered.emit(WindowResolver.strip_attention(w))
 				return  # playback resumes via resolve_event once answered
 			"month_open":
 				_finish_month_playback()
@@ -935,25 +941,36 @@ func _apply_difficulty_settings():
 		print("[GameManager] ERROR: Invalid difficulty value (%d), defaulting to Standard" % GameConfig.difficulty)
 		GameConfig.difficulty = 1
 
-	# Difficulty modifiers come from the Balance surface ("difficulty.*", L9 #621);
-	# fallbacks are the pre-L9 literals (easy 1.5x/4AP, standard 1.0x/3AP, hard 0.75x/2AP).
-	# This replaces the dormant data/events/balancing/difficulty.json (deleted in L9).
+	# Difficulty modifiers come from the Balance surface ("difficulty.*", L9 #621).
+	# T2: difficulty scales the MONTHLY ATTENTION GRANT, not a per-turn AP cap (the AP pool
+	# is deleted). Fallbacks keep the old easy/standard/hard ORDERING at the Attention
+	# denomination (24 / 20 / 16 against a 20 default grant).
 	match GameConfig.difficulty:
 		0:  # Easy
 			print("[GameManager] Applying EASY difficulty modifiers")
 			state.money *= Balance.num("difficulty.easy.money_multiplier", 1.5)  # 50% more starting money
-			state.max_action_points = Balance.inum("difficulty.easy.max_action_points", 4)  # Extra AP
+			_set_attention_grant(Balance.inum("difficulty.easy.attention_per_month", 24))
 		1:  # Standard
 			print("[GameManager] Applying STANDARD difficulty (default)")
 			state.money *= Balance.num("difficulty.standard.money_multiplier", 1.0)
-			state.max_action_points = Balance.inum("difficulty.standard.max_action_points", 3)
+			_set_attention_grant(Balance.inum("difficulty.standard.attention_per_month", 20))
 		2:  # Hard
 			print("[GameManager] Applying HARD difficulty modifiers")
 			state.money *= Balance.num("difficulty.hard.money_multiplier", 0.75)  # 25% less starting money
-			state.max_action_points = Balance.inum("difficulty.hard.max_action_points", 2)  # Less AP
+			_set_attention_grant(Balance.inum("difficulty.hard.attention_per_month", 16))
 		_:  # Safety default case (should never reach here after validation)
 			print("[GameManager] WARNING: Unexpected difficulty value, using Standard")
 			# Apply standard difficulty (no changes)
+
+
+func _set_attention_grant(per_month: int) -> void:
+	"""Set the founder's monthly Attention grant and re-open the CURRENT month at the new
+	size. Difficulty/scenario overrides are applied AFTER GameState.reset() has opened month
+	0, so the grant has to be restated -- month 0 is untouched at that point (nothing spent),
+	which is why a plain re-begin is safe here and would not be mid-month."""
+	state.attention_per_month = per_month
+	if state.month_plan != null:
+		state.month_plan.begin_month(per_month, state.month_plan.month_ordinal)
 
 func _apply_scenario_overrides():
 	"""Apply scenario pack overrides to game state (Issue #483)"""
@@ -992,9 +1009,13 @@ func _apply_scenario_overrides():
 		if state.doom_system:
 			state.doom_system.current_doom = state.doom
 		print("  Doom: %.1f" % state.doom)
-	if resources.has("action_points"):
-		state.action_points = int(resources["action_points"])
-		print("  Action Points: %d" % state.action_points)
+	# T2: scenario packs override the monthly ATTENTION grant. `action_points` is read as a
+	# legacy alias so pre-migration scenario JSON keeps loading instead of silently doing
+	# nothing (the scenario surface is content, and content lags a code migration).
+	if resources.has("attention_per_month") or resources.has("action_points"):
+		var grant: int = int(resources.get("attention_per_month", resources.get("action_points", 0)))
+		_set_attention_grant(grant)
+		print("  Attention per month: %d" % state.attention_per_month)
 	if resources.has("stationery"):
 		state.stationery = float(resources["stationery"])
 		print("  Stationery: %.1f" % state.stationery)

--- a/godot/scripts/ui/event_dialog.gd
+++ b/godot/scripts/ui/event_dialog.gd
@@ -65,7 +65,7 @@ static func format_cost_summary(costs: Dictionary) -> String:
 			continue  # a zero/negative-cost entry is not a real cost -- don't clutter the face
 		if resource == "money":
 			parts.append(GameConfig.format_money(amount))
-		elif resource == "action_points":
+		elif resource == "attention":
 			parts.append("%d AP" % int(amount))
 		else:
 			parts.append("%d %s" % [int(amount), str(resource).capitalize()])
@@ -235,16 +235,16 @@ func _show_next_event() -> void:
 			var cost = costs[resource]
 			var available = 0
 
-			# Special handling for action_points - use total AP (FIX #453)
+			# Special handling for attention - read the month plan, not a per-turn pool
 			# Must match can_afford() logic in GameState:130
-			if resource == "action_points":
-				available = current_state.get("action_points", 0)
+			if resource == "attention":
+				available = current_state.get("attention", 0)
 			else:
 				available = current_state.get(resource, 0)
 
 			if available < cost:
 				can_afford = false
-				if resource == "action_points":
+				if resource == "attention":
 					missing_resources.append("AP (need %s, have %s available)" % [cost, available])
 				else:
 					missing_resources.append("%s (need %s, have %s)" % [resource, cost, available])

--- a/godot/scripts/ui/hiring_panel_controller.gd
+++ b/godot/scripts/ui/hiring_panel_controller.gd
@@ -76,7 +76,7 @@ func _show_hiring_submenu():
 	header.add_theme_color_override("font_color", Color(0.3, 0.8, 0.3))
 	root.add_child(header)
 
-	var att: int = st.get_available_ap()
+	var att: int = st.get_available_attention()
 	var sub := Label.new()
 	sub.text = "Attention available: %d   |   Money: %s   |   Reputation: %d" % [att, GameConfig.format_money(st.money), int(st.reputation)]
 	sub.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -962,17 +962,17 @@ func _on_end_turn_button_pressed():
 		screen_mode.enter_watch()
 
 func _on_commit_plan_button_pressed():
-	"""Commit queued actions AND reserve remaining AP (no warnings)"""
+	"""Commit queued actions AND reserve the remaining Attention (no warnings)"""
 	var current_state = game_manager.get_game_state()
-	var available_ap = current_state.get("available_ap", 0)
+	var available_ap = current_state.get("attention", 0)
 
 	# If there are queued actions, commit them + reserve balance
 	if plan_controller.queue_size() > 0:
-		log_message("[color=cyan]Committing %d queued actions + reserving %d remaining AP...[/color]" % [plan_controller.queue_size(), available_ap])
+		log_message("[color=cyan]Committing %d queued actions + reserving %d remaining Attention...[/color]" % [plan_controller.queue_size(), available_ap])
 	else:
 		# No queued actions - just reserve all AP (reactive strategy). PlanController owns the
 		# reserve-all queue mutation (mirror entry + backend pass id); the view just logs + redraws.
-		log_message("[color=cyan]Committing plan: Reserving all %d AP for reactive responses...[/color]" % available_ap)
+		log_message("[color=cyan]Committing plan: Reserving all %d Attention for reactive responses...[/color]" % available_ap)
 		plan_controller.append_reserve_all()
 		update_queued_actions_display()
 
@@ -1061,39 +1061,42 @@ func _on_game_state_updated(state: Dictionary):
 	for _i in range(compute_eng):
 		blob_display += "[color=dodger_blue]*[/color]"
 
-	# L2 (ADR-0011): the founder currency is the monthly ATTENTION budget (month_plan), not
-	# the retired per-turn AP pool. Read the plan's Attention split so the HUD is honest --
-	# "~20 decisions this month" is now the true, spendable number.
+	# T2 (ADR-0011): the founder currency is the monthly ATTENTION budget (month_plan); the
+	# per-turn AP pool no longer exists anywhere. Read the plan's Attention split so the HUD
+	# is honest -- "~20 decisions this month" is the true, spendable number.
 	var mp = state.get("month_plan", {})
-	var total_ap = int(mp.get("attention_total", 0))
-	var committed_ap = int(mp.get("attention_spent", 0))
-	var reserved_ap = int(mp.get("attention_reserved", 0))
-	var remaining_ap = total_ap - committed_ap - reserved_ap
+	var total_att = int(mp.get("attention_total", 0))
+	var committed_att = int(mp.get("attention_spent", 0))
+	var reserved_att = int(mp.get("attention_reserved", 0))
+	var remaining_att = total_att - committed_att - reserved_att
 
 	# Color-code Attention text based on remaining budget
 	var ap_color_name = "white"  # Default
-	if remaining_ap <= 0:
+	if remaining_att <= 0:
 		ap_color_name = "red"  # Depleted
-	elif remaining_ap == 1:
+	elif remaining_att == 1:
 		ap_color_name = "yellow"  # Low
-	elif remaining_ap < total_ap:
+	elif remaining_att < total_att:
 		ap_color_name = "lime"  # Partially committed
 
 	# Build BBCode text for RichTextLabel
 	var ap_text = ""
-	if reserved_ap > 0:
-		ap_text = "[color=%s]Attention: %d (%d free, %d reserved)[/color]  %s" % [ap_color_name, total_ap, remaining_ap, reserved_ap, blob_display]
-	elif committed_ap > 0:
-		ap_text = "[color=%s]Attention: %d (%d free, %d queued)[/color]  %s" % [ap_color_name, total_ap, remaining_ap, committed_ap, blob_display]
+	if reserved_att > 0:
+		ap_text = "[color=%s]Attention: %d (%d free, %d reserved)[/color]  %s" % [ap_color_name, total_att, remaining_att, reserved_att, blob_display]
+	elif committed_att > 0:
+		ap_text = "[color=%s]Attention: %d (%d free, %d queued)[/color]  %s" % [ap_color_name, total_att, remaining_att, committed_att, blob_display]
 	else:
-		ap_text = "[color=%s]Attention: %d[/color]  %s" % [ap_color_name, total_ap, blob_display]
+		ap_text = "[color=%s]Attention: %d[/color]  %s" % [ap_color_name, total_att, blob_display]
 
 	ap_label.text = ap_text
-	# AP tooltip: base is difficulty-set (state.max_action_points), per-staff bonus
-	# from Balance -- both the real inputs to turn_manager._step_grant_action_points.
-	var ap_base := int(state.get("max_action_points", 3))
-	var per_staff = Balance.num("action_points.per_staff", 0.5)
-	ap_label.tooltip_text = "Action Points. Limits actions per turn. Base %d + %s per staff." % [ap_base, str(per_staff)]
+	# Attention tooltip: the monthly grant is difficulty-set (attention_per_month), and the
+	# 2-way founder-hour split is what actually binds -- surface both, because "I have
+	# Attention left but the button is dead" is otherwise an unexplainable UI state.
+	ap_label.tooltip_text = "Attention -- the founder's month. Grant %d/month. Hours left: %d planning, %d operating. Planning hours queue strategic work; operating hours pay response windows, hiring and travel. A crisis can eat your planning hours; planning can never buy back presence." % [
+		int(state.get("attention_per_month", 20)),
+		int(state.get("planning_hours_left", 0)),
+		int(state.get("operating_hours_left", 0)),
+	]
 
 	# Update doom displays (both text label and visual meter)
 	var doom = state.get("doom", 0)
@@ -1145,8 +1148,9 @@ func _on_game_state_updated(state: Dictionary):
 
 	# Enable controls after first init
 	if state.get("turn", 0) >= 0:
-		# Enable/disable Reserve AP button based on available AP
-		var available = state.get("available_ap", 0)
+		# Enable/disable the Reserve button based on available OPERATING hours -- the crisp
+		# reserve is operating capacity by definition (MonthPlan.set_reserve).
+		var available = state.get("operating_hours_left", 0)
 		reserve_ap_button.disabled = (available < 1)
 
 		# Note: Actions are now included in init_game response
@@ -1522,11 +1526,14 @@ func _on_dynamic_action_pressed(action_id: String, action_name: String):
 
 	# Check if action can be afforded before adding to UI queue (#456)
 	var action_def = _get_action_by_id(action_id)
-	var ap_cost = action_def.get("costs", {}).get("action_points", 0)
-	var available_ap = game_manager.state.get_available_ap()
+	var attention_cost: int = GameActions.attention_cost(action_def)
+	var hour_type: String = GameActions.hour_type(action_def)
+	var available_attention = game_manager.state.get_available_attention()
+	var available_hours = game_manager.state.get_available_hours(hour_type)
 
-	if available_ap < ap_cost:
-		log_message("[color=red]Not enough AP: need %d, have %d[/color]" % [ap_cost, available_ap])
+	if available_attention < attention_cost or available_hours < attention_cost:
+		log_message("[color=red]Not enough Attention: need %d %s hours, have %d[/color]" % [
+			attention_cost, hour_type, mini(available_hours, available_attention)])
 		return
 
 	if not game_manager.state.can_afford(action_def.get("costs", {})):
@@ -1692,12 +1699,12 @@ func _format_costs_inline(costs: Dictionary) -> String:
 	"""Shared cost-summary formatter for the icon-grid submenus (fundraising / publicity /
 	strategic / travel / operations). Cost-display sweep (2026-07-24, Pip playtest): these
 	buttons were only showing cost on hover (tooltip_text) -- this is what now also goes ON
-	the button face via a dedicated cost label, so a hidden-AP surprise (e.g. Compute
+	the button face via a dedicated cost label, so a hidden-Attention surprise (e.g. Compute
 	Partnership, Intelligence Opportunity) can't happen here. Returns 'Free' for an empty/
 	zero-cost dict."""
 	var parts: Array[String] = []
-	if costs.get("action_points", 0) > 0:
-		parts.append("%d AP" % int(costs["action_points"]))
+	if int(costs.get("attention", 0)) > 0:
+		parts.append("%d Attention" % int(costs["attention"]))
 	if costs.get("money", 0) > 0:
 		parts.append(GameConfig.format_money(costs["money"]))
 	if costs.get("reputation", 0) > 0:
@@ -1714,16 +1721,18 @@ func _format_costs_inline(costs: Dictionary) -> String:
 
 
 func _costs_affordable(costs: Dictionary, state: Dictionary) -> bool:
-	"""Shared affordability check for the icon-grid submenus. IMPORTANT: action_points must be
-	checked against the monthly Attention budget (available_ap), not the raw legacy
-	action_points primitive -- get_available_ap() nets out what's already committed/reserved
-	this plan month (see GameState.get_available_ap docstring). Using the raw field under-
-	reported unaffordable options as affordable (cost-display sweep, #822-adjacent)."""
+	"""Shared affordability check for the icon-grid submenus. IMPORTANT: `attention` must be
+	checked against the monthly Attention budget, which nets out what is already committed
+	and reserved this plan month (GameState.get_available_attention). Checking a raw field
+	under-reported unaffordable options as affordable (cost-display sweep, #822-adjacent).
+	`hour_type` is a TYPE TAG, not a resource -- it must never be treated as a cost."""
 	for resource in costs.keys():
+		if resource == "hour_type":
+			continue
 		var need = costs[resource]
 		if need <= 0:
 			continue
-		var have = state.get("available_ap", 0) if resource == "action_points" else state.get(resource, 0)
+		var have = state.get("attention", 0) if resource == "attention" else state.get(resource, 0)
 		if have < need:
 			return false
 	return true
@@ -1846,12 +1855,12 @@ func update_queued_actions_display():
 			label.add_theme_font_size_override("font_size", 11)
 			vbox.add_child(label)
 
-			# AP cost indicator
+			# Attention cost indicator
 			var action_def = _get_action_by_id(action_id)
-			var ap_cost = action_def.get("costs", {}).get("action_points", 0)
+			var ap_cost: int = GameActions.attention_cost(action_def)
 			if ap_cost > 0:
 				var ap_cost_label = Label.new()
-				ap_cost_label.text = "-%d AP" % ap_cost
+				ap_cost_label.text = "-%d Attention" % ap_cost
 				ap_cost_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 				ap_cost_label.add_theme_color_override("font_color", Color(0.9, 0.7, 0.2))
 				ap_cost_label.add_theme_font_size_override("font_size", 10)
@@ -1894,8 +1903,8 @@ func update_queued_actions_display():
 				var formatted = ""
 				if resource == "money":
 					formatted = GameConfig.format_money(-cost_value)
-				elif resource == "action_points":
-					formatted = "-%d AP" % cost_value
+				elif resource == "attention":
+					formatted = "-%d Attention" % cost_value
 				else:
 					formatted = "-%d %s" % [cost_value, resource]
 				cost_label.text = formatted
@@ -1975,8 +1984,8 @@ func _on_action_hover(action: Dictionary, can_afford: bool, missing_resources: A
 		var cost_parts = []
 
 		# Format each resource cost with appropriate color
-		if action_costs.has("action_points"):
-			cost_parts.append("[color=magenta]%d AP[/color]" % action_costs["action_points"])
+		if action_costs.has("attention"):
+			cost_parts.append("[color=magenta]%d Attention[/color]" % action_costs["attention"])
 		if action_costs.has("money"):
 			cost_parts.append("[color=gold]%s[/color]" % GameConfig.format_money(action_costs["money"]))
 		if action_costs.has("reputation"):
@@ -2074,12 +2083,12 @@ func _on_pass_button_pressed():
 		log_message("[color=red]Cannot pass - not in action selection phase[/color]")
 		return
 
-	# Check AP availability (pass costs 0 AP but still need to verify game state)
-	var available_ap = game_manager.state.get_available_ap()
-	var ap_cost = pass_action.get("costs", {}).get("action_points", 0)
+	# Check Attention availability (pass costs 0 but still verify game state)
+	var available_ap = game_manager.state.get_available_attention()
+	var ap_cost: int = GameActions.attention_cost(pass_action)
 
 	if available_ap < ap_cost:
-		log_message("[color=red]Not enough AP: need %d, have %d[/color]" % [ap_cost, available_ap])
+		log_message("[color=red]Not enough Attention: need %d, have %d[/color]" % [ap_cost, available_ap])
 		return
 
 	log_message("[color=gray]%s - skipping this action[/color]" % action_name)

--- a/godot/scripts/ui/plan_controller.gd
+++ b/godot/scripts/ui/plan_controller.gd
@@ -37,7 +37,7 @@ func _init(gm = null) -> void:
 # --- Cost aggregation (was main_ui._calculate_queued_costs) -------------------------------
 
 func calculate_queued_costs() -> Dictionary:
-	"""Total the projected costs of every queued action for the turn preview. action_points is
+	"""Total the projected costs of every queued action for the turn preview. attention is
 	tracked separately as Attention, so it is skipped here (verbatim from the pre-carve view)."""
 	var total_costs: Dictionary = {}
 	for queued_action in queued_actions:
@@ -45,7 +45,7 @@ func calculate_queued_costs() -> Dictionary:
 		var action_def: Dictionary = GameActions.get_action_by_id(action_id)
 		var costs = action_def.get("costs", {})
 		for resource in costs.keys():
-			if resource == "action_points":
+			if resource == "attention" or resource == "hour_type":
 				continue  # AP is already tracked separately
 			if not total_costs.has(resource):
 				total_costs[resource] = 0
@@ -83,7 +83,7 @@ func remove_action(action_id: String) -> Dictionary:
 	queued_actions.remove_at(removed_index)
 	game_manager.remove_queued_action(action_id)
 	var action_def: Dictionary = GameActions.get_action_by_id(action_id)
-	var attention_cost: int = action_def.get("costs", {}).get("action_points", 0)
+	var attention_cost: int = GameActions.attention_cost(action_def)
 	return {"removed": true, "attention_cost": attention_cost}
 
 

--- a/godot/scripts/ui/resource_display.gd
+++ b/godot/scripts/ui/resource_display.gd
@@ -35,7 +35,7 @@ func update_resources(state: Dictionary):
 	resources["papers"]["value"] = state.get("papers_published", 0)
 	resources["reputation"]["value"] = state.get("reputation", 0)
 	resources["doom"]["value"] = state.get("doom", 0)
-	resources["ap"]["value"] = state.get("action_points", 0)
+	resources["ap"]["value"] = state.get("attention", 0)
 
 	_update_display()
 

--- a/godot/scripts/ui/submenu_controller.gd
+++ b/godot/scripts/ui/submenu_controller.gd
@@ -144,10 +144,13 @@ func on_option_selected(action_id: String, action_name: String, dialog: Control,
 	host.active_dialog_buttons = []
 
 	var action_def = host._get_action_by_id(action_id)
-	var ap_cost = action_def.get("costs", {}).get("action_points", 0)
-	var available_ap = host.game_manager.state.get_available_ap()
-	if available_ap < ap_cost:
-		host.log_message("[color=red]Not enough AP: need %d, have %d[/color]" % [ap_cost, available_ap])
+	var attention_cost: int = GameActions.attention_cost(action_def)
+	var hour_type: String = GameActions.hour_type(action_def)
+	var available_hours: int = host.game_manager.state.get_available_hours(hour_type)
+	var available_attention: int = host.game_manager.state.get_available_attention()
+	if available_attention < attention_cost or available_hours < attention_cost:
+		host.log_message("[color=red]Not enough Attention: need %d %s hours, have %d[/color]" % [
+			attention_cost, hour_type, mini(available_hours, available_attention)])
 		return
 	if not host.game_manager.state.can_afford(action_def.get("costs", {})):
 		host.log_message("[color=red]Cannot afford: %s[/color]" % action_name)
@@ -368,8 +371,8 @@ func _build_financing_submenu() -> void:
 		btn.custom_minimum_size = Vector2(0, 44)
 		var key = key_labels[idx] if idx < key_labels.size() else ""
 		var cost_bits := []
-		if opt_costs.get("action_points", 0) > 0:
-			cost_bits.append("%d AP" % opt_costs["action_points"])
+		if int(opt_costs.get("attention", 0)) > 0:
+			cost_bits.append("%d Attention" % int(opt_costs["attention"]))
 		if opt_costs.get("money", 0) > 0:
 			cost_bits.append(GameConfig.format_money(opt_costs["money"]))
 		var cost_txt = (" (%s)" % ", ".join(cost_bits)) if cost_bits.size() > 0 else ""

--- a/godot/tests/manual/l1_month_driver.gd
+++ b/godot/tests/manual/l1_month_driver.gd
@@ -37,13 +37,14 @@ const DEFAULT_MAX_MONTHS := 420  # ADR-0002 mortality guard: > the 400-month har
 # ============================================================================
 
 static func ap_cost(id: String) -> int:
-	# L2 (ADR-0011): the action's legacy action_points cost IS its Attention cost.
-	return int(GameActions.get_action_by_id(id).get("costs", {}).get("action_points", 1))
+	# T2 (ADR-0011): the founder cost of an action is its Attention cost.
+	return maxi(1, GameActions.attention_cost(GameActions.get_action_by_id(id)))
 
 
 static func non_ap_costs(id: String) -> Dictionary:
 	var c: Dictionary = GameActions.get_action_by_id(id).get("costs", {}).duplicate()
-	c.erase("action_points")
+	c.erase("attention")
+	c.erase("hour_type")
 	return c
 
 

--- a/godot/tests/manual/reactive_policy.gd
+++ b/godot/tests/manual/reactive_policy.gd
@@ -57,7 +57,7 @@ static func features(state) -> Dictionary:
 		"capability_researchers": state.capability_researchers,
 		"papers": state.papers,
 		"turn": state.turn,
-		"ap": state.action_points,
+		"ap": state.get_available_attention(),
 		"attention_available": plan.available() if plan != null else 0,
 		"reserve_remaining": plan.reserve_remaining() if plan != null else 0,
 		"ledger_outstanding": ledger_outstanding,

--- a/godot/tests/manual/test_exploit_sweep.gd
+++ b/godot/tests/manual/test_exploit_sweep.gd
@@ -54,7 +54,7 @@ func _seeds() -> Array:
 	return a
 
 func _ap_cost(id: String) -> int:
-	return int(GameActions.get_action_by_id(id).get("costs", {}).get("action_points", 1))
+	return maxi(1, GameActions.attention_cost(GameActions.get_action_by_id(id)))
 
 func _money_cost(id: String) -> float:
 	return float(GameActions.get_action_by_id(id).get("costs", {}).get("money", 0.0))
@@ -70,7 +70,7 @@ func _fill(acts: Array, state, ap_box: Array, priority: Array) -> void:
 
 func _choose_actions(policy: String, state) -> Array:
 	var acts := []
-	var ap := [state.action_points]
+	var ap := [state.get_available_attention()]
 	var priority := []
 	match policy:
 		"safety_lean":

--- a/godot/tests/manual/test_verification_quick.gd
+++ b/godot/tests/manual/test_verification_quick.gd
@@ -68,7 +68,6 @@ func run_test_game(seed: String) -> String:
 	# Simulate 5 turns
 	for turn in range(1, 6):
 		state.turn = turn
-		state.action_points = 3
 
 		# Turn start
 		print("  Turn %d..." % turn)
@@ -107,7 +106,6 @@ func run_test_game_variant(seed: String) -> String:
 
 	for turn in range(1, 6):
 		state.turn = turn
-		state.action_points = 3
 
 		# Different actions
 		match turn:

--- a/godot/tests/test_researcher_system.gd
+++ b/godot/tests/test_researcher_system.gd
@@ -280,7 +280,6 @@ func test_hiring_action_creates_researcher():
 func test_hiring_all_specializations():
 	var state = GameState.new("test_all_specs")
 	state.money = 500000.0  # Enough for all hires
-	state.action_points = 10
 
 	GameActions.execute_action("hire_safety_researcher", state)
 	GameActions.execute_action("hire_capability_researcher", state)

--- a/godot/tests/unit/simulation/test_events.gd
+++ b/godot/tests/unit/simulation/test_events.gd
@@ -321,7 +321,6 @@ func test_execute_event_choice_checks_affordability():
 	assert_false(ai_breakthrough.is_empty(), "AI breakthrough event should exist")
 
 	state.money = 5000  # Not enough for safety review
-	state.action_points = 0  # No AP
 
 	# Try safety review option (costs $20k + 1 AP)
 	var result = GameEvents.execute_event_choice(ai_breakthrough, "safety_review", state)
@@ -569,7 +568,7 @@ const HANDLED_EFFECT_KEYS := [
 
 # Every cost key can_afford/spend_resources actually checks and deducts.
 const PAYABLE_COST_KEYS := [
-	"money", "compute", "research", "papers", "reputation", "action_points",
+	"money", "compute", "research", "papers", "reputation", "attention",
 ]
 
 func test_all_core_event_effect_keys_are_handled():

--- a/godot/tests/unit/simulation/test_game_manager.gd
+++ b/godot/tests/unit/simulation/test_game_manager.gd
@@ -98,17 +98,17 @@ func test_select_action_queues_action():
 	assert_eq(game_manager.state.queued_actions[0], "buy_compute",
 		"Correct action should be queued")
 
-func test_select_action_deducts_action_points():
-	# Selecting an action commits AP (committed_ap); available AP drops immediately.
-	# state.action_points itself only decrements at execution (end_turn).
+func test_select_action_deducts_attention():
+	# Selecting an action debits the month plan's Attention immediately (T2: there is no
+	# separate per-turn pool that lags behind it).
 	game_manager.start_new_game("test_seed")
 	game_manager.state.research = 100  # safety_research costs 10 research + 1 AP
-	var initial_available = game_manager.state.get_available_ap()
+	var initial_available = game_manager.state.get_available_attention()
 
 	game_manager.select_action("buy_compute")  # Costs 0 AP in current impl
 	game_manager.select_action("safety_research")  # Costs 1 AP
 
-	assert_lt(game_manager.state.get_available_ap(), initial_available,
+	assert_lt(game_manager.state.get_available_attention(), initial_available,
 		"Available action points should decrease after committing actions")
 
 func test_select_action_validates_affordability():
@@ -257,14 +257,14 @@ func test_new_plan_month_resets_attention():
 	# day-step. Queuing spends Attention; a fresh plan-month restores the full grant.
 	game_manager.start_new_game("test_seed")
 	game_manager.state.research = 100  # safety_research costs 10 research + 1 Attention
-	var full_budget = game_manager.state.get_available_ap()
+	var full_budget = game_manager.state.get_available_attention()
 	game_manager.select_action("safety_research")  # spends 1 Attention
-	assert_lt(game_manager.state.get_available_ap(), full_budget,
+	assert_lt(game_manager.state.get_available_attention(), full_budget,
 		"queuing an action spends from the monthly Attention budget")
 
 	# Simulate crossing a month boundary (what MonthController._open_plan_month does).
 	game_manager.state.month_plan.begin_month(Balance.inum("attention.per_month", 20), 1)
-	assert_eq(game_manager.state.get_available_ap(), full_budget,
+	assert_eq(game_manager.state.get_available_attention(), full_budget,
 		"a fresh plan-month restores the full Attention grant (crisp reserve evaporated)")
 
 func test_start_next_turn_emits_actions_available_when_no_events():
@@ -472,17 +472,17 @@ func test_standard_difficulty_uses_base_money():
 	assert_almost_eq(game_manager.state.money, _BASE_MONEY, 0.01,
 		"Standard should use unmodified base money")
 
-func test_difficulty_changes_turn1_action_points():
-	# Issue #541: max_action_points (set by difficulty) must feed start_turn's AP.
+func test_difficulty_changes_attention_grant():
+	# Issue #541, T2 denomination: difficulty sets the MONTHLY ATTENTION GRANT.
 	# Staff scaling is identical across difficulties, so Easy base (4) must exceed
 	# Hard base (2) by exactly 2 on turn 1.
 	GameConfig.difficulty = 0  # Easy
 	game_manager.start_new_game("difficulty_seed")
-	var easy_ap = game_manager.state.action_points
+	var easy_ap = game_manager.state.attention_per_month
 
 	GameConfig.difficulty = 2  # Hard
 	game_manager.start_new_game("difficulty_seed")
-	var hard_ap = game_manager.state.action_points
+	var hard_ap = game_manager.state.attention_per_month
 
 	assert_gt(easy_ap, hard_ap,
 		"Easy should grant more turn-1 AP than Hard (#541)")

--- a/godot/tests/unit/simulation/test_game_manager.gd
+++ b/godot/tests/unit/simulation/test_game_manager.gd
@@ -473,18 +473,22 @@ func test_standard_difficulty_uses_base_money():
 		"Standard should use unmodified base money")
 
 func test_difficulty_changes_attention_grant():
-	# Issue #541, T2 denomination: difficulty sets the MONTHLY ATTENTION GRANT.
-	# Staff scaling is identical across difficulties, so Easy base (4) must exceed
-	# Hard base (2) by exactly 2 on turn 1.
+	# Issue #541, T2 denomination: difficulty sets the MONTHLY ATTENTION GRANT (24/20/16),
+	# not a per-turn AP cap. force=true on the second start is required -- start_new_game
+	# self-guards against silently destroying a live run (the #979 sibling fix), and without
+	# it the second call is REFUSED and both reads return the Easy grant.
 	GameConfig.difficulty = 0  # Easy
 	game_manager.start_new_game("difficulty_seed")
-	var easy_ap = game_manager.state.attention_per_month
+	var easy_grant: int = game_manager.state.attention_per_month
+	assert_eq(easy_grant, game_manager.state.month_plan.attention_total,
+		"the opening month was re-granted at the difficulty size, not the Balance default")
 
 	GameConfig.difficulty = 2  # Hard
-	game_manager.start_new_game("difficulty_seed")
-	var hard_ap = game_manager.state.attention_per_month
+	game_manager.start_new_game("difficulty_seed", true)
+	var hard_grant: int = game_manager.state.attention_per_month
 
-	assert_gt(easy_ap, hard_ap,
-		"Easy should grant more turn-1 AP than Hard (#541)")
-	assert_eq(easy_ap - hard_ap, 2,
-		"Easy base AP (4) minus Hard base AP (2) should be 2 on turn 1")
+	assert_gt(easy_grant, hard_grant,
+		"Easy should grant more monthly Attention than Hard (#541)")
+	assert_eq(easy_grant - hard_grant,
+		Balance.inum("difficulty.easy.attention_per_month", 24) - Balance.inum("difficulty.hard.attention_per_month", 16),
+		"the gap is exactly what the Balance surface declares")

--- a/godot/tests/unit/test_actions.gd
+++ b/godot/tests/unit/test_actions.gd
@@ -172,9 +172,9 @@ func test_all_hiring_options_cost_money_and_ap():
 	for option in hiring_options:
 		var costs = option["costs"]
 		assert_has(costs, "money", "Hiring option should cost money")
-		assert_has(costs, "action_points", "Hiring option should cost AP")
+		assert_has(costs, "attention", "Hiring option should cost Attention")
 		assert_gt(costs["money"], 0, "Money cost should be positive")
-		assert_gt(costs["action_points"], 0, "AP cost should be positive")
+		assert_gt(costs["attention"], 0, "Attention cost should be positive")
 
 func test_safety_audit_execution():
 	# Test safety audit action - action id is "audit_safety" not "safety_audit"
@@ -204,7 +204,6 @@ func test_unknown_action_returns_empty_dict():
 func test_lobby_government_affordable_without_reputation():
 	# Issue #449: lobby_government should not require reputation as a cost
 	state.money = 100000
-	state.action_points = 3
 	state.reputation = 5  # Low reputation - should NOT block action
 
 	# lobby_government is a submenu item (under publicity), not a top-level action

--- a/godot/tests/unit/test_bug_fixes.gd
+++ b/godot/tests/unit/test_bug_fixes.gd
@@ -27,13 +27,12 @@ func test_lobby_government_no_reputation_cost():
 	var costs = lobby_action.get("costs", {})
 	assert_false(costs.has("reputation"), "lobby_government should NOT cost reputation (issue #449)")
 	assert_true(costs.has("money"), "lobby_government should cost money")
-	assert_true(costs.has("action_points"), "lobby_government should cost AP")
+	assert_true(costs.has("attention"), "lobby_government should cost Attention")
 
 func test_lobby_government_applies_reputation_penalty():
 	# Test that lobby_government applies -10 reputation as effect, not cost
 	var initial_reputation = state.reputation
 	state.money = 100000  # Ensure we can afford it
-	state.action_points = 3
 
 	var result = GameActions.execute_action("lobby_government", state)
 
@@ -44,10 +43,9 @@ func test_lobby_government_applies_reputation_penalty():
 func test_lobby_government_affordable_with_money_and_ap():
 	# Test that action is affordable with just money and AP (no rep requirement)
 	state.money = 100000
-	state.action_points = 3
 	state.reputation = 5  # Low reputation - but shouldn't block action
 
-	var can_afford = state.can_afford({"money": 80000, "action_points": 2})
+	var can_afford = state.can_afford({"money": 80000, "attention": 2})
 	assert_true(can_afford, "Should be affordable with money and AP only (issue #449)")
 
 ## Issue #447: Difficulty validation
@@ -167,7 +165,6 @@ func test_all_actions_execute_without_errors():
 	# Ensure all actions can be executed without crashing
 	# Set up state with sufficient resources
 	state.money = 1000000
-	state.action_points = 10
 	state.reputation = 100
 	state.research = 100
 	state.compute = 100
@@ -192,15 +189,14 @@ func test_all_actions_execute_without_errors():
 func test_can_afford_validates_all_resources():
 	# Test that can_afford checks all resource types correctly
 	state.money = 50000
-	state.action_points = 2
 	state.reputation = 30
 	state.papers = 5
 
 	# Should afford if all resources are available
-	assert_true(state.can_afford({"money": 40000, "action_points": 1}), "Should afford with sufficient resources")
+	assert_true(state.can_afford({"money": 40000, "attention": 1}), "Should afford with sufficient resources")
 
 	# Should not afford if any resource is insufficient
 	assert_false(state.can_afford({"money": 60000}), "Should not afford with insufficient money")
-	assert_false(state.can_afford({"action_points": 5}), "Should not afford with insufficient AP")
+	assert_false(state.can_afford({"attention": 999}), "Should not afford with insufficient Attention")
 	assert_false(state.can_afford({"reputation": 50}), "Should not afford with insufficient reputation")
 	assert_false(state.can_afford({"papers": 10}), "Should not afford with insufficient papers")

--- a/godot/tests/unit/test_conference_trip.gd
+++ b/godot/tests/unit/test_conference_trip.gd
@@ -163,13 +163,22 @@ func test_real_away_window_produces_a_readable_backlog():
 # ---------------------------------------------------------------------------
 # The costs that keep this from being a free button
 # ---------------------------------------------------------------------------
-func test_trip_consumes_all_remaining_founder_attention():
-	var before: int = state.month_plan.available()
-	assert_gt(before, 0, "the founder starts the month with Attention to lose")
+func test_trip_consumes_all_remaining_operating_hours():
+	# Pip ruling 2026-07-27 1555 ("attending consumes the founder's remaining capacity"),
+	# REFINED by his #980 noticing and cashed out by T2's 2-way founder hours: being away is
+	# a loss of OPERATOR PRESENCE, not of PLANNER MIND. So the trip must drain the operating
+	# pool to nothing, and must NOT touch planning hours -- next month's direction is still
+	# decidable from a hotel room. The anti-free-button property is preserved: every form of
+	# presence work (windows, hiring, interviews, travel) is dead for the rest of the month.
+	var before_operating: int = state.month_plan.hours_available(MonthPlan.HOUR_OPERATING)
+	var before_planning: int = state.month_plan.hours_available(MonthPlan.HOUR_PLANNING)
+	assert_gt(before_operating, 0, "the founder starts the month with presence to lose")
 	var trip: Dictionary = ConferenceTrip.run_trip(state, controller, "safety_retreat")
 	assert_true(bool(trip.get("success", false)), "committed")
-	assert_eq(state.month_plan.available(), 0,
-		"no Attention is left to plan with from the road (Pip ruling 2026-07-27 1555)")
+	assert_eq(state.month_plan.hours_available(MonthPlan.HOUR_OPERATING), 0,
+		"no operating hours are left -- the founder is not in the building")
+	assert_eq(state.month_plan.hours_available(MonthPlan.HOUR_PLANNING), before_planning,
+		"planner mind survives the trip (#980)")
 	assert_gt(int(trip.get("attention_consumed", 0)), 0, "the cost is reported back to the player")
 
 

--- a/godot/tests/unit/test_cost_display.gd
+++ b/godot/tests/unit/test_cost_display.gd
@@ -94,7 +94,7 @@ func test_format_costs_inline_free_when_empty():
 func test_format_costs_inline_lists_all_known_resources():
 	var ui = _main_ui_script.new()
 	var text: String = ui._format_costs_inline({"attention": 2, "money": 8000, "reputation": 1})
-	assert_string_contains(text, "2 AP")
+	assert_string_contains(text, "2 Attention")
 	assert_string_contains(text, "$8,000")
 	assert_string_contains(text, "1 Rep")
 	ui.free()

--- a/godot/tests/unit/test_cost_display.gd
+++ b/godot/tests/unit/test_cost_display.gd
@@ -13,7 +13,7 @@ var _main_ui_script: GDScript = load("res://scripts/ui/main_ui.gd")
 # --- EventDialog.format_cost_summary (event-dialog options) -------------------------------
 
 func test_format_cost_summary_shows_money_and_ap():
-	var text := EventDialog.format_cost_summary({"money": 35000, "action_points": 1})
+	var text := EventDialog.format_cost_summary({"money": 35000, "attention": 1})
 	assert_string_contains(text, "1 AP", "AP cost must be on the button face, not hover-only")
 	assert_string_contains(text, "$35,000", "money cost must be on the button face")
 
@@ -22,13 +22,13 @@ func test_format_cost_summary_zero_cost_is_free():
 		"a costless option must say Free, not show nothing (ambiguous != free)")
 
 func test_format_cost_summary_zero_valued_entries_do_not_render_as_a_cost():
-	# A {"action_points": 0} entry is not a real cost -- must not clutter the face as "0 AP".
-	var text := EventDialog.format_cost_summary({"action_points": 0})
+	# An {"attention": 0} entry is not a real cost -- must not clutter the face.
+	var text := EventDialog.format_cost_summary({"attention": 0})
 	assert_eq(text, " (Free)", "a zero-valued cost entry must read as Free, not '0 AP'")
 
 func test_format_cost_summary_reputation_cost_shown():
 	# Regression: reputation-only costs (e.g. compute_deal's "Negotiate Better Terms") must
-	# not be silently dropped -- only money/action_points had bespoke handling historically.
+	# not be silently dropped -- only money/attention had bespoke handling historically.
 	var text := EventDialog.format_cost_summary({"reputation": 5})
 	assert_string_contains(text, "5 Reputation")
 
@@ -62,7 +62,7 @@ func test_core_events_option_text_has_no_baked_in_cost_strings():
 
 # --- Free-out options cost 0 Attention (task requirement 4) --------------------------------
 
-func test_declineignore_style_outs_cost_zero_action_points():
+func test_declineignore_style_outs_cost_zero_attention():
 	# "defer / reject offer / ignore / acknowledge"-style free outs must cost 0 AP. This does
 	# not change gameplay -- it is a regression lock on the existing data.
 	GameEvents.reload_definitions()
@@ -78,7 +78,7 @@ func test_declineignore_style_outs_cost_zero_action_points():
 					is_free_out = true
 					break
 			if is_free_out:
-				var ap_cost = option.get("costs", {}).get("action_points", 0)
+				var ap_cost = option.get("costs", {}).get("attention", 0)
 				if ap_cost > 0:
 					violations.append("%s/%s costs %s AP" % [event.get("id", "?"), option.get("id", "?"), ap_cost])
 	assert_eq(violations.size(), 0, "free-out style options must cost 0 Attention: %s" % [violations])
@@ -93,20 +93,20 @@ func test_format_costs_inline_free_when_empty():
 
 func test_format_costs_inline_lists_all_known_resources():
 	var ui = _main_ui_script.new()
-	var text: String = ui._format_costs_inline({"action_points": 2, "money": 8000, "reputation": 1})
+	var text: String = ui._format_costs_inline({"attention": 2, "money": 8000, "reputation": 1})
 	assert_string_contains(text, "2 AP")
 	assert_string_contains(text, "$8,000")
 	assert_string_contains(text, "1 Rep")
 	ui.free()
 
-func test_costs_affordable_uses_available_ap_not_raw_action_points():
-	# Regression for the AP-skip / raw-action_points bug found during the sweep: a state
-	# with plenty of raw action_points but a fully committed monthly Attention budget
+func test_costs_affordable_uses_month_plan_attention():
+	# Regression for the AP-skip bug found during the sweep: a state whose monthly
+	# Attention budget is fully committed
 	# (available_ap == 0) must NOT read as affordable for an AP-costing option.
 	var ui = _main_ui_script.new()
-	var state := {"action_points": 5, "available_ap": 0, "money": 100000}
-	assert_false(ui._costs_affordable({"action_points": 1}, state),
-		"available_ap (not the raw action_points primitive) must gate AP affordability")
+	var state := {"attention": 0, "money": 100000}
+	assert_false(ui._costs_affordable({"attention": 1}, state),
+		"the month plan's spendable Attention must gate affordability")
 	assert_true(ui._costs_affordable({"money": 50000}, state),
 		"a money-only cost within budget should be affordable")
 	assert_false(ui._costs_affordable({"money": 200000}, state),

--- a/godot/tests/unit/test_event_affordable_out.gd
+++ b/godot/tests/unit/test_event_affordable_out.gd
@@ -1,6 +1,6 @@
 extends GutTest
 ## Outs sweep (launch guard, L2). Every player-CHOICE event must offer at least one
-## AFFORDABLE OUT: an option that costs neither money nor action_points, so a money-
+## AFFORDABLE OUT: an option that costs neither money nor attention, so a money-
 ## constrained OR Attention-constrained player always has a legible legal response and
 ## can never be walled by an event. This guards two option sources:
 ##   1. the data-driven core events (GameEvents.get_all_events -> core_events.json), and
@@ -8,7 +8,7 @@ extends GutTest
 ## A month-controller auto-lapse safety net exists too, but this asserts the OUT is a real
 ## CHOICE the player can pick -- not something the engine silently does for them.
 
-const CONSTRAINED := ["money", "action_points"]
+const CONSTRAINED := ["money", "attention"]
 
 
 func _has_affordable_out(options: Array) -> bool:
@@ -37,7 +37,7 @@ func test_every_core_event_has_an_affordable_out():
 		if options.is_empty():
 			continue  # non-choice / auto-applied event -- no dead-end is possible
 		assert_true(_has_affordable_out(options),
-			"core event '%s' must offer an option costing neither money nor action_points" % String(ev.get("id", "?")))
+			"core event '%s' must offer an option costing neither money nor attention" % String(ev.get("id", "?")))
 
 
 func test_every_event_service_category_has_an_affordable_out():

--- a/godot/tests/unit/test_finance_engine.gd
+++ b/godot/tests/unit/test_finance_engine.gd
@@ -27,7 +27,6 @@ var _created: Array = []
 func _fresh_state(seed_str: String = "l5-test") -> GameState:
 	var s := GameState.new(seed_str)
 	s.money = 300000
-	s.action_points = 6
 	_created.append(s)
 	return s
 

--- a/godot/tests/unit/test_founder_hours.gd
+++ b/godot/tests/unit/test_founder_hours.gd
@@ -1,0 +1,209 @@
+extends GutTest
+## T2 (ADR-0011 amendment (a)+(c)): the AP pool is dead and founder Attention is typed
+## 2-way into PLANNING vs OPERATING hours. This file pins BOTH halves.
+##
+## The 2-way split is the T3-rung FLOOR. The 4-way refinement (doors / approvals / audits /
+## reserve) subdivides these two later; these tests are written against the two-type API
+## (MonthPlan.HOUR_*) so that subdivision extends them rather than rewriting them.
+##
+## Load-bearing invariants pinned here:
+##   1. sum(hours_total) == attention_total and sum(hours_spent) == attention_spent -- the
+##      typed pools are ADDITIVE accounting over an AUTHORITATIVE scalar (the N2 typed-rep
+##      shape). If this drifts, the HUD and the affordability gate disagree.
+##   2. Overflow is ASYMMETRIC: operating may eat planning, planning may never eat
+##      operating. This is the whole mechanical point of the split.
+##   3. There is no `action_points` anywhere -- no field, no cost key, no per-turn grant.
+
+
+func _plan(total: int = 20, planning_share: float = 0.5) -> MonthPlan:
+	var mp := MonthPlan.new()
+	mp.begin_month(total, 0, planning_share)
+	return mp
+
+
+func _sum(d: Dictionary) -> int:
+	return int(d.get(MonthPlan.HOUR_PLANNING, 0)) + int(d.get(MonthPlan.HOUR_OPERATING, 0))
+
+
+# --- Invariant 1: typed pools are additive over the authoritative scalar ------------------
+
+func test_begin_month_splits_grant_without_losing_hours():
+	var mp := _plan(20, 0.5)
+	assert_eq(mp.hours_total[MonthPlan.HOUR_PLANNING], 10, "half the grant is planning")
+	assert_eq(mp.hours_total[MonthPlan.HOUR_OPERATING], 10, "half the grant is operating")
+	assert_eq(_sum(mp.hours_total), mp.attention_total, "typed hours must sum to the grant")
+
+
+func test_odd_grant_remainder_goes_to_operating():
+	# floor() on the planning side means an odd hour must land somewhere, not vanish.
+	var mp := _plan(21, 0.5)
+	assert_eq(mp.hours_total[MonthPlan.HOUR_PLANNING], 10, "planning takes the floor")
+	assert_eq(mp.hours_total[MonthPlan.HOUR_OPERATING], 11, "the remainder goes to operating")
+	assert_eq(_sum(mp.hours_total), 21, "no hour is lost to integer division")
+
+
+func test_spend_keeps_typed_and_scalar_in_step():
+	var mp := _plan()
+	assert_true(mp.spend_attention(3, MonthPlan.HOUR_PLANNING), "planning spend fits")
+	assert_true(mp.spend_attention(2, MonthPlan.HOUR_OPERATING), "operating spend fits")
+	assert_eq(mp.attention_spent, 5, "scalar tracks the total")
+	assert_eq(_sum(mp.hours_spent), mp.attention_spent, "typed spend sums to the scalar")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 3, "planning booked correctly")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_OPERATING], 2, "operating booked correctly")
+
+
+func test_refund_keeps_typed_and_scalar_in_step():
+	var mp := _plan()
+	mp.spend_attention(4, MonthPlan.HOUR_PLANNING)
+	mp.refund_attention(3, MonthPlan.HOUR_PLANNING)
+	assert_eq(mp.attention_spent, 1, "scalar refunded")
+	assert_eq(_sum(mp.hours_spent), 1, "typed refunded in step")
+
+
+func test_refund_cannot_mint_attention():
+	var mp := _plan()
+	mp.spend_attention(1, MonthPlan.HOUR_OPERATING)
+	mp.refund_attention(99, MonthPlan.HOUR_OPERATING)
+	assert_eq(mp.attention_spent, 0, "clamped at zero")
+	assert_eq(_sum(mp.hours_spent), 0, "typed pools clamped too")
+
+
+# --- Invariant 2: the overflow asymmetry --------------------------------------------------
+
+func test_operating_may_overflow_into_planning():
+	# A crisis costs you the time you meant to spend thinking. 10 operating hours exist;
+	# spending 13 operating must succeed by eating 3 planning hours.
+	var mp := _plan(20, 0.5)
+	assert_true(mp.spend_attention(13, MonthPlan.HOUR_OPERATING), "operating overflows")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_OPERATING], 10, "operating pool drained first")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 3, "the spill ate planning hours")
+	assert_eq(_sum(mp.hours_spent), 13, "invariant holds through an overflow")
+
+
+func test_planning_may_not_overflow_into_operating():
+	# You cannot retroactively have been in the room: running out of planner hours BLOCKS
+	# further strategic queuing even while operating hours sit unused.
+	var mp := _plan(20, 0.5)
+	assert_true(mp.spend_attention(10, MonthPlan.HOUR_PLANNING), "the planning pool is spendable")
+	assert_eq(mp.available(), 10, "aggregate Attention remains")
+	assert_false(mp.can_spend_hours(1, MonthPlan.HOUR_PLANNING), "but planner mind is exhausted")
+	assert_false(mp.spend_attention(1, MonthPlan.HOUR_PLANNING), "and the spend is refused")
+	assert_true(mp.can_spend_hours(1, MonthPlan.HOUR_OPERATING), "operating work still possible")
+
+
+func test_queue_strategic_bills_planning_hours():
+	var mp := _plan(20, 0.5)
+	assert_true(mp.queue_strategic("some_action", 4, 2, 0), "queues")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 4, "queuing is planner mind")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_OPERATING], 0, "and costs no presence")
+
+
+func test_queue_strategic_refused_when_planner_mind_is_gone():
+	var mp := _plan(20, 0.5)
+	mp.spend_attention(10, MonthPlan.HOUR_PLANNING)
+	assert_false(mp.queue_strategic("late_idea", 1, 2, 0), "no planning hours -> no new strategy")
+	assert_eq(mp.queued_strategic.size(), 0, "and nothing was queued")
+
+
+func test_cannibalizing_a_window_converts_planning_into_operating():
+	# The designed pain: the crisis you handled is the strategy month you did not get.
+	var mp := _plan(20, 0.5)
+	mp.queue_strategic("big_bet", 8, 3, 0)
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 8, "planning committed to the bet")
+	var pay: Dictionary = mp.pay_by_cannibalizing(12)
+	assert_true(pay.get("paid", false), "the window is paid")
+	assert_eq(pay.get("cancelled", []).size(), 1, "the queued bet was sacrificed")
+	assert_eq(mp.attention_spent, 12, "scalar reflects the window only")
+	assert_eq(_sum(mp.hours_spent), 12, "invariant survives the cancel-then-spend path")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_OPERATING], 10, "operating drained first")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 2, "the rest came out of planning")
+
+
+func test_reserve_is_gated_on_operating_hours():
+	# The crisp reserve is presence capacity by definition -- you cannot hold back more
+	# firefighting than you have operating hours for.
+	var mp := _plan(20, 0.5)
+	assert_true(mp.set_reserve(10), "reserving the whole operating pool is legal")
+	assert_false(mp.set_reserve(11), "reserving past it is not, even with planning free")
+
+
+func test_grant_hours_buys_presence_not_planner_mind():
+	# ADR-0011 point 6: ops/admin staff reduce the founder-price of routine work. They do
+	# NOT top up the founder's capacity to think (point 1: the pool illusion is dead).
+	var mp := _plan(20, 0.5)
+	mp.grant_hours(2, MonthPlan.HOUR_OPERATING)
+	assert_eq(mp.hours_total[MonthPlan.HOUR_OPERATING], 12, "operating capacity bought")
+	assert_eq(mp.hours_total[MonthPlan.HOUR_PLANNING], 10, "planner mind untouched")
+	assert_eq(_sum(mp.hours_total), mp.attention_total, "invariant holds after a grant")
+
+
+func test_begin_month_evaporates_typed_hours_too():
+	# ADR-0009 S4: no banking, ever. A new month must not inherit last month's leftovers.
+	var mp := _plan(20, 0.5)
+	mp.spend_attention(6, MonthPlan.HOUR_OPERATING)
+	mp.begin_month(20, 1, 0.5)
+	assert_eq(mp.attention_spent, 0, "scalar reset")
+	assert_eq(_sum(mp.hours_spent), 0, "typed pools reset")
+	assert_eq(mp.hours_total[MonthPlan.HOUR_OPERATING], 10, "fresh operating grant")
+
+
+# --- Serialization ------------------------------------------------------------------------
+
+func test_typed_hours_survive_a_roundtrip():
+	var mp := _plan(20, 0.5)
+	mp.spend_attention(3, MonthPlan.HOUR_PLANNING)
+	mp.spend_attention(2, MonthPlan.HOUR_OPERATING)
+	var clone := MonthPlan.new()
+	clone.from_dict(mp.to_dict())
+	assert_eq(clone.hours_total, mp.hours_total, "grants survive")
+	assert_eq(clone.hours_spent, mp.hours_spent, "typed spend survives")
+	assert_eq(clone.available(), mp.available(), "aggregate survives")
+
+
+func test_pre_t2_save_without_typed_hours_loads_into_a_legal_state():
+	# A save written before this migration has neither hours key. It must reconstruct a
+	# split and book the already-spent Attention as OPERATING -- not zero the pools, which
+	# would silently block every further spend.
+	var legacy := {
+		"attention_total": 20,
+		"attention_spent": 5,
+		"attention_reserved": 0,
+		"reserve_used": 0,
+		"month_ordinal": 2,
+		"queued_strategic": [],
+	}
+	var mp := MonthPlan.new()
+	mp.from_dict(legacy)
+	assert_eq(_sum(mp.hours_total), 20, "a split was reconstructed from the grant")
+	assert_eq(_sum(mp.hours_spent), 5, "the legacy spend was booked, not lost")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_OPERATING], 5, "booked as un-typed = operating")
+	assert_eq(mp.available(), 15, "and the plan is spendable")
+
+
+# --- Invariant 3: AP is gone ---------------------------------------------------------------
+
+func test_game_state_has_no_action_point_field():
+	var state := GameState.new("t2_seed")
+	assert_false("action_points" in state, "the AP pool field is deleted")
+	assert_false("max_action_points" in state, "the AP cap field is deleted")
+	assert_false("committed_ap" in state, "the AP reserve trio is deleted")
+
+
+func test_state_dict_reports_attention_not_ap():
+	var state := GameState.new("t2_seed")
+	var d: Dictionary = state.to_dict()
+	assert_false(d.has("action_points"), "no AP in the serialized state")
+	assert_true(d.has("attention"), "Attention is the founder currency in the state dict")
+	assert_true(d.has("planning_hours_left"), "typed hours are surfaced for the HUD")
+	assert_true(d.has("operating_hours_left"), "typed hours are surfaced for the HUD")
+
+
+func test_no_action_definition_still_prices_in_ap():
+	# The data migration must be complete: if ANY action def still carries action_points,
+	# it is silently un-gated content. attention_cost() would still read it via the legacy
+	# alias, which is exactly why this has to be pinned rather than trusted.
+	var offenders: Array[String] = []
+	for action in GameActions.get_all_actions():
+		if action.get("costs", {}).has("action_points"):
+			offenders.append(String(action.get("id", "?")))
+	assert_eq(offenders, [] as Array[String], "no action def may price in action_points")

--- a/godot/tests/unit/test_founder_hours.gd
+++ b/godot/tests/unit/test_founder_hours.gd
@@ -110,21 +110,26 @@ func test_cannibalizing_a_window_converts_planning_into_operating():
 	var mp := _plan(20, 0.5)
 	mp.queue_strategic("big_bet", 8, 3, 0)
 	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 8, "planning committed to the bet")
-	var pay: Dictionary = mp.pay_by_cannibalizing(12)
+	# 14 exceeds the 12 un-committed Attention, so the queued bet MUST be sacrificed first.
+	var pay: Dictionary = mp.pay_by_cannibalizing(14)
 	assert_true(pay.get("paid", false), "the window is paid")
 	assert_eq(pay.get("cancelled", []).size(), 1, "the queued bet was sacrificed")
-	assert_eq(mp.attention_spent, 12, "scalar reflects the window only")
-	assert_eq(_sum(mp.hours_spent), 12, "invariant survives the cancel-then-spend path")
+	assert_eq(mp.attention_spent, 14, "scalar reflects the window only (the bet was refunded)")
+	assert_eq(_sum(mp.hours_spent), 14, "invariant survives the cancel-then-spend path")
 	assert_eq(mp.hours_spent[MonthPlan.HOUR_OPERATING], 10, "operating drained first")
-	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 2, "the rest came out of planning")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 4, "the rest came out of planning")
 
 
-func test_reserve_is_gated_on_operating_hours():
-	# The crisp reserve is presence capacity by definition -- you cannot hold back more
-	# firefighting than you have operating hours for.
+func test_reserve_is_deliberately_untyped():
+	# DESIGN CALL (see MonthPlan.set_reserve): the crisp reserve is NOT capped at the
+	# operating pool. The reserve is the emergency channel, and an emergency is exactly
+	# where the type wall is allowed to break (operating already overflows into planning).
+	# Capping the pre-declared reserve would forbid at plan time what the overflow rule
+	# permits at crisis time. This test exists so that call cannot be reverted silently.
 	var mp := _plan(20, 0.5)
-	assert_true(mp.set_reserve(10), "reserving the whole operating pool is legal")
-	assert_false(mp.set_reserve(11), "reserving past it is not, even with planning free")
+	assert_true(mp.set_reserve(14), "reserving past the operating pool is legal")
+	assert_eq(mp.available(), 6, "the reserve still competes with plan-speed work")
+	assert_eq(_sum(mp.hours_spent), mp.attention_spent, "reserving books no typed hours")
 
 
 func test_grant_hours_buys_presence_not_planner_mind():

--- a/godot/tests/unit/test_founder_hours.gd.uid
+++ b/godot/tests/unit/test_founder_hours.gd.uid
@@ -1,0 +1,1 @@
+uid://cq4dwelkwy82a

--- a/godot/tests/unit/test_game_state.gd
+++ b/godot/tests/unit/test_game_state.gd
@@ -12,7 +12,9 @@ func test_game_state_initialization_defaults():
 	assert_eq(state.reputation, 50.0, "Should start with 50 reputation")
 	# Start doom is Balance-driven (dial 2, #638: the 2017 spawn starts LOW -- 20, was 50).
 	assert_eq(state.doom, Balance.num("starting_resources.doom", 20.0), "Start doom matches Balance starting_resources.doom")
-	assert_eq(state.action_points, 3, "Should start with 3 AP")
+	# T2: no AP pool. The founder starts a fresh PLAN MONTH with the Balance grant.
+	assert_eq(state.attention_per_month, Balance.inum("attention.per_month", 20), "Attention grant matches Balance")
+	assert_eq(state.get_available_attention(), state.attention_per_month, "Full month's Attention available at boot")
 	assert_eq(state.turn, 0, "Should start at turn 0")
 	assert_false(state.game_over, "Game should not be over initially")
 	assert_false(state.victory, "Should not be victorious initially")
@@ -38,8 +40,8 @@ func test_can_afford_sufficient_resources():
 
 	assert_true(state.can_afford({"money": 50000}), "Should afford $50k")
 	assert_true(state.can_afford({"compute": 50}), "Should afford 50 compute")
-	assert_true(state.can_afford({"action_points": 2}), "Should afford 2 AP")
-	assert_true(state.can_afford({"money": 50000, "action_points": 1}), "Should afford combo")
+	assert_true(state.can_afford({"attention": 2}), "Should afford 2 Attention")
+	assert_true(state.can_afford({"money": 50000, "attention": 1}), "Should afford combo")
 
 func test_can_afford_insufficient_resources():
 	# Test can_afford returns false when resources are insufficient
@@ -47,7 +49,7 @@ func test_can_afford_insufficient_resources():
 
 	assert_false(state.can_afford({"money": 300000}), "Should not afford $300k")
 	assert_false(state.can_afford({"compute": 500}), "Should not afford 500 compute")
-	assert_false(state.can_afford({"action_points": 5}), "Should not afford 5 AP")
+	assert_false(state.can_afford({"attention": 999}), "Should not afford 999 Attention")
 	assert_false(state.can_afford({"money": 50000, "compute": 500}), "Should not afford if one resource insufficient")
 
 func test_spend_resources_deducts_correctly():
@@ -57,9 +59,10 @@ func test_spend_resources_deducts_correctly():
 	state.spend_resources({"money": 10000})
 	assert_eq(state.money, 235000.0, "Money should decrease by $10k")
 
-	state.spend_resources({"compute": 20, "action_points": 1})
+	var attention_before := state.get_available_attention()
+	state.spend_resources({"compute": 20, "attention": 1})
 	assert_eq(state.compute, 80.0, "Compute should decrease by 20")
-	assert_eq(state.action_points, 2, "AP should decrease by 1")
+	assert_eq(state.get_available_attention(), attention_before - 1, "Attention should decrease by 1")
 
 func test_add_resources_increases_correctly():
 	# Test add_resources increases the correct amounts
@@ -171,7 +174,9 @@ func test_to_dict_serialization():
 	assert_eq(dict["turn"], 5, "Serialized turn should match")
 	assert_has(dict, "doom", "Should include doom")
 	assert_has(dict, "reputation", "Should include reputation")
-	assert_has(dict, "action_points", "Should include AP")
+	assert_has(dict, "attention", "Should include Attention")
+	assert_has(dict, "planning_hours_left", "Should include planning hours")
+	assert_has(dict, "operating_hours_left", "Should include operating hours")
 
 func test_queued_actions_initialization():
 	# Test that queued_actions starts empty
@@ -200,7 +205,7 @@ func test_can_afford_reputation_sufficient():
 
 	assert_true(state.can_afford({"reputation": 5}), "Should afford 5 reputation")
 	assert_true(state.can_afford({"reputation": 50}), "Should afford 50 reputation (exact match)")
-	assert_true(state.can_afford({"reputation": 10, "action_points": 1}), "Should afford combo with reputation")
+	assert_true(state.can_afford({"reputation": 10, "attention": 1}), "Should afford combo with reputation")
 
 func test_can_afford_reputation_insufficient():
 	# Test can_afford returns false when reputation is insufficient (FIX #407)
@@ -217,9 +222,10 @@ func test_spend_resources_reputation_deduction():
 	state.spend_resources({"reputation": 10})
 	assert_eq(state.reputation, 40.0, "Reputation should decrease by 10")
 
-	state.spend_resources({"reputation": 5, "action_points": 1})
+	var att_before := state.get_available_attention()
+	state.spend_resources({"reputation": 5, "attention": 1})
 	assert_eq(state.reputation, 35.0, "Reputation should decrease by another 5")
-	assert_eq(state.action_points, 2, "AP should also decrease")
+	assert_eq(state.get_available_attention(), att_before - 1, "Attention should also decrease")
 
 func test_spend_resources_reputation_clamped_to_zero():
 	# Test that reputation is clamped to 0 when spending
@@ -243,13 +249,12 @@ func test_action_validation_fundraise_with_insufficient_reputation():
 
 func test_action_validation_fundraise_with_sufficient_reputation():
 	# Test that fundraise_big action is allowed with enough reputation (FIX #407)
-	# fundraise_big costs 2 AP + 8 reputation
+	# fundraise_big costs 2 Attention + 8 reputation
 	var state = GameState.new("test_seed")
 	state.reputation = 50.0  # Default starting value (well above 8)
-	state.action_points = 3
 
 	var fundraise_action = GameActions.get_action_by_id("fundraise_big")
-	assert_true(state.can_afford(fundraise_action["costs"]), "Should afford fundraise_big with 50 reputation and 3 AP")
+	assert_true(state.can_afford(fundraise_action["costs"]), "Should afford fundraise_big with 50 reputation and a fresh Attention month")
 
 # FIX #424: Unmanaged employee productivity tests
 func test_get_unmanaged_count_legacy():

--- a/godot/tests/unit/test_ledger_actions.gd
+++ b/godot/tests/unit/test_ledger_actions.gd
@@ -5,7 +5,6 @@ extends GutTest
 func _fresh_state(seed_str: String = "bl1-test") -> GameState:
 	var s = GameState.new(seed_str)
 	s.money = 200000
-	s.action_points = 5
 	return s
 
 func test_take_loan_pays_out_and_adds_bill():
@@ -39,9 +38,10 @@ func test_desperation_lever_plants_secret_without_printed_doom():
 
 func test_staff_rider_grants_ap_and_rider():
 	var s = _fresh_state()
-	var before_ap = s.action_points
+	var before_hours = s.get_available_hours(MonthPlan.HOUR_OPERATING)
 	GameActions.execute_action("staff_rider", s)
-	assert_eq(s.action_points, before_ap + 2, "contractor grants +2 AP now")
+	assert_eq(s.get_available_hours(MonthPlan.HOUR_OPERATING), before_hours + 2,
+		"T2: contractor grants +2 OPERATING hours (bought presence), never founder planner mind")
 	assert_eq(s.ledger.entries.size(), 1, "staff rider adds a ledger entry")
 
 func test_exposure_fires_and_chains():

--- a/godot/tests/unit/test_office_economy.gd
+++ b/godot/tests/unit/test_office_economy.gd
@@ -9,7 +9,6 @@ func _fresh_state(seed_str: String = "office-test") -> GameState:
 	var s := GameState.new(seed_str)
 	s.reset()
 	s.money = 245000.0
-	s.action_points = 6
 	_created.append(s)
 	return s
 

--- a/godot/tests/unit/test_plan_controller.gd
+++ b/godot/tests/unit/test_plan_controller.gd
@@ -6,7 +6,7 @@ extends GutTest
 ## refactor target: these tests pin the CURRENT behaviour so the extraction cannot drift it.
 ## Behaviour under test, verbatim from the pre-carve code:
 ##   - sum every cost resource across the queued actions,
-##   - EXCEPT "action_points" (tracked separately as Attention), which is skipped,
+##   - EXCEPT "attention" / "hour_type" (Attention is tracked on the month plan), which is skipped,
 ##   - an unknown action id resolves to {} costs and contributes nothing,
 ##   - an empty queue yields {}.
 
@@ -24,13 +24,13 @@ func _controller(queue: Array) -> PlanController:
 # --- Cost aggregation contract (PlanController.calculate_queued_costs) --------------------
 
 func test_money_costs_sum_and_ap_is_skipped():
-	# buy_compute {money:50000}; team_building {money:10000, action_points:1}
+	# buy_compute {money:50000}; team_building {money:10000, attention:1}
 	var costs: Dictionary = _controller([
 		{"id": "buy_compute", "name": "Buy Compute"},
 		{"id": "team_building", "name": "Team Building"},
 	]).calculate_queued_costs()
 	assert_eq(costs.get("money", 0), 60000, "money costs sum across queued actions")
-	assert_false(costs.has("action_points"), "action_points is tracked as Attention, never summed here")
+	assert_false(costs.has("attention"), "attention is tracked on the month plan, never summed here")
 
 
 func test_non_money_resource_costs_sum():
@@ -40,11 +40,11 @@ func test_non_money_resource_costs_sum():
 		{"id": "publish_paper", "name": "Publish Paper"},
 	]).calculate_queued_costs()
 	assert_eq(costs.get("research", 0), 30, "research costs aggregate")
-	assert_false(costs.has("action_points"), "AP still skipped for research-costing actions")
+	assert_false(costs.has("attention"), "Attention still skipped for research-costing actions")
 
 
 func test_reputation_cost_surfaces():
-	# fundraise_small {action_points:1, reputation:2}
+	# fundraise_small {attention:1, reputation:2}
 	var costs: Dictionary = _controller([
 		{"id": "fundraise_small", "name": "Small Fundraise"},
 	]).calculate_queued_costs()
@@ -64,7 +64,7 @@ func test_empty_queue_is_empty_costs():
 
 
 func test_ap_only_action_yields_empty_costs():
-	# take_loan {action_points:1} -- the only cost is AP, which is skipped.
+	# take_loan {attention:1} -- the only cost is Attention, which is skipped.
 	var costs: Dictionary = _controller([
 		{"id": "take_loan", "name": "Take Loan"},
 	]).calculate_queued_costs()

--- a/godot/tests/unit/test_property_boot_invariants.gd
+++ b/godot/tests/unit/test_property_boot_invariants.gd
@@ -64,7 +64,7 @@ func _assert_actionable(game_seed: String, label: String) -> void:
 	assert_gt(state.money, 0.0, "[%s] starts with positive money" % label)
 	assert_true(is_finite(state.doom), "[%s] doom finite" % label)
 	assert_between(state.doom, 0.0, 100.0, "[%s] doom within [0,100] and not yet lost" % label)
-	assert_gt(state.action_points, 0, "[%s] has action points to spend" % label)
+	assert_gt(state.get_available_attention(), 0, "[%s] has Attention to spend" % label)
 
 	# The core "actionable" claim: at least one action is affordable at boot. A run
 	# that boots with nothing affordable is soft-locked from move one.

--- a/godot/tests/unit/test_risk_system.gd
+++ b/godot/tests/unit/test_risk_system.gd
@@ -253,7 +253,6 @@ func test_capability_research_adds_risk():
 	state.money = 100000
 	state.compute = 100
 	state.research = 20  # Need research to spend on capability research
-	state.action_points = 3  # Need AP to execute action
 	state.capability_researchers = 2  # Need researchers to do research
 
 	var initial_cap = state.risk_system.pools["capability_overhang"]

--- a/godot/tests/unit/test_save_load_roundtrip.gd
+++ b/godot/tests/unit/test_save_load_roundtrip.gd
@@ -58,8 +58,7 @@ func _play_full_turn(tm: TurnManager, state: GameState) -> void:
 
 func _end_turn(tm: TurnManager, state: GameState) -> void:
 	# Mirrors GameManager.end_turn(): committed AP converts to spent AP.
-	state.action_points -= state.committed_ap
-	state.committed_ap = 0
+	# T2: no AP pool to reconcile -- queued-card Attention already sits in month_plan.
 	tm.execute_turn()
 
 
@@ -150,7 +149,7 @@ func test_save_load_roundtrip_deep_equality_and_next_turn_identical():
 	# Mid-planning snapshot: an action queued but not yet executed
 	# (mirrors GameManager.select_action's bookkeeping).
 	state1.queued_actions.append("fundraise")
-	state1.committed_ap += 1
+	state1.month_plan.spend_attention(1, MonthPlan.HOUR_PLANNING)
 
 	# SAVE -> LOAD through the real file path (JSON coercions included).
 	assert_eq(SaveLoad.save_game(state1, TEST_SAVE_PATH), OK, "save must write")
@@ -172,8 +171,10 @@ func test_save_load_roundtrip_deep_equality_and_next_turn_identical():
 			"ledger entry %d" % i)
 	assert_eq(state2.governance, state1.governance, "governance")
 	assert_eq(state2.queued_actions, state1.queued_actions, "queued_actions")
-	assert_eq(state2.committed_ap, state1.committed_ap, "committed_ap")
-	assert_eq(state2.max_action_points, state1.max_action_points, "max_action_points (difficulty)")
+	assert_eq(state2.month_plan.attention_spent, state1.month_plan.attention_spent, "attention_spent")
+	assert_eq(state2.month_plan.hours_spent, state1.month_plan.hours_spent, "typed founder hours spent")
+	assert_eq(state2.month_plan.hours_total, state1.month_plan.hours_total, "typed founder hours granted")
+	assert_eq(state2.attention_per_month, state1.attention_per_month, "attention_per_month (difficulty)")
 	assert_eq(state2.rng.state, state1.rng.state, "rng stream position")
 	assert_eq(state2.rival_labs.size(), state1.rival_labs.size(), "rival count")
 	for i in range(state1.rival_labs.size()):

--- a/godot/tests/unit/test_travel_panel_controller.gd
+++ b/godot/tests/unit/test_travel_panel_controller.gd
@@ -84,11 +84,11 @@ func test_travel_option_set_and_costs_are_pinned():
 
 	# submit_paper: the paper-submission entry, 1 AP (matches the "Submit Paper (1 AP)" sub-dialog button).
 	var submit: Dictionary = by_id["submit_paper"]
-	assert_eq(int(submit.get("costs", {}).get("action_points", -1)), 1, "submit_paper costs 1 AP")
+	assert_eq(int(submit.get("costs", {}).get("attention", -1)), 1, "submit_paper costs 1 Attention")
 
 	# attend_conference: the attendance entry, 2 AP (matches the "Attend (2 AP)" sub-dialog button).
 	var attend: Dictionary = by_id["attend_conference"]
-	assert_eq(int(attend.get("costs", {}).get("action_points", -1)), 2, "attend_conference costs 2 AP")
+	assert_eq(int(attend.get("costs", {}).get("attention", -1)), 2, "attend_conference costs 2 Attention")
 
 	# send_delegation is still the not-yet-built stub (Issue #411) -- the panel greys it out.
 	var deleg: Dictionary = by_id["send_delegation"]

--- a/godot/tests/unit/test_turn_manager.gd
+++ b/godot/tests/unit/test_turn_manager.gd
@@ -33,23 +33,29 @@ func test_start_turn_increments_turn_counter():
 	turn_manager.start_turn()
 	assert_eq(state.turn, 2, "Turn should increment to 2")
 
-func test_start_turn_resets_action_points():
-	# Test that start_turn resets AP to base amount
-	state.action_points = 0  # Deplete AP
+func test_start_turn_does_not_regrant_founder_capacity():
+	# T2 (ADR-0011 amendment (a)): the per-turn AP grant is DELETED. A day tick must NOT
+	# hand the founder more capacity -- Attention is granted per PLAN MONTH, by
+	# MonthController. Spending inside a month has to stay spent across the day ticks.
+	state.month_plan.spend_attention(4, MonthPlan.HOUR_OPERATING)
+	var after_spend := state.get_available_attention()
 
 	turn_manager.start_turn()
 
-	assert_eq(state.action_points, 3, "AP should reset to base 3")
+	assert_eq(state.get_available_attention(), after_spend,
+		"a day tick must not re-grant founder Attention")
 
-func test_start_turn_ap_scales_with_staff():
-	# Test that AP increases with staff count (base 3 + 0.5 per employee)
+func test_staff_do_not_add_founder_attention():
+	# ADR-0011 point 1: "the pool illusion dies; staff never add founder AP." Under the old
+	# AP pool, 6 staff bought the founder 3 extra points per turn. That is now gone.
 	state.safety_researchers = 2
-	state.compute_engineers = 4
-	# Total staff = 6, so AP = 3 + int(6 * 0.5) = 3 + 3 = 6
+	state.compute_engineers = 4  # total staff = 6
+	var before := state.get_available_attention()
 
 	turn_manager.start_turn()
 
-	assert_eq(state.action_points, 6, "AP should scale: 3 + int(6 * 0.5) = 6")
+	assert_eq(state.get_available_attention(), before,
+		"hiring staff must not top up the founder budget")
 
 func test_start_turn_deducts_staff_salaries():
 	# #573: salaries are now per-workday (annual / 260), not a flat $5k/turn.
@@ -121,7 +127,6 @@ func test_start_turn_compute_not_burned_without_researchers():
 func test_execute_turn_processes_queued_actions():
 	# Test that execute_turn runs queued actions
 	state.queued_actions = ["buy_compute"]
-	state.action_points = 3
 
 	var result = turn_manager.execute_turn()
 
@@ -216,7 +221,7 @@ func test_turn_sequence_integration():
 	# Start turn
 	var start_result = turn_manager.start_turn()
 	assert_eq(state.turn, initial_turn + 1, "Turn should increment")
-	assert_eq(state.action_points, 3, "AP should be 3")
+	assert_eq(state.get_available_attention(), state.attention_per_month, "Full Attention month still available")
 
 	# Queue actions
 	state.queued_actions = ["buy_compute"]

--- a/godot/tests/unit/test_window_option_routing.gd
+++ b/godot/tests/unit/test_window_option_routing.gd
@@ -27,7 +27,7 @@ func _research_event() -> Dictionary:
 	return {
 		"id": "hist_some_paper", "name": "Some Paper", "type": "popup", "category": "research",
 		"options": [
-			{"id": "build_upon", "text": "Build", "costs": {"action_points": 1, "money": 10000},
+			{"id": "build_upon", "text": "Build", "costs": {"attention": 1, "money": 10000},
 			 "effects": {"research": 15, "doom": 1}, "message": "Advancing."},
 			{"id": "acknowledge", "text": "Ack", "costs": {}, "effects": {"research": 2}, "message": "Noted."},
 		],
@@ -38,7 +38,7 @@ func _policy_event() -> Dictionary:
 	return {
 		"id": "hist_some_policy", "name": "Some Policy", "type": "popup", "category": "policy",
 		"options": [
-			{"id": "support", "text": "Support", "costs": {"action_points": 1},
+			{"id": "support", "text": "Support", "costs": {"attention": 1},
 			 "effects": {"reputation": 5, "doom": -3}, "message": "Supported."},
 			{"id": "stay_neutral", "text": "Neutral", "costs": {}, "effects": {}, "message": "Neutral."},
 		],

--- a/godot/tests/unit/test_window_resolver.gd
+++ b/godot/tests/unit/test_window_resolver.gd
@@ -18,7 +18,7 @@ func _deferrable_window() -> Dictionary:
 		"event_class": "deferrable",
 		"source_id": "legal_counsel",
 		"options": [
-			{"id": "settle", "costs": {"money": 20000, "action_points": 1}, "effects": {"reputation": 5}, "message": "Settled"},
+			{"id": "settle", "costs": {"money": 20000, "attention": 1}, "effects": {"reputation": 5}, "message": "Settled"},
 			{"id": "let_it_ride", "costs": {}, "effects": {"reputation": -3}, "message": "Ignored the notice"},
 		],
 		"window": {"attention_cost": 2, "handle_option": "settle", "ignore_option": "let_it_ride", "defer": {"factory": "loan", "amount": 20000}},
@@ -47,7 +47,8 @@ func test_handle_from_reserve_fails_without_enough_reserve():
 
 func test_handle_by_cannibalizing_ignores_legacy_ap():
 	var s := _state()
-	s.action_points = 0  # prove Attention, not AP, is the window currency (AP stripped)
+	# T2: there is no AP pool at all -- the window currency is Attention, and the option's
+	# own attention cost is stripped so the founder is charged exactly once.
 	s.month_plan.set_reserve(0)  # 20 available
 	var r := WindowResolver.resolve(s, s.month_plan, _deferrable_window(), "handle_cannibalize")
 	assert_true(r.success, "cannibalizing free capacity handles the window even with zero AP")

--- a/godot/tools/dev_tool.gd
+++ b/godot/tools/dev_tool.gd
@@ -122,14 +122,14 @@ func test_game_state():
 	print("    Staff: %d" % game_state.staff)
 	print("    Reputation: %.1f" % game_state.reputation)
 	print("    Doom: %.1f%%" % game_state.doom)
-	print("    Action Points: %d / %d" % [game_state.action_points, game_state.max_action_points])
+	print("    Attention: %d free / %d granted" % [game_state.get_available_attention(), game_state.attention_per_month])
 
 	# Test turn advancement
 	print("\n  Testing turn advancement...")
 	var initial_turn = game_state.turn
 	game_state.advance_turn()
 	print("    Turn advanced: %d -> %d" % [initial_turn, game_state.turn])
-	print("    Action Points reset: %d" % game_state.action_points)
+	print("    Attention reset: %d" % game_state.get_available_attention())
 
 	game_state.free()
 	print("\n[[OK]] GameState working correctly")

--- a/godot/tools/dev_tool_v2.gd
+++ b/godot/tools/dev_tool_v2.gd
@@ -108,8 +108,8 @@ func test_game_state():
 	print("  Staff: %d" % gs.staff)
 	print("  Reputation: %.1f" % gs.reputation)
 	print("  Doom: %.1f%%" % gs.doom)
-	if "action_points" in gs and "max_action_points" in gs:
-		print("  Action Points: %d / %d" % [gs.action_points, gs.max_action_points])
+	if "attention_per_month" in gs:
+		print("  Attention: %d free / %d granted" % [gs.get_available_attention(), gs.attention_per_month])
 
 	# Test turn advancement
 	print("\n[INFO] Testing turn advancement...")


### PR DESCRIPTION
## Lane T2 -- the AP -> Attention migration

RIP AP, dead 1h03m on Monday as a *design* concept (ADR-0011 amendment (a)). This is the
code death. Nothing anywhere reads `action_points` any more.

**Fast gate: 959 tests, 0 failures, 94/94 files collected.**

---

### What is deleted

- `GameState.action_points` / `max_action_points` / `committed_ap` / `reserved_ap` /
  `used_event_ap`, plus `reserve_ap_amount` / `commit_ap_amount` / `spend_event_ap` /
  `reset_turn_ap` / `get_event_ap`.
- `turn_manager._step_grant_action_points`. There is now **no per-turn founder grant of any
  kind** -- ADR-0011 point 1 ("the pool illusion dies; staff never add founder AP") is
  structural rather than a convention. **RNG-safe**: that step drew nothing from
  `state.rng`, so the recorded-replay stream is unchanged.
- Balance keys `starting_resources.action_points` and the whole `action_points` block.

### What replaces it

- `attention` is the cost key in every action / event / scenario JSON -- 72 keys across 13
  files -- and in `event_service`'s inline windows. `GameActions.attention_cost()` and
  `GameActions.hour_type()` are the ONE read point.
- `can_afford` / `spend_resources` understand `attention` and route it to the month plan.
  `WindowResolver.strip_ap` -> `strip_attention`.
- Difficulty scales the **monthly Attention grant** (easy/standard/hard = 24 / 20 / 16)
  instead of a per-turn cap.
- `GameState.get_available_ap()` -> `get_available_attention()`, plus
  `get_available_hours(type)` and `get_reserve_attention()`.

### 2-way founder hours (the T3-rung floor)

Every Attention spend is **PLANNING** (planner mind: queuing strategic work, direction) or
**OPERATING** (presence: response windows, hiring loop, travel, interviews).

Typed pools are **additive accounting over the authoritative scalar** -- deliberately the
same shape N2 used for typed reputation, so `attention_total`/`attention_spent` stay
authoritative and every caller that only knows the aggregate keeps working. The invariant
`sum(hours_spent) == attention_spent` is pinned by tests.

**Overflow is asymmetric, and that asymmetry is the whole design:**

| direction | allowed? | why |
|---|---|---|
| operating -> planning | YES | a crisis costs you the month you meant to spend thinking |
| planning -> operating | NO | you cannot retroactively have been in the room |

Running out of planner hours **blocks** further strategic queuing that month even while
operating hours sit unused. That is the intended bite.

This also closes the seam **#980** named: conference travel now drains OPERATING hours
only, overflow forbidden. Away costs operator presence, not planner mind -- next month's
direction is still decidable from a hotel room. The anti-free-button property survives:
every form of presence work is dead for the rest of the month.

The **4-way** split (doors / approvals / audits / reserve) is NOT in this PR, per the lane
brief. It subdivides these two later; the two subdivision points are
`GameActions.hour_type()` and `GameState._cost_hour_type()`.

---

## Judgment calls, flagged for review

1. **`planning_share` = 0.6 (hand-set, un-swept).** With a 20/month grant that is 12
   planning / 8 operating. This is now a real cap on strategic cards per month, so it is the
   single biggest balance lever in the PR. The audacity ruling says do not block on it; it
   wants the exploit-finder before the ADR's 2026-08-31 review.

2. **The crisp reserve is deliberately UNTYPED.** I built the operating-pool gate on
   `set_reserve`, then reverted it. Reason: the reserve is the emergency channel, and an
   emergency is exactly where the type wall is allowed to break (cannibalizing already lets
   operating overflow into planning). Gating the *pre-declared* reserve at operating hours
   forbids at plan time what the overflow rule permits at crisis time -- and it silently
   truncated the implicit end-of-month reserve that the #789 hiring flow depends on. Pinned
   by a test so it cannot be reverted silently. **Overrule me if you want the reserve to be
   a hard presence commitment.**

3. **`staff_rider` re-expressed.** The contractor action used to do
   `state.action_points += 2` -- staff minting founder capacity, which ADR-0011 point 1
   forbids outright. It now grants +2 OPERATING hours for the month (point 6: ops/admin
   staff reduce the founder-price of routine work -- bought presence). It cannot buy
   planner mind.

4. **Default hour type differs by surface, on purpose.** A queued *action* defaults to
   PLANNING (`GameActions.hour_type`); a bare cost dict handed to `spend_resources` defaults
   to OPERATING (`GameState._cost_hour_type`). Rationale: queuing is deciding, whereas an
   un-typed subsystem charge (hiring, ledger, media) is somebody physically doing a thing.
   Data overrides either with an `hour_type` key. If that split reads as a trap, the fix is
   to make every cost dict declare its type explicitly.

5. **Presence-typed the obvious content by hand**, not by sweep: submit_paper, conference
   attendance and travel, exclusive interview, ledger time-liabilities and the hiring
   pipeline all bill OPERATING. Everything else inherits the queue default. Nobody has read
   all the action defs asking "is this thinking, or is this showing up?" -- that pass is
   worth doing once, with the 4-way lane, rather than twice.

6. **`action_points` survives as a READ-ONLY cost-key alias.** In-repo data carries none (a
   test pins that), but scenario packs / timeline / future mod content lag a code migration.
   Nothing writes it. Say the word and it goes.

7. **Sandbox scenario re-denominated by hand**: `action_points: 5` (per turn) became
   `attention_per_month: 40`. Guessed generous; it is a sandbox.

8. **`test_conference_trip` changed its assertion, not just its wording.** It asserted the
   1555 ruling literally ("no Attention left"). It now asserts the #980 refinement (no
   OPERATING hours left, planning untouched). That is me reading a later noticing as
   superseding an earlier ruling -- worth a glance.

## Deliberately NOT taken: the resolve-time-spend spike

`origin/spike-resolve-time-spend` was mined for shape and left on the shelf. It is an
orthogonal axis (commit at queue time, DEBIT at resolution, so unresolved cards stay
divertible) and it predates Monday's rulings. It composes cleanly with this PR -- its
`attention_committed` pool would sit beside the typed hours rather than fight them -- but
landing both at once would have made the month accounting un-reviewable. Its
`commit_attention` / `resolve_committed` / `release_committed` trio is still the right shape
when that lane runs.

## Files touched outside actions.gd + tests

Core: `month_plan.gd` (typed hours -- the substantive new code), `game_state.gd`,
`turn_manager.gd`, `game_manager.gd`, `window_resolver.gd`, `month_controller.gd`,
`ledger.gd`, `media_system.gd`, `resource_accessor.gd`, `conference_trip.gd` (the function
that named T2 as its owner).
UI: `main_ui.gd`, `plan_controller.gd`, `submenu_controller.gd`, `event_dialog.gd`,
`resource_display.gd`, `hiring_panel_controller.gd`.
Debug/tools: `debug_overlay.gd`, `dev_mode_overlay.gd`, `dev_mode_readout.gd`,
`dev_tool.gd`, `dev_tool_v2.gd`, `definition_loader.gd`, `event_service.gd`.
Data: 10 `data/actions/*.json`, `core_events.json`, `2017.json`, `sandbox.json`,
`balance/defaults.json`, `icon_mapping.json`.
Docs: ADR-0011 amendments (d)-(g); `ARCHITECTURE.md` -- the "dual currency (AP vs
Attention)" live edge is retired and replaced with the honest remaining flags.

Closes the code half of ADR-0011 amendment (a). Refs #613, #980.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
