### PR TITLE
feat(effort): 4-way founder hours -- doors/approvals/audits/reserve + audit hours close #980

### DIFF
--- a/godot/data/actions/core.json
+++ b/godot/data/actions/core.json
@@ -24,10 +24,10 @@
 			"description": "Conduct AI safety research",
 			"costs": {
 				"research": 10,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "research"
+			"category": "research",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "capability_research",
@@ -35,10 +35,10 @@
 			"description": "Advance AI capabilities",
 			"costs": {
 				"research": 10,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "research"
+			"category": "research",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "publish_paper",
@@ -46,10 +46,10 @@
 			"description": "Publish research to raise global alarm (adopted safety concern)",
 			"costs": {
 				"research": 20,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "research"
+			"category": "research",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "fundraise",
@@ -73,13 +73,13 @@
 			"description": "Improve morale",
 			"costs": {
 				"money": 10000,
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
 			"category": "management",
 			"unlock_conditions": {
 				"staff_min": 2
-			}
+			},
+			"hour_type": "doors"
 		},
 		{
 			"id": "audit_safety",
@@ -87,13 +87,13 @@
 			"description": "Comprehensive safety review",
 			"costs": {
 				"money": 40000,
-				"attention": 2,
-				"hour_type": "audits"
+				"attention": 2
 			},
 			"category": "research",
 			"unlock_conditions": {
 				"turn_min": 5
-			}
+			},
+			"hour_type": "audits"
 		},
 		{
 			"id": "operations",

--- a/godot/data/actions/core.json
+++ b/godot/data/actions/core.json
@@ -24,7 +24,8 @@
 			"description": "Conduct AI safety research",
 			"costs": {
 				"research": 10,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "research"
 		},
@@ -34,7 +35,8 @@
 			"description": "Advance AI capabilities",
 			"costs": {
 				"research": 10,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "research"
 		},
@@ -44,7 +46,8 @@
 			"description": "Publish research to raise global alarm (adopted safety concern)",
 			"costs": {
 				"research": 20,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "research"
 		},
@@ -70,7 +73,8 @@
 			"description": "Improve morale",
 			"costs": {
 				"money": 10000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "management",
 			"unlock_conditions": {
@@ -83,7 +87,8 @@
 			"description": "Comprehensive safety review",
 			"costs": {
 				"money": 40000,
-				"attention": 2
+				"attention": 2,
+				"hour_type": "audits"
 			},
 			"category": "research",
 			"unlock_conditions": {

--- a/godot/data/actions/financing.json
+++ b/godot/data/actions/financing.json
@@ -6,30 +6,30 @@
 			"name": "Take Loan",
 			"description": "+$50k now; a balloon repayment (~$60k) bills in 4 turns and compounds until paid.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
-			"category": "financing"
+			"category": "financing",
+			"hour_type": "doors"
 		},
 		{
 			"id": "funding_strings",
 			"name": "Funding (Strings)",
 			"description": "+$40k now; a governance obligation bills in 6 turns.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
-			"category": "financing"
+			"category": "financing",
+			"hour_type": "doors"
 		},
 		{
 			"id": "desperation_lever",
 			"name": "Desperation Lever",
 			"description": "Suppress doom now; plants a SECRET, compounding governance liability that rivals can expose.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "financing"
+			"category": "financing",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "staff_rider",
@@ -37,40 +37,40 @@
 			"description": "+2 action points now; a small governance rider bills later.",
 			"costs": {
 				"money": 15000,
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
-			"category": "financing"
+			"category": "financing",
+			"hour_type": "doors"
 		},
 		{
 			"id": "seek_financing",
 			"name": "Seek Financing",
 			"description": "Run a raise (ADR-0013): the cost-of-debt engine quotes 2-3 concurrent offers priced by org type, counterparty, reputation and leverage. Offers stand until they expire; accept at plan speed.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
-			"category": "financing"
+			"category": "financing",
+			"hour_type": "doors"
 		},
 		{
 			"id": "accept_financing_offer",
 			"name": "Accept Offer",
 			"description": "Accept a standing financing offer by id (from Seek Financing) -- cash now, its quoted terms mint a ledger entry.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "financing"
+			"category": "financing",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "pay_bills",
 			"name": "Pay the Bill",
 			"description": "Settle the soonest-due affordable loan early from cash (#566), retiring its balloon before it bills.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "financing"
+			"category": "financing",
+			"hour_type": "approvals"
 		}
 	]
 }

--- a/godot/data/actions/financing.json
+++ b/godot/data/actions/financing.json
@@ -6,7 +6,8 @@
 			"name": "Take Loan",
 			"description": "+$50k now; a balloon repayment (~$60k) bills in 4 turns and compounds until paid.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "financing"
 		},
@@ -15,7 +16,8 @@
 			"name": "Funding (Strings)",
 			"description": "+$40k now; a governance obligation bills in 6 turns.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "financing"
 		},
@@ -24,7 +26,8 @@
 			"name": "Desperation Lever",
 			"description": "Suppress doom now; plants a SECRET, compounding governance liability that rivals can expose.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "financing"
 		},
@@ -34,7 +37,8 @@
 			"description": "+2 action points now; a small governance rider bills later.",
 			"costs": {
 				"money": 15000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "financing"
 		},
@@ -43,7 +47,8 @@
 			"name": "Seek Financing",
 			"description": "Run a raise (ADR-0013): the cost-of-debt engine quotes 2-3 concurrent offers priced by org type, counterparty, reputation and leverage. Offers stand until they expire; accept at plan speed.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "financing"
 		},
@@ -52,7 +57,8 @@
 			"name": "Accept Offer",
 			"description": "Accept a standing financing offer by id (from Seek Financing) -- cash now, its quoted terms mint a ledger entry.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "financing"
 		},
@@ -61,7 +67,8 @@
 			"name": "Pay the Bill",
 			"description": "Settle the soonest-due affordable loan early from cash (#566), retiring its balloon before it bills.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "financing"
 		}

--- a/godot/data/actions/fundraising.json
+++ b/godot/data/actions/fundraising.json
@@ -7,14 +7,14 @@
 			"description": "Conservative fundraising - lower amounts, lower risk, always available",
 			"costs": {
 				"attention": 1,
-				"reputation": 2,
-				"hour_type": "doors"
+				"reputation": 2
 			},
 			"gains": {
 				"money_min": 30000,
 				"money_max": 60000
 			},
-			"category": "funding"
+			"category": "funding",
+			"hour_type": "doors"
 		},
 		{
 			"id": "fundraise_big",
@@ -22,28 +22,28 @@
 			"description": "Aggressive funding - higher amounts but requires strong reputation",
 			"costs": {
 				"attention": 2,
-				"reputation": 8,
-				"hour_type": "doors"
+				"reputation": 8
 			},
 			"gains": {
 				"money_min": 80000,
 				"money_max": 150000
 			},
-			"category": "funding"
+			"category": "funding",
+			"hour_type": "doors"
 		},
 		{
 			"id": "take_loan",
 			"name": "Business Loan",
 			"description": "Immediate funds via debt - creates future repayment obligation",
 			"costs": {
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
 			"gains": {
 				"money": 75000,
 				"debt": 90000
 			},
-			"category": "funding"
+			"category": "funding",
+			"hour_type": "doors"
 		},
 		{
 			"id": "apply_grant",
@@ -51,14 +51,14 @@
 			"description": "Government/foundation funding - requires published papers",
 			"costs": {
 				"attention": 1,
-				"papers": 1,
-				"hour_type": "approvals"
+				"papers": 1
 			},
 			"gains": {
 				"money_min": 50000,
 				"money_max": 100000
 			},
-			"category": "funding"
+			"category": "funding",
+			"hour_type": "approvals"
 		}
 	]
 }

