### PR TITLE
fix(upgrades): wire or retire six no-op upgrades + hire_ethicist claim (#970)

### DIFF
--- a/godot/data/balance/defaults.json
+++ b/godot/data/balance/defaults.json
@@ -274,5 +274,12 @@
 				"availability": { "min_rep": 0, "org_types": [] }
 			}
 		}
+	},
+	"upgrades": {
+		"_description": "Issue #970: coefficients for the six upgrades that used to print effect claims with zero backing code. Wired into actions.gd (capability_research) and doom_system.gd (_advance_intermediaries).",
+		"upgrade_computer": { "research_bonus": 1.0 },
+		"hpc_cluster": { "research_multiplier": 0.25 },
+		"research_automation": { "compute_scale": 0.02 },
+		"secure_cloud": { "frontier_dampen": 0.15 }
 	}
 }

--- a/godot/scripts/core/actions.gd
+++ b/godot/scripts/core/actions.gd
@@ -405,6 +405,15 @@ static func execute_action(action_id: String, state: GameState) -> Dictionary:
 		"capability_research":
 			# Capability research generates research points
 			var research_gained = state.capability_researchers * 5.0
+			# #970: upgrade_computer/hpc_cluster/research_automation used to print effect
+			# claims with zero backing code. Wired here -- the only action that GENERATES
+			# research points, matching each upgrade's own description text.
+			if state.has_upgrade("upgrade_computer"):
+				research_gained += Balance.num("upgrades.upgrade_computer.research_bonus", 1.0)
+			if state.has_upgrade("hpc_cluster"):
+				research_gained *= 1.0 + Balance.num("upgrades.hpc_cluster.research_multiplier", 0.25)
+			if state.has_upgrade("research_automation"):
+				research_gained += state.compute * Balance.num("upgrades.research_automation.compute_scale", 0.02)
 			state.add_resources({"research": research_gained})
 			result["message"] = "Capability research (+%0.1f research)" % research_gained
 
@@ -783,10 +792,14 @@ static func execute_action(action_id: String, state: GameState) -> Dictionary:
 			result["message"] = "Grant approved! Received %s" % GameConfig.format_money(total)
 
 		"hire_ethicist":
-			# Ethicist improves safety research effectiveness
+			# #970: "improves safety research" was an unbacked claim (no ethicist-count
+			# state field, nothing read it -- comment admitted it: "Would track ethicist
+			# count in expanded state"). Tracking a persistent ethicist headcount and wiring
+			# it into the safety-research effectiveness stream is a real design question
+			# (does it stack? decay? cap?) -- Pip's call, not stripped in silently. Only the
+			# +5 reputation, which does fire, is claimed here.
 			state.add_resources({"reputation": 5})
-			# Note: Would track ethicist count in expanded state
-			result["message"] = "Hired AI ethicist (+5 reputation, improves safety research)"
+			result["message"] = "Hired AI ethicist (+5 reputation)"
 
 	# === RISK SYSTEM INTEGRATION ===
 	# Apply risk contributions for successful actions

--- a/godot/scripts/core/doom_system.gd
+++ b/godot/scripts/core/doom_system.gd
@@ -206,8 +206,15 @@ func _advance_intermediaries(state: GameState) -> void:
 				"safety", "interpretability", "alignment":
 					safety_workers += 1
 
+	# #970: secure_cloud claimed "reduces doom spikes from lab breakthroughs" with zero
+	# backing code. Wired here -- it dampens the player-frontier growth rate driven by
+	# productive capability researchers (the actual "breakthrough" -> doom-relevant channel).
+	var effective_cap_gain := cap_gain
+	if state.has_upgrade("secure_cloud"):
+		effective_cap_gain *= 1.0 - Balance.num("upgrades.secure_cloud.frontier_dampen", 0.15)
+
 	var pf: float = float(state.frontier_capability.get("player", 0.0))
-	pf += cap_workers * cap_gain
+	pf += cap_workers * effective_cap_gain
 	state.frontier_capability["player"] = pf
 	state.safety_absorption += safety_workers * absorb_gain
 	state.global_alarm += safety_workers * alarm_gain

