### PR TITLE
docs(readme): fix the 404 download link + stop claiming mac/linux do not exist (#917)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,49 @@
 
 ## Download & Play
 
-Grab the **[latest release](https://github.com/PipFoweraker/pdoom1/releases/latest)** -- Windows build:
+Grab the **[latest release](https://github.com/PipFoweraker/pdoom1/releases/latest)** --
+Windows, macOS and Linux builds are all published. No installer for any of them.
 
-- **[Windows](https://github.com/PipFoweraker/pdoom1/releases/latest/download/PDoom.exe)** -- download and run. No installer.
+| Platform | File on the release page | Status |
+|---|---|---|
+| Windows | `PDoom-Windows-<version>.zip` | Tested |
+| macOS | `PDoom-macOS-<version>.zip` | Ships, boot-test not yet confirmed by us |
+| Linux | `PDoom-Linux-<version>.zip` | Ships, boot-test not yet confirmed by us |
 
-Linux and macOS builds are not published yet. Until they are, run from source with Godot 4.5.1 (see [For Developers](#for-developers)).
+**Extract the zip before running it.** Launching the executable from inside the
+zip viewer will fail in confusing ways on every platform.
+
+### Running it -- first-launch friction, by platform
+
+The builds are **not code-signed yet** ([#917](https://github.com/PipFoweraker/pdoom1/issues/917)),
+so each OS will warn you that the developer is unidentified. This is expected,
+and here is how to get past it.
+
+**Windows.** SmartScreen shows "Windows protected your PC". Click **More info**,
+then **Run anyway**.
+
+**macOS.** Double-clicking gives "cannot be opened because it is from an
+unidentified developer". On macOS Sequoia (15.x) Apple **removed** the old
+right-click-then-Open workaround, so that route now offers only Cancel and Move
+to Trash. Instead:
+
+1. Try to open the app once and dismiss the warning.
+2. Open **System Settings -> Privacy & Security**, scroll to **Security**.
+3. Click **Open Anyway** next to the P(Doom) entry, then confirm.
+
+Or, from Terminal: `xattr -dr com.apple.quarantine /path/to/PDoom.app`
+
+*(We do not develop on macOS and have limited test coverage there. If these
+steps do not work for you, please
+[open an issue](https://github.com/PipFoweraker/pdoom1/issues) -- that is
+genuinely useful to us.)*
+
+**Linux.** Mark the binary executable before running it:
+`chmod +x PDoom.x86_64`
+
+### Or run from source
+
+Any platform, with Godot 4.5.1 -- see [For Developers](#for-developers).
 
 ## About the Game
 


### PR DESCRIPTION
Found while investigating why a funder could not launch the game on macOS. Two defects, both user-facing, both live right now on the repo front page.

## 1. The Windows download link was a 404

README linked `releases/latest/download/PDoom.exe`. **No such asset has ever existed.** Verified:

```
404  PDoom.exe
200  PDoom-Windows-v0.13.1.zip
200  PDoom-macOS-v0.13.1.zip
```

## 2. README claimed macOS and Linux builds did not exist

Verbatim: *"Linux and macOS builds are not published yet."* They are, and people are taking them -- `PDoom-macOS-v0.13.1.zip` has 6 downloads, `PDoom.app.zip` 3, `PDoom-Linux-v0.13.1.zip` 4.

So Mac users were downloading a build the project told them did not exist, then hitting Gatekeeper with nowhere to turn. That is exactly what happened to Austin Chen, who gave up before playing (see #917 for the report).

## The fix

- Per-platform table with **honest test status** per #917 item 3: Windows tested; macOS and Linux ship but have no confirmed boot test.
- First-launch instructions per platform, since nothing is signed yet (#917, #683).
- **The macOS instructions are the point.** Apple removed the right-click-then-Open Gatekeeper bypass in Sequoia 15.x, so the instruction every guide still gives now offers only Cancel and Move to Trash. Documented the System Settings -> Privacy & Security -> Open Anyway path, with `xattr -dr com.apple.quarantine` as the terminal alternative.
- Links point at the `releases/latest` **page**, not direct asset URLs -- asset names are versioned, so any hardcoded direct link breaks on the next release. That is how defect 1 happened.
- Added the extract-before-running warning, which bites on all three platforms.

## Scope

Docs-only. No mechanics, no data, no scenes. Permitted past the league freeze (playbook: "After the freeze only: pack content, art, docs, and bugfixes labeled league-critical").

## Related

- #917 -- robust cross-OS releases, now carrying Austin's report as first real-world evidence
- #683 -- signing secrets; documentation reduces friction, signing removes it
- pdoom1-website #199 -- filed so their in-flight Mac work does not publish the dead right-click instruction

Generated with [Claude Code](https://claude.com/claude-code)