--- a/godot/data/actions/fundraising.json
+++ b/godot/data/actions/fundraising.json
@@ -7,7 +7,8 @@
 			"description": "Conservative fundraising - lower amounts, lower risk, always available",
 			"costs": {
 				"attention": 1,
-				"reputation": 2
+				"reputation": 2,
+				"hour_type": "doors"
 			},
 			"gains": {
 				"money_min": 30000,
@@ -21,7 +22,8 @@
 			"description": "Aggressive funding - higher amounts but requires strong reputation",
 			"costs": {
 				"attention": 2,
-				"reputation": 8
+				"reputation": 8,
+				"hour_type": "doors"
 			},
 			"gains": {
 				"money_min": 80000,
@@ -34,7 +36,8 @@
 			"name": "Business Loan",
 			"description": "Immediate funds via debt - creates future repayment obligation",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"gains": {
 				"money": 75000,
@@ -48,7 +51,8 @@
 			"description": "Government/foundation funding - requires published papers",
 			"costs": {
 				"attention": 1,
-				"papers": 1
+				"papers": 1,
+				"hour_type": "approvals"
 			},
 			"gains": {
 				"money_min": 50000,

--- a/godot/data/actions/hiring.json
+++ b/godot/data/actions/hiring.json
@@ -7,7 +7,8 @@
 			"description": "Focused on AI safety and alignment research",
 			"costs": {
 				"money": 60000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "hiring"
 		},
@@ -17,7 +18,8 @@
 			"description": "Advances AI capabilities (increases doom!)",
 			"costs": {
 				"money": 60000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "hiring"
 		},
@@ -27,7 +29,8 @@
 			"description": "Improves compute efficiency",
 			"costs": {
 				"money": 50000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "hiring"
 		},
@@ -37,7 +40,8 @@
 			"description": "Oversees a team of up to 8 researchers",
 			"costs": {
 				"money": 80000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "hiring"
 		},
@@ -47,7 +51,8 @@
 			"description": "Add philosophical perspective to research (+5 reputation)",
 			"costs": {
 				"money": 70000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "hiring"
 		},
@@ -57,7 +62,8 @@
 			"description": "Probes how models work internally (safety-aligned research)",
 			"costs": {
 				"money": 60000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "hiring"
 		},
@@ -67,7 +73,8 @@
 			"description": "Aligns AI goals with human values (safety-aligned research)",
 			"costs": {
 				"money": 60000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "hiring"
 		}

--- a/godot/data/actions/hiring.json
+++ b/godot/data/actions/hiring.json
@@ -7,10 +7,10 @@
 			"description": "Focused on AI safety and alignment research",
 			"costs": {
 				"money": 60000,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "hiring"
+			"category": "hiring",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "hire_capability_researcher",
@@ -18,10 +18,10 @@
 			"description": "Advances AI capabilities (increases doom!)",
 			"costs": {
 				"money": 60000,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "hiring"
+			"category": "hiring",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "hire_compute_engineer",
@@ -29,10 +29,10 @@
 			"description": "Improves compute efficiency",
 			"costs": {
 				"money": 50000,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "hiring"
+			"category": "hiring",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "hire_manager",
@@ -40,10 +40,10 @@
 			"description": "Oversees a team of up to 8 researchers",
 			"costs": {
 				"money": 80000,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "hiring"
+			"category": "hiring",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "hire_ethicist",
@@ -51,10 +51,10 @@
 			"description": "Add philosophical perspective to research (+5 reputation)",
 			"costs": {
 				"money": 70000,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "hiring"
+			"category": "hiring",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "hire_interpretability_researcher",
@@ -62,10 +62,10 @@
 			"description": "Probes how models work internally (safety-aligned research)",
 			"costs": {
 				"money": 60000,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "hiring"
+			"category": "hiring",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "hire_alignment_researcher",
@@ -73,10 +73,10 @@
 			"description": "Aligns AI goals with human values (safety-aligned research)",
 			"costs": {
 				"money": 60000,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "hiring"
+			"category": "hiring",
+			"hour_type": "approvals"
 		}
 	]
 }

--- a/godot/data/actions/office.json
+++ b/godot/data/actions/office.json
@@ -6,40 +6,40 @@
 			"name": "Tour Offices",
 			"description": "Go and look at what is on the market. Three landlords will quote you terms; the offers stand for a while.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
-			"category": "office"
+			"category": "office",
+			"hour_type": "doors"
 		},
 		{
 			"id": "sign_lease_coworking_corner",
 			"name": "Sign: Co-working corner",
 			"description": "Cheap in, cheap out, low ceiling. Requires a current quote (tour first).",
 			"costs": {
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "office"
+			"category": "office",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "sign_lease_walkup_office",
 			"name": "Sign: Walk-up office",
 			"description": "Middle of everything -- more desks, more rent, a year on the term. Requires a current quote.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "office"
+			"category": "office",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "sign_lease_university_annex",
 			"name": "Sign: University annex",
 			"description": "The cheapest desk in town if you last two years. Big deposit. Requires a current quote.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "office"
+			"category": "office",
+			"hour_type": "approvals"
 		}
 	]
 }

--- a/godot/data/actions/office.json
+++ b/godot/data/actions/office.json
@@ -6,7 +6,8 @@
 			"name": "Tour Offices",
 			"description": "Go and look at what is on the market. Three landlords will quote you terms; the offers stand for a while.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "office"
 		},
@@ -15,7 +16,8 @@
 			"name": "Sign: Co-working corner",
 			"description": "Cheap in, cheap out, low ceiling. Requires a current quote (tour first).",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "office"
 		},
@@ -24,7 +26,8 @@
 			"name": "Sign: Walk-up office",
 			"description": "Middle of everything -- more desks, more rent, a year on the term. Requires a current quote.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "office"
 		},
@@ -33,7 +36,8 @@
 			"name": "Sign: University annex",
 			"description": "The cheapest desk in town if you last two years. Big deposit. Requires a current quote.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "office"
 		}

--- a/godot/data/actions/operations.json
+++ b/godot/data/actions/operations.json
@@ -7,10 +7,10 @@
 			"description": "Restock stationery (+50 supplies). Staff consume supplies each turn.",
 			"costs": {
 				"money": 2000,
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
-			"category": "operations"
+			"category": "operations",
+			"hour_type": "doors"
 		},
 		{
 			"id": "office_maintenance",
@@ -18,10 +18,20 @@
 			"description": "Routine repairs and cleaning. Improves morale slightly.",
 			"costs": {
 				"money": 5000,
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
-			"category": "operations"
+			"category": "operations",
+			"hour_type": "doors"
+		},
+		{
+			"id": "audit_self_directed",
+			"name": "Audit Self-Directed Work",
+			"description": "Go and look. Unassigned staff report their own progress optimistically -- an audit hour ground-truths the biggest claimed-vs-true gap and corrects the books. Impossible while away.",
+			"costs": {
+				"attention": 1
+			},
+			"category": "operations",
+			"hour_type": "audits"
 		}
 	]
 }

--- a/godot/data/actions/operations.json
+++ b/godot/data/actions/operations.json
@@ -7,7 +7,8 @@
 			"description": "Restock stationery (+50 supplies). Staff consume supplies each turn.",
 			"costs": {
 				"money": 2000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "operations"
 		},
@@ -17,7 +18,8 @@
 			"description": "Routine repairs and cleaning. Improves morale slightly.",
 			"costs": {
 				"money": 5000,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "operations"
 		}

--- a/godot/data/actions/publicity.json
+++ b/godot/data/actions/publicity.json
@@ -6,7 +6,8 @@
 			"name": "Networking",
 			"description": "Build relationships and connections in the AI safety community",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "influence"
 		},
@@ -16,7 +17,8 @@
 			"description": "Public outreach through press and social media",
 			"costs": {
 				"money": 30000,
-				"attention": 2
+				"attention": 2,
+				"hour_type": "doors"
 			},
 			"category": "influence"
 		},
@@ -26,7 +28,8 @@
 			"description": "Advocate for AI safety regulation (costly but impactful)",
 			"costs": {
 				"money": 80000,
-				"attention": 2
+				"attention": 2,
+				"hour_type": "doors"
 			},
 			"category": "influence"
 		},
@@ -36,7 +39,8 @@
 			"description": "Warn public about AI risks - risky but high impact",
 			"costs": {
 				"attention": 2,
-				"reputation": 15
+				"reputation": 15,
+				"hour_type": "approvals"
 			},
 			"category": "influence"
 		},
@@ -46,7 +50,8 @@
 			"description": "Release safety research publicly for community benefit",
 			"costs": {
 				"papers": 3,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "influence"
 		}

--- a/godot/data/actions/publicity.json
+++ b/godot/data/actions/publicity.json
@@ -6,10 +6,10 @@
 			"name": "Networking",
 			"description": "Build relationships and connections in the AI safety community",
 			"costs": {
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
-			"category": "influence"
+			"category": "influence",
+			"hour_type": "doors"
 		},
 		{
 			"id": "media_campaign",
@@ -17,10 +17,10 @@
 			"description": "Public outreach through press and social media",
 			"costs": {
 				"money": 30000,
-				"attention": 2,
-				"hour_type": "doors"
+				"attention": 2
 			},
-			"category": "influence"
+			"category": "influence",
+			"hour_type": "doors"
 		},
 		{
 			"id": "lobby_government",
@@ -28,10 +28,10 @@
 			"description": "Advocate for AI safety regulation (costly but impactful)",
 			"costs": {
 				"money": 80000,
-				"attention": 2,
-				"hour_type": "doors"
+				"attention": 2
 			},
-			"category": "influence"
+			"category": "influence",
+			"hour_type": "doors"
 		},
 		{
 			"id": "release_warning",
@@ -39,10 +39,10 @@
 			"description": "Warn public about AI risks - risky but high impact",
 			"costs": {
 				"attention": 2,
-				"reputation": 15,
-				"hour_type": "approvals"
+				"reputation": 15
 			},
-			"category": "influence"
+			"category": "influence",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "open_source_release",
@@ -50,10 +50,10 @@
 			"description": "Release safety research publicly for community benefit",
 			"costs": {
 				"papers": 3,
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "influence"
+			"category": "influence",
+			"hour_type": "approvals"
 		}
 	]
 }

--- a/godot/data/actions/scouting.json
+++ b/godot/data/actions/scouting.json
@@ -6,10 +6,10 @@
 			"name": "Read the Literature",
 			"description": "Sit down with the arxiv firehose. Slow, free, and the only scouting that makes you better at the actual work.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "scouting"
+			"category": "scouting",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "scout_meetups",
@@ -17,20 +17,20 @@
 			"description": "Drinks, badges, a talk you half-listen to. People remember you, and sometimes one of them is looking for a job.",
 			"costs": {
 				"attention": 1,
-				"money": 300,
-				"hour_type": "doors"
+				"money": 300
 			},
-			"category": "scouting"
+			"category": "scouting",
+			"hour_type": "doors"
 		},
 		{
 			"id": "scout_shitpost",
 			"name": "Post Online",
 			"description": "Be loud. Hype is not respect -- it buys you attention from people who fund things and costs you standing with people who read things.",
 			"costs": {
-				"attention": 1,
-				"hour_type": "approvals"
+				"attention": 1
 			},
-			"category": "scouting"
+			"category": "scouting",
+			"hour_type": "approvals"
 		}
 	]
 }

--- a/godot/data/actions/scouting.json
+++ b/godot/data/actions/scouting.json
@@ -6,7 +6,8 @@
 			"name": "Read the Literature",
 			"description": "Sit down with the arxiv firehose. Slow, free, and the only scouting that makes you better at the actual work.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "scouting"
 		},
@@ -16,7 +17,8 @@
 			"description": "Drinks, badges, a talk you half-listen to. People remember you, and sometimes one of them is looking for a job.",
 			"costs": {
 				"attention": 1,
-				"money": 300
+				"money": 300,
+				"hour_type": "doors"
 			},
 			"category": "scouting"
 		},
@@ -25,7 +27,8 @@
 			"name": "Post Online",
 			"description": "Be loud. Hype is not respect -- it buys you attention from people who fund things and costs you standing with people who read things.",
 			"costs": {
-				"attention": 1
+				"attention": 1,
+				"hour_type": "approvals"
 			},
 			"category": "scouting"
 		}

--- a/godot/data/actions/strategic.json
+++ b/godot/data/actions/strategic.json
@@ -7,10 +7,10 @@
 			"description": "Buy struggling AI startup for talent and compute",
 			"costs": {
 				"money": 150000,
-				"attention": 2,
-				"hour_type": "doors"
+				"attention": 2
 			},