--- a/godot/scripts/core/upgrades.gd
+++ b/godot/scripts/core/upgrades.gd
@@ -14,26 +14,35 @@ static func get_all_upgrades() -> Array[Dictionary]:
 			"category": "infrastructure"
 		},
 		{
+			# 970: "less likely to lose staff on low funds" was unbacked -- no low-funds
+			# staff-attrition system exists to hook into. Inventing one is a design call
+			# (Pip's), not a silent reinterpretation onto an unrelated system. Re-priced
+			# to 0 and relabelled as flavor-only pending that call.
 			"id": "comfy_chairs",
 			"name": "Buy Comfy Office Chairs",
-			"description": "Staff morale up (less likely to lose staff on low funds)",
-			"cost": 120000,
+			"description": "Nicer office chairs. Flavor only for now -- no mechanical effect (#970).",
+			"cost": 0,
 			"effect_key": "comfy_chairs",
 			"category": "office"
 		},
 		{
 			"id": "secure_cloud",
 			"name": "Secure Cloud Provider",
-			"description": "Reduces doom spikes from lab breakthroughs",
+			"description": "Dampens player-frontier growth from capability breakthroughs",
 			"cost": 160000,
 			"effect_key": "secure_cloud",
 			"category": "infrastructure"
 		},
 		{
+			# 970: "cash flow tracking" and "prevents board oversight" were both unbacked --
+			# board_seat ledger riders are explicitly inert-by-design (ledger.gd: "consequences
+			# are owned by other lanes... L5's boundary forbids doom conversion here"), so
+			# there is nothing real to prevent yet. Re-priced to 0 and relabelled pending a
+			# real governance/board-oversight mechanic (Pip's design call).
 			"id": "accounting_software",
 			"name": "Accounting Software",
-			"description": "Enables cash flow tracking, prevents board oversight",
-			"cost": 500000,
+			"description": "Basic bookkeeping tooling. Flavor only for now -- no mechanical effect (#970).",
+			"cost": 0,
 			"effect_key": "accounting_software",
 			"category": "management"
 		},
@@ -96,27 +105,36 @@ static func purchase_upgrade(upgrade_id: String, state: GameState) -> Dictionary
 
 	match upgrade_id:
 		"upgrade_computer":
-			# Note: Effect is applied passively in research actions
+			# #970: wired -- GameActions.execute_action("capability_research", ...) reads
+			# has_upgrade("upgrade_computer") and adds the flat research bonus.
 			result["message"] += " Research actions now more effective!"
 
 		"comfy_chairs":
-			# Passive morale effect
-			result["message"] += " Staff morale improved!"
+			# #970: STOP SELLING -- no low-funds staff-attrition system exists to back
+			# "less likely to lose staff on low funds". Re-priced to 0 (see get_all_upgrades);
+			# flavor-only, no gameplay claim.
+			result["message"] += " Chairs installed. Purely cosmetic for now."
 
 		"secure_cloud":
-			# Passive doom mitigation
+			# #970: wired -- DoomSystem._advance_intermediaries reads has_upgrade("secure_cloud")
+			# and dampens player-frontier growth from capabilities researchers.
 			result["message"] += " Research breakthroughs less risky!"
 
 		"accounting_software":
-			# Unlocks cash flow tracking
-			result["message"] += " Cash flow tracking enabled!"
+			# #970: STOP SELLING -- "cash flow tracking" / "prevents board oversight" had no
+			# backing system (board_seat riders are explicitly inert-by-design). Re-priced to
+			# 0 (see get_all_upgrades); flavor-only, no gameplay claim.
+			result["message"] += " Software installed. Purely cosmetic for now."
 
 		"hpc_cluster":
 			state.add_resources({"compute": 20})
+			# #970: wired -- GameActions.execute_action("capability_research", ...) reads
+			# has_upgrade("hpc_cluster") and applies the +25% research multiplier.
 			result["message"] += " +20 compute, research 25% more effective!"
 
 		"research_automation":
