### PR TITLE
fix(release): v0.13.1.json download URLs + contact address (#963)

### DIFF
--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -332,6 +332,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Anti-rot guard (issue #963): the generator has drifted from the real
+  # build/upload pipeline before (PDoom.exe / PDoom.x86_64 were 404s against
+  # every release since the versioned-zip pipeline landed) and nothing
+  # caught it until a human noticed. Runs AFTER create-github-release so the
+  # asset URLs actually exist to check. Blocking: a future generator/build
+  # mismatch fails this job (and therefore the workflow run) instead of
+  # silently shipping broken URLs.
+  verify-release-urls:
+    name: Verify Release Download URLs
+    runs-on: ubuntu-latest
+    needs: [create-github-release]
+    if: needs.create-github-release.result == 'success'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Download feed artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: release-feeds
+          path: public/releases/
+
+      - name: Verify this release's download URLs resolve
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
+        run: |
+          python scripts/verify_release_urls.py --file "public/releases/${RELEASE_VERSION}.json"
+
+      - name: Sweep committed feed index for rotted entries (report-only)
+        # Report-only on purpose: an OLD entry going 404 (e.g. a release that
+        # was later deleted, like v0.9.0) is a separate, non-urgent cleanup
+        # concern, not something that should block THIS release from
+        # shipping. The step above is what's blocking for the new tag.
+        continue-on-error: true
+        run: |
+          python scripts/verify_release_urls.py --sweep public/releases/releases.json
+
   # Explicitly drive the website version sync. Required because this workflow
   # publishes the release with GITHUB_TOKEN, and a release published by a
   # GITHUB_TOKEN-authored action does NOT fire the `release: published` event

--- a/godot/scripts/ui/bug_report_panel.gd
+++ b/godot/scripts/ui/bug_report_panel.gd
@@ -183,7 +183,7 @@ func _on_report_saved(filepath: String):
 	# truth (was implying an auto-filed GitHub issue) and surface the path + an email
 	# so tester feedback actually reaches us.
 	var global_path := ProjectSettings.globalize_path(filepath)
-	show_confirmation("Thanks! Saved locally to:\n%s\n\nThis build does not send reports automatically yet -- please email that file to pip@beacongcr.org so it reaches us." % global_path)
+	show_confirmation("Thanks! Saved locally to:\n%s\n\nThis build does not send reports automatically yet -- please email that file to team@pdoom1.com so it reaches us." % global_path)
 
 	# Reset form after a longer delay so the path is readable.
 	await get_tree().create_timer(6.0).timeout

--- a/public/releases/v0.13.1.json
+++ b/public/releases/v0.13.1.json
@@ -1,0 +1,24 @@
+{
+  "version": "v0.13.1",
+  "version_number": "0.13.1",
+  "release_date": "2026-07-25T22:23:46+10:00",
+  "commit_hash": "409535dc0215d5e7bf4ff1b83025e8da98d7b4ef",
+  "is_prerelease": false,
+  "changelog": "Release v0.13.1\n\nSee CHANGELOG.md for details.",
+  "downloads": {
+    "windows": "https://github.com/PipFoweraker/pdoom1/releases/download/v0.13.1/PDoom-Windows-v0.13.1.zip",
+    "linux": "https://github.com/PipFoweraker/pdoom1/releases/download/v0.13.1/PDoom-Linux-v0.13.1.zip",
+    "mac": "https://github.com/PipFoweraker/pdoom1/releases/download/v0.13.1/PDoom-macOS-v0.13.1.zip",
+    "source_zip": "https://github.com/PipFoweraker/pdoom1/archive/refs/tags/v0.13.1.zip",
+    "source_tar": "https://github.com/PipFoweraker/pdoom1/archive/refs/tags/v0.13.1.tar.gz"
+  },
+  "metadata": {
+    "engine": "Godot 4.5.1",
+    "platforms": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ],
+    "tag_message": "fix(ui): tie staff-card blocker to panel lifetime -- fixes ESC dead-mouse soft-lock (non-forking, L2) (#887)\n\nThe staff ID card (EmployeePanel) raises a full-rect z=998 MOUSE_FILTER_STOP\nblocker behind the perks panel. The blocker was torn down ONLY by the panel's\nown click/close lambdas, and those lambdas free perks_panel FIRST -- so when\nESC frees the panel via MainUI._close_active_submenu (which frees active_dialog\n== perks_panel but never the blocker), the blocker is orphaned and swallows\nevery mouse click forever = dead UI. Double-opening stacks two unclosable\nblockers.\n\nFix (mirrors main_ui.gd _present_modal_dialog's tree_exited idiom): connect the\nblocker teardown to perks_panel.tree_exited so the blocker is freed whenever the\npanel leaves the tree by ANY path (ESC, replacing dialog, click, close). Also\nharden the close/click lambdas: guard each queue_free with is_instance_valid and\nfree the blocker BEFORE the panel so a freed panel can't strand the blocker even\nwithout the signal.\n\nNon-forking: pure UI-lifecycle fix, no game-state/board-key impact.\n\nRefs #886 (adversarial fuzz found it), #877 (scene-nav/chokepoint follow-up).\n\nCo-authored-by: Claude Opus 4.8 <noreply@anthropic.com>"
+  }
+}

--- a/scripts/generate_release_metadata.py
+++ b/scripts/generate_release_metadata.py
@@ -125,12 +125,21 @@ class ReleaseMetadataGenerator:
             "commit_hash": tag_info["commit"],
             "is_prerelease": is_prerelease,
             "changelog": changelog,
+            # Asset names must match what scripts/build_all_platforms.py actually
+            # produces and enhanced-release.yml actually uploads (build-windows/
+            # **/*.zip, build-linux/**/*.zip, build-mac/**/*.zip) -- NOT a guessed
+            # shape. Verified against the real v0.13.1 release asset list
+            # (issue #963: PDoom.exe / PDoom.x86_64 / pdoom-*-source.* were all
+            # 404s because no such assets are ever produced).
             "downloads": {
-                "windows": f"{base_url}/PDoom.exe",
-                "linux": f"{base_url}/PDoom.x86_64",
-                "mac": f"{base_url}/PDoom.app.zip",
-                "source_zip": f"{base_url}/pdoom-{version_num}-source.zip",
-                "source_tar": f"{base_url}/pdoom-{version_num}-source.tar.gz",
+                "windows": f"{base_url}/PDoom-Windows-{version}.zip",
+                "linux": f"{base_url}/PDoom-Linux-{version}.zip",
+                "mac": f"{base_url}/PDoom-macOS-{version}.zip",
+                # GitHub auto-generates these codeload archives for every tag;
+                # they are not uploaded release assets, so this URL shape works
+                # even though no matching file appears in `gh release view`.
+                "source_zip": f"https://github.com/{github_repo}/archive/refs/tags/{version}.zip",
+                "source_tar": f"https://github.com/{github_repo}/archive/refs/tags/{version}.tar.gz",
             },
             "metadata": {
                 "engine": "Godot 4.5.1",

--- a/scripts/generate_release_metadata.py
+++ b/scripts/generate_release_metadata.py
@@ -9,12 +9,19 @@ changelog entries, and download links to make releases easily discoverable.
 Usage:
     python scripts/generate_release_metadata.py --version v0.10.1
     python scripts/generate_release_metadata.py --latest
+    python scripts/generate_release_metadata.py --version v0.10.1 --verify
+
+--verify HEADs every generated download URL (via scripts/verify_release_urls.py)
+after writing the files and exits nonzero on any non-200. This is the same
+check CI runs (blocking) after a release's assets are uploaded -- use it
+locally to catch a generator/build-pipeline mismatch before pushing a tag.
 """
 
 import argparse
 import datetime
 import json
 import subprocess
+import sys
 import xml.etree.ElementTree as ElementTree
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -231,8 +238,9 @@ class ReleaseMetadataGenerator:
         dom = minidom.parseString(xml_string)
         return dom.toprettyxml(indent="  ")
 
-    def generate_all_metadata(self, specific_version: Optional[str] = None):
-        """Generate all metadata files."""
+    def generate_all_metadata(self, specific_version: Optional[str] = None) -> List[Path]:
+        """Generate all metadata files. Returns the list of individual
+        per-release JSON files written (used by --verify)."""
         print("[*] Generating release metadata for P(Doom)...")
 
         # Get all release tags
@@ -243,12 +251,13 @@ class ReleaseMetadataGenerator:
 
         if not tags:
             print("[!] No release tags found!")
-            return
+            return []
 
         print(f"[*] Found {len(tags)} release(s)")
 
         # Generate metadata for each release
         releases = []
+        release_files: List[Path] = []
         for tag in tags:
             print(f"  Processing {tag}...")
             tag_info = self.get_git_tag_info(tag)
@@ -262,6 +271,7 @@ class ReleaseMetadataGenerator:
                 with open(release_file, "w", encoding="utf-8") as f:
                     json.dump(release_data, f, indent=2, ensure_ascii=False)
                 print(f"    [+] Generated {release_file.name}")
+                release_files.append(release_file)
 
         # Generate releases index
         index_data = self.generate_releases_index(releases)
@@ -282,6 +292,8 @@ class ReleaseMetadataGenerator:
         print(f"[*] Latest version: {index_data['latest_version']}")
         print(f"[*] Latest stable: {index_data['latest_stable']}")
 
+        return release_files
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -293,6 +305,12 @@ def main():
     parser.add_argument(
         "--latest", action="store_true", help="Only generate metadata for the latest release"
     )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="After generating, HEAD every download URL and exit nonzero on any non-200 "
+        "(see scripts/verify_release_urls.py)",
+    )
 
     args = parser.parse_args()
 
@@ -301,15 +319,27 @@ def main():
 
     generator = ReleaseMetadataGenerator(repo_root)
 
+    generated_files: List[Path] = []
     if args.latest and not args.version:
         # Get latest tag
         tags = generator.get_all_release_tags()
         if tags:
-            generator.generate_all_metadata(specific_version=tags[0])
+            generated_files = generator.generate_all_metadata(specific_version=tags[0])
         else:
             print("WARNING  No release tags found!")
     else:
-        generator.generate_all_metadata(specific_version=args.version)
+        generated_files = generator.generate_all_metadata(specific_version=args.version)
+
+    if args.verify:
+        sys.path.insert(0, str(Path(__file__).parent))
+        import verify_release_urls  # noqa: E402  (deliberate late import, sys.path just set)
+
+        print("\n[*] --verify: checking generated download URLs resolve...")
+        exit_code = 0
+        for release_file in generated_files:
+            exit_code = max(exit_code, verify_release_urls.cmd_file(release_file))
+        if exit_code != 0:
+            sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/scripts/verify_release_urls.py
+++ b/scripts/verify_release_urls.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Verify release-feed download URLs actually resolve.
+
+Anti-rot guard for public/releases/*.json (issue #963 follow-up). The
+release-metadata generator has drifted from the real build/upload pipeline
+before: PDoom.exe / PDoom.x86_64 / pdoom-*-source.* were hardcoded into
+every generated release JSON and were 404s against every real release
+since the versioned-zip build pipeline landed, and nothing caught it until
+a human noticed. This script closes that gap by actually resolving the
+URLs it is asked to check, instead of trusting the generator's output.
+
+Two modes:
+
+  --file PATH   Blocking check. HEADs every URL in a single release JSON's
+                "downloads" block. Exits nonzero on any non-200. This is
+                meant to run in CI right after a release's assets are
+                uploaded, so a future generator/pipeline mismatch fails the
+                workflow instead of silently shipping 404s.
+
+  --sweep PATH  Report-only sweep (unless --strict). Walks every entry in a
+                releases.json index, checks whether a matching GitHub
+                Release still exists (via the Releases API, NOT the tag
+                page -- a bare git tag with no Release object still 200s
+                the tag page, which is exactly how the v0.9.0 feed-rot went
+                unnoticed), and checks its download URLs too. Old entries
+                that have rotted (e.g. a release that was later deleted)
+                are reported but do not fail the run by default -- pass
+                --strict to make sweep failures blocking as well.
+
+Usage:
+    python scripts/verify_release_urls.py --file public/releases/v0.13.1.json
+    python scripts/verify_release_urls.py --sweep public/releases/releases.json
+    python scripts/verify_release_urls.py --sweep public/releases/releases.json --strict
+    python scripts/verify_release_urls.py --file public/releases/v0.13.1.json --sweep public/releases/releases.json
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+GITHUB_REPO = "PipFoweraker/pdoom1"
+USER_AGENT = "pdoom1-release-url-verifier"
+TIMEOUT_SECONDS = 15.0
+
+
+def check_url(url: str) -> Tuple[int, str]:
+    """HEAD a URL, following redirects. Returns (status_code, error_str).
+
+    status_code is 0 on a network-level failure (no response at all), in
+    which case error_str carries the reason.
+    """
+    req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
+            return resp.status, ""
+    except urllib.error.HTTPError as e:
+        return e.code, str(e.reason)
+    except urllib.error.URLError as e:
+        return 0, str(e.reason)
+
+
+def verify_downloads(downloads: Dict[str, str], label: str) -> List[str]:
+    """Check every URL in a `downloads` dict. Prints a line per URL, returns
+    a list of human-readable failure descriptions (empty if all resolved)."""
+    failures = []
+    if not downloads:
+        msg = f"{label}: no 'downloads' block found"
+        print(f"  [!] {msg}")
+        return [msg]
+
+    for platform, url in downloads.items():
+        status, err = check_url(url)
+        ok = status == 200
+        marker = "[OK]" if ok else "[!]"
+        detail = str(status) if status else "ERR"
+        if err:
+            detail = f"{detail} ({err})"
+        print(f"  {marker} {label}.{platform:12s} {detail:24s} {url}")
+        if not ok:
+            failures.append(f"{label}.{platform} -> {detail} :: {url}")
+    return failures
+
+
+def release_exists(version: str) -> bool:
+    """True iff a GitHub Release object exists for this tag.
+
+    Deliberately uses the Releases API, not the tag page: a git tag can
+    exist with no Release attached (e.g. a deleted/never-published
+    release) and https://github.com/{repo}/releases/tag/{tag} still
+    returns 200 in that case -- checked against v0.9.0, which is exactly
+    the rot this sweep mode exists to catch.
+    """
+    api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/{version}"
+    status, _ = check_url(api_url)
+    return status == 200
+
+
+def cmd_file(path: Path) -> int:
+    """Blocking: verify one release JSON's download URLs."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    version = data.get("version", path.stem)
+    print(f"[*] Verifying download URLs for {version} ({path})")
+
+    failures = verify_downloads(data.get("downloads", {}), version)
+    if failures:
+        print(f"\n[!] {len(failures)} broken URL(s) in {path}:")
+        for f in failures:
+            print(f"  [!] {f}")
+        return 1
+
+    print(f"[OK] All download URLs for {version} resolve")
+    return 0
+
+
+def cmd_sweep(path: Path, strict: bool) -> int:
+    """Report-only (unless --strict): sweep a releases.json index for rot."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    releases = data.get("releases", [])
+    plural = "y" if len(releases) == 1 else "ies"
+    print(f"[*] Sweeping {len(releases)} feed entr{plural} in {path}")
+
+    rotten = []
+    for entry in releases:
+        version = entry.get("version", "?")
+        if not release_exists(version):
+            print(f"  [!] {version}: no matching GitHub release (feed rot -- release is gone)")
+            rotten.append(version)
+            continue
+        print(f"  [*] {version}: release exists, checking downloads...")
+        if verify_downloads(entry.get("downloads", {}), version):
+            rotten.append(version)
+
+    if rotten:
+        are = "is" if len(rotten) == 1 else "are"
+        print(
+            f"\n[!] {len(rotten)} feed entr{'y' if are == 'is' else 'ies'} {are} rotten: "
+            f"{', '.join(rotten)}"
+        )
+        if strict:
+            return 1
+        print("[*] --strict not set: old-entry rot is report-only, exiting 0")
+        return 0
+
+    print("[OK] No rot found in feed index")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify release-feed download URLs actually resolve (issue #963)"
+    )
+    parser.add_argument(
+        "--file", type=Path, help="A single release JSON to verify (blocking on any 404)"
+    )
+    parser.add_argument(
+        "--sweep",
+        type=Path,
+        help="A releases.json index to sweep for rotted entries (report-only unless --strict)",
+    )
+    parser.add_argument(
+        "--strict", action="store_true", help="Make --sweep rot findings exit nonzero too"
+    )
+    args = parser.parse_args()
+
+    if not args.file and not args.sweep:
+        parser.error("pass --file and/or --sweep")
+
+    exit_code = 0
+    if args.file:
+        exit_code = max(exit_code, cmd_file(args.file))
+    if args.sweep:
+        exit_code = max(exit_code, cmd_sweep(args.sweep, args.strict))
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/release_notes/HOW-TO-RUN-linux.txt
+++ b/tools/release_notes/HOW-TO-RUN-linux.txt
@@ -21,7 +21,7 @@ HEADS UP
 
 FEEDBACK
    In-game F8 saves a bug report to your disk and shows you the file path --
-   please email that file to pip@beacongcr.org (the in-game reporter does not
+   please email that file to team@pdoom1.com (the in-game reporter does not
    send anything itself yet).
 
 Thanks for playing -- Pip

--- a/tools/release_notes/HOW-TO-RUN-macos.txt
+++ b/tools/release_notes/HOW-TO-RUN-macos.txt
@@ -20,7 +20,7 @@ HEADS UP
 
 FEEDBACK
    In-game F8 saves a bug report to your disk and shows you the file path --
-   please email that file to pip@beacongcr.org (the in-game reporter does not
+   please email that file to team@pdoom1.com (the in-game reporter does not
    send anything itself yet).
 
 Thanks for playing -- Pip

--- a/tools/release_notes/HOW-TO-RUN-windows.txt
+++ b/tools/release_notes/HOW-TO-RUN-windows.txt
@@ -16,7 +16,7 @@ WHATS IN HERE
 
 FEEDBACK
    In-game F8 saves a bug report to your disk and shows you the file path --
-   please email that file to pip@beacongcr.org (the in-game reporter does not
+   please email that file to team@pdoom1.com (the in-game reporter does not
    send anything itself yet).
 
 Thanks for playing -- Pip


### PR DESCRIPTION
## Summary
Fixes #963. The release-metadata generator (`scripts/generate_release_metadata.py`) hardcoded a download-URL shape that the actual build/upload pipeline (`scripts/build_all_platforms.py` + `.github/workflows/enhanced-release.yml`) has never produced -- every generated `vX.Y.Z.json` has advertised 404s since the versioned-zip pipeline landed. Also aligned the in-zip feedback contact address with the website's, then extended (per Pip's follow-up) to add fail-loud verification tooling and a full-repo contact-address sweep.

## Root cause
**Generator bug**, not a hand-authored artifact. `generate_release_json()` in `scripts/generate_release_metadata.py` built URLs as `{base}/PDoom.exe`, `{base}/PDoom.x86_64`, `{base}/pdoom-<ver>-source.{zip,tar.gz}` -- names that don't match what `build_all_platforms.py` actually zips (`PDoom-Windows-<ver>.zip`, `PDoom-Linux-<ver>.zip`, `PDoom-macOS-<ver>.zip`) or what the workflow ever uploads. `mac` happened to work because an *unversioned* `PDoom.app.zip` also gets uploaded as a compatibility copy -- coincidence, not correctness. No source-archive assets are ever uploaded at all.

Fixed the generator (so every future tag is correct) **and** the already-published `v0.13.1.json` release asset (asset replace via `gh release upload --clobber`, not a retag) **and** the live release body's contact line (`gh release edit`), since the issue was reported against the live release, not just future ones.

## URLs: before -> after (verified against `gh release view v0.13.1 --json assets`)

| Field | Before (404) | After (200, verified with curl) |
|---|---|---|
| `downloads.windows` | `.../v0.13.1/PDoom.exe` | `.../v0.13.1/PDoom-Windows-v0.13.1.zip` |
| `downloads.linux` | `.../v0.13.1/PDoom.x86_64` | `.../v0.13.1/PDoom-Linux-v0.13.1.zip` |
| `downloads.mac` | `.../v0.13.1/PDoom.app.zip` (worked, but not the canonical/versioned asset) | `.../v0.13.1/PDoom-macOS-v0.13.1.zip` |
| `downloads.source_zip` | `.../v0.13.1/pdoom-0.13.1-source.zip` (no such asset, 404) | `https://github.com/PipFoweraker/pdoom1/archive/refs/tags/v0.13.1.zip` (GitHub codeload auto-archive, no upload needed) |
| `downloads.source_tar` | `.../v0.13.1/pdoom-0.13.1-source.tar.gz` (404) | `.../archive/refs/tags/v0.13.1.tar.gz` |

Actual v0.13.1 release assets (`gh release view v0.13.1 --json assets`): `PDoom-Linux-v0.13.1.zip`, `PDoom-macOS-v0.13.1.zip`, `PDoom-Windows-v0.13.1.zip`, `PDoom-Windows.zip`, `PDoom.app.zip`, `releases.json`, `releases.rss`, `release_manifest.json`, `v0.13.1.json`, `v0.9.0.json`. Confirmed each new URL 200s and each old URL 404s via `curl -sIL`.

---

## Extension 1: fail-loud anti-rot verification (Pip's follow-up)

The generator fix alone doesn't stop the next drift, so this adds actual verification instead of trusting the generator's output.

**New: `scripts/verify_release_urls.py`**
- `--file PATH`: HEADs every URL in one release JSON's `downloads` block, exits **nonzero on any non-200**. Blocking by design.
- `--sweep PATH`: walks a `releases.json` index and, for each entry, checks whether a matching GitHub **Release object** still exists -- via the Releases API (`api.github.com/repos/{repo}/releases/tags/{tag}`), **not** the tag page. This distinction matters: `https://github.com/PipFoweraker/pdoom1/releases/tag/v0.9.0` returns **200** even though the v0.9.0 release was deleted (`gh release view v0.9.0` -> "release not found") -- a naive tag-page check would have missed exactly the rot this mode exists to catch. The API endpoint correctly returns 404 for v0.9.0 and 200 for v0.13.1. Report-only by default (old entries rotting isn't this release's fault); `--strict` makes it blocking too.
- `generate_release_metadata.py` gets a `--verify` convenience flag that runs the `--file` check locally right after generating.

**Verified locally:**
```
$ python scripts/verify_release_urls.py --file public/releases/v0.13.1.json
  [OK] v0.13.1.windows      200   .../PDoom-Windows-v0.13.1.zip
  [OK] v0.13.1.linux        200   .../PDoom-Linux-v0.13.1.zip
  [OK] v0.13.1.mac          200   .../PDoom-macOS-v0.13.1.zip
  [OK] v0.13.1.source_zip   200   .../archive/refs/tags/v0.13.1.zip
  [OK] v0.13.1.source_tar   200   .../archive/refs/tags/v0.13.1.tar.gz
[OK] All download URLs for v0.13.1 resolve   (exit 0)

$ python scripts/verify_release_urls.py --sweep public/releases/releases.json
  [!] v0.9.0: no matching GitHub release (feed rot -- release is gone)
[!] 1 feed entry is rotten: v0.9.0
[*] --strict not set: old-entry rot is report-only, exiting 0   (exit 0, reported)

# synthetic 404 injected into a copy of v0.13.1.json:
$ python scripts/verify_release_urls.py --file bad.json
  [!] v0.13.1.windows      404 (Not Found)   .../PDoom.exe
[!] 1 broken URL(s) ...   (exit 1 -- confirmed it actually fails loud)
```

**Workflow wiring point**: `.github/workflows/enhanced-release.yml`, new job `verify-release-urls`, `needs: [create-github-release]`. This has to run *after* `create-github-release` (not in `generate-feeds`, which runs before assets are uploaded and would just check URLs that don't exist yet) -- matches the task's own hint about "whichever runs after assets upload." `pre-release-checks.yml` runs on tag-push *before* the build/upload, so it's the wrong home entirely.
- Step 1 (blocking): downloads the `release-feeds` artifact, runs `verify_release_urls.py --file public/releases/<tag>.json` against the just-published release. A future generator/pipeline mismatch fails this job -> fails the workflow run.
- Step 2 (`continue-on-error: true`, report-only): sweeps the committed `public/releases/releases.json` for rot, so old-release deletions get surfaced without blocking new releases from shipping.

## Extension 2: contact-address sweep (Pip ruled: standardize on `team@pdoom1.com`)

Swept the whole repo (`git grep` for `[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}`, plus a targeted `beacongcr` pass) for email addresses on any other domain.

**Files changed (product-facing addresses -> `team@pdoom1.com`):**
| File | Before |
|---|---|
| `tools/release_notes/HOW-TO-RUN-windows.txt` | `pip@beacongcr.org` (previous commit on this PR) |
| `tools/release_notes/HOW-TO-RUN-linux.txt` | `pip@beacongcr.org` (previous commit on this PR) |
| `tools/release_notes/HOW-TO-RUN-macos.txt` | `pip@beacongcr.org` (previous commit on this PR) |
| Live v0.13.1 release body (`gh release edit`) | `pip@beacongcr.org` (previous commit on this PR) |
| Live `v0.13.1.json` release asset (`gh release upload --clobber`) | n/a, URL-only (previous commit) |
| `godot/scripts/ui/bug_report_panel.gd` | `pip@beacongcr.org` in the in-game "email us your bug report" confirmation dialog -- **the first pass missed this one**, caught on the re-sweep |

Post-sweep, `git grep -in beacongcr` across the tracked tree returns nothing.

**Excluded (bot git-identity emails, not product contact addresses)**: `dev+blog-sync@pdoom.net` (`sync-dev-blog.yml`), `docs-sync+bot@pdoom.net` (`sync-documentation.yml`), `bot@pdoom.org` (`docs/WEBSITE_INTEGRATION.md`), plus `docs-sync@pdoom.net` / `dev@pdoom.net` in `docs/archive/**` and `docs/shared/CROSS_REPOSITORY_DOCUMENTATION_STRATEGY.md`. These are `git config user.email` values for CI bot commits, analogous to a noreply/Co-Authored-By convention -- not addresses a user would ever email. Flagging the `bot@pdoom.org` vs `*@pdoom.net` domain inconsistency as an FYI, not something I changed.

**Excluded (test fixtures / GitHub Actions bot identity / not-repo-owned)**: `email@example.com` (`docs/CONTRIBUTOR_SYSTEM.md`, placeholder), `test@example.com` / `testplayer@example.com` (test fixtures), `action@github.com` / `actions@github.com` (`github-actions[bot]` CI identity).

**Excluded (clearly personal-correspondence identities, not product contacts)**: the ~60 academic-paper author emails in `godot/data/historical_events.json` (e.g. `csummerfield@deepmind.com`, `hod.lipson@columbia.edu`) -- these are citation metadata for real AI-safety papers referenced in-game, not contact addresses for this project.

**Ambiguous -- flagging as a question rather than changing blind**:
- `docs/BACKEND_PRIVACY_ARCHITECTURE.md:377`: `privacy@pdoom.com` (note: `.com`, a *third* domain, distinct from both `pdoom1.com` and the bots' `pdoom.net`). This is inside a design doc with an "Implementation Checklist Phase 1" section reading as not-yet-built backend architecture, not a live policy. Should this become `team@pdoom1.com`, stay a separate `privacy@` alias once the domain is fixed to `pdoom1.com`, or is it stale/aspirational text that doesn't need to track the live decision at all? Left untouched pending your call.

## Not touched
`public/releases/v0.9.0.json` / the `v0.9.0.json` entry in `releases.json` -- the `v0.9.0` GitHub release itself no longer exists (confirmed via the new `--sweep` mode and directly via `gh release view v0.9.0` -> "release not found"), so regenerating it fixes nothing. This is exactly the rot the new report-only sweep now surfaces on every release going forward, rather than something to fix by hand here.

The `HOW-TO-RUN.txt` baked *inside* the already-uploaded v0.13.1 platform zips still has the old email (confirmed via `unzip -p`) -- fixing that requires re-cutting the release (rebuilding platform zips), out of scope per task instructions; future tags pick up the corrected template automatically.

## Test plan
- [x] `python -m black --check` on both touched/new Python files -- clean
- [x] `python scripts/generate_release_metadata.py --version v0.13.1 --verify` -- generates + verifies in one pass, exit 0
- [x] `verify_release_urls.py --file` tested against both the real v0.13.1.json (all 200, exit 0) and a synthetic-404 copy (exit 1) -- confirmed it actually fails loud
- [x] `verify_release_urls.py --sweep` tested against the committed `releases.json` -- correctly flags v0.9.0 as rotten, report-only exit 0
- [x] `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -- 941 tests, 0 failures, 93/93 files (ran because `godot/scripts/ui/bug_report_panel.gd` was touched)
- [x] `git status` clean of `.import`/`.uid` churn before each commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