-			"category": "strategic"
+			"category": "strategic",
+			"hour_type": "doors"
 		},
 		{
 			"id": "sabotage_competitor",
@@ -19,10 +19,10 @@
 			"costs": {
 				"money": 100000,
 				"attention": 3,
-				"reputation": 20,
-				"hour_type": "doors"
+				"reputation": 20
 			},
-			"category": "strategic"
+			"category": "strategic",
+			"hour_type": "doors"
 		},
 		{
 			"id": "emergency_pivot",
@@ -30,10 +30,10 @@
 			"description": "Convert capability researchers to safety focus",
 			"costs": {
 				"money": 50000,
-				"attention": 2,
-				"hour_type": "approvals"
+				"attention": 2
 			},
-			"category": "strategic"
+			"category": "strategic",
+			"hour_type": "approvals"
 		},
 		{
 			"id": "grant_proposal",
@@ -41,10 +41,10 @@
 			"description": "Apply for government/foundation funding",
 			"costs": {
 				"attention": 1,
-				"papers": 1,
-				"hour_type": "approvals"
+				"papers": 1
 			},
-			"category": "strategic"
+			"category": "strategic",
+			"hour_type": "approvals"
 		}
 	]
 }

--- a/godot/data/actions/strategic.json
+++ b/godot/data/actions/strategic.json
@@ -7,7 +7,8 @@
 			"description": "Buy struggling AI startup for talent and compute",
 			"costs": {
 				"money": 150000,
-				"attention": 2
+				"attention": 2,
+				"hour_type": "doors"
 			},
 			"category": "strategic"
 		},
@@ -18,7 +19,8 @@
 			"costs": {
 				"money": 100000,
 				"attention": 3,
-				"reputation": 20
+				"reputation": 20,
+				"hour_type": "doors"
 			},
 			"category": "strategic"
 		},
@@ -28,7 +30,8 @@
 			"description": "Convert capability researchers to safety focus",
 			"costs": {
 				"money": 50000,
-				"attention": 2
+				"attention": 2,
+				"hour_type": "approvals"
 			},
 			"category": "strategic"
 		},
@@ -38,7 +41,8 @@
 			"description": "Apply for government/foundation funding",
 			"costs": {
 				"attention": 1,
-				"papers": 1
+				"papers": 1,
+				"hour_type": "approvals"
 			},
 			"category": "strategic"
 		}

--- a/godot/data/actions/travel.json
+++ b/godot/data/actions/travel.json
@@ -7,41 +7,39 @@
 			"description": "Submit research paper to a conference (multi-turn review process)",
 			"costs": {
 				"research": 15,
-				"attention": 1,
-				"hour_type": "doors"
+				"attention": 1
 			},
-			"category": "travel"
+			"category": "travel",
+			"hour_type": "doors"
 		},
 		{
 			"id": "attend_conference",
 			"name": "Attend Conference",
 			"description": "[Coming Soon] Travel to present accepted paper or network at a conference -- day-bound scheduling is not available yet",
 			"costs": {
-				"attention": 2,
-				"hour_type": "doors"
+				"attention": 2
 			},
 			"category": "travel",
-			"is_stub": true
+			"is_stub": true,
+			"hour_type": "doors"
 		},
 		{
 			"id": "attend_conference_trip",
 			"name": "Attend Conference (trip)",
 			"description": "Leave for a few days. Travel cash up front, ALL your remaining Attention for the window, and the world keeps running while you are gone -- you come home to a backlog.",
-			"costs": {
-				"hour_type": "doors"
-			},
+			"costs": {},
 			"category": "travel",
-			"_seam": "ADR-0014 rhythm-break SHELL (scripts/core/conference_trip.gd). Costs are {} on purpose: travel cash and Attention are consumed by ConferenceTrip at commit time, not by the plan queue, because the trip resolves synchronously instead of queueing. The legacy instant attend_conference (#468/#469) above is untouched -- the two merge when adoption-v1 lands."
+			"_seam": "ADR-0014 rhythm-break SHELL (scripts/core/conference_trip.gd). Costs are {} on purpose: travel cash and Attention are consumed by ConferenceTrip at commit time, not by the plan queue, because the trip resolves synchronously instead of queueing. The legacy instant attend_conference (#468/#469) above is untouched -- the two merge when adoption-v1 lands.",
+			"hour_type": "doors"
 		},
 		{
 			"id": "send_delegation",
 			"name": "Send Delegation",
 			"description": "[Coming Soon] Send researchers to attend on your behalf",
-			"costs": {
-				"hour_type": "approvals"
-			},
+			"costs": {},
 			"category": "travel",
-			"is_stub": true
+			"is_stub": true,
+			"hour_type": "approvals"
 		}
 	]
 }

--- a/godot/data/actions/travel.json
+++ b/godot/data/actions/travel.json
@@ -7,7 +7,8 @@
 			"description": "Submit research paper to a conference (multi-turn review process)",
 			"costs": {
 				"research": 15,
-				"attention": 1
+				"attention": 1,
+				"hour_type": "doors"
 			},
 			"category": "travel"
 		},
@@ -16,7 +17,8 @@
 			"name": "Attend Conference",
 			"description": "[Coming Soon] Travel to present accepted paper or network at a conference -- day-bound scheduling is not available yet",
 			"costs": {
-				"attention": 2
+				"attention": 2,
+				"hour_type": "doors"
 			},
 			"category": "travel",
 			"is_stub": true
@@ -25,7 +27,9 @@
 			"id": "attend_conference_trip",
 			"name": "Attend Conference (trip)",
 			"description": "Leave for a few days. Travel cash up front, ALL your remaining Attention for the window, and the world keeps running while you are gone -- you come home to a backlog.",
-			"costs": {},
+			"costs": {
+				"hour_type": "doors"
+			},
 			"category": "travel",
 			"_seam": "ADR-0014 rhythm-break SHELL (scripts/core/conference_trip.gd). Costs are {} on purpose: travel cash and Attention are consumed by ConferenceTrip at commit time, not by the plan queue, because the trip resolves synchronously instead of queueing. The legacy instant attend_conference (#468/#469) above is untouched -- the two merge when adoption-v1 lands."
 		},
@@ -33,7 +37,9 @@
 			"id": "send_delegation",
 			"name": "Send Delegation",
 			"description": "[Coming Soon] Send researchers to attend on your behalf",
-			"costs": {},
+			"costs": {
+				"hour_type": "approvals"
+			},
 			"category": "travel",
 			"is_stub": true
 		}

--- a/godot/data/icon_mapping.json
+++ b/godot/data/icon_mapping.json
@@ -55,6 +55,11 @@
       "icon": "res://assets/icons/employee_roles/employee_role_auditor_64.png",
       "status": "mapped"
     },
+    "audit_self_directed": {
+      "icon": "res://assets/icons/employee_roles/employee_role_auditor_64.png",
+      "status": "mapped",
+      "note": "shares the auditor icon with audit_safety -- both are the AUDITS founder-hour kind (Ballot 4); a dedicated skip-level/ground-truthing icon is queued"
+    },
     "lobby_government": {
       "icon": "res://assets/icons/actions_publicity/lobby_government_64.png",
       "status": "mapped",

--- a/godot/scripts/core/actions.gd
+++ b/godot/scripts/core/actions.gd
@@ -38,17 +38,28 @@ static func attention_cost(action: Dictionary) -> int:
 
 
 static func hour_type(action: Dictionary) -> String:
-	"""Which founder hour token an action bills. Data may declare `costs.hour_type` as either
-	a 2-way FAMILY ("planning" | "operating") or a 4-way KIND ("doors" | "approvals" |
-	"audits" | "reserve"); both are returned verbatim because MonthPlan.family_of/kind_of
-	resolve either. Unrecognised values fall back to the family default.
+	"""Which founder hour token an action bills. Declared as a 2-way FAMILY ("planning" |
+	"operating") or a 4-way KIND ("doors" | "approvals" | "audits" | "reserve"); both are
+	returned verbatim because MonthPlan.family_of/kind_of resolve either. Unrecognised values
+	fall back to the family default.
+
+	WHERE IT LIVES -- read the TOP-LEVEL `hour_type` field first, `costs.hour_type` second.
+	The 4-way lane MOVED action-def typing out of the cost dict: an hour type is a property
+	of the ACTION, not a resource price, and living inside `costs` meant every site that
+	iterates cost key/value pairs numerically tripped over a String (it broke the fresh-game
+	action render and test_bug_fixes' non-negative-costs sweep the moment the data pass
+	landed -- exactly the trap actions.gd:273 / main_ui.gd:1730 / plan_controller.gd:48 were
+	each patching one at a time). `costs.hour_type` survives as the fallback because a BARE
+	cost dict (a code-side subsystem charge with no action def) has nowhere else to put it;
+	that channel is read by GameState._cost_hour_type.
 
 	DEFAULT for a queued strategic action is PLANNING (booked as `approvals`) -- picking what
 	the org does next is planner mind, not presence (the #980 seam: that is exactly the part
-	you keep while away). Presence work declares "operating"/"doors"/"audits" in its data.
+	you keep while away). Presence work declares "doors"/"audits"/"operating" in its data.
 	KEPT (not fixed) from T2 judgment call 4: this default is PLANNING while the bare-cost-
 	dict default in GameState._cost_hour_type is OPERATING. See that function's note."""
-	var declared: String = String(action.get("costs", {}).get("hour_type", MonthPlan.HOUR_PLANNING))
+	var fallback: Variant = action.get("costs", {}).get("hour_type", MonthPlan.HOUR_PLANNING)
+	var declared: String = String(action.get("hour_type", fallback))
 	if MonthPlan.KIND_FAMILY.has(declared):
 		return declared
 	if declared == MonthPlan.HOUR_OPERATING:
@@ -294,6 +305,14 @@ static func execute_action(action_id: String, state: GameState) -> Dictionary:
 		"pass":
 			# Do nothing action - just waste the action point with no effect
 			result["message"] = "Passed this action. No resources spent."