-			# Passive research boost with compute
+			# #970: wired -- GameActions.execute_action("capability_research", ...) reads
+			# has_upgrade("research_automation") and adds a compute-scaled research bonus.
 			result["message"] += " Research scales with compute!"
 
 		"cat_adoption":

--- a/godot/tests/unit/test_actions.gd
+++ b/godot/tests/unit/test_actions.gd
@@ -118,6 +118,60 @@ func test_safety_research_execution():
 		initial_absorb + 1.0 * Balance.num("doom.streams.action_safety_absorb", 0.0), 0.0001,
 		"Safety research raises safety_absorption by the Balance-priced amount")
 
+func test_capability_research_upgrade_computer_wired():
+	# #970: upgrade_computer claimed "Research actions now more effective!" with zero
+	# backing code. GameActions.execute_action("capability_research", ...) now reads it.
+	state.capability_researchers = 1
+	state.research = 100.0
+	var baseline = GameActions.execute_action("capability_research", state)
+	var baseline_gained: float = state.research
+
+	state.research = 100.0
+	state.add_upgrade("upgrade_computer")
+	GameActions.execute_action("capability_research", state)
+	var with_upgrade_gained: float = state.research
+
+	assert_gt(with_upgrade_gained, baseline_gained, "upgrade_computer should raise research gained by capability_research")
+
+func test_capability_research_hpc_cluster_wired():
+	# #970: hpc_cluster claimed "research 25% more effective!" with zero backing code.
+	state.capability_researchers = 1
+	state.research = 100.0
+	GameActions.execute_action("capability_research", state)
+	var baseline_gained: float = state.research
+
+	state.research = 100.0
+	state.add_upgrade("hpc_cluster")
+	GameActions.execute_action("capability_research", state)
+	var with_upgrade_gained: float = state.research
+
+	assert_gt(with_upgrade_gained, baseline_gained, "hpc_cluster should raise research gained by capability_research by 25%")
+
+func test_capability_research_research_automation_wired():
+	# #970: research_automation claimed "Research scales with compute!" with zero backing code.
+	state.capability_researchers = 1
+	state.compute = 200.0
+	state.research = 100.0
+	GameActions.execute_action("capability_research", state)
+	var baseline_gained: float = state.research
+
+	state.research = 100.0
+	state.compute = 200.0
+	state.add_upgrade("research_automation")
+	GameActions.execute_action("capability_research", state)
+	var with_upgrade_gained: float = state.research
+
+	assert_gt(with_upgrade_gained, baseline_gained, "research_automation should raise research gained when compute is available")
+
+func test_hire_ethicist_only_claims_reputation():
+	# #970: "improves safety research" was an unbacked claim (no state ever read it).
+	# Only the reputation gain, which fires, is claimed in the message now.
+	state.money = 200000.0
+	var result = GameActions.execute_action("hire_ethicist", state)
+	assert_true(result.get("success", false), "hire_ethicist should succeed")
+	assert_string_contains(String(result.get("message", "")), "reputation", "Message should mention reputation")
+	assert_false(String(result.get("message", "")).contains("safety research"), "Message should not claim an unbacked safety-research effect")
+
 func test_team_building_execution():
 	# Test team building action
 	var initial_reputation = state.reputation

--- a/godot/tests/unit/test_doom_system.gd
+++ b/godot/tests/unit/test_doom_system.gd
@@ -80,6 +80,27 @@ func test_safety_absorption_reduces_overhang():
 	var result = ds.calculate_doom_change(state)
 	assert_eq(result["sources"]["overhang"], 0.0, "overhang clamps at 0 when absorption exceeds frontier (v1 R2-Q9)")
 
