### PR TITLE
ui(nomenclature): finish killing player-facing "AP" -- the currency was retired in #996

### DIFF
--- a/godot/scenes/main.tscn
+++ b/godot/scenes/main.tscn
@@ -100,8 +100,7 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_TurnCounter")
 
 [node name="TurnCountLabel" type="Label" parent="TabManager/MainUI/TopBar"]
 layout_mode = 2
-text = "Turn 1"
-tooltip_text = "Turn counter — number of workdays elapsed this run."
+tooltip_text = "Turn counter -- number of workdays elapsed this run."
 theme_override_font_sizes/font_size = 14
 mouse_filter = 0
 
@@ -173,7 +172,7 @@ modulate = Color(0.4, 0.4, 0.5, 1)
 [node name="APLabel" type="RichTextLabel" parent="TabManager/MainUI/TopBar"]
 layout_mode = 2
 bbcode_enabled = true
-text = "AP: 0"
+text = "--"
 tooltip_text = "Action Points. Limits actions per turn. Base 3 + 0.5 per staff."
 fit_content = false
 custom_minimum_size = Vector2(300, 0)
@@ -352,7 +351,7 @@ theme_override_constants/separation = 3
 
 [node name="ReserveAPButton" type="Button" parent="TabManager/MainUI/BottomBar/ControlButtons"]
 layout_mode = 2
-text = "Reserve AP"
+text = "Reserve Attention"
 disabled = true
 theme_override_font_sizes/font_size = 12
 

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -870,8 +870,8 @@ func _show_conference_backlog(trip: Dictionary) -> void:
 
 
 func _on_reserve_ap_button_pressed():
-	"""Reserve 1 AP for event responses"""
-	log_message("[color=cyan]Reserving 1 AP for events...[/color]")
+	"""Reserve 1 Attention for event responses"""
+	log_message("[color=cyan]Reserving 1 Attention for events...[/color]")
 	game_manager.reserve_ap(1)
 
 func _on_undo_last_button_pressed():
@@ -896,7 +896,7 @@ func _on_clear_queue_button_pressed():
 	# Update local display
 	update_queued_actions_display()
 
-	log_message("[color=yellow]Action queue cleared - AP refunded[/color]")
+	log_message("[color=yellow]Action queue cleared - Attention refunded[/color]")
 
 func _remove_queued_action(action_id: String, action_name: String):
 	"""Remove a specific action from the queue. The queue mutation + Attention refund live in
@@ -906,7 +906,7 @@ func _remove_queued_action(action_id: String, action_name: String):
 	var result := plan_controller.remove_action(action_id)
 	if result.get("removed", false):
 		var ap_cost: int = result.get("attention_cost", 0)
-		log_message("[color=yellow]Removed: %s (+%d AP)[/color]" % [action_name, ap_cost])
+		log_message("[color=yellow]Removed: %s (+%d Attention)[/color]" % [action_name, ap_cost])
 		update_queued_actions_display()
 	else:
 		print("[MainUI] ERROR: Could not find action to remove: %s" % action_id)

--- a/godot/scripts/ui/plan_controller.gd
+++ b/godot/scripts/ui/plan_controller.gd
@@ -135,8 +135,8 @@ func append_reserve_all() -> void:
 	(L0 #620: ONE pass id)."""
 	var reserve_action := {
 		"id": GameActions.PASS_ACTION_ID,
-		"name": "Reserve All AP",
-		"description": "No planned actions - keep all AP available for responding to events",
+		"name": "Reserve All Attention",
+		"description": "No planned actions - keep all Attention available for responding to events",
 		"ap_cost": 0,
 		"money_cost": 0
 	}

--- a/godot/scripts/ui/travel_panel_controller.gd
+++ b/godot/scripts/ui/travel_panel_controller.gd
@@ -516,7 +516,7 @@ func _show_paper_submission_dialog():
 	button_hbox.add_child(cancel_btn)
 
 	var submit_btn = Button.new()
-	submit_btn.text = "Submit Paper (1 AP)"
+	submit_btn.text = "Submit Paper (1 Attention)"
 	submit_btn.disabled = current_research < 15
 	submit_btn.pressed.connect(func():
 		var conf_id = conf_dropdown.get_item_metadata(conf_dropdown.selected)
@@ -612,7 +612,7 @@ func _show_conference_attendance_dialog():
 		var conf = Conferences.get_conference_by_id(conf_id)
 		if conf:
 			var travel = conf.get_travel_cost()
-			cost_label.text = "Flights: %s | Hotel: %s | Registration: %s\nTotal: %s + 2 AP" % [
+			cost_label.text = "Flights: %s | Hotel: %s | Registration: %s\nTotal: %s + 2 Attention" % [
 				GameConfig.format_money(travel.flights),
 				GameConfig.format_money(travel.accommodation),
 				GameConfig.format_money(travel.registration),
@@ -635,7 +635,7 @@ func _show_conference_attendance_dialog():
 	button_hbox.add_child(cancel_btn)
 
 	var attend_btn = Button.new()
-	attend_btn.text = "Attend (2 AP)"
+	attend_btn.text = "Attend (2 Attention)"
 	attend_btn.pressed.connect(func():
 		var conf_id = conf_dropdown.get_item_metadata(conf_dropdown.selected)
 		# Issue #469: Apply jet lag to first researcher (economy class default)


### PR DESCRIPTION
The AP pool was removed on 2026-07-28 (#996) and replaced by founder **Attention**. The mechanic changed; nine strings the player actually reads did not. Pip found one by playing; the rest were sitting behind it.

## The live one that matters most

**`main.tscn` -> `ReserveAPButton`, text `"Reserve AP"`.** Its text is **never written at runtime** — nothing but an `@onready` reference exists — so it is a permanently visible button in the bottom bar naming a currency that no longer exists. It is visible in the 2026-07-29 playtest screenshot.

## Also live, also read by players

- `travel_panel_controller.gd` — `"Submit Paper (1 AP)"`, `"Attend (2 AP)"`, and the conference cost breakdown `"Total: %s + 2 AP"`
- `plan_controller.gd` — the **`"Reserve All AP"` action name** and its description
- `main_ui.gd` — three feed lines the player reads as events: reserving, queue-cleared, and action-removed

All now say **Attention**.

## Two placeholders that only ever appear when boot fails (#1031)

- **Top bar `"AP: 0"` -> `"--"`.** Overwritten with `Attention: N` in normal play, so its authored text is visible *only* when boot has failed — it should read as absent data, not as a retired mechanic.
- **`TurnCountLabel`: dropped the authored `"Turn 1"` entirely.** The label is hidden at runtime (superseded by the date badge), so that string could only ever be seen in the failure case. Deleting the property is what the placeholder audit recommended over sentinel-ing it. Its tooltip also carried a non-ASCII em dash, now `--` (#1035).

*Incidental:* that tooltip reads **"number of workdays elapsed"** — which is the codebase confirming Pip's playtest complaint that "Turn" is counting days. **That naming question is #1041 and is deliberately not touched here.**

## Deliberately not swept

Code comments and identifiers (`ap_cost`, `# reserve all AP`), `patch_notes.json`, and the design-ruling quotations in `actions.gd` / `turn_manager.gd` / `office.gd`. Those use "AP" correctly to describe history or internals, and **rewriting words inside a quotation falsifies the citation** (#1037).

## Scope

Text and labels only. No logic, no data, no mechanics. Fast gate: **995 tests, 0 failures, 96/96 files collected.**

Wants to ride this morning's re-cut. Closes the player-facing half of #1037.

Generated with [Claude Code](https://claude.com/claude-code)