+
+		"audit_self_directed":
+			# The AUDITS founder-hour kind, cashed out (Ballot 4). Attention was already
+			# debited at queue time by GameManager, so charge=false here.
+			var audit: Dictionary = state.audit_self_directed("", false)
+			result["success"] = bool(audit.get("ok", false))
+			result["message"] = String(audit.get("message", ""))
+			result["audit"] = audit
 
 		"hire_staff":
 			# Submenu action - doesn't execute, opens dialog

--- a/godot/scripts/core/actions.gd
+++ b/godot/scripts/core/actions.gd
@@ -38,11 +38,19 @@ static func attention_cost(action: Dictionary) -> int:
 
 
 static func hour_type(action: Dictionary) -> String:
-	"""Which founder hour type an action bills. Data may declare `costs.hour_type`; the
-	DEFAULT for a queued strategic action is PLANNING -- picking what the org does next is
-	planner mind, not presence (the #980 seam: that is exactly the part you keep while
-	away). Actions that are inherently presence work declare "operating" in their data."""
+	"""Which founder hour token an action bills. Data may declare `costs.hour_type` as either
+	a 2-way FAMILY ("planning" | "operating") or a 4-way KIND ("doors" | "approvals" |
+	"audits" | "reserve"); both are returned verbatim because MonthPlan.family_of/kind_of
+	resolve either. Unrecognised values fall back to the family default.
+
+	DEFAULT for a queued strategic action is PLANNING (booked as `approvals`) -- picking what
+	the org does next is planner mind, not presence (the #980 seam: that is exactly the part
+	you keep while away). Presence work declares "operating"/"doors"/"audits" in its data.
+	KEPT (not fixed) from T2 judgment call 4: this default is PLANNING while the bare-cost-
+	dict default in GameState._cost_hour_type is OPERATING. See that function's note."""
 	var declared: String = String(action.get("costs", {}).get("hour_type", MonthPlan.HOUR_PLANNING))
+	if MonthPlan.KIND_FAMILY.has(declared):
+		return declared
 	if declared == MonthPlan.HOUR_OPERATING:
 		return MonthPlan.HOUR_OPERATING
 	return MonthPlan.HOUR_PLANNING

--- a/godot/scripts/core/conference_trip.gd
+++ b/godot/scripts/core/conference_trip.gd
@@ -218,7 +218,11 @@ static func collect_tick(backlog: Array, turn: int, tick_result: Dictionary) -> 
 			"kind": "month_opened",
 			"turn": turn,
 			"name": "A new month opened while you were away",
-			"message": "The month's Attention grant went unplanned -- you were not there to spend it.",
+			# COPY UPDATED WITH #980 (4-way lane). The old line ("the grant went unplanned")
+			# is literally false now: travel drains the OPERATING family only, so the
+			# planning half of the grant survives the boundary and next month's direction is
+			# still decidable from the road. What is gone is presence: doors and audits.
+			"message": "The month opened with nobody in the building -- its doors and audit hours are gone. Next month's direction is still yours to set.",
 		})
 
 	for released in tick_result.get("released", []):
@@ -260,6 +264,14 @@ static func _consume_founder_capacity(state: GameState) -> int:
 	PLANNER MIND. So the trip drains only the OPERATING pool, and drains it with overflow
 	FORBIDDEN -- travel must never eat the planning hours that let you decide next month's
 	direction from a hotel room. Everything else about the trip's cost model is unchanged.