+func test_secure_cloud_dampens_player_frontier_growth():
+	# #970: secure_cloud claimed "reduces doom spikes from lab breakthroughs" with zero
+	# backing code. Wired into _advance_intermediaries: it dampens the player-frontier
+	# growth rate driven by productive capability researchers.
+	var ds_plain = _create_doom_system()
+	var state_plain = _create_minimal_game_state()
+	state_plain.capability_researchers = 1
+	ds_plain.calculate_doom_change(state_plain)
+	var frontier_without_upgrade: float = float(state_plain.frontier_capability.get("player", 0.0))
+	assert_gt(frontier_without_upgrade, 0.0, "capability researcher should grow player frontier at all")
+
+	var ds_upgraded = _create_doom_system()
+	var state_upgraded = _create_minimal_game_state()
+	state_upgraded.capability_researchers = 1
+	state_upgraded.add_upgrade("secure_cloud")
+	ds_upgraded.calculate_doom_change(state_upgraded)
+	var frontier_with_upgrade: float = float(state_upgraded.frontier_capability.get("player", 0.0))
+
+	assert_lt(frontier_with_upgrade, frontier_without_upgrade, "secure_cloud should dampen player-frontier growth")
+	assert_gt(frontier_with_upgrade, 0.0, "secure_cloud dampens, does not zero, frontier growth")
+
 func test_alarm_stream_is_negative_relief():
 	# global_alarm produces a small NEGATIVE stream (the natively-negative component).
 	var ds = _create_doom_system()

--- a/godot/tests/unit/test_upgrades.gd
+++ b/godot/tests/unit/test_upgrades.gd
@@ -47,3 +47,23 @@ func test_upgrade_ids_are_unique():
 		var id = upgrade["id"]
 		assert_false(ids.has(id), "Upgrade ID should be unique: " + id)
 		ids.append(id)
+
+func test_comfy_chairs_and_accounting_software_are_flavor_only():
+	# #970: both upgrades charged real money for claimed effects with zero backing code
+	# (no low-funds staff-attrition system; no cash-flow-tracking / board-oversight system).
+	# STOP SELLING: re-priced to 0 and relabelled as flavor-only pending a design ruling.
+	var comfy = GameUpgrades.get_upgrade_by_id("comfy_chairs")
+	assert_eq(int(comfy.get("cost", -1)), 0, "comfy_chairs should be free (no mechanical effect)")
+	assert_string_contains(String(comfy.get("description", "")), "970", "description should point at the tracking issue")
+
+	var accounting = GameUpgrades.get_upgrade_by_id("accounting_software")
+	assert_eq(int(accounting.get("cost", -1)), 0, "accounting_software should be free (no mechanical effect)")
+	assert_string_contains(String(accounting.get("description", "")), "970", "description should point at the tracking issue")
+
+func test_secure_cloud_purchase_succeeds_and_is_recorded():
+	# The purchase surface itself (money -> has_upgrade) for a WIRED upgrade; the mechanical
+	# effect (frontier-growth dampening) is covered by test_doom_system.gd.
+	state.money = 200000.0
+	var result = GameUpgrades.purchase_upgrade("secure_cloud", state)
+	assert_true(result.get("success", false), "secure_cloud purchase should succeed")
+	assert_true(state.has_upgrade("secure_cloud"), "secure_cloud should be recorded as purchased")


### PR DESCRIPTION
## Summary

