### PR TITLE
fix(league): lock difficulty to Standard -- one comparable ladder while the base is small

### DIFF
--- a/godot/scripts/ui/pregame_setup.gd
+++ b/godot/scripts/ui/pregame_setup.gd
@@ -51,7 +51,18 @@ func _ready():
 	player_name_input.text = GameConfig.player_name
 	lab_name_input.text = GameConfig.lab_name
 	seed_input.text = GameConfig.game_seed
-	difficulty_option.selected = GameConfig.difficulty
+	# ONE LADDER while the player base is small (Pip's ruling, 2026-07-31).
+	# Difficulty appears NOWHERE in the leaderboard submission or the board key --
+	# an Easy run and a Hard run post to the same (seed, epoch) board with nothing
+	# marking which is which, so their scores are silently incomparable. The honest
+	# options were: fork the board per difficulty (three near-empty boards for a
+	# handful of players), submit difficulty so the site can filter (needs website
+	# work), or ship one difficulty. This is the third, and it is reversible in one
+	# line once #1058 lands.
+	GameConfig.difficulty = 1  # Standard
+	difficulty_option.selected = 1
+	difficulty_option.disabled = true
+	difficulty_option.tooltip_text = "Locked to Standard for the first leagues -- every score sits on one comparable board. Difficulty tiers return once the board can tell them apart."
 
 	# Set up button icons
 	_setup_button_icons()


### PR DESCRIPTION
Pip's ruling 2026-07-31. It closes a **live integrity hole**, not just a menu.

## The hole

`difficulty` exists (0=Easy, 1=Standard, 2=Hard, `game_config.gd:9`) and is persisted — but it appears **nowhere** in the leaderboard submission or the board key. A grep across `game_over_screen.gd`, `leaderboard.gd` and `leaderboard_sync.gd` returns nothing.

So an Easy run and a Hard run post to the **same** `(seed, epoch)` board with nothing marking which is which. Their scores are silently incomparable and the board cannot tell anyone.

Same class as everything else this week: the data renders, the numbers look fine, the comparison underneath is meaningless.

## Why this option

- **Fork the board per difficulty** -> three near-empty boards for a handful of players, which reads as a dead game.
- **Submit difficulty so the site can filter** -> needs website work, not a today change.
- **Ship one difficulty** -> honest, one line, reversible. Pip: *aim for one global ladder by default, at least until the player base grows.*

Selector is locked to Standard and disabled, with a tooltip saying why, so it reads as a deliberate constraint rather than a broken control.

## Gate status — read this

**`main` is currently RED and it is not this change.** With this change stashed, and with my destructive-test file removed, the same test fails:

```
test_game_lifecycle_hygiene.gd :: test_start_new_game_frees_prior_game_node_subsystems
  second start_new_game must not leak the prior game's Node subsystems (orphan delta=1)
```

It is a **hygiene** failure (memory grows across repeated runs in one session), not correctness, and it appeared today from #1050 or #1051. Worth knowing that **Accept Your Fate makes replaying easy** — a per-run leak mattered less when quitting meant alt-F4.

This PR neither causes nor fixes it. Merging is safe; the red needs its own decision.