### PR TITLE
chore: prune stale v0.9.0 release entry, fix privacy contact email

### DIFF
--- a/docs/BACKEND_PRIVACY_ARCHITECTURE.md
+++ b/docs/BACKEND_PRIVACY_ARCHITECTURE.md
@@ -374,7 +374,7 @@ third-party analytics or tracking services.
 
 ## Contact
 
-Questions about your data: privacy@pdoom.com
+Questions about your data: team@pdoom1.com
 ```
 
 ## Implementation Checklist

--- a/public/releases/releases.json
+++ b/public/releases/releases.json
@@ -1,32 +1,7 @@
 {
-  "generated_at": "2025-11-08T01:17:49.037051+00:00",
-  "latest_version": "v0.9.0",
-  "latest_stable": "v0.9.0",
-  "releases": [
-    {
-      "version": "v0.9.0",
-      "version_number": "0.9.0",
-      "release_date": "2025-09-28T11:58:20+10:00",
-      "commit_hash": "cd054e6b9e4cc2fb0bca7464280a843e9d6f0cc4",
-      "is_prerelease": false,
-      "changelog": "Release v0.9.0\n\nSee CHANGELOG.md for details.",
-      "downloads": {
-        "windows": "https://github.com/PipFoweraker/pdoom1/releases/download/v0.9.0/PDoom.exe",
-        "linux": "https://github.com/PipFoweraker/pdoom1/releases/download/v0.9.0/PDoom.x86_64",
-        "mac": "https://github.com/PipFoweraker/pdoom1/releases/download/v0.9.0/PDoom.app.zip",
-        "source_zip": "https://github.com/PipFoweraker/pdoom1/releases/download/v0.9.0/pdoom-0.9.0-source.zip",
-        "source_tar": "https://github.com/PipFoweraker/pdoom1/releases/download/v0.9.0/pdoom-0.9.0-source.tar.gz"
-      },
-      "metadata": {
-        "engine": "Godot 4.5.1",
-        "platforms": [
-          "Windows",
-          "Linux",
-          "macOS"
-        ],
-        "tag_message": "v0.9.0: Alpha Stability & Audio System\n\nMajor milestone release featuring:\n- Complete audio system breakthrough (fixed since inception)\n- Monolith architecture extraction (558+ lines)\n- Critical stability improvements (5 GitHub issues resolved)\n- Comprehensive documentation reorganization\n- Enhanced test suite with re-enabled sound tests\n- Ready for stable alpha and beta progression"
-      }
-    }
-  ],
-  "total_releases": 1
+  "generated_at": "2026-07-28T00:00:00+00:00",
+  "latest_version": null,
+  "latest_stable": null,
+  "releases": [],
+  "total_releases": 0
 }

--- a/public/releases/releases.rss
+++ b/public/releases/releases.rss
@@ -5,16 +5,7 @@
     <link>https://pdoom.net</link>
     <description>Latest releases of P(Doom) - AI Safety Strategy Game</description>
     <language>en-us</language>
-    <lastBuildDate>Sat, 08 Nov 2025 01:17:49 +0000</lastBuildDate>
+    <lastBuildDate>Tue, 28 Jul 2026 00:00:00 +0000</lastBuildDate>
     <atom:link href="https://pdoom.net/releases/releases.rss" rel="self" type="application/rss+xml"/>
-    <item>
-      <title>P(Doom) v0.9.0</title>
-      <link>https://github.com/PipFoweraker/pdoom1/releases/tag/v0.9.0</link>
-      <description>Release v0.9.0
-
-See CHANGELOG.md for details.</description>
-      <pubDate>Sun, 28 Sep 2025 11:58:20 +1000</pubDate>
-      <guid isPermaLink="false">pdoom-release-v0.9.0</guid>
-    </item>
   </channel>
 </rss>


### PR DESCRIPTION
## Summary

Two pre-approved hygiene fixes (issue #1005 + a docs correction from Pip).

**1. Prune stale v0.9.0 release feed entry (#1005)**

`public/releases/releases.json` (the public releases index consumed by the website) still advertised `v0.9.0`, but that GitHub Release no longer exists upstream (confirmed via `gh release list --repo PipFoweraker/pdoom1` -- oldest listed release is `v0.10.1`).

- Removed the `v0.9.0` entry from `public/releases/releases.json` (index is now `"releases": [], "total_releases": 0, "latest_version": null, "latest_stable": null"`) and from `public/releases/releases.rss`.
- Left `public/releases/v0.9.0.json` in place on disk for history -- it is no longer referenced by the advertised index/RSS, so nothing points a user at the dead release.
- Note (out of scope for this PR, flagging for a follow-up): the index was already missing `v0.13.0`/`v0.13.1` before this change -- it only ever had the one (now-removed) v0.9.0 entry. A full index regen via `scripts/generate_release_metadata.py` is needed separately to repopulate it with the current real releases.

Verification (`scripts/verify_release_urls.py --sweep`) output, run against the file as committed:

```
[*] Sweeping 0 feed entries in public\releases\releases.json
[OK] No rot found in feed index
```

**2. Fix privacy contact email (Pip ruling)**

`docs/BACKEND_PRIVACY_ARCHITECTURE.md` line ~377 listed `privacy@pdoom.com`, which is not a real alias. Changed to `team@pdoom1.com`, the standard contact per Pip.

## Test plan

- [x] `python scripts/verify_release_urls.py --sweep public/releases/releases.json` -- clean, output above
- [x] docs/public JSON/RSS only, no game code touched -- no Godot test gate needed
- [ ] Pip: confirm the empty-index tradeoff is acceptable, or request a full regen in a follow-up

Generated with [Claude Code](https://claude.com/claude-code)
