### PR TITLE
ci(godot-tests): surface non-blocking sim-tier red instead of hiding it (#964)

### DIFF
--- a/.github/workflows/godot-tests.yml
+++ b/.github/workflows/godot-tests.yml
@@ -118,14 +118,23 @@ jobs:
 
   simulation-tests:
     # SLOW suite: full-game / replay / determinism simulations (~3 min).
-    # Kept VISIBLE but non-blocking initially (not wired into Test Summary and
-    # not a required status check) -- promote to required once it is stable in
-    # CI. continue-on-error lets a failure show as an annotation without failing
-    # the overall run. (#629 runtime-split requirement.)
-    name: Simulation Tests (slow, non-blocking)
+    # Kept VISIBLE but non-blocking: this job is NOT in the required-checks
+    # list (see branch protection -- only "GDScript Syntax Check", "Unit
+    # Tests" and "quality-checks" are required), so it never blocks a merge
+    # regardless of its own conclusion.
+    #
+    # #964: deliberately does NOT use continue-on-error. continue-on-error
+    # makes a failed job report a green check in the PR checks list (GitHub
+    # hides the failure behind success) -- that is exactly how the sim tier
+    # went red on 5 straight main-branch runs unnoticed (#964). Letting the
+    # job fail for real gives a plain red X in the checks list -- visible in
+    # one click -- while staying non-blocking because it is not a required
+    # context. Failure here does not fail the workflow's required jobs.
+    name: Simulation Tests (slow, non-blocking, SIM-TIER)
     runs-on: ubuntu-latest
     needs: syntax-check
-    continue-on-error: true
+    outputs:
+      sim_conclusion: ${{ steps.run_sim.outcome }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -142,15 +151,99 @@ jobs:
           python-version: '3.11'
 
       - name: Run simulation suite
+        id: run_sim
         run: |
-          python scripts/run_godot_tests.py --simulation --ci-mode --min-tests 80
+          python scripts/run_godot_tests.py --simulation --ci-mode --min-tests 80 \
+            --summary-file godot/test-results-simulation-summary.md
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: simulation-test-results
-          path: godot/test-results-simulation.xml
+          path: |
+            godot/test-results-simulation.xml
+            godot/test-results-simulation-summary.md
+          if-no-files-found: warn
+
+  sim-tier-pr-status:
+    # #964 half 2: surface non-blocking sim-tier red on PRs without making it
+    # a required check. Job summary (GITHUB_STEP_SUMMARY, written by
+    # run_godot_tests.py in the job above) already gives a one-click view on
+    # the Actions run page; this job additionally posts/updates a single
+    # PR comment so the red is visible on the PR itself, not just in Actions.
+    # Update-in-place via a hidden marker -- never spams a new comment per push.
+    name: Sim Tier PR Status
+    runs-on: ubuntu-latest
+    needs: simulation-tests
+    if: always() && github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download sim-tier summary
+        if: always()
+        uses: actions/download-artifact@v8
+        continue-on-error: true  # artifact upload itself can fail; comment step must still run
+        with:
+          name: simulation-test-results
+          path: sim-tier-artifact
+
+      - name: Post or update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- sim-tier-pr-status -->';
+            const outcome = '${{ needs.simulation-tests.outputs.sim_conclusion }}';
+
+            let body;
+            if (outcome === 'failure') {
+              let details = '';
+              try {
+                details = fs.readFileSync('sim-tier-artifact/test-results-simulation-summary.md', 'utf8');
+              } catch (e) {
+                details = '(summary file not found -- see the Simulation Tests job log/summary directly.)';
+              }
+              body = marker + '\n' +
+                '## [!] SIM TIER RED\n\n' +
+                'The non-blocking Simulation Tests job failed on this PR. ' +
+                'This does NOT block merge (not a required check), but is a ' +
+                'real signal -- see [ADR context / issue #964](https://github.com/' +
+                context.repo.owner + '/' + context.repo.repo + '/issues/964).\n\n' +
+                details;
+            } else if (outcome === 'success') {
+              body = marker + '\n' + 'SIM TIER: simulation tests passed on this PR.';
+            } else {
+              // cancelled / skipped / unknown -- don't create noise, but update
+              // an existing comment so it doesn't say stale RED forever.
+              body = marker + '\n' + 'SIM TIER: run did not complete cleanly (outcome: ' + outcome + '). Check the Simulation Tests job.';
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else if (outcome === 'failure') {
+              // Only create a NEW comment for the red case -- a passing sim
+              // tier on a PR that never went red should not add clutter.
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
   test-summary:
     name: Test Summary

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ temp_package/
 # GUT JUnit test result artifacts (written by scripts/run_godot_tests.py)
 godot/test-results-*.xml
 test-results-*.xml
+# --summary-file markdown output (same script, #964 sim-tier surfacing)
+godot/test-results-*-summary.md
+test-results-*-summary.md
 
 # Asset generation pipeline (raw generated images - keep only promoted assets)
 art_generated/

--- a/scripts/run_godot_tests.py
+++ b/scripts/run_godot_tests.py
@@ -18,6 +18,14 @@ old runner did NOT, each of which is why CI was green while running zero tests:
      skips (parse error, or `extends Node` instead of GutTest) => count mismatch
      => hard failure naming the offending files. Silence is failure.
 
+Non-blocking-tier surfacing (#964): the simulation tier is intentionally
+non-blocking in CI (slow, run-simulating). A failure there must still be LOUD,
+not silently green -- format_summary_markdown() emits a "[!] <MODE> TIER RED"
+banner plus a per-test failure table for any non-blocking mode that failed.
+This is written to GITHUB_STEP_SUMMARY automatically, and available via
+--summary (stdout) / --summary-file PATH for CI steps that need it as a file
+(e.g. to attach to a PR comment) so local runs and CI share one formatter.
+
 Usage:
     python scripts/run_godot_tests.py                 # unit (fast) + simulation + integration
     python scripts/run_godot_tests.py --quick         # fast unit gate only (tests/unit, non-recursive)
@@ -25,6 +33,8 @@ Usage:
     python scripts/run_godot_tests.py --integration-only
     python scripts/run_godot_tests.py --smoke-only
     python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300
+    python scripts/run_godot_tests.py --simulation --summary            # print the RED-banner table locally
+    python scripts/run_godot_tests.py --simulation --summary-file out.md
 """
 
 import argparse
@@ -151,7 +161,10 @@ def _disk_test_files(test_dir):
 def _parse_junit(junit_path):
     """Parse a GUT JUnit XML file.
 
-    Returns dict {tests, failures, suites:set(basenames)} or None if unparseable.
+    Returns dict {tests, failures, suites:set(basenames), failing_tests:list}
+    or None if unparseable. failing_tests is a list of dicts
+    {suite, test, message} -- one per failed <testcase>, message truncated to
+    one line so it is safe to drop straight into a markdown table cell.
     """
     if not junit_path.exists():
         return None
@@ -160,10 +173,35 @@ def _parse_junit(junit_path):
         tests = int(root.get("tests", "0"))
         failures = int(root.get("failures", "0"))
         suites = set()
+        failing_tests = []
         for suite in root.findall("testsuite"):
             name = suite.get("name", "")  # e.g. "tests/unit/test_foo.gd"
-            suites.add(Path(name).name)
-        return {"tests": tests, "failures": failures, "suites": suites}
+            suite_basename = Path(name).name
+            suites.add(suite_basename)
+            for case in suite.findall("testcase"):
+                fail_el = case.find("failure")
+                if fail_el is None:
+                    continue
+                msg = (fail_el.get("message") or fail_el.text or "").strip()
+                msg = msg.splitlines()[0] if msg else "(no message)"
+                # Keep table rows sane-length; full text is still in the XML artifact.
+                if len(msg) > 160:
+                    msg = msg[:157] + "..."
+                # Markdown table cells can't contain a literal pipe.
+                msg = msg.replace("|", "\\|")
+                failing_tests.append(
+                    {
+                        "suite": suite_basename,
+                        "test": case.get("name", "?"),
+                        "message": msg,
+                    }
+                )
+        return {
+            "tests": tests,
+            "failures": failures,
+            "suites": suites,
+            "failing_tests": failing_tests,
+        }
     except ET.ParseError as e:
         print(f"[PARSE][ERROR] JUnit XML at {junit_path} is malformed: {e}")
         return None
@@ -172,7 +210,7 @@ def _parse_junit(junit_path):
 def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
     """Run one test directory and hard-gate on the JUnit results.
 
-    Returns (ok: bool, tests: int, failures: int).
+    Returns (ok: bool, tests: int, failures: int, failing_tests: list).
     """
     disk_files = _disk_test_files(test_dir)
     if disk_files is None:
@@ -180,11 +218,11 @@ def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
         # runner skipped missing dirs, which is exactly how the smoke gate
         # "passed" while pointing at a nonexistent tests/smoke (#629).
         print(f"\n[FAIL] Test directory {test_dir} does not exist -- cannot run '{mode}'.")
-        return (False, 0, 0)
+        return (False, 0, 0, [])
 
     if not disk_files:
         print(f"\n[FAIL] No test_*.gd files found in {test_dir} for '{mode}'.")
-        return (False, 0, 0)
+        return (False, 0, 0, [])
 
     junit_fs = GODOT_PROJECT / f"test-results-{mode}.xml"
     junit_res = f"res://test-results-{mode}.xml"
@@ -215,10 +253,10 @@ def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
         exit_code = result.returncode
     except subprocess.TimeoutExpired:
         print("\n[FAIL] Tests timed out after 15 minutes!")
-        return (False, 0, 0)
+        return (False, 0, 0, [])
     except Exception as e:
         print(f"\n[FAIL] Failed to run tests: {e}")
-        return (False, 0, 0)
+        return (False, 0, 0, [])
 
     # --- The gate: trust the JUnit file, not the exit code. ---
     parsed = _parse_junit(junit_fs)
@@ -227,11 +265,12 @@ def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
             f"\n[FAIL] '{mode}': no parseable JUnit results at {junit_fs}. "
             "GUT ran nothing or quit early (missing import pass? bad args?)."
         )
-        return (False, 0, 0)
+        return (False, 0, 0, [])
 
     tests = parsed["tests"]
     failures = parsed["failures"]
     collected = parsed["suites"]
+    failing_tests = parsed["failing_tests"]
 
     ok = True
 
@@ -271,29 +310,84 @@ def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
         f"\n[{status}] '{mode}': {tests} tests, {failures} failures, "
         f"{len(collected)}/{len(disk_files)} files collected."
     )
-    return (ok, tests, failures)
+    return (ok, tests, failures, failing_tests)
+
+
+# Modes considered "non-blocking" tiers in CI: a failure here does not fail the
+# required gate, so it needs its own loud banner or nobody will ever see it
+# (issue #964 -- the simulation tier was red on 5 straight main runs, silently,
+# because the only visible signal was a job that stayed green via
+# continue-on-error). Keyed by MODE_DIRS name.
+NON_BLOCKING_MODES = {"simulation"}
+
+
+def format_summary_markdown(rows):
+    """Build one markdown report shared by GITHUB_STEP_SUMMARY, --summary, and
+    the PR-comment step (issue #964). `rows` is a list of
+    (mode, tests, failures, ok, failing_tests) tuples.
+
+    Non-blocking tiers (currently: simulation) get an unmissable
+    '[!] <MODE> TIER RED' banner plus a per-test failure table when they fail,
+    since a plain PASS/FAIL row in a wall of green is exactly what went
+    unnoticed for 5 main-branch runs before this was added.
+    """
+    lines = []
+
+    for mode, tests, failures, ok, failing_tests in rows:
+        if not ok and failing_tests and mode in NON_BLOCKING_MODES:
+            lines.append("")
+            lines.append(f"## [!] {mode.upper()} TIER RED (non-blocking, but real)")
+            lines.append("")
+            lines.append(
+                f"`{mode}` tier: {failures}/{tests} test failures. This tier does "
+                "NOT block merges -- it is surfaced here so it is not silently red. "
+                "See docs/ARCHITECTURE.md / the sim-tier test files for context."
+            )
+            lines.append("")
+            lines.append("| Suite | Test | Failure |")
+            lines.append("|---|---|---|")
+            for ft in failing_tests:
+                lines.append(f"| {ft['suite']} | {ft['test']} | {ft['message']} |")
+            lines.append("")
+
+    lines.append("")
+    lines.append("### Godot test results")
+    lines.append("")
+    lines.append("| Suite | Tests | Failures | Result |")
+    lines.append("|---|---:|---:|---|")
+    for mode, tests, failures, ok, _failing_tests in rows:
+        tier_note = " (non-blocking)" if mode in NON_BLOCKING_MODES else ""
+        lines.append(f"| {mode}{tier_note} | {tests} | {failures} | {'PASS' if ok else 'FAIL'} |")
+    lines.append("")
+
+    return "\n".join(lines)
 
 
 def _write_step_summary(rows):
-    """Append a counts table to GITHUB_STEP_SUMMARY so a human sees 'N tests ran'."""
+    """Append the shared markdown report to GITHUB_STEP_SUMMARY so a human sees
+    'N tests ran' -- and, for non-blocking tiers, the [!] RED banner -- with one
+    click on the GitHub Actions run page.
+    """
     path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not path:
         return
-    lines = [
-        "",
-        "### Godot test results",
-        "",
-        "| Suite | Tests | Failures | Result |",
-        "|---|---:|---:|---|",
-    ]
-    for name, tests, failures, ok in rows:
-        lines.append(f"| {name} | {tests} | {failures} | {'PASS' if ok else 'FAIL'} |")
-    lines.append("")
     try:
         with open(path, "a", encoding="utf-8") as f:
-            f.write("\n".join(lines))
+            f.write(format_summary_markdown(rows))
     except Exception as e:
         print(f"[WARN] Could not write step summary: {e}")
+
+
+def _write_summary_file(rows, out_path):
+    """Write the shared markdown report to a plain file (used by --summary /
+    downstream CI steps such as the PR-comment job, which cannot see another
+    job's GITHUB_STEP_SUMMARY and needs the content as a build artifact).
+    """
+    try:
+        out_path.write_text(format_summary_markdown(rows), encoding="utf-8")
+        print(f"\n[SUMMARY] Wrote markdown summary to {out_path}")
+    except Exception as e:
+        print(f"[WARN] Could not write summary file {out_path}: {e}")
 
 
 def main():
@@ -344,6 +438,26 @@ def main():
         help="Skip the headless import pass (only if the class cache is already warm)",
     )
     parser.add_argument("--verbose", action="store_true", help="Verbose GUT output (log level 3)")
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help=(
+            "Print the shared markdown summary (counts table + [!] RED banner/"
+            "failure table for any non-blocking tier that failed) to stdout at "
+            "the end of the run. Same formatter CI uses for GITHUB_STEP_SUMMARY "
+            "and the PR-comment step (#964), so local runs and CI agree."
+        ),
+    )
+    parser.add_argument(
+        "--summary-file",
+        dest="summary_file",
+        default=None,
+        help=(
+            "Also write the shared markdown summary to this path (e.g. for a "
+            "downstream CI job / artifact to consume, since GITHUB_STEP_SUMMARY "
+            "is not visible across jobs)."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -379,19 +493,24 @@ def main():
     all_passed = True
     summary_rows = []
     for mode in modes:
-        ok, tests, failures = run_gut_tests(
+        ok, tests, failures, failing_tests = run_gut_tests(
             godot_path, mode, MODE_DIRS[mode], log_level, args.min_tests
         )
-        summary_rows.append((mode, tests, failures, ok))
+        summary_rows.append((mode, tests, failures, ok, failing_tests))
         all_passed = all_passed and ok
 
     _write_step_summary(summary_rows)
+    if args.summary_file:
+        _write_summary_file(summary_rows, Path(args.summary_file))
+    if args.summary:
+        print("\n" + format_summary_markdown(summary_rows))
 
     print("\n" + "=" * 60)
     print(
         "[TOTALS] "
         + " | ".join(
-            f"{m}: {t} tests, {fl} fail ({'ok' if o else 'FAIL'})" for (m, t, fl, o) in summary_rows
+            f"{m}: {t} tests, {fl} fail ({'ok' if o else 'FAIL'})"
+            for (m, t, fl, o, _ft) in summary_rows
         )
     )
     if all_passed:


### PR DESCRIPTION
## Summary

Second half of #964. Mechanics half is done (#1002, merged): sim tier is
green (107 tests, 0 failures, 8/8 files, confirmed locally on this branch
before making any change). This PR is pure CI plumbing so a FUTURE sim-tier
regression is loudly visible instead of repeating the "red for 5 straight
main runs, nobody noticed" failure mode from the issue.

## Root cause of the original silence

`simulation-tests` used job-level `continue-on-error: true`. GitHub Actions'
own behavior: when `continue-on-error` is set and the job's steps fail, the
job still reports a **green check** in the PR checks list -- the failure is
hidden behind success, not merely de-prioritized. That is a documented
GitHub Actions gotcha, not a pdoom1-specific bug -- see e.g.
https://github.com/orgs/community/discussions/27069. It is exactly why 5
consecutive red main-branch runs produced zero visible signal.

## What changed and why (smallest robust combination)

1. **`simulation-tests` job no longer uses `continue-on-error`.**
   Checked branch protection directly (`gh api .../branches/main/protection`):
   the required contexts are `GDScript Syntax Check`, `Unit Tests`,
   `quality-checks` only -- `Simulation Tests (...)` was never a required
   check. So a job that fails for real still cannot block a merge; it just
   stops lying about its own status. A failing sim tier now shows a genuine
   red X in the PR checks list, one click from the PR page, with zero new
   infrastructure.

2. **`scripts/run_godot_tests.py`: richer JUnit parsing + shared formatter.**
   `_parse_junit()` now extracts per-testcase failure messages, not just
   aggregate counts. A new `format_summary_markdown()` builds one markdown
   report used by all three consumers below, so local runs and CI never
   disagree on the format (the "nice to have" from the brief):
   - `GITHUB_STEP_SUMMARY` (job summary tab, one click from the Actions run)
   - `--summary` (prints the same table to stdout for local runs)
   - `--summary-file PATH` (writes it to disk so a *different* CI job can
     pick it up -- job summaries aren't visible cross-job, but files
     attached as artifacts are)

   For any tier in `NON_BLOCKING_MODES` (currently just `simulation`) that
   fails, the report leads with a `[!] SIMULATION TIER RED` banner and a
   per-test `Suite | Test | Failure` table, instead of a single PASS/FAIL
   row buried in a wall of green -- a plain counts row is exactly what went
   unnoticed for 5 runs.

3. **New `sim-tier-pr-status` job**: on `pull_request` events only, reads
   the uploaded summary artifact and posts/updates a single PR comment
   (marker `<!-- sim-tier-pr-status -->`, found via `updateComment` when
   present) so the red is visible on the PR conversation itself, not just
   in the Actions tab. A passing sim tier does not create a new comment
   (only updates an existing one, to close out a prior red state) -- no
   comment spam on green PRs.

Push-only events (main branch) get the job-summary and checks-list signal
but not a PR comment, since there is no PR to comment on; that is an
acceptable gap for this half of the issue -- a scheduled/main-branch digest
would be a separate follow-up if Pip wants one.

## Mock of what a future red run looks like

Job summary / PR comment body when the sim tier goes red again:

```
## [!] SIMULATION TIER RED (non-blocking, but real)

`simulation` tier: 6/106 test failures. This tier does NOT block merges --
it is surfaced here so it is not silently red. See docs/ARCHITECTURE.md /
the sim-tier test files for context.

| Suite | Test | Failure |
|---|---|---|
| test_adversarial_ui_state.gd | test_every_dialog_kind_opens_and_closes_clean | 2 invariant violations: dialog stack depth mismatch |
| test_adversarial_ui_state.gd | test_monkey_full_ops_seeded | breaks at step 12 (seed 727272) |

### Godot test results

| Suite | Tests | Failures | Result |
|---|---:|---:|---|
| simulation (non-blocking) | 106 | 6 | FAIL |
```

(Generated locally against the actual formatter with synthetic failure data
shaped like the #964 report -- not a live CI screenshot, since the sim tier
is currently green on this branch.)

Plus: a genuine red X for "Simulation Tests (slow, non-blocking, SIM-TIER)"
in the PR checks list, and (on PRs) an auto-comment with the same table.

## Constraints honored

- Sim tier stays non-blocking: confirmed via branch protection API, not
  assumed -- it was never in the required-contexts list.
- ASCII only, no emoji anywhere (workflow names, job names, summary text,
  this PR body).
- Fast gate untouched -- no changes to `syntax-check` / `unit-tests` /
  `integration-tests` jobs or their timing.
- No comment spam -- single marker-tagged comment, updated in place.

## Tested locally

- `python scripts/run_godot_tests.py --simulation` (foreground): confirms
  the green baseline -- 107 tests, 0 failures, 8/8 files collected.
- Exercised `_parse_junit()` / `format_summary_markdown()` / `--summary-file`
  against the real JUnit XML from that run (green path) and against
  synthetic failure data shaped like the #964 report (red path, shown
  above) -- both produce the expected markdown.
- `.github/workflows/godot-tests.yml` parsed with `yaml.safe_load` (valid)
  and reviewed by hand; `actionlint` was not available in this environment
  so the workflow logic was reviewed manually instead (see "not testable
  locally" below).

## Not testable locally

- The actual GitHub Actions behavior of `sim-tier-pr-status` (artifact
  download, marker-based comment update/create, `needs.simulation-tests.
  outputs.sim_conclusion` propagating from a job that legitimately fails)
  can only be verified by a real workflow run on this PR or a deliberately
  broken follow-up PR. Worth a quick look at the Checks tab once this PR's
  own CI runs.
- Whether GitHub actually renders "Simulation Tests (slow, non-blocking,
  SIM-TIER)" as a red X (vs some other treatment) for a job that is not a
  required check -- expected based on how GitHub Actions checks work, but
  unverified against a real red run.

Generated with [Claude Code](https://claude.com/claude-code)
