### PR TITLE
feat(ux): "Accept Your Fate" -- let a player end a run and reach the leaderboard (#959)

### DIFF
--- a/godot/scenes/pause_menu.tscn
+++ b/godot/scenes/pause_menu.tscn
@@ -162,6 +162,15 @@ size_flags_horizontal = 4
 theme_override_font_sizes/font_size = 16
 text = "Resume Game (ESC)"
 
+[node name="ResignButton" type="Button" parent="Panel/VBox/ButtonContainer"]
+custom_minimum_size = Vector2(250, 40)
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 16
+theme_override_colors/font_color = Color(0.85, 0.45, 0.35, 1)
+text = "Accept Your Fate (end run)"
+tooltip_text = "End this run now and go to the score screen and leaderboard. Your run still counts -- the turns you survived are your score. There is no way to win P(Doom); you are only ever buying time."
+
 [node name="SaveButton" type="Button" parent="Panel/VBox/ButtonContainer"]
 custom_minimum_size = Vector2(250, 40)
 layout_mode = 2
@@ -187,6 +196,7 @@ text = "Quit to Desktop"
 [connection signal="value_changed" from="Panel/VBox/SettingsContainer/AudioSettings/SFXVolumeRow/Slider" to="." method="_on_sfx_volume_changed"]
 [connection signal="value_changed" from="Panel/VBox/SettingsContainer/AudioSettings/MusicVolumeRow/Slider" to="." method="_on_music_volume_changed"]
 [connection signal="pressed" from="Panel/VBox/ButtonContainer/ResumeButton" to="." method="_on_resume_pressed"]
+[connection signal="pressed" from="Panel/VBox/ButtonContainer/ResignButton" to="." method="_on_resign_pressed"]
 [connection signal="pressed" from="Panel/VBox/ButtonContainer/SaveButton" to="." method="_on_save_pressed"]
 [connection signal="pressed" from="Panel/VBox/ButtonContainer/MainMenuButton" to="." method="_on_main_menu_pressed"]
 [connection signal="pressed" from="Panel/VBox/ButtonContainer/QuitButton" to="." method="_on_quit_pressed"]

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -455,6 +455,39 @@ func remove_queued_action(action_id: String):
 	else:
 		print("[GameManager] WARNING: Action not found in queue: %s" % action_id)
 
+func resign() -> void:
+	"""End the run deliberately and route to the game-over screen (#959, cheap form).
+
+	Deliberately NOT a new path into game-over. It drives doom to the lose
+	threshold and then calls the SAME check_win_lose() -> game_state_updated ->
+	MainUI -> game_over_screen route that every ordinary loss takes. The
+	game-over -> leaderboard transition is the one that segfaulted the v0.11.0
+	release, so this adds a new TRIGGER for a proven route rather than a new
+	route.
+
+	Doom is written through doom_system, not through state.doom: check_win_lose()
+	re-syncs `doom = doom_system.current_doom` before testing the threshold, so a
+	direct write to state.doom would be silently overwritten and the run would
+	simply carry on -- a failure that would have looked exactly like a dead
+	button.
+
+	Not routed through end_turn(): that refuses when the action queue is empty,
+	which is precisely the state a bored player is in.
+	"""
+	if not is_initialized or state == null:
+		push_warning("[GameManager] resign() ignored: no live run")
+		return
+	if state.game_over:
+		return
+	print("[GameManager] Player resigned at turn %d" % state.turn)
+	PerfLog.mark("player_resigned", {"turn": state.turn, "doom": state.doom})
+	if state.doom_system:
+		state.doom_system.current_doom = 100.0
+	state.doom = 100.0
+	state.check_win_lose()
+	game_state_updated.emit(state.to_dict())
+
+
 func end_turn():
 	"""Execute queued actions and process turn"""
 	# Validation: Game initialized

--- a/godot/scripts/ui/pause_menu.gd
+++ b/godot/scripts/ui/pause_menu.gd
@@ -65,6 +65,20 @@ func _on_save_pressed():
 	else:
 		save_button.text = "Save failed"
 
+func _on_resign_pressed():
+	"""Accept your fate: end the run and go to the score screen (#959).
+
+	Unpause BEFORE resigning. The game-over screen and the leaderboard
+	transition run on a live tree; resigning while paused would fire the
+	state update into a frozen scene and leave the player looking at a paused
+	game that has quietly ended.
+	"""
+	print("[PauseMenu] Player accepted their fate -- ending run")
+	get_tree().paused = false
+	visible = false
+	GameManager.resign()
+
+
 func _on_main_menu_pressed():
 	"""Return to main menu"""
 	print("[PauseMenu] Returning to main menu...")

--- a/godot/tests/unit/test_resign_destructive.gd
+++ b/godot/tests/unit/test_resign_destructive.gd
@@ -1,0 +1,123 @@
+extends GutTest
+## Destructive tests for GameManager.resign() -- the "Accept Your Fate" path (#959).
+##
+## WHY DESTRUCTIVE RATHER THAN HAPPY-PATH. resign() is a brand-new trigger into the
+## game-over -> leaderboard transition, and that transition is the one that segfaulted
+## the v0.11.0 release. A happy-path test proves the button works when everything is
+## fine, which is the case nobody was worried about. These push at the states a real
+## player is actually in when they give up: nothing queued, mid-turn, already dead,
+## clicking twice because the first click did not obviously do anything.
+##
+## Two traps were found by construction while writing resign(), and both are pinned
+## here so they cannot come back silently:
+##
+##   1. Doom must be written through state.doom_system.current_doom, NOT state.doom.
+##      check_win_lose() re-syncs `doom = doom_system.current_doom` before testing the
+##      threshold, so a direct write to state.doom is overwritten and the run simply
+##      carries on. That failure mode is a button that looks perfect and does nothing.
+##
+##   2. resign() must not route through end_turn(), which REFUSES when the action queue
+##      is empty -- precisely the state a bored player is in. The one player it exists
+##      for is the one it would have failed.
+##
+## GameManager is an autoload, so every test drives it to a known state first rather
+## than trusting whatever an earlier file left behind (the ordering-accident hazard,
+## #1036).
+##
+## NOT covered here: resign() with no live run. It guards correctly (early return plus
+## push_warning), but GUT counts push_warning as an unexpected error, so asserting it
+## fails the test ON THE GUARD WORKING. Left to a manual check rather than weakened.
+
+const SEED := "resign-destructive-seed"
+
+
+func before_each() -> void:
+	GameManager.start_new_game(SEED, true)
+
+
+func after_all() -> void:
+	# Leave the autoload live but consistent for whatever runs next.
+	GameManager.start_new_game(SEED, true)
+
+
+func _doom() -> float:
+	return GameManager.state.doom
+
+
+func test_resign_from_a_fresh_turn_with_nothing_queued_ends_the_run() -> void:
+	# The canonical bored player: turn 1, no actions, wants out.
+	assert_false(GameManager.state.game_over, "precondition: run is live")
+	assert_true(GameManager.state.queued_actions.is_empty(),
+		"precondition: nothing queued -- this is the state end_turn() refuses")
+
+	GameManager.resign()
+
+	assert_true(GameManager.state.game_over,
+		"resign() must end the run even with an EMPTY action queue -- routing through "
+		+ "end_turn() would refuse here, which is the one player this feature is for")
+	assert_false(GameManager.state.victory, "a resigned run is not a victory")
+
+
+func test_resign_drives_doom_through_the_doom_system_not_around_it() -> void:
+	# Trap 1. If doom is written to state.doom only, check_win_lose() re-syncs from
+	# doom_system and clobbers it -- the run continues and the button looks dead.
+	GameManager.resign()
+
+	assert_true(GameManager.state.game_over, "run ended")
+	assert_almost_eq(_doom(), 100.0, 0.01, "doom reached the lose threshold")
+	if GameManager.state.doom_system != null:
+		assert_almost_eq(GameManager.state.doom_system.current_doom, 100.0, 0.01,
+			"doom_system is the source of truth check_win_lose() re-syncs FROM -- if this "
+			+ "is not 100 the write went to the wrong place and the guard is vacuous")
+
+
+func test_resigning_twice_is_harmless() -> void:
+	# A player clicks, nothing visibly happens for a frame, they click again.
+	GameManager.resign()
+	var turn_after_first := GameManager.state.turn
+	var doom_after_first := _doom()
+
+	GameManager.resign()
+
+	assert_true(GameManager.state.game_over, "still over")
+	assert_eq(GameManager.state.turn, turn_after_first,
+		"a second resign must not advance or mutate the finished run")
+	assert_almost_eq(_doom(), doom_after_first, 0.01, "doom unchanged by the second call")
+
+
+func test_resign_after_a_natural_loss_does_not_disturb_the_result() -> void:
+	# Someone opens the pause menu on the game-over screen and hits it anyway.
+	GameManager.state.doom_system.current_doom = 100.0
+	GameManager.state.check_win_lose()
+	assert_true(GameManager.state.game_over, "precondition: already lost naturally")
+	var turn_at_death := GameManager.state.turn
+
+	GameManager.resign()
+
+	assert_eq(GameManager.state.turn, turn_at_death,
+		"resign() on an already-finished run must be a no-op, not a second death")
+
+
+func test_resign_preserves_the_score_the_run_earned() -> void:
+	# The whole point: the run still counts. Turns survived is the score (ADR-0002),
+	# so resigning must not zero or inflate it.
+	var turns_survived := GameManager.state.turn
+
+	GameManager.resign()
+
+	assert_eq(GameManager.state.turn, turns_survived,
+		"resigning must not alter turns survived -- that IS the score")
+	assert_true(GameManager.state.turn >= 1, "a resigned run still has a real score")
+
+
+func test_resign_with_a_queued_action_still_ends_the_run() -> void:
+	# Mid-planning abandonment: cards on the table, player is done anyway.
+	# queued_actions is Array[String] (game_state.gd:251) -- appending a Dictionary is
+	# type-rejected and leaves the array empty, which is how this test first failed.
+	GameManager.state.queued_actions.append("test_action")
+	assert_false(GameManager.state.queued_actions.is_empty(), "precondition: something queued")
+
+	GameManager.resign()
+
+	assert_true(GameManager.state.game_over,
+		"a queued action must not block resignation")


### PR DESCRIPTION
> *"it's kind of funny we only realised at the last second that there wasn't any mechanism for a player to Accept Their Fate."* -- Pip, 2026-07-31

## The gap is a league problem, not a UX nit

Until now a bored, stuck or finished player had exactly one exit: **alt-F4**. No score submitted, no board entry, no trace they played.

On a league night that means a board with almost nothing on it while dozens of people actually played. Pip's framing, which is the sharp version:

> *"I as dev don't see the player quitting, just the ones that finish the game."*

**Same family as everything else this week** -- the data looks healthy because the people missing from it are invisible.

It also fits the design rather than working around it. There is no way to win P(Doom); you are only buying time. A player choosing when to stop buying is *the game working*, and the run still counts -- turns survived is the score (ADR-0002). It doubles as **abort-but-keep-the-decision-tree**, which is the analyse-and-try-again loop the game is built for.

## A new trigger for a proven route, not a new route

`GameManager.resign()` drives doom to the lose threshold and then calls the **same** `check_win_lose()` -> `game_state_updated` -> `MainUI` -> `game_over_screen` path every ordinary loss takes.

That transition is the one that **segfaulted the v0.11.0 release** and only reproduces in a real build. So it gets a new way *in*, not a new way *through*.

## Two traps found while building it

Both would have shipped a dead button that looked completely fine:

1. **Doom must be written through `state.doom_system.current_doom`, not `state.doom`.** `check_win_lose()` re-syncs `doom = doom_system.current_doom` *before* testing the threshold — so a direct write to `state.doom` is silently overwritten and the run just carries on.
2. **Must not route through `end_turn()`**, which refuses when the action queue is empty — precisely the state a bored player is in.

The pause menu also **unpauses before resigning**: the game-over screen needs a live tree, and firing the state update into a frozen scene would leave the player staring at a paused game that had quietly ended.

## Wording

**"Accept Your Fate (end run)"**, tinted rather than styled destructive, because it isn't. The tooltip carries the three things a player needs: the run still counts, turns survived is the score, and there is no way to win — you're only buying time.

## Scope

Deliberately **not** the full #959 (a considered surrender flow with confirmation and framing). That gets built with time to playtest. This is the cheap 80% so tonight's players have an exit.

Fast gate: **995 tests, 0 failures, 96/96 files collected.**

**Wants an artifact playtest of the resign path specifically** before the ceremony — pause, Accept Your Fate, confirm you land on the score screen and can reach the leaderboard.

Generated with [Claude Code](https://claude.com/claude-code)