+
+	==== 4-WAY LANE (Ballot 4) ====
+	No code change was needed here, and that is the point: `doors` and `audits` both live in
+	the OPERATING family (MonthPlan.KIND_FAMILY), so draining that family kills exactly the
+	two presence kinds -- you cannot hold a stakeholder room you are not in, and you cannot
+	skip-level ground-truth a researcher from a conference floor. `approvals` (the PLANNING
+	family) survives untouched, which IS #980's "planner mind, not operator presence". The
+	`month_opened` backlog copy above was rewritten to stop asserting the pre-#980 rule.
 	Returns the Attention actually consumed (for the return panel's honesty about the cost)."""
 	if state.month_plan == null:
 		return 0

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -952,6 +952,65 @@ func record_self_directed(topic_key: String, actual: float, reported: float) -> 
 	self_directed_progress[topic_key] = bucket
 
 
+func audit_self_directed(topic_key: String = "", charge: bool = true) -> Dictionary:
+	"""Spend a founder AUDIT hour to ground-truth one topic's self-directed progress.
+
+	This is the consumer the T1 substrate left a SEAM for at every touch point
+	(researcher.gd:129, record_self_directed above): unassigned staff self-direct and report
+	OPTIMISTICALLY, and until now nothing read `reported`. An audit is skip-level
+	ground-truthing -- the founder goes and looks -- so it bills the `audits` kind, which
+	sits in the OPERATING family and is therefore impossible while away (#980 falls out).
+
+	`topic_key` empty audits the topic with the LARGEST claimed-vs-true gap, tie-broken by
+	sorted key. Deterministic, no RNG source touched -- the optimism factor is already a
+	per-person hash (researcher.gd:632) and this only reads it.
+
+	EFFECT (the conservative S-cut answer to the ADR's open 'what do audits audit'): the
+	audited topic's ORG-LEVEL books are corrected -- `reported` collapses onto `actual`, so
+	the gap closes and cannot be double-counted by a later reader. Deliberately NOT taken:
+	reputation/trust penalties or departure risk against the individual (needs a target
+	system that does not exist pre-T4), and per-person `self_directed_reported` is left
+	alone on purpose -- an audit corrects what the ORG believes, not what the person
+	claimed. Returns {ok, topic, actual, reported, gap, message}."""
+	if month_plan == null:
+		return {"ok": false, "topic": "", "gap": 0.0, "message": "No month plan -- nothing to audit."}
+	if self_directed_progress.is_empty():
+		return {"ok": false, "topic": "", "gap": 0.0, "message": "Nobody is self-directing -- there is nothing to ground-truth."}
+	var target: String = topic_key
+	if target == "":
+		var topics: Array = self_directed_progress.keys()
+		topics.sort()  # order-stable pick regardless of Dictionary iteration order
+		var best_gap: float = -1.0
+		for t in topics:
+			var b: Dictionary = self_directed_progress[t]
+			var g: float = float(b.get("reported", 0.0)) - float(b.get("actual", 0.0))
+			if g > best_gap:
+				best_gap = g
+				target = String(t)
+	if not self_directed_progress.has(target):
+		return {"ok": false, "topic": target, "gap": 0.0, "message": "No self-directed work recorded on that topic."}
+	# `charge` false when the caller already paid at QUEUE time (the action path: GameManager
+	# debits the month plan when the card is queued, execute_action only applies the effect).
+	if charge and not month_plan.spend_attention(1, MonthPlan.KIND_AUDITS):
+		return {"ok": false, "topic": target, "gap": 0.0, "message": "No founder hours left to audit with."}
+	var bucket: Dictionary = self_directed_progress[target]
+	var actual: float = float(bucket.get("actual", 0.0))
+	var reported: float = float(bucket.get("reported", 0.0))
+	var gap: float = DoomSystem._snap(reported - actual)
+	bucket["reported"] = DoomSystem._snap(actual)
+	self_directed_progress[target] = bucket
+	return {
+		"ok": true,
+		"topic": target,
+		"actual": actual,
+		"reported": reported,
+		"gap": gap,
+		"message": "Audited %s: claimed %.1f, actually %.1f (overstated by %.1f). Books corrected." % [
+			target, reported, actual, gap,
+		],
+	}
+
+
 func workstream_readout() -> Array[String]:
 	"""Minimal ASCII debug readout for this lane (the plan-screen assignment verb is a
 	separate UI carve). Lists running workstreams, then the self-directed drift with the

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -536,10 +536,25 @@ func can_afford(costs: Dictionary) -> bool:
 
 
 func _cost_hour_type(costs: Dictionary) -> String:
-	"""Which founder hour type a cost dict bills. Data may name it explicitly with an
-	`hour_type` key ("planning" | "operating"); anything else is OPERATING (presence work).
-	Kept in ONE place so the later 4-way lane subdivides here, not at 40 call sites."""
+	"""Which founder hour token a cost dict bills. Data may name it explicitly with an
+	`hour_type` key -- either a 2-way FAMILY ("planning" | "operating") or a 4-way KIND
+	("doors" | "approvals" | "audits" | "reserve"); MonthPlan.family_of/kind_of resolve
+	either. Anything unrecognised is OPERATING (presence work).
+	This is ONE of the two subdivision points the 4-way lane widened (the other is
+	GameActions.hour_type); the 40 call sites stayed untouched.
+
+	DEFAULT ASYMMETRY -- KEPT DELIBERATELY (T2 judgment call 4, re-examined by this lane and
+	upheld). A bare cost dict handed to spend_resources defaults to OPERATING; a queued
+	ACTION defaults to PLANNING. Rationale unchanged: queuing is deciding, whereas an
+	un-typed subsystem charge (hiring, ledger, media) is somebody physically doing a thing.
+	The alternative -- one default everywhere -- would silently re-type either every
+	subsystem charge or every strategic card, i.e. a balance change disguised as a cleanup,
+	on the eve of the 2026-08-31 review. Both defaults are now pinned by tests so the split
+	cannot drift unnoticed; the real fix (every cost dict declares its type explicitly) is a
+	data pass, not a code change, and is tracked for post-review."""
 	var declared: String = String(costs.get("hour_type", MonthPlan.HOUR_OPERATING))
+	if MonthPlan.KIND_FAMILY.has(declared):
+		return declared
 	if declared == MonthPlan.HOUR_PLANNING:
 		return MonthPlan.HOUR_PLANNING
 	return MonthPlan.HOUR_OPERATING

--- a/godot/scripts/core/month_plan.gd
+++ b/godot/scripts/core/month_plan.gd
@@ -35,8 +35,29 @@ extends RefCounted
 ##     spend thinking. (ADR-0011: "reserve -- instant-speed firefighting".)
 ##   PLANNING may NOT overflow into OPERATING -- you cannot retroactively have been in the
 ##     room. Running out of planner hours BLOCKS more strategic queuing this month.
-## The 4-way refinement (doors / approvals / audits / reserve, ADR-0011 amendment (c)) is a
-## LATER lane; it subdivides these two, it does not replace them.
+##
+## FOUNDER-HOUR KINDS (4-way, ADR-0011 point 2 / Ballot 4 ruled 2026-07-27, REVIEW-BY
+## 2026-08-31). The four kinds SUBDIVIDE the two families; they do not replace them:
+##   doors     -- stakeholder face-time, being in rooms         (family: OPERATING)
+##   approvals -- hires, direction rulings, queuing strategy    (family: PLANNING)
+##   audits    -- skip-level ground-truthing of reported work   (family: OPERATING)
+##   reserve   -- instant-speed firefighting (the crisp reserve)(family: OPERATING)
+## Third storey of the SAME additive-accounting tower: an authoritative scalar
+## (attention_total/spent), typed by a 2-way family layer (hours_total/hours_spent), labelled
+## by a 4-way kind layer (kind_spent). Each storey is additive over the one below, so the
+## 2026-08-31 review can DELETE the kind layer without touching the gate logic if 4-way did
+## not earn its complexity.
+##
+## DELIBERATE S-CUT SCOPE: kinds ACCOUNT, families GATE. There are no per-kind monthly
+## budgets -- admissibility is decided entirely by the family pools and the asymmetric
+## overflow rule above. Per-kind caps would be four more balance dials to sweep before a
+## review that may collapse the split back to 2-way; that is a post-review call.
+##
+## Why audits and doors are OPERATING: both are presence by definition (you cannot
+## skip-level ground-truth a researcher's real progress from a hotel room, and a door you
+## are not standing in is not open). This is what makes #980 fall out for free -- travel
+## drains the OPERATING family, so it kills doors and audits and leaves approvals (next
+## month's direction) decidable from the road.
 ##
 ## Strategic actions carry DURATIONS (ADR-0009 S5 -- nothing strategic resolves instantly);
 ## queued items land on a future resolution tick. This is the seam L2 workstreams extend.
@@ -45,6 +66,29 @@ extends RefCounted
 const HOUR_PLANNING := "planning"
 const HOUR_OPERATING := "operating"
 const HOUR_TYPES := [HOUR_PLANNING, HOUR_OPERATING]
+
+# --- Founder hour kinds (4-way, Ballot 4) -- labels over the families above ---
+const KIND_DOORS := "doors"
+const KIND_APPROVALS := "approvals"
+const KIND_AUDITS := "audits"
+const KIND_RESERVE := "reserve"
+const HOUR_KINDS := [KIND_DOORS, KIND_APPROVALS, KIND_AUDITS, KIND_RESERVE]
+
+## Which family each kind bills. THE one place the 4-way maps onto the 2-way.
+const KIND_FAMILY := {
+	KIND_DOORS: HOUR_OPERATING,
+	KIND_APPROVALS: HOUR_PLANNING,
+	KIND_AUDITS: HOUR_OPERATING,
+	KIND_RESERVE: HOUR_OPERATING,
+}
+
+## What an un-subdivided family spend is LABELLED as. Presence-by-default is face-time;
+## planner-mind-by-default is a direction ruling. Callers/data that mean something finer
+## name the kind explicitly.
+const FAMILY_DEFAULT_KIND := {
+	HOUR_PLANNING: KIND_APPROVALS,
+	HOUR_OPERATING: KIND_DOORS,
+}
 
 # --- Attention accounting (all integer Attention units) ---
 var attention_total: int = 0        # granted this plan-month (Balance attention.per_month)
@@ -57,6 +101,12 @@ var reserve_used: int = 0           # reserve consumed by HANDLE-from-reserve th
 # every spend that goes through spend_attention/queue_strategic/the window payers.
 var hours_total: Dictionary = {HOUR_PLANNING: 0, HOUR_OPERATING: 0}
 var hours_spent: Dictionary = {HOUR_PLANNING: 0, HOUR_OPERATING: 0}
+
+# 4-way kind labels over hours_spent. Invariants pinned by test_founder_hours.gd:
+#   kind_spent[doors] + [approvals] + [audits] == attention_spent
+#   kind_spent[reserve] == reserve_used   (the reserve is accounted separately -- see
+#   set_reserve's T2 design note, which this lane deliberately did NOT overrule)
+var kind_spent: Dictionary = {KIND_DOORS: 0, KIND_APPROVALS: 0, KIND_AUDITS: 0, KIND_RESERVE: 0}
 
 # Which plan-month this is (0-based from run start) -- stamps the replay artifact (ADR-0016).
 var month_ordinal: int = 0
@@ -87,16 +137,46 @@ func begin_month(attention_per_month: int, ordinal: int, planning_share: float =
 	planning = clampi(planning, 0, attention_per_month)
 	hours_total = {HOUR_PLANNING: planning, HOUR_OPERATING: attention_per_month - planning}
 	hours_spent = {HOUR_PLANNING: 0, HOUR_OPERATING: 0}
+	kind_spent = {KIND_DOORS: 0, KIND_APPROVALS: 0, KIND_AUDITS: 0, KIND_RESERVE: 0}
 	# In-flight strategic actions persist across the boundary (they have durations);
 	# resolved ones are pruned by the controller, not here.
 
 
-# --- Typed founder hours (2-way floor) ---
+# --- Typed founder hours (2-way families gate; 4-way kinds label) ---
+
+static func family_of(hour_type: String) -> String:
+	"""Resolve ANY hour token -- a 4-way kind OR a 2-way family -- to the family that gates
+	it. Unknown tokens resolve to OPERATING (presence is the safe assumption: it is the
+	family that can overflow, so a mis-typed spend is never silently granted planner mind).
+	Every public entry point funnels through here, which is why callers written against the
+	2-way API keep working verbatim after the 4-way landed."""
+	if KIND_FAMILY.has(hour_type):
+		return String(KIND_FAMILY[hour_type])
+	if hour_type == HOUR_PLANNING:
+		return HOUR_PLANNING
+	return HOUR_OPERATING
+
+
+static func kind_of(hour_type: String) -> String:
+	"""Resolve ANY hour token to the 4-way kind it is BOOKED as. A family name maps to its
+	default kind (see FAMILY_DEFAULT_KIND); an unknown token follows family_of to OPERATING
+	and so books as doors."""
+	if KIND_FAMILY.has(hour_type):
+		return hour_type
+	return String(FAMILY_DEFAULT_KIND.get(family_of(hour_type), KIND_DOORS))
+
 
 func hours_available(hour_type: String) -> int:
-	"""Hours of `hour_type` not yet spent. This is the TYPE gate only -- a spend must also
-	fit inside the authoritative aggregate available() (which nets out the reserve)."""
-	return int(hours_total.get(hour_type, 0)) - int(hours_spent.get(hour_type, 0))
+	"""Hours of `hour_type`'s FAMILY not yet spent. Accepts a kind or a family. This is the
+	TYPE gate only -- a spend must also fit inside the authoritative aggregate available()
+	(which nets out the reserve). There is deliberately no per-KIND budget (see header)."""
+	var fam: String = family_of(hour_type)
+	return int(hours_total.get(fam, 0)) - int(hours_spent.get(fam, 0))
+
+
+func kind_spend(kind: String) -> int:
+	"""Hours booked against one 4-way kind this month. Read-only accounting/readout surface."""
+	return int(kind_spent.get(kind, 0))
 
 
 func can_spend_hours(cost: int, hour_type: String) -> bool:
@@ -110,20 +190,26 @@ func can_spend_hours(cost: int, hour_type: String) -> bool:
 		return true
 	# OPERATING may eat PLANNING hours (a crisis costs you thinking time). PLANNING may not
 	# eat OPERATING hours -- you cannot retroactively have been in the room.
-	return hour_type == HOUR_OPERATING
+	return family_of(hour_type) == HOUR_OPERATING
 
 
 func _debit_hours(cost: int, hour_type: String) -> void:
-	"""Record `cost` hours against the typed pools, spilling into the other type per the
-	asymmetric-overflow rule. Callers gate with can_spend_hours() first; this only books."""
+	"""Record `cost` hours against the typed pools, spilling into the other FAMILY per the
+	asymmetric-overflow rule, and label the whole spend with its 4-way KIND. Callers gate
+	with can_spend_hours() first; this only books.
+	Note the kind is booked whole even when the family spills: an audit hour that overflowed
+	into planning capacity is still an audit -- the spill records WHERE the time came from,
+	the kind records WHAT it was spent on."""
 	if cost <= 0:
 		return
-	var from_type: int = mini(cost, maxi(0, hours_available(hour_type)))
-	hours_spent[hour_type] = int(hours_spent.get(hour_type, 0)) + from_type
+	var fam: String = family_of(hour_type)
+	kind_spent[kind_of(hour_type)] = int(kind_spent.get(kind_of(hour_type), 0)) + cost
+	var from_type: int = mini(cost, maxi(0, hours_available(fam)))
+	hours_spent[fam] = int(hours_spent.get(fam, 0)) + from_type
 	var spill: int = cost - from_type
 	if spill <= 0:
 		return
-	var other: String = HOUR_PLANNING if hour_type == HOUR_OPERATING else HOUR_OPERATING
+	var other: String = HOUR_PLANNING if fam == HOUR_OPERATING else HOUR_OPERATING
 	hours_spent[other] = int(hours_spent.get(other, 0)) + spill
 
 
@@ -191,7 +277,8 @@ func grant_hours(amount: int, hour_type: String = HOUR_OPERATING) -> void:
 	everything else -- begin_month resets both pools."""
 	if amount <= 0:
 		return
-	hours_total[hour_type] = int(hours_total.get(hour_type, 0)) + amount
+	var fam: String = family_of(hour_type)
+	hours_total[fam] = int(hours_total.get(fam, 0)) + amount
 	attention_total += amount
 
 
@@ -202,12 +289,15 @@ func refund_attention(cost: int, hour_type: String = HOUR_OPERATING) -> void:
 	if cost <= 0:
 		return
 	attention_spent = maxi(0, attention_spent - cost)
-	var booked: int = int(hours_spent.get(hour_type, 0))
+	var fam: String = family_of(hour_type)
+	var kind: String = kind_of(hour_type)
+	kind_spent[kind] = maxi(0, int(kind_spent.get(kind, 0)) - cost)
+	var booked: int = int(hours_spent.get(fam, 0))
 	var from_type: int = mini(cost, booked)
-	hours_spent[hour_type] = booked - from_type
+	hours_spent[fam] = booked - from_type
 	var spill: int = cost - from_type
 	if spill > 0:
-		var other: String = HOUR_PLANNING if hour_type == HOUR_OPERATING else HOUR_OPERATING
+		var other: String = HOUR_PLANNING if fam == HOUR_OPERATING else HOUR_OPERATING
 		hours_spent[other] = maxi(0, int(hours_spent.get(other, 0)) - spill)
 
 
@@ -252,6 +342,12 @@ func pay_from_reserve(cost: int) -> bool:
 	if reserve_remaining() < cost:
 		return false
 	reserve_used += cost
+	# 4-way LABEL only: the reserve kind mirrors reserve_used, it does not book into
+	# hours_spent. Ballot 4 names `reserve` as one of the four kinds; T2's judgment call 2
+	# left the crisp reserve's ACCOUNTING deliberately untyped and un-gated (an emergency is
+	# exactly where the type wall may break). Both hold at once because this storey labels
+	# rather than gates -- see the PR body's reconciliation note.
+	kind_spent[KIND_RESERVE] = reserve_used
 	return true
 
 
@@ -290,6 +386,7 @@ func to_dict() -> Dictionary:
 		"month_ordinal": month_ordinal,
 		"hours_total": hours_total.duplicate(),
 		"hours_spent": hours_spent.duplicate(),
+		"kind_spent": kind_spent.duplicate(),
 		"queued_strategic": queued_strategic.duplicate(true),
 	}
 
@@ -322,7 +419,21 @@ func from_dict(data: Dictionary) -> void:
 		}
 	else:
 		hours_spent = {HOUR_PLANNING: 0, HOUR_OPERATING: 0}
+		kind_spent = {KIND_DOORS: 0, KIND_APPROVALS: 0, KIND_AUDITS: 0, KIND_RESERVE: 0}
 		_debit_hours(attention_spent, HOUR_OPERATING)
+	# 4-way kind labels. A pre-Ballot-4 save has no `kind_spent`: rebuild it by labelling
+	# each family's booked hours with that family's DEFAULT kind, so the invariant
+	# sum(doors, approvals, audits) == attention_spent holds on load rather than reading zero.
+	var raw_kinds: Variant = data.get("kind_spent", null)
+	if raw_kinds is Dictionary and not (raw_kinds as Dictionary).is_empty():
+		kind_spent = {}
+		for kind in HOUR_KINDS:
+			kind_spent[kind] = int((raw_kinds as Dictionary).get(kind, 0))
+	else:
+		kind_spent = {KIND_DOORS: 0, KIND_APPROVALS: 0, KIND_AUDITS: 0, KIND_RESERVE: 0}
+		kind_spent[KIND_APPROVALS] = int(hours_spent.get(HOUR_PLANNING, 0))
+		kind_spent[KIND_DOORS] = maxi(0, attention_spent - int(hours_spent.get(HOUR_PLANNING, 0)))
+		kind_spent[KIND_RESERVE] = reserve_used
 	queued_strategic = []
 	for item in data.get("queued_strategic", []):
 		if item is Dictionary:

--- a/godot/tests/unit/test_founder_hour_kinds.gd
+++ b/godot/tests/unit/test_founder_hour_kinds.gd
@@ -1,0 +1,278 @@
+extends GutTest
+## Ballot 4 (2026-07-27, REVIEW-BY 2026-08-31): founder hours subdivide 4 ways into
+## doors / approvals / audits / reserve. This file pins the KIND layer; test_founder_hours.gd
+## still pins the 2-way FAMILY layer underneath it, unchanged and unrewritten -- which is
+## itself the evidence that the subdivision extends rather than replaces.
+##
+## Load-bearing invariants pinned here:
+##   1. kinds ACCOUNT, families GATE. There are no per-kind budgets; admissibility is
+##      decided entirely by family_of() + the asymmetric overflow rule.
+##   2. kind_spent[doors] + [approvals] + [audits] == attention_spent, and
+##      kind_spent[reserve] == reserve_used. The reserve is LABELLED by the kind layer but
+##      still ACCOUNTED separately -- T2's judgment call 2 (crisp reserve untyped/un-gated)
+##      was upheld by this lane, not overruled.
+##   3. doors and audits are OPERATING; approvals is PLANNING. That mapping is what makes
+##      #980 fall out with no change to conference_trip: draining the operating family kills
+##      exactly the presence kinds and leaves next month's direction decidable.
+
+
+func _plan(total: int = 20, planning_share: float = 0.5) -> MonthPlan:
+	var mp := MonthPlan.new()
+	mp.begin_month(total, 0, planning_share)
+	return mp
+
+
+func _work_sum(mp: MonthPlan) -> int:
+	return mp.kind_spend(MonthPlan.KIND_DOORS) + mp.kind_spend(MonthPlan.KIND_APPROVALS) \
+		+ mp.kind_spend(MonthPlan.KIND_AUDITS)
+
+
+# --- Invariant 3: the kind -> family mapping ---------------------------------------------
+
+func test_presence_kinds_are_operating_and_approvals_is_planning():
+	assert_eq(MonthPlan.family_of(MonthPlan.KIND_DOORS), MonthPlan.HOUR_OPERATING, "doors are presence")
+	assert_eq(MonthPlan.family_of(MonthPlan.KIND_AUDITS), MonthPlan.HOUR_OPERATING, "you cannot audit from a hotel")
+	assert_eq(MonthPlan.family_of(MonthPlan.KIND_RESERVE), MonthPlan.HOUR_OPERATING, "firefighting is presence")
+	assert_eq(MonthPlan.family_of(MonthPlan.KIND_APPROVALS), MonthPlan.HOUR_PLANNING, "rulings are planner mind")
+
+
+func test_family_tokens_still_resolve_so_2way_callers_keep_working():
+	assert_eq(MonthPlan.family_of(MonthPlan.HOUR_PLANNING), MonthPlan.HOUR_PLANNING, "family passes through")
+	assert_eq(MonthPlan.family_of(MonthPlan.HOUR_OPERATING), MonthPlan.HOUR_OPERATING, "family passes through")
+	assert_eq(MonthPlan.family_of("nonsense"), MonthPlan.HOUR_OPERATING, "unknown falls to presence, never to planner mind")
+
+
+func test_family_tokens_book_their_default_kind():
+	assert_eq(MonthPlan.kind_of(MonthPlan.HOUR_PLANNING), MonthPlan.KIND_APPROVALS, "un-subdivided planning is a ruling")
+	assert_eq(MonthPlan.kind_of(MonthPlan.HOUR_OPERATING), MonthPlan.KIND_DOORS, "un-subdivided presence is face-time")
+	assert_eq(MonthPlan.kind_of(MonthPlan.KIND_AUDITS), MonthPlan.KIND_AUDITS, "a kind is itself")
+
+
+# --- Invariant 1: kinds account, families gate -------------------------------------------
+
+func test_a_kind_spend_debits_its_family_pool():
+	var mp := _plan(20, 0.5)
+	assert_true(mp.spend_attention(3, MonthPlan.KIND_AUDITS), "audits fit in the operating pool")
+	assert_eq(mp.kind_spend(MonthPlan.KIND_AUDITS), 3, "booked as audits")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_OPERATING], 3, "and charged to the operating family")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 0, "planner mind untouched")
+
+
+func test_there_are_no_per_kind_budgets_only_family_gates():
+	var mp := _plan(20, 0.5)  # 10 planning / 10 operating
+	# Ten straight audit hours would blow any plausible per-kind cap; the family is the only
+	# gate, so all ten are admissible.
+	assert_true(mp.spend_attention(10, MonthPlan.KIND_AUDITS), "the whole operating pool may be audits")
+	assert_eq(mp.kind_spend(MonthPlan.KIND_AUDITS), 10, "all ten booked to one kind")
+	assert_eq(mp.hours_available(MonthPlan.KIND_DOORS), 0, "doors read the same drained family pool")
+
+
+func test_kind_survives_a_family_overflow():
+	var mp := _plan(20, 0.5)
+	# 13 audit hours against a 10-hour operating pool: 3 spill into planning capacity.
+	assert_true(mp.spend_attention(13, MonthPlan.KIND_AUDITS), "operating kinds may overflow")
+	assert_eq(mp.kind_spend(MonthPlan.KIND_AUDITS), 13, "the kind books whole -- it was all auditing")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_OPERATING], 10, "operating drained first")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_PLANNING], 3, "the spill records where the time came from")
+	assert_eq(_work_sum(mp), mp.attention_spent, "kind invariant survives an overflow")
+
+
+func test_approvals_may_not_borrow_presence():
+	var mp := _plan(20, 0.5)
+	assert_true(mp.spend_attention(10, MonthPlan.KIND_APPROVALS), "the planning pool is spendable as approvals")
+	assert_false(mp.can_spend_hours(1, MonthPlan.KIND_APPROVALS), "planner mind is exhausted")
+	assert_true(mp.can_spend_hours(1, MonthPlan.KIND_DOORS), "presence work still possible")
+
+
+func test_queuing_strategic_books_approvals():
+	var mp := _plan(20, 0.5)
+	assert_true(mp.queue_strategic("bet", 4, 2, 0), "queued")
+	assert_eq(mp.kind_spend(MonthPlan.KIND_APPROVALS), 4, "queuing is a direction ruling")
+	assert_eq(_work_sum(mp), mp.attention_spent, "kind invariant holds")
+
+
+func test_refund_unbooks_the_kind():
+	var mp := _plan(20, 0.5)
+	mp.spend_attention(4, MonthPlan.KIND_DOORS)
+	mp.refund_attention(3, MonthPlan.KIND_DOORS)
+	assert_eq(mp.kind_spend(MonthPlan.KIND_DOORS), 1, "kind refunded in step")
+	assert_eq(_work_sum(mp), mp.attention_spent, "kind invariant holds through a refund")
+
+
+# --- Invariant 2: the reserve is labelled but still accounted separately -----------------
+
+func test_reserve_kind_mirrors_reserve_used_without_booking_hours():
+	var mp := _plan(20, 0.5)
+	assert_true(mp.set_reserve(6), "reserve is NOT gated at the operating pool (T2 call 2 upheld)")
+	assert_eq(mp.kind_spend(MonthPlan.KIND_RESERVE), 0, "declaring a reserve spends nothing yet")
+	assert_true(mp.pay_from_reserve(4), "a window draws on it")
+	assert_eq(mp.kind_spend(MonthPlan.KIND_RESERVE), 4, "the reserve kind mirrors reserve_used")
+	assert_eq(mp.reserve_used, 4, "and reserve_used is still the authority")
+	assert_eq(mp.hours_spent[MonthPlan.HOUR_OPERATING], 0, "the reserve books no typed family hours")
+	assert_eq(_work_sum(mp), mp.attention_spent, "work kinds still sum to the scalar")
+
+
+func test_reserve_bigger_than_the_operating_pool_is_still_legal():
+	var mp := _plan(20, 0.5)  # only 10 operating hours exist
+	assert_true(mp.set_reserve(15), "an emergency is where the type wall is allowed to break")
+
+
+# --- Save round-trip + legacy save -------------------------------------------------------
+
+func test_kind_spend_round_trips():
+	var mp := _plan(20, 0.5)
+	mp.spend_attention(2, MonthPlan.KIND_AUDITS)
+	mp.spend_attention(3, MonthPlan.KIND_APPROVALS)
+	mp.set_reserve(4)
+	mp.pay_from_reserve(1)
+	var clone := MonthPlan.new()
+	clone.from_dict(mp.to_dict())
+	assert_eq(clone.kind_spent, mp.kind_spent, "kind labels survive a save")
+	assert_eq(clone.hours_spent, mp.hours_spent, "family pools survive a save")
+
+
+func test_pre_ballot4_save_rebuilds_kinds_from_the_family_pools():
+	# A save written by T2: hours_* present, kind_spent absent. It must load into a legal
+	# state (the invariant satisfied) rather than reading zero and forking the books.
+	var mp := MonthPlan.new()
+	mp.from_dict({
+		"attention_total": 20,
+		"attention_spent": 7,
+		"attention_reserved": 0,
+		"reserve_used": 0,
+		"month_ordinal": 0,
+		"hours_total": {MonthPlan.HOUR_PLANNING: 10, MonthPlan.HOUR_OPERATING: 10},
+		"hours_spent": {MonthPlan.HOUR_PLANNING: 4, MonthPlan.HOUR_OPERATING: 3},
+	})
+	assert_eq(mp.kind_spend(MonthPlan.KIND_APPROVALS), 4, "planning hours label as approvals")
+	assert_eq(mp.kind_spend(MonthPlan.KIND_DOORS), 3, "operating hours label as doors")
+	assert_eq(_work_sum(mp), 7, "the legacy spend was labelled, not lost")
+
+
+func test_begin_month_resets_the_kind_labels():
+	var mp := _plan(20, 0.5)
+	mp.spend_attention(5, MonthPlan.KIND_AUDITS)
+	mp.begin_month(20, 1, 0.5)
+	assert_eq(_work_sum(mp), 0, "kinds reset with everything else -- no banking")
+	assert_eq(mp.kind_spend(MonthPlan.KIND_RESERVE), 0, "the reserve label resets too")
+
+
+# --- Data typing: the presence pass ------------------------------------------------------
+
+func test_action_data_declares_its_kind_at_the_TOP_LEVEL_not_inside_costs():
+	# The 4-way lane moved action-def typing out of `costs`: an hour type is a property of the
+	# action, not a resource price. Living inside `costs` broke every site that iterates cost
+	# pairs numerically (the fresh-game render + the non-negative-costs sweep both blew up).
+	var doors := {"costs": {"attention": 1}, "hour_type": MonthPlan.KIND_DOORS}
+	assert_eq(GameActions.hour_type(doors), MonthPlan.KIND_DOORS, "a declared kind is returned verbatim")
+	var audits := {"costs": {"attention": 1}, "hour_type": MonthPlan.KIND_AUDITS}
+	assert_eq(GameActions.hour_type(audits), MonthPlan.KIND_AUDITS, "audits type survives the read")
+
+
+func test_no_action_data_hides_a_type_tag_inside_its_cost_dict():
+	# Regression pin: a String in `costs` is a landmine for every numeric cost consumer.
+	var pools: Array = _all_priced_pools()
+	for a in pools:
+		assert_false(a.get("costs", {}).has("hour_type"),
+			"action %s must declare hour_type at the top level, not in costs" % [a.get("id", "?")])
+
+
+func test_bare_cost_dicts_may_still_carry_the_tag():
+	# The code-side channel: a subsystem charge with no action def has nowhere else to put it.
+	var s := GameState.new("bare-cost")
+	s.month_plan = MonthPlan.new()
+	s.month_plan.begin_month(20, 0, 0.5)
+	assert_eq(s._cost_hour_type({"attention": 1, "hour_type": MonthPlan.KIND_AUDITS}),
+		MonthPlan.KIND_AUDITS, "a bare cost dict may name a kind")
+	assert_eq(s._cost_hour_type({"attention": 1}), MonthPlan.HOUR_OPERATING,
+		"and an un-typed one is presence -- T2 judgment call 4, upheld")
+
+
+func test_undeclared_action_still_defaults_to_planning():
+	# T2 judgment call 4, KEPT by this lane: a queued action defaults to PLANNING while a
+	# bare cost dict defaults to OPERATING. Pinned so the asymmetry cannot drift unnoticed.
+	assert_eq(GameActions.hour_type({"costs": {"attention": 1}}), MonthPlan.HOUR_PLANNING,
+		"queuing is deciding")
+
+
+func test_the_audit_action_is_typed_audits_in_data():
+	var act: Dictionary = {}
+	for a in GameActions.get_operations_options():
+		if String(a.get("id", "")) == "audit_self_directed":
+			act = a
+	assert_false(act.is_empty(), "the audit action exists in data")
+	assert_eq(GameActions.hour_type(act), MonthPlan.KIND_AUDITS, "and it bills the audits kind")
+
+
+func test_every_priced_action_declares_its_hour_type():
+	# The presence pass (PR #996 judgment call 5's inheritance): every action that costs
+	# Attention was read once and asked "thinking, or showing up?". A new priced action with
+	# no declared type silently inherits PLANNING, which is the trap this pins shut.
+	var undeclared: Array = []
+	for a in _all_priced_pools():
+		if int(a.get("costs", {}).get("attention", 0)) > 0 and not a.has("hour_type"):
+			undeclared.append(String(a.get("id", "?")))
+	assert_eq(undeclared, [], "priced actions missing an hour_type: %s" % [undeclared])
+
+
+func _all_priced_pools() -> Array:
+	var pools: Array = []
+	pools.append_array(GameActions.get_all_actions())
+	pools.append_array(GameActions.get_hiring_options())
+	pools.append_array(GameActions.get_fundraising_options())
+	pools.append_array(GameActions.get_publicity_options())
+	pools.append_array(GameActions.get_strategic_options())
+	pools.append_array(GameActions.get_travel_options())
+	pools.append_array(GameActions.get_operations_options())
+	return pools
+
+
+# --- The audit verb: the consumer for T1's reported-vs-actual seam ------------------------
+
+func _state_with_a_liar() -> GameState:
+	var s := GameState.new("audit-seed")
+	s.turn = 1
+	s.month_plan = MonthPlan.new()
+	s.month_plan.begin_month(20, 0, 0.5)
+	s.record_self_directed("interpretability", 4.0, 7.0)  # claimed 7, did 4
+	s.record_self_directed("alignment", 3.0, 3.5)         # a smaller fib
+	return s
+
+
+func test_an_audit_hour_ground_truths_the_biggest_gap():
+	var s := _state_with_a_liar()
+	var result: Dictionary = s.audit_self_directed()
+	assert_true(bool(result.get("ok", false)), "the audit ran")
+	assert_eq(String(result.get("topic", "")), "interpretability", "it went where the gap was biggest")
+	assert_almost_eq(float(result.get("gap", 0.0)), 3.0, 0.01, "and reported the overstatement")
+	var bucket: Dictionary = s.self_directed_progress["interpretability"]
+	assert_almost_eq(float(bucket["reported"]), 4.0, 0.01, "the books now say what actually happened")
+	assert_almost_eq(float(bucket["actual"]), 4.0, 0.01, "truth is never edited by an audit")
+	assert_almost_eq(float(s.self_directed_progress["alignment"]["reported"]), 3.5, 0.01,
+		"an audit ground-truths ONE topic, not the whole org")
+
+
+func test_an_audit_bills_an_audits_hour():
+	var s := _state_with_a_liar()
+	s.audit_self_directed()
+	assert_eq(s.month_plan.kind_spend(MonthPlan.KIND_AUDITS), 1, "one audit hour spent")
+	assert_eq(s.month_plan.hours_spent[MonthPlan.HOUR_OPERATING], 1, "charged to presence")
+
+
+func test_an_audit_is_impossible_with_no_presence_left():
+	# The #980 shape: travel drains the operating family, so it kills auditing outright.
+	var s := _state_with_a_liar()
+	s.month_plan.spend_attention(20, MonthPlan.KIND_DOORS)  # every hour gone
+	var result: Dictionary = s.audit_self_directed()
+	assert_false(bool(result.get("ok", false)), "no hours, no ground-truthing")
+	assert_almost_eq(float(s.self_directed_progress["interpretability"]["reported"]), 7.0, 0.01,
+		"and the inflated claim stands uncorrected")
+
+
+func test_auditing_nothing_is_refused_and_free():
+	var s := GameState.new("audit-empty")
+	s.month_plan = MonthPlan.new()
+	s.month_plan.begin_month(20, 0, 0.5)
+	var result: Dictionary = s.audit_self_directed()
+	assert_false(bool(result.get("ok", false)), "nobody is self-directing")
+	assert_eq(s.month_plan.kind_spend(MonthPlan.KIND_AUDITS), 0, "and no hour was burned finding that out")


