### PR TITLE
ui(leaderboard): explain what a board IS, on the screen where people look at boards

### DIFF
--- a/godot/scenes/leaderboard_screen.tscn
+++ b/godot/scenes/leaderboard_screen.tscn
@@ -69,6 +69,14 @@ text = "Top scores across all seeds"
 theme_override_font_sizes/font_size = 18
 horizontal_alignment = 1
 
+[node name="LadderExplainer" type="Label" parent="MarginContainer/VBoxContainer/Header"]
+layout_mode = 2
+text = "A board is one SEED played on one LADDER EPOCH. A new seed opens a fresh board on the same rules -- the ladder does not move for a seed roll, so those scores stay comparable. A new epoch means the rules themselves changed, so scores are never compared across epochs."
+theme_override_font_sizes/font_size = 13
+theme_override_colors/font_color = Color(0.65, 0.68, 0.72, 1)
+horizontal_alignment = 1
+autowrap_mode = 3
+
 [node name="HSeparator" type="HSeparator" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 


### PR DESCRIPTION
New-player legibility, landing on the day the board opens to strangers.

## The gap

The leaderboard already says **which** board you are on -- `Global board: weekly-2026-w31 (epoch L3, build v0.13.2)` -- and that line is meaningless unless you already know what an epoch is. The screen was answering a question nobody had while leaving the real one unanswered.

## The text

> **A board is one SEED played on one LADDER EPOCH. A new seed opens a fresh board on the same rules -- the ladder does not move for a seed roll, so those scores stay comparable. A new epoch means the rules themselves changed, so scores are never compared across epochs.**

Three things, in the order a confused player needs them:

1. **Defines the unit** (seed x epoch) *before* using either word.
2. **Says what a seed roll costs you: nothing.** Comparability survives. This is the case that happens today -- w30 to w31 on an unchanged L3.
3. **Says what an epoch change costs you: comparability, permanently.** Which is why boards are never merged across epochs, and why nobody should ask.

## Kept in sync with the website deliberately

The same wording is going to pdoom1-website so the site corpus and the game say the **same thing in the same words**. Two explanations of one concept is how a concept drifts, and this week has been a catalogue of exactly that.

## Scope

Static label, no runtime write, no logic. Fast gate: **995 tests, 0 failures, 96/96 files.**

Wants to ride the same re-cut as the seed roll (#1047) rather than a second build pass.

Generated with [Claude Code](https://claude.com/claude-code)