### PR TITLE
fix(ui): shared LIFO modal chokepoint -- ModalStack (#877, sim tier 6 -> 0)

### DIFF
--- a/godot/scripts/ui/employee_panel.gd
+++ b/godot/scripts/ui/employee_panel.gd
@@ -217,6 +217,11 @@ func show_staff_id_card(data: Dictionary) -> void:
 
 	# Add panel
 	overlay_parent.add_child(perks_panel)
+	# #877: pin the blocker to the CARD's lifetime. Both close lambdas above/below capture
+	# perks_panel, so once anything else freed the card (ESC via MainUI, a replacing modal)
+	# neither lambda could ever run again and the z=998 MOUSE_FILTER_STOP blocker was
+	# stranded over the whole board -- a dead-mouse soft-lock with nothing visible to blame.
+	perks_panel.tree_exited.connect(blocker.queue_free)
 	perks_panel.z_index = 999
 	perks_panel.visible = true
 

--- a/godot/scripts/ui/event_dialog.gd
+++ b/godot/scripts/ui/event_dialog.gd
@@ -39,6 +39,15 @@ var _pending_event: Dictionary = {}
 var _pending_choice_id: String = ""
 var _reason_label: Label = null
 
+## #877: the dialog currently on screen. The presenter used to have NO handle on an
+## externally-destroyed panel: click_blocker lived at the viewport root and was freed only by
+## report_choice_result(success), and is_showing_event was only ever cleared on that same path.
+## So a panel torn down any other way (a replacing modal, a scene teardown) stranded a
+## full-screen MOUSE_FILTER_STOP blocker AND left is_showing_event stuck true -- every future
+## event then queued forever behind a presenter that thought it was still busy. This handle +
+## the tree_exited hook below make the teardown self-healing whoever performs it.
+var _showing_dialog: Control = null
+
 func present(event: Dictionary) -> void:
 	"""Handle event trigger - queue event for sequential presentation"""
 	print("[EventDialog] === EVENT TRIGGERED: %s ===" % event.get("name", "Unknown"))
@@ -283,6 +292,12 @@ func _show_next_event() -> void:
 	# Mark this as an event dialog to prevent ESC from closing it (issue #452)
 	dialog.set_meta("is_event_dialog", true)
 
+	# #877: pin the root-level blocker to the panel's lifetime, so ANY teardown path takes the
+	# blocker with it -- the same idiom main_ui._present_modal_dialog uses for its barrier.
+	_showing_dialog = dialog
+	dialog.tree_exited.connect(click_blocker.queue_free)
+	dialog.tree_exited.connect(_on_shown_dialog_gone.bind(dialog))
+
 	# Hand the dialog + buttons to the host for keyboard routing (MainUI._input)
 	print("[EventDialog] Emitting dialog_opened with %d buttons" % buttons.size())
 	dialog_opened.emit(dialog, buttons)
@@ -341,6 +356,10 @@ func report_choice_result(success: bool, message: String) -> void:
 
 	# SUCCESS: the choice actually resolved -- close this dialog and move on.
 	message_logged.emit("[color=cyan]Event choice: %s[/color]" % _pending_choice_id)
+	# #877: hand the teardown off from the tree_exited safety net to this (correct) path, so
+	# the net does not double-fire dialog_closed / clobber the next event's presenter state.
+	if _showing_dialog == _pending_dialog:
+		_showing_dialog = null
 	if is_instance_valid(_pending_dialog):
 		_pending_dialog.queue_free()
 	if is_instance_valid(_pending_blocker):
@@ -360,6 +379,26 @@ func report_choice_result(success: bool, message: String) -> void:
 	else:
 		print("[EventDialog] Event resolved, queue empty")
 		is_showing_event = false
+
+
+func _on_shown_dialog_gone(dialog: Control) -> void:
+	"""#877 safety net: the on-screen event panel left the tree WITHOUT resolving (the success
+	path clears _showing_dialog first, so this only runs on an external teardown). Reset the
+	presenter instead of leaving it stuck 'busy' forever, and tell the host to clear its
+	key-routing slots. If events were waiting behind this one, present the next once the tree
+	settles -- an unanswered queue with an idle presenter is the stuck-queue failure."""
+	if _showing_dialog != dialog:
+		return
+	_showing_dialog = null
+	_pending_dialog = null
+	_pending_blocker = null
+	_pending_event = {}
+	_pending_choice_id = ""
+	_reason_label = null
+	is_showing_event = false
+	dialog_closed.emit()
+	if not event_queue.is_empty():
+		call_deferred("_show_next_event")
 
 
 func _show_reason(message: String) -> void:

--- a/godot/scripts/ui/hiring_panel_controller.gd
+++ b/godot/scripts/ui/hiring_panel_controller.gd
@@ -41,10 +41,8 @@ func _show_hiring_submenu():
 	every action routes through the existing GameManager.hiring_* delegates and the panel
 	reads the live Researcher objects in state.candidate_pool / state.researchers, so
 	reveal-gated card data (get_card_data) shows exactly what interviewing has earned."""
-	if host.active_dialog != null and is_instance_valid(host.active_dialog):
-		host.active_dialog.queue_free()
-		host.active_dialog = null
-		host.active_dialog_buttons = []
+	# #877: free-first moved into ModalStack (via host._present_modal_dialog) -- it pops the
+	# incumbent top-first, or refuses this open when an unanswered event holds the top.
 
 	var st = host.game_manager.state
 	if st == null:
@@ -409,10 +407,8 @@ func _show_offer_dialog(candidate_id: String) -> void:
 	var cand = st.hiring.find_pool_candidate(st, candidate_id)
 	if cand == null:
 		return
-	if host.active_dialog != null and is_instance_valid(host.active_dialog):
-		host.active_dialog.queue_free()
-		host.active_dialog = null
-		host.active_dialog_buttons = []
+	# #877: free-first moved into ModalStack (via host._present_modal_dialog) -- it pops the
+	# incumbent top-first, or refuses this open when an unanswered event holds the top.
 
 	var dialog := Panel.new()
 	var dsize := Vector2(460, 470)

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -138,12 +138,23 @@ var _feed_important_only: bool = true    # default view hides the flavour spam
 var _feed_hide_rivals: bool = not GameConfig.show_rivals_feed
 const FEED_MAX_LINES: int = 500          # cap the backing model so a long run stays bounded (trim oldest)
 
-# Active dialog state for keyboard shortcuts
+# Active dialog state for keyboard shortcuts. #877: these two are still READ all over
+# _input/_unhandled_input, but ModalStack is now their ONLY writer -- nothing else may
+# assign them, or the dual-source-of-truth orphan class comes straight back.
 var active_dialog: Control = null
 var active_dialog_buttons: Array = []
+## #877: the shared LIFO overlay chokepoint. Every modal surface in the game --
+## submenus, ledger, doom trend, hiring, travel, the event dialog, the staff ID card and
+## the bug-report form -- registers here, so ESC/close always acts on the TOP one and no
+## panel can survive untracked. Created first thing in _ready: dialogs can be presented
+## from boot-time signals.
+var modal_stack: ModalStack = null
 
 func _ready():
 	print("[MainUI] Initializing UI...")
+
+	# #877: build the modal chokepoint BEFORE anything can present a dialog.
+	modal_stack = ModalStack.new(self)
 
 	# HUD tooltips that quote balance numbers are built from Balance here, so they
 	# track the mechanic instead of drifting from a hardcoded literal in the scene
@@ -524,16 +535,10 @@ func _input(event: InputEvent):
 			# ESC key: only close submenu dialogs (hiring, fundraising), NOT event dialogs
 			# Event dialogs must be completed to prevent soft-lock (issue #452)
 			if event.keycode == KEY_ESCAPE:
-				# Check if this is an event dialog by looking for "event_dialog" meta flag
-				if active_dialog.has_meta("is_event_dialog"):
-					# Event dialogs cannot be closed with ESC - player must make a choice
-					print("[MainUI] ESC pressed but this is an event dialog - ignoring (must complete event)")
-					get_viewport().set_input_as_handled()
-					return
-				else:
-					# Submenu dialogs can be closed with ESC
-					print("[MainUI] ESC pressed on submenu dialog - closing")
-					_close_active_submenu()
+				# #877: ESC goes to the chokepoint, which closes STRICTLY the topmost modal
+				# and refuses on an unanswered event dialog (#452). One rule, one place --
+				# no key path can reach past what the player is looking at.
+				if modal_stack.handle_escape():
 					get_viewport().set_input_as_handled()
 					return
 
@@ -588,7 +593,7 @@ func _input(event: InputEvent):
 		# N key to open bug reporter (backslash was reclaimed for the DEV MODE overlay)
 		elif event.keycode == KEY_N:
 			if bug_report_panel:
-				bug_report_panel.show_panel()
+				_open_bug_report_panel()
 				get_viewport().set_input_as_handled()
 
 		# Quick menu shortcuts (H, F, R, P, T)
@@ -849,8 +854,11 @@ func _show_conference_backlog(trip: Dictionary) -> void:
 		game_manager.surface_pending_events())
 	vbox.add_child(close_btn)
 
-	_present_modal_dialog(dialog)
+	# #877: assign BEFORE presenting -- _present_modal_dialog reads the slot to pick up the
+	# routed buttons and re-asserts the truth if the open is refused. Assigning after would
+	# stamp a discarded panel back into the tracked slot.
 	active_dialog = dialog
+	_present_modal_dialog(dialog)
 	# One compressed feed line is the persistent record; the panel is the readable surface.
 	log_message("[color=#c8b98a]Back from %s -- %d items waiting.[/color]" % [conf_name, backlog.size()])
 
@@ -1001,7 +1009,20 @@ func _on_open_employee_screen() -> void:
 
 func _on_bug_report_button_pressed():
 	"""Open bug report panel"""
-	if bug_report_panel:
+	_open_bug_report_panel()
+
+func _open_bug_report_panel() -> void:
+	"""#877 headline repro: BugReportPanel is a persistent scene member that used to live
+	OUTSIDE the modal bookkeeping entirely, so it could sit open UNDERNEATH a ledger. Its
+	focused LineEdit then tripped the #575 text-focus gate in _input, which returns before
+	ESC/L are read -- the top modal became un-closeable ('ESC twice, blind'). Registering it
+	in the stack (close_mode HIDE -- it must never be freed out of the scene) makes that
+	arrangement unreachable: opening the form pops whatever was up, and opening anything else
+	pops the form. An unanswered event still outranks it, so present() can refuse."""
+	if bug_report_panel == null:
+		return
+	if modal_stack.present(bug_report_panel, [], {
+			"kind": "bug_report", "close_mode": ModalStack.CloseMode.HIDE}):
 		bug_report_panel.show_panel()
 
 func _on_research_quality_selected(mode: String):
@@ -1579,11 +1600,10 @@ func _add_submenu_close_affordance(dialog: Control) -> void:
 	SubmenuChrome.add_close_affordance(dialog, _close_active_submenu)
 
 func _close_active_submenu() -> void:
-	"""Close the active submenu dialog (shared by [X] click and ESC)."""
-	if active_dialog != null and is_instance_valid(active_dialog):
-		active_dialog.queue_free()
-	active_dialog = null
-	active_dialog_buttons = []
+	"""Close the active submenu dialog (shared by [X] click and ESC). #877: delegates to
+	the chokepoint so it closes STRICTLY the topmost modal and honours each modal's close
+	mode (the bug-report form hides, it must not be freed out of the scene)."""
+	modal_stack.dismiss_top()
 
 func _present_modal_dialog(dialog: Control) -> void:
 	"""Mount a modal Panel over the board WITH a full-rect input barrier beneath it
@@ -1594,7 +1614,21 @@ func _present_modal_dialog(dialog: Control) -> void:
 	swallows every click to the board. The barrier is a sibling added just BEFORE the
 	dialog (so the dialog, a later sibling, still receives its own clicks) and is freed
 	automatically when the dialog leaves the tree -- via ANY close path (X, ESC, cancel,
-	or a replacing dialog's queue_free) -- so no call site needs to manage it."""
+	or a replacing dialog's queue_free) -- so no call site needs to manage it.
+
+	#877: this is also the REGISTRATION point for every board-mounted modal. Call sites
+	still assign active_dialog/active_dialog_buttons just before calling (that shape is
+	preserved so ~10 builders across four files stay untouched); those writes are read
+	back here and handed to ModalStack, which is what actually owns the slot afterwards.
+	If a higher-priority modal (an unanswered event, #452) holds the top, the newcomer is
+	REFUSED here: the freshly-built panel is discarded and the tracked slot re-asserted,
+	instead of the old free-first idiom silently orphaning the event dialog's blocker."""
+	var buttons: Array = active_dialog_buttons if active_dialog == dialog else []
+	if not modal_stack.can_present():
+		modal_stack.sync()          # undo the call site's optimistic active_dialog write
+		dialog.queue_free()
+		return
+
 	var barrier := ColorRect.new()
 	barrier.name = "ModalInputBarrier"
 	barrier.color = Color(0.0, 0.0, 0.0, 0.35)   # faint dim so the board reads as "behind"
@@ -1605,6 +1639,7 @@ func _present_modal_dialog(dialog: Control) -> void:
 	# Free the barrier whenever the dialog leaves the tree -- via ANY close path (X, ESC,
 	# cancel button, or a replacing dialog's queue_free). No call site manages it.
 	dialog.tree_exited.connect(barrier.queue_free)
+	modal_stack.present(dialog, buttons)
 
 
 func _debug_nudge_doom(delta: float) -> void:
@@ -1624,11 +1659,8 @@ func _debug_nudge_doom(delta: float) -> void:
 
 func _show_doom_trend_expanded() -> void:
 	"""Expanded full-history doom trend panel (#512), reusing the #510 close affordance."""
-	if active_dialog != null and is_instance_valid(active_dialog):
-		active_dialog.queue_free()
-		active_dialog = null
-		active_dialog_buttons = []
-
+	# #877: no local free-first block any more -- _present_modal_dialog -> ModalStack pops
+	# the previous modal (or refuses this open outright if an event is waiting on an answer).
 	var dialog := Panel.new()
 	dialog.custom_minimum_size = Vector2(560, 360)
 	dialog.size = Vector2(560, 360)
@@ -1756,12 +1788,9 @@ func _make_cost_label(cost_text: String, is_free: bool) -> Label:
 func _show_ledger_screen():
 	"""BL-1/#601: open the full Liability Ledger screen. #622 L10: the panel itself is
 	built by LedgerScreen; this stays the single entry point (L key, summary click,
-	financing submenu, dev overlay) and owns the active_dialog bookkeeping."""
-	if active_dialog != null and is_instance_valid(active_dialog):
-		active_dialog.queue_free()
-		active_dialog = null
-		active_dialog_buttons = []
-
+	financing submenu, dev overlay). #877: the free-first block moved into ModalStack --
+	_present_modal_dialog pops the previous modal, or refuses this open if an unanswered
+	event holds the top (which used to orphan the event's root-level blocker)."""
 	var ledger = game_manager.state.ledger if (game_manager and game_manager.state) else null
 	# fix/ui-no-dead-ends: build_screen now attaches the close [X] + intrinsic Esc
 	# (ui_cancel) affordance itself, wired to our _close_active_submenu so the dialog
@@ -1940,19 +1969,19 @@ func _on_event_dialog_opened(dialog: Control, buttons: Array) -> void:
 	"""EventDialog put its modal up (#622) -- route MainUI keyboard shortcuts to it.
 	The dialog carries the is_event_dialog meta, so ESC handling keeps refusing to
 	close it (#452)."""
-	# An event can fire while a submenu/ledger is already open. Overwriting active_dialog
-	# without freeing the prior panel ORPHANS it (visible with its input barrier, but
-	# untracked -> Esc/L/N no longer close it). Free it first so the visible overlay and
-	# the tracked slot can never diverge. (Mirrors _on_employee_dialog_opened.)
-	if active_dialog != null and is_instance_valid(active_dialog) and active_dialog != dialog:
-		active_dialog.queue_free()
-	active_dialog = dialog
-	active_dialog_buttons = buttons
+	# #877: an event can fire while a submenu/ledger is already open. The chokepoint pops
+	# the incumbent top-first (freeing it AND its barrier via tree_exited) before the event
+	# panel takes the slot, so the visible overlay and the tracked slot cannot diverge.
+	# PRIORITY_MUST_ANSWER also makes the inverse direction safe: nothing else may open
+	# over an unanswered event and orphan its root-level blocker.
+	modal_stack.present(dialog, buttons, {
+		"kind": "event", "priority": ModalStack.PRIORITY_MUST_ANSWER,
+	})
 
 func _on_event_dialog_closed() -> void:
-	"""EventDialog dismissed its modal -- clear the keyboard-routing state (#622)."""
-	active_dialog = null
-	active_dialog_buttons = []
+	"""EventDialog dismissed its modal -- clear the keyboard-routing state (#622).
+	#877: the panel already freed itself, so this is a re-sync, not a second close path."""
+	modal_stack.sync()
 
 func _on_event_choice_selected(event: Dictionary, choice_id: String) -> void:
 	"""Resolution stays signal-driven through game_manager.resolve_event (#622, L1 reuse).
@@ -2049,16 +2078,17 @@ func _reset_resource_highlights():
 	# ap_label is RichTextLabel - skip color override reset (it uses BBCode colors)
 
 func _on_employee_dialog_opened(dialog: Control) -> void:
-	"""EmployeePanel put the staff ID card up (#622). Preserves the old behavior:
-	any existing dialog is closed first, then the ID card becomes the active dialog
-	(the buttons array is left as-is, exactly as before the extraction)."""
-	if active_dialog != null and is_instance_valid(active_dialog) and active_dialog != dialog:
-		active_dialog.queue_free()
-	active_dialog = dialog
+	"""EmployeePanel put the staff ID card up (#622). #877: routed through the chokepoint,
+	which closes the incumbent top-first. EmployeePanel mounts the card before emitting, so
+	a REFUSAL (an unanswered event holds the top) has to unwind the mount -- freeing the
+	card also frees its blocker, which employee_panel now ties to the card's tree_exited."""
+	if not modal_stack.present(dialog, [], {"kind": "employee_card"}):
+		dialog.queue_free()
 
 func _on_employee_dialog_closed() -> void:
-	"""Staff ID card dismissed (blocker click or its own close button)."""
-	active_dialog = null
+	"""Staff ID card dismissed (blocker click or its own close button). #877: the card
+	frees itself, so this only re-syncs the routing slots."""
+	modal_stack.sync()
 
 func _on_employee_info_text(text: String) -> void:
 	"""Perk hover details from the staff ID card feed the shared info bar."""

--- a/godot/scripts/ui/modal_stack.gd
+++ b/godot/scripts/ui/modal_stack.gd
@@ -1,0 +1,238 @@
+class_name ModalStack
+extends RefCounted
+## Issue #877: THE single LIFO chokepoint that owns modal/overlay lifetime.
+##
+## WHY: before this, four independent systems wrote MainUI.active_dialog BY HAND --
+## the submenu/ledger/hiring/travel builders (free-first idiom), EventDialog
+## (_on_event_dialog_opened), EmployeePanel (_on_employee_dialog_opened) and the
+## standalone BugReportPanel (which never registered at all). A single slot kept in
+## sync by N hand-written call sites is a dual source of truth: the scene tree says
+## one thing, `active_dialog` says another. Every symptom in #877/#883/#886 is one
+## instance of that desync -- orphaned panels still visible at z=1000 with a live
+## input barrier but untracked, so no key path could close them (soft-lock).
+##
+## THE RULE: nothing sets `active_dialog` directly any more. Call sites `present()`
+## here; this class owns:
+##   * the LIFO list (`_entries`, last == topmost),
+##   * strict top-first teardown (a newcomer pops the whole stack before taking the
+##     slot -- these modals are exclusive by design, none of them compose visually),
+##   * priority refusal: an event dialog is PRIORITY_MUST_ANSWER (#452 -- events must
+##     be answered, not dismissed), so a lower-priority modal opening over one is
+##     REFUSED rather than allowed to orphan it,
+##   * self-healing bookkeeping: every entry is pinned to its node's `tree_exited`
+##     (and, for hide-mode entries, `visibility_changed`), so however a panel dies --
+##     its own [X] lambda, a cancel button's `queue_free()`, a replacing dialog, the
+##     scene going away -- the stack pops it and re-syncs the host. That is what makes
+##     an orphan structurally impossible rather than merely unlikely.
+##
+## BARRIERS: this class deliberately does NOT own input barriers. Each mount point
+## ties its barrier to `dialog.tree_exited` (main_ui._present_modal_dialog,
+## event_dialog._show_next_event, employee_panel.show_staff_id_card), so freeing the
+## node always frees its barrier. Owning them here would just add a second slot to
+## keep in sync -- the exact bug class this exists to kill.
+
+enum CloseMode {
+	FREE,   ## the node is built per-open and is queue_free()d on close (every dialog)
+	HIDE,   ## the node is a persistent scene member; close means hide (BugReportPanel)
+}
+
+## A modal at this priority cannot be preempted by a lower one; the lower open is
+## refused outright. Event dialogs use it (#452: an event must be answered).
+const PRIORITY_MUST_ANSWER := 10
+const PRIORITY_NORMAL := 0
+
+var host   # MainUI node (untyped: avoids a class_name coupling cycle, as with SubmenuController)
+
+var _entries: Array = []   # LIFO: _entries[-1] is the topmost modal
+
+
+func _init(host_ref) -> void:
+	host = host_ref
+
+
+# --- queries -----------------------------------------------------------------------
+
+func depth() -> int:
+	_prune()
+	return _entries.size()
+
+
+func is_empty() -> bool:
+	return depth() == 0
+
+
+func top_node() -> Control:
+	_prune()
+	if _entries.is_empty():
+		return null
+	return _entries[-1]["node"]
+
+
+func top_kind() -> String:
+	_prune()
+	if _entries.is_empty():
+		return ""
+	return String(_entries[-1]["kind"])
+
+
+func can_present(priority: int = PRIORITY_NORMAL) -> bool:
+	"""False when the topmost modal outranks the newcomer (an event dialog blocks
+	everything below PRIORITY_MUST_ANSWER). Call sites check this BEFORE building a
+	panel where that is cheaper than building-then-discarding."""
+	_prune()
+	if _entries.is_empty():
+		return true
+	return priority >= int(_entries[-1]["priority"])
+
+
+# --- the chokepoint ----------------------------------------------------------------
+
+func present(node: Control, buttons: Array = [], opts: Dictionary = {}) -> bool:
+	"""Push `node` as the topmost modal. Returns false (and changes nothing) if a
+	higher-priority modal holds the top. Re-entrant: presenting the current top again
+	only refreshes its key routing, so a double-fire of an `opened` signal is a no-op."""
+	if node == null or not is_instance_valid(node):
+		return false
+	var priority := int(opts.get("priority", PRIORITY_NORMAL))
+
+	_prune()
+	if not _entries.is_empty() and _entries[-1]["node"] == node:
+		_entries[-1]["buttons"] = buttons
+		sync()
+		return true
+
+	if not can_present(priority):
+		# Refused: re-assert the truth in case a call site optimistically wrote
+		# host.active_dialog before mounting.
+		sync()
+		return false
+
+	_pop_all(node)
+
+	_entries.append({
+		"node": node,
+		"buttons": buttons,
+		"priority": priority,
+		"close_mode": int(opts.get("close_mode", CloseMode.FREE)),
+		"kind": String(opts.get("kind", "")),
+	})
+	var gone_cb := _on_node_gone.bind(node)
+	if not node.tree_exited.is_connected(gone_cb):
+		node.tree_exited.connect(gone_cb, CONNECT_ONE_SHOT)
+	if int(opts.get("close_mode", CloseMode.FREE)) == CloseMode.HIDE:
+		var vis_cb := _on_node_visibility_changed.bind(node)
+		if not node.visibility_changed.is_connected(vis_cb):
+			node.visibility_changed.connect(vis_cb)
+	sync()
+	return true
+
+
+func dismiss_top() -> bool:
+	"""Close STRICTLY the topmost modal (the LIFO half of #877). Never touches a
+	buried one, so a close key can never reach past what the player is looking at."""
+	_prune()
+	if _entries.is_empty():
+		sync()
+		return false
+	var entry: Dictionary = _entries.pop_back()
+	_close_entry(entry)
+	sync()
+	return true
+
+
+func dismiss_all() -> void:
+	"""Tear the whole stack down top-first (scene exit / hard reset paths)."""
+	_pop_all(null)
+	sync()
+
+
+func dismiss(node: Control) -> bool:
+	"""Close a specific registered modal wherever it sits in the stack."""
+	_prune()
+	for i in range(_entries.size() - 1, -1, -1):
+		if _entries[i]["node"] == node:
+			var entry: Dictionary = _entries[i]
+			_entries.remove_at(i)
+			_close_entry(entry)
+			sync()
+			return true
+	return false
+
+
+func handle_escape() -> bool:
+	"""ESC closes the TOPMOST modal only. Returns true when ESC was consumed --
+	including the refusal case (an event dialog swallows ESC per #452 rather than
+	letting it fall through to the pause menu behind the still-visible dialog)."""
+	_prune()
+	if _entries.is_empty():
+		return false
+	if int(_entries[-1]["priority"]) >= PRIORITY_MUST_ANSWER:
+		return true
+	dismiss_top()
+	return true
+
+
+# --- bookkeeping -------------------------------------------------------------------
+
+func sync() -> void:
+	"""Push the stack's truth into the host's key-routing slots. These stay public on
+	MainUI because _input/_unhandled_input read them, but this is now their ONLY writer."""
+	_prune()
+	if host == null or not is_instance_valid(host):
+		return
+	if _entries.is_empty():
+		host.active_dialog = null
+		host.active_dialog_buttons = []
+	else:
+		host.active_dialog = _entries[-1]["node"]
+		host.active_dialog_buttons = _entries[-1]["buttons"]
+
+
+func _prune() -> void:
+	"""Drop entries whose node died or is dying. `is_queued_for_deletion` counts: a
+	queue_free()d panel is already gone as far as the player is concerned, and leaving
+	it in `active_dialog` is exactly the 'tracked slot points at a dying node' failure."""
+	for i in range(_entries.size() - 1, -1, -1):
+		var n = _entries[i]["node"]
+		if n == null or not is_instance_valid(n) or n.is_queued_for_deletion():
+			_entries.remove_at(i)
+
+
+func _pop_all(exclude: Control) -> void:
+	while not _entries.is_empty():
+		var entry: Dictionary = _entries.pop_back()
+		if entry["node"] == exclude:
+			continue
+		_close_entry(entry)
+
+
+func _close_entry(entry: Dictionary) -> void:
+	var n = entry["node"]
+	if n == null or not is_instance_valid(n):
+		return
+	if int(entry["close_mode"]) == CloseMode.HIDE:
+		if n.has_method("hide_panel"):
+			n.hide_panel()
+		else:
+			n.visible = false
+	elif not n.is_queued_for_deletion():
+		n.queue_free()
+
+
+func _forget(node: Control) -> void:
+	for i in range(_entries.size() - 1, -1, -1):
+		if _entries[i]["node"] == node:
+			_entries.remove_at(i)
+
+
+func _on_node_gone(node: Control) -> void:
+	"""A registered modal left the tree by ANY path. This is the self-healing edge:
+	the stack never needs the closer to tell it what happened."""
+	_forget(node)
+	sync()
+
+
+func _on_node_visibility_changed(node: Control) -> void:
+	if node != null and is_instance_valid(node) and not node.visible:
+		_forget(node)
+		sync()

--- a/godot/scripts/ui/modal_stack.gd.uid
+++ b/godot/scripts/ui/modal_stack.gd.uid
@@ -1,0 +1,1 @@
+uid://drbgmux304xi8

--- a/godot/scripts/ui/submenu_controller.gd
+++ b/godot/scripts/ui/submenu_controller.gd
@@ -166,11 +166,8 @@ func on_option_selected(action_id: String, action_name: String, dialog: Control,
 func _build_grid_submenu(id: String) -> void:
 	var cfg: Dictionary = GRID_CONFIG[id]
 
-	# Close any existing dialog first (single-active-submenu invariant).
-	if host.active_dialog != null and is_instance_valid(host.active_dialog):
-		host.active_dialog.queue_free()
-		host.active_dialog = null
-		host.active_dialog_buttons = []
+	# Single-active-submenu invariant. #877: free-first moved into ModalStack (via host._present_modal_dialog) -- it pops the
+	# incumbent top-first, or refuses this open when an unanswered event holds the top.
 
 	var dialog := Panel.new()
 	var psize: Vector2 = cfg["panel_size"]
@@ -331,10 +328,8 @@ func _build_financing_submenu() -> void:
 	button that opens the full switchable ledger screen. A LIST, not an icon grid, so it is a
 	sibling special-case; it still shares on_option_selected() and the modal mount. Verbatim
 	move of the pre-carve _show_financing_submenu."""
-	if host.active_dialog != null and is_instance_valid(host.active_dialog):
-		host.active_dialog.queue_free()
-		host.active_dialog = null
-		host.active_dialog_buttons = []
+	# #877: free-first moved into ModalStack (via host._present_modal_dialog) -- it pops the
+	# incumbent top-first, or refuses this open when an unanswered event holds the top.
 
 	var dialog := Panel.new()
 	dialog.custom_minimum_size = Vector2(440, 330)

--- a/godot/scripts/ui/travel_panel_controller.gd
+++ b/godot/scripts/ui/travel_panel_controller.gd
@@ -42,12 +42,9 @@ func _show_travel_submenu():
 	"""Show popup dialog with travel/conference options - Issue #468"""
 	print("[MainUI] === TRAVEL SUBMENU STARTING ===")
 
-	# Close any existing dialog first
-	if host.active_dialog != null and is_instance_valid(host.active_dialog):
-		print("[MainUI] Closing existing dialog...")
-		host.active_dialog.queue_free()
-		host.active_dialog = null
-		host.active_dialog_buttons = []
+	# #877: the local free-first block moved into ModalStack (via host._present_modal_dialog),
+	# so the incumbent is popped top-first -- or this open is refused outright when an
+	# unanswered event holds the top, instead of stranding that event's blocker.
 
 	# Use Panel
 	var dialog = Panel.new()
@@ -404,8 +401,10 @@ func _show_conference_trip_dialog() -> void:
 		host.active_dialog = null)
 	vbox.add_child(cancel)
 
-	host._present_modal_dialog(dialog)
+	# #877: assign BEFORE presenting -- the chokepoint reads the slot and re-asserts it if
+	# the open is refused (an unanswered event outranks every other modal).
 	host.active_dialog = dialog
+	host._present_modal_dialog(dialog)
 
 
 func _on_conference_trip_committed(conf_id: String, dialog: Control) -> void:


### PR DESCRIPTION
Closes #877. Fixes the sim-tier red in #964.

## The chokepoint

`godot/scripts/ui/modal_stack.gd` (`ModalStack`, a RefCounted owned by MainUI -- same idiom as `SubmenuController` / `PlanController`, no new autoload) is now the **only writer** of `MainUI.active_dialog` / `active_dialog_buttons`. It holds a LIFO list of registered modals and tears down strictly top-first: a newcomer pops the incumbent before taking the slot, `dismiss_top()` never reaches past what the player is looking at, and ESC routes through `handle_escape()`. It adds a **priority** rule -- an event dialog registers at `PRIORITY_MUST_ANSWER` (#452: events must be answered, not dismissed), so opening any other modal over an unanswered event is **refused** instead of being allowed to free the event panel and strand its viewport-root blocker. The load-bearing property is that every entry is pinned to its node's `tree_exited` (plus `visibility_changed` for hide-mode entries), so however a panel dies -- its own `[X]` lambda, a cancel button's `queue_free()`, a replacing dialog, scene teardown -- the stack pops it and re-syncs the host. That makes an orphan structurally impossible rather than merely unlikely. Barriers are deliberately **not** owned by the stack: each mount point ties its barrier to its dialog's `tree_exited`, because a second slot to keep in sync is the exact bug class this exists to kill.

Registered surfaces: every board-mounted modal (submenus, ledger, doom trend, hiring, travel and their sub-dialogs) via the existing shared mount `main_ui._present_modal_dialog`, which is now also the registration point -- so the ~10 builders across four files kept their `active_dialog = dialog` shape and only lost their local free-first blocks. Plus the event dialog, the staff ID card, and `BugReportPanel` (`close_mode: HIDE` -- it is a persistent scene member and must never be freed out of the scene).

## The 6 violations and what routed each

| Failing test | Violations | Root cause | Fix |
|---|---|---|---|
| `test_every_dialog_kind_opens_and_closes_clean` | 2 | staff-card ESC dead-mouse: `employee_panel.gd`'s z=998 `MOUSE_FILTER_STOP` blocker was freed only by two lambdas that both capture `perks_panel`; once MainUI freed the card, neither could ever run (I3 orphan barrier, I7 unclosable) | `perks_panel.tree_exited.connect(blocker.queue_free)` |
| `test_event_firing_over_each_open_dialog_kind` | 3 | an event firing over ANY open dialog adopted the slot; the incumbent's teardown and the slot write were separate hand-written steps | `_on_event_dialog_opened` -> `modal_stack.present(...)`, which pops the incumbent top-first (freeing its barrier via `tree_exited`) before the event takes the slot |
| `test_opening_each_dialog_kind_over_a_live_event_dialog` | 15 | the inverse: the free-first idiom freed the event **panel** but its blocker lived at the viewport root, untracked, freed only by `report_choice_result(success)`; `is_showing_event` also stuck true -> permanent mouse block + every future event queued forever | `PRIORITY_MUST_ANSWER` refuses the open outright (the test explicitly allows "either refused, or both torn down"); belt-and-braces, the blocker is now pinned to the panel's `tree_exited` and `EventDialog._on_shown_dialog_gone` resets the presenter on any external teardown |
| `test_same_frame_collision_event_then_ledger` | 3 | same as above, hit inside `present()`'s await window | same refusal path; it is synchronous, so the frame-exact interleave lands on the same rule |
| `test_rapid_double_open_same_kind` | 2 | double-open of the staff card left the first card's blocker stranded (I4: two simultaneous barriers) | the `tree_exited` pin above; `present()` is also re-entrant (presenting the current top only refreshes key routing) |
| `test_monkey_full_ops_seeded` | 2 (broke at step 12) | the full hostile op set is a mixture of the above | all of the above; 140 ops now hold every invariant |

Held green throughout: `test_pairwise_dialog_replacement_matrix` (81 ordered pairs), `test_monkey_safe_ops_seeded`, `test_two_queued_events_resolve_sequentially_clean`, `test_orphaned_ledger_amplifies_on_reopen`.

## Assertions I believe are wrong

**None.** Every one of the 6 was a real invariant violation, exactly as #964 read them. No assertion, threshold, seed or invariant was touched -- `test_adversarial_ui_state.gd` is byte-identical to `main`.

One judgement call worth review: `test_opening_each_dialog_kind_over_a_live_event_dialog` offers two legal outcomes ("either refused, or the event dialog + ITS ROOT-LEVEL BLOCKER are both torn down"). I took **refused**, because an event dialog is already a must-answer modal (#452 forbids ESC on it), so letting a submenu dismiss one would have been a quiet gameplay change -- it would let a player duck an unanswered event by pressing L. The consequence is that dev-overlay jump buttons are now no-ops while an event is up; that is the correct read of the priority rule, not a regression.

## Also fixed on the way (same class, #886 findings)

- `event_dialog.gd`: the root-level `click_blocker` is pinned to the panel, and an externally-destroyed panel now resets `is_showing_event` / `_pending_*` and drains any queued events instead of wedging the presenter forever.
- `bug_report_panel` registration closes the **#877 headline repro**: the form can no longer sit open *underneath* another modal, so the #575 text-focus gate can never suppress the top modal's own ESC/L close keys ("ESC twice, blind").
- `_close_active_submenu()` no longer blind-`queue_free`s `active_dialog`; it delegates to `dismiss_top()`, which honours each modal's close mode.

## Gates

- **Sim tier before:** `107 tests, 6 failures, 8/8 files collected` (matches #964's `Failing 6`, byte-identical deterministic violations, seed 727272).
- **Sim tier after:** `107 tests, 0 failures, 8/8 files collected`.
- **Fast gate:** `983 tests, 0 failures, 95/95 files collected`.

Note #964's second ask -- a surfacing mechanism so non-blocking red is visible -- is **not** in this PR; it is a CI-plumbing change, not a UI fix. Worth splitting out so #964 can close on both halves.

Not merging; over to Pip for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