### PR DESCRIPTION
## Lane: founder-hour typing (4-way) + issue #980

Ballot 4 (2026-07-27, **REVIEW-BY 2026-08-31**) subdivides T2's PLANNING/OPERATING floor
into ADR-0011's four kinds. Built directly on merged main (`ad3ece78`, PR #996) -- the brief
predated that merge, so this branched from `origin/main` rather than T2's branch.

**Fast gate: 983 tests, 0 failures, 95/95 files collected.** (main was 959 at #996; +24 new.)

---

## 1. Pool shape chosen: a THIRD storey on the same additive tower

```
attention_total / attention_spent      <- authoritative SCALAR   (pre-T2)
  hours_total / hours_spent            <- 2-way FAMILY  -- GATES  (T2)
    kind_spent                         <- 4-way KIND    -- LABELS (this lane)
```

`KIND_FAMILY` is the one mapping: **doors, audits, reserve -> OPERATING; approvals ->
PLANNING**. `MonthPlan.family_of()` / `kind_of()` resolve either token, so **every 2-way
caller keeps working verbatim** -- `test_founder_hours.gd` is untouched by this PR, which is
the evidence the subdivision extends rather than rewrites.

This is the brief's open-question-1 recommendation (sub-counters, not a new cost-dict model)
taken one step further: because the kind layer is purely additive, the 2026-08-31 review can
**delete `kind_spent` and the KIND_* constants without touching a single gate decision** if
4-way did not earn its complexity. That reversibility is the reason for the shape.

**Deliberate S-cut scope: kinds ACCOUNT, families GATE.** There are no per-kind monthly
budgets. Four more balance dials to hand-set and sweep, five weeks before a review that may
collapse the split back to 2-way, is the definition of over-engineering. Pinned by
`test_there_are_no_per_kind_budgets_only_family_gates`.

### Why audits and doors are OPERATING (the load-bearing thematic call)

Both are presence by definition: you cannot skip-level ground-truth a researcher's real
progress from a conference floor, and a door you are not standing in is not open. This is
what makes **#980 fall out with no behaviour change** (section 3).

---

## 2. Presence-typing pass -- the full read (PR #996 judgment call 5, inherited)

#996 typed the obvious content in CODE and left every JSON action def untyped -- so **all 61
data-defined actions were inheriting the PLANNING default**. Every def was read once asking
"is this thinking, or is this showing up?".

| kind | count | examples |
|---|---|---|
| **approvals** | 24 | all 7 `hire_*` (ADR-0011: "approvals -- hires"), lease signings, `emergency_pivot`, `scout_read`, `release_warning`, research direction |
| **doors** | 20 | `network`, `lobby_government`, `scout_meetups`, `tour_offices`, all financing counterparty work, `acquire_startup`, conference travel |
| **audits** | 2 | `audit_safety` (already existed and was already literally an audit), `audit_self_directed` (new) |
| **left on default** | 16 | zero-Attention menu openers (`hire_staff`, `travel`, ...) and the hiring-loop verbs (`interview_next`, `onboard_next`, ...) which bill through the pipeline, already typed OPERATING in code |

`test_every_priced_action_declares_its_hour_type` now **blocks** a new priced action that
silently inherits PLANNING.

### Load-bearing incidental fix: `hour_type` moved OUT of the cost dict

The data pass immediately broke the fresh-game action render (`Invalid operands 'int' and
'String' in operator '<'`) and `test_bug_fixes.test_all_actions_costs_are_non_negative`. Root
cause: a **String living inside `costs`** is a landmine for every consumer that iterates cost
pairs numerically -- which is exactly why `actions.gd:273`, `main_ui.gd:1730` and
`plan_controller.gd:48` were each patching the same trap separately.

An hour type is a property of the **action**, not a resource price. It is now a top-level
`hour_type` field on the action def. `costs.hour_type` **survives as the fallback** because a
bare cost dict (a code-side subsystem charge with no action def) has nowhere else to put it.
Both channels pinned by tests; `test_no_action_data_hides_a_type_tag_inside_its_cost_dict`
stops the landmine being re-planted.

---

## 3. #980 wiring -- the answer is that no simulation change was needed

`_consume_founder_capacity` already drains the OPERATING family with overflow forbidden
(#996). Because `doors` and `audits` are both OPERATING, that existing drain **kills exactly
the two presence kinds and leaves `approvals` untouched** -- which is verbatim Pip's ruling
("away removes OPERATOR PRESENCE, not PLANNER MIND"). Pinned by
`test_an_audit_is_impossible_with_no_presence_left`.

What DID need changing was **player-facing copy that asserted the pre-#980 rule**: the
`month_opened` backlog line said "The month's Attention grant went unplanned -- you were not
there to spend it." That is now literally false. Rewritten to: *"The month opened with nobody
in the building -- its doors and audit hours are gone. Next month's direction is still yours
to set."*

---

## 4. Audit MVP -- the consumer for T1's seam

`GameState.audit_self_directed()` spends one `audits` hour, picks the topic with the largest
claimed-vs-true gap (deterministic; **no RNG source touched** -- the optimism factor is
already a per-person hash at `researcher.gd:632` and this only reads it), and collapses
`reported` onto `actual`. Surfaced as the `audit_self_directed` action in the operations
submenu. The T1 seam comments at `researcher.gd:129` / `record_self_directed` finally have a
reader.

The gap was ALREADY visible in `workstream_readout()`, so the brief's "(a) pure display"
S-cut would have been a no-op -- hence (b), the cheap real mutation. See open question 2.

---

## Open questions -- most conservative defensible pick taken on each

**Q1 (pool model) -- picked: four sub-counters, as a purely additive LABEL layer.** Not a
typed-cost-dict model. Smallest diff on `month_plan.gd`, zero changes to gate logic, and
trivially deletable at the 2026-08-31 review. Explicitly rejected: per-kind budgets.

**Q2 (audit consequence) -- picked: (b) correct the books, and stop there.** The org's
`self_directed_progress[topic].reported` collapses onto `actual`. Deliberately NOT taken:
(c) reputation/trust penalty on the researcher (needs a target system that does not exist
pre-T4) and (d) departure-risk/quirk-reveal (clearly M-cut). Also deliberately NOT mutated:
the per-person `self_directed_reported` -- an audit corrects what the ORG believes, not what
the person claimed. **If Pip wants an audit to bite the liar rather than just the ledger,
that is a follow-up lane, not a tweak.**

**Q3 (#980 UX) -- picked: the latter.** No interactive mid-trip planning surface. `run_trip()`
keeps its synchronous-resolve invariant that PR #979's docstring explicitly protects; the
player simply no longer loses planning hours they would have had. A real mid-trip planning
panel remains M-cut.

**Q4 (type coverage) -- OVERRULED the brief's "curated subset" recommendation, upward.** The
full pass was done (all 61 defs, 45 typed) because Pip named it as this lane's explicit
inheritance from #996 judgment call 5, and because a half-pass leaves the PLANNING default
silently mis-pricing the untyped remainder. Data entry, no design risk, and the guard test
now keeps it complete.

---

## Judgment calls, flagged for review

1. **T2's judgment call 2 (crisp reserve deliberately UNTYPED) is UPHELD, not overruled --
   and it does not actually conflict with Ballot 4.** Ballot 4 names `reserve` as one of the
   four; #996 kept the reserve's accounting separate (`attention_reserved`/`reserve_used`,
   never booking into `hours_spent`) and un-gated at the operating pool. Both hold at once
   *because this storey labels rather than gates*: `KIND_RESERVE` exists as a full member of
   the taxonomy and `kind_spent[reserve]` mirrors `reserve_used`, while the emergency channel
   keeps its untyped math verbatim. `test_reserve_bigger_than_the_operating_pool_is_still_legal`
   pins the un-gating; `test_reserve_kind_mirrors_reserve_used_without_booking_hours` pins the
   separation. **If you want the reserve to be a hard presence commitment, that is still one
   line in `set_reserve` -- and it is still your call, not mine.**

2. **T2's judgment call 4 (default hour type differs by surface) -- KEPT, consciously.** A
   queued action defaults to PLANNING; a bare cost dict defaults to OPERATING. You flagged
   this as the most trap-like bit. The reason for keeping it: "fixing" it to one default
   would silently re-type either every subsystem charge or every strategic card -- a balance
   change disguised as a cleanup, five weeks before the review. Both defaults are now
   **pinned by tests** so the split cannot drift unnoticed, and both are documented at the two
   read points. The real fix (every cost dict declares its type explicitly) is a data pass,
   tracked for post-review.

3. **`scout_shitpost` and `release_warning` typed as `approvals`, not `doors`.** Both are
   public acts, but neither needs a room -- they are decidable and executable from anywhere,
   so they must stay spendable while away. Arguable; a cheap re-type if you disagree.

4. **`order_supplies` / `office_maintenance` typed `doors`.** Routine ops is presence but is
   not really face-time; `doors` is the least-wrong of four. This is the clearest single
   piece of evidence for the review question "does 4-way earn its complexity" -- a 5th
   "admin" kind would be the honest label, and adding one is exactly the creep the review
   timer exists to catch.

5. **`audit_self_directed` shares the auditor icon with `audit_safety`.** Dedicated
   skip-level icon queued, not blocking.

## Not done (parked, per the S-cut boundary)

- Interactive mid-trip planning UI (Q3).
- Doors/approvals gating which strategic paths unlock (ADR-0011 point 2's "which rooms you're
  in locks strategic paths") -- a content/branching system, not hour-typing plumbing.
- Balance dials for the split: `attention.planning_share` is still #996's un-swept 0.6 and
  remains the single biggest lever here. Untouched on purpose -- this lane changed no numbers.
- Per-kind budgets, audit consequences beyond the books, T4 manager-era distortion.
- The overnight ADR prose for the hour-typing ruling (Ballot 4 says it must carry the
  review-by clause, ADR-0018 pattern) -- this lane wrote the review-by into the code headers,
  not into a new ADR file.

Closes #980.

Related: #984 (the 2026-08-31 review workshop), ADR-0011, ADR-0009, PR #996, PR #981, PR #979.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