Fixes #970: `upgrades.gd` `purchase_upgrade()` charged real money and printed effect
claims for six upgrades that had zero implementing code, plus `hire_ethicist` made an
unbacked claim (the code comment admitted it). Per the issue's fix pattern, each item
below was either **(a) WIRED** onto the smallest honest implementation that maps
cleanly onto an existing system, or **(b) STOPPED SELLING** (re-priced to 0 /
relabelled honestly, comment points at #970) when the honest implementation would
invent a new mechanic -- that's Pip's design call, not mine.

## Per-upgrade table

| Upgrade | Claimed effect | Choice | What happens now | Evidence (test) |
|---|---|---|---|---|
| `upgrade_computer` | "Research actions now more effective! (+1 research per action)" | (a) WIRE | `capability_research` action reads `has_upgrade("upgrade_computer")` and adds a flat research bonus (`Balance: upgrades.upgrade_computer.research_bonus`, default 1.0) | `test_capability_research_upgrade_computer_wired` |
| `hpc_cluster` | "+20 compute, research 25% more effective!" | (a) WIRE | +20 compute already fired (unchanged); `capability_research` now also applies a +25% multiplier when owned (`Balance: upgrades.hpc_cluster.research_multiplier`, default 0.25) | `test_capability_research_hpc_cluster_wired` |
| `research_automation` | "Research scales with compute!" | (a) WIRE | `capability_research` adds a compute-scaled bonus (`research_gained += state.compute * Balance("upgrades.research_automation.compute_scale", 0.02)`) | `test_capability_research_research_automation_wired` |
| `secure_cloud` | "Research breakthroughs less risky! (reduces doom spikes from lab breakthroughs)" | (a) WIRE | `DoomSystem._advance_intermediaries` dampens player-frontier growth from productive capability researchers -- the real "breakthrough" hazard channel (overhang stream reads frontier) -- when owned (`Balance: upgrades.secure_cloud.frontier_dampen`, default 0.15) | `test_secure_cloud_dampens_player_frontier_growth` |
| `comfy_chairs` | "Staff morale improved! (less likely to lose staff on low funds)" | (b) STOP SELLING | No low-funds staff-attrition system exists anywhere in the codebase to hook into -- inventing one is a real design question. Re-priced to 0, relabelled "flavor only for now -- no mechanical effect (#970)" | `test_comfy_chairs_and_accounting_software_are_flavor_only` |
| `accounting_software` | "Cash flow tracking enabled! (prevents board oversight)" | (b) STOP SELLING | No cash-flow-tracking system exists; `board_seat` ledger riders are explicitly documented as inert-by-design ("consequences are owned by other lanes... L5's boundary forbids doom conversion here") -- there's nothing real to "prevent" yet. Re-priced to 0, relabelled flavor-only | `test_comfy_chairs_and_accounting_software_are_flavor_only` |
| `hire_ethicist` | "+5 reputation, improves safety research" | (b) STOP CLAIMING | The +5 reputation is real and fires (kept, unchanged). "Improves safety research" had no backing state -- no ethicist-count field existed anywhere; the in-code comment admitted "Would track ethicist count in expanded state". Tracking headcount and wiring it into the safety-research effectiveness stream (stacking? decay? cap?) is Pip's call. Claim stripped from the message. | `test_hire_ethicist_only_claims_reputation` |

**Choice count: 4x (a) wire, 3x (b) stop selling.**

## Needs Pip's design call

- **comfy_chairs**: what should a "less likely to lose staff on low funds" mechanic
  actually look like? There's currently no staff-attrition-from-low-funds system at
  all (the only existing staff-quit mechanic is un-mentored onboarding quit risk in
  `hiring_pipeline.gd`, which is a different trigger).
- **accounting_software**: `board_seat` ledger riders (from equity financing) are
  parked/inert by explicit design (`ledger.gd`). If/when a real governance/board-oversight
  mechanic lands, this upgrade is the natural place to gate it.
- **hire_ethicist**: whether/how to track a persistent ethicist headcount and feed it
  into the safety-research effectiveness stream (`safety_absorption`/`global_alarm`,
  mirroring how `safety_researchers` count already works in `turn_manager.gd` /
  `actions.gd`).

## New Balance keys (data-driven, `godot/data/balance/defaults.json`)

Added a new top-level `"upgrades"` section: `upgrade_computer.research_bonus` (1.0),
`hpc_cluster.research_multiplier` (0.25), `research_automation.compute_scale` (0.02),
`secure_cloud.frontier_dampen` (0.15). Required by `test_balance_key_coverage.gd`
(issue #971's guard), which fails CI if a `Balance.num()` key in `actions.gd` is
missing from `defaults.json`.

## Compatibility notes

- Branched fresh from `origin/main`, after PR #996 (AP pool removed, costs are
  attention now) and PR #1000 (hour typing) -- no collision, this touches
  `capability_research`'s money/research-cost path and `hire_ethicist`'s effect
  block, neither of which those PRs touched.
- Per the audacity ruling (balance breakage accepted this week), the new coefficients
  are reasonable defaults, not tuned -- Pip can retune via `defaults.json` freely.

## Gate

`python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **990 tests,
0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
