### PR TITLE
release(league): roll the featured seed to weekly-2026-w31 for the Fri 07-31 league

### DIFF
--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -459,7 +459,7 @@ func increment_games_played() -> void:
 ## league seed -- the metabolic cycle rotates it at Pip's call ("manual for now",
 ## see docs/RELEASE_AND_LEAGUE_CYCLE.html). To rotate the league, edit this const
 ## (or clear it to fall back to the calendar-week auto-seed below).
-const FEATURED_SEED_OVERRIDE: String = "weekly-2026-w30"
+const FEATURED_SEED_OVERRIDE: String = "weekly-2026-w31"
 
 ## Get weekly challenge seed (the featured/default league seed).
 func get_weekly_seed() -> String:


### PR DESCRIPTION
## The values, up front, so a wrong one is caught before merge

| | |
|---|---|
| **SEED** | **`weekly-2026-w31`** |
| LADDER | **L3** -- unchanged |
| BUILD | **0.13.2** -- unchanged |

Ruled by Pip 2026-07-31 06:30, agreed with pdoom-data.

## Why this is a source change, not a ceremony action

`GameConfig.FEATURED_SEED_OVERRIDE` (`game_config.gd:462`) pins the featured board, and the shipped client posts to whatever that const says. So a seed cannot be "blessed" at the ceremony unless the binary already carries it.

pdoom1-website's warning, which is what surfaced this in time:

> "If you bless `weekly-2026-w31` on Friday without the client's const changing, the blessed board and the posted board diverge -- the exact silent failure our ledger exists to prevent."

**Rolling therefore requires a re-cut, and [Gate 4: PROVEN BUILD] must be re-run against the new artifact before the blessing.**

## Why the seed rolls at all

Three runs already stand on `(weekly-2026-w30, L3)` from yesterday's testing, and a live board cannot be selectively cleaned. Their framing, which we endorse: **"filtering standings is editing them."** So the choice was to open the league with those runs standing, or to roll. Pip rolled.

## What deliberately does not move

- **`ladder_version.txt` stays 3.** A fresh seed on *unchanged rules* is a Seed beat, not an Epoch (`RELEASE_NOMENCLATURE.md:32`). Nothing about the ruleset changed, so nothing about comparability changed.
- **`version.txt` stays 0.13.2.** The artifact differs by one string and the ladder is untouched. Bumping the build number would imply a change that did not happen.
- **The const stays explicitly pinned**, not cleared to auto-derive. An auto-rolling seed would change under the project without a rebuild -- the same divergence hazard this PR closes, just on a timer.

## Verification

`sync_version.py --check` green (0.13.2 / L3 in sync across all stamped targets).
Fast gate: **995 tests, 0 failures, 96/96 files collected.**

## Required after merge, in order

1. `git pull origin main`
2. `python tools/build_release.py`
3. **Fresh-brain playtest on the NEW artifact** -- the current build on disk posts to w30 and is no longer the thing shipping
4. Say **[Gate 4]**
5. Bless `weekly-2026-w31` at the ceremony, then post it to pdoom1-website **#151** and **#201**

Generated with [Claude Code](https://claude.com/claude-code)