### PR TITLE
fix(league): scenario runs are UNRANKED, and the player is told before they pick (#1058 sibling)

### DIFF
--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -567,6 +567,26 @@ func get_current_version() -> String:
 ## not fork the existing board.
 func get_board_version() -> String:
 	return "L" + LADDER_VERSION
+
+## Does this run count for the leaderboard? (Pip's ruling, 2026-07-31)
+##
+## Scenario packs rewrite the starting state -- Sandbox Mode opens with $10,000,000
+## and 1000 compute, Crisis Mode with doom already at 65. Scenario appears NOWHERE
+## in the board key (see get_board_version above: seed + ladder epoch only), so
+## before this gate a Sandbox run posted turns-survived to the SAME board as a
+## Standard run, unmarked and silently incomparable. Exactly the hole #1058 closed
+## for difficulty, one control further down the same pre-game screen.
+##
+## The ruling was NOT to remove the scenarios -- they stay playable. An unranked
+## run is locked out of the board and the player is told so twice: at the moment
+## they pick the scenario, and again on the game-over screen. Warned, not blocked.
+##
+## SINGLE SOURCE OF TRUTH: every board-write site must route through this. There
+## is exactly one today (GameOverScreen._persist_and_submit_score); a second one
+## added later that forgets this check silently reopens the hole.
+func is_ranked_run() -> bool:
+	return scenario_id.strip_edges().is_empty()
+
 ## Should the first-launch welcome/help overlay be shown? (issue #720)
 ## True only on a genuine first launch (no games played yet), when it has never
 ## been shown before, and while gameplay hints are enabled. The welcome_seen gate

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -873,6 +873,7 @@ func load_saved_game(path: String = SaveLoad.QUICKSAVE_PATH, force: bool = false
 	if not save_scenario_id.is_empty():
 		var loader = ScenarioLoader.new()
 		var scenario = loader.load_scenario(save_scenario_id)
+		loader.free()  # extends Node, never added to the tree -- dropping it orphans it
 		var custom_events = scenario.get("events", [])
 		if custom_events.size() > 0:
 			state.set_meta("scenario_events", custom_events)
@@ -1013,6 +1014,9 @@ func _apply_scenario_overrides():
 
 	var loader = ScenarioLoader.new()
 	var scenario = loader.load_scenario(scenario_id)
+	loader.free()  # extends Node, never added to the tree -- dropping it orphans it
+	# (one leaked Node per run on any machine with a scenario selected; this is what
+	# reddened test_game_lifecycle_hygiene's orphan-delta assertion on 2026-07-31)
 
 	if scenario.is_empty():
 		push_warning("[GameManager] Failed to load scenario: %s" % scenario_id)

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -246,6 +246,22 @@ func _persist_and_submit_score(final_state: Dictionary, game_seed: String) -> vo
 	error cannot lose it. The remote POST is fire-and-forget on the LeaderboardSync autoload
 	(lifecycle-independent from this screen) and internally bulletproof against network
 	failure, so nothing here can crash or freeze the end-game."""
+	# UNRANKED RUNS NEVER TOUCH THE BOARD (Pip's ruling, 2026-07-31). Scenario packs
+	# rewrite the starting position -- Sandbox opens with $10,000,000 -- and scenario
+	# is not part of the board key, so a scenario score is silently incomparable with
+	# every Standard score sitting beside it. Same hole #1058 closed for difficulty.
+	# Gated here rather than at the remote submit because the LOCAL board must stay
+	# clean too: it is what the leaderboard screen renders and what the player reads
+	# as "the board". The player was warned when they picked the scenario; this is the
+	# second telling, and it is deliberately SHOWN rather than failing quietly -- a
+	# score that just never appears is precisely this week's failure mode.
+	if not GameConfig.is_ranked_run():
+		print("[GameOverScreen] Unranked run (scenario '%s') - no local save, no remote submit" % GameConfig.scenario_id)
+		_ensure_sync_status_label()
+		sync_status_label.visible = true
+		sync_status_label.text = "NOT RANKED: scenario runs stay off the leaderboard. Play Standard Game for the board."
+		sync_status_label.add_theme_color_override("font_color", Color(1.0, 0.75, 0.25))
+		return
 	var duration = Time.get_ticks_msec() / 1000.0 - game_start_time
 	var entry = Leaderboard.ScoreEntry.new(
 		final_turns,

--- a/godot/scripts/ui/pregame_setup.gd
+++ b/godot/scripts/ui/pregame_setup.gd
@@ -83,6 +83,11 @@ func _populate_scenarios():
 	"""Load and populate the scenarios dropdown"""
 	var loader = ScenarioLoader.new()
 	available_scenarios = loader.get_available_scenarios()
+	# ScenarioLoader extends Node and is never added to the tree, so dropping this
+	# local orphans it. Harmless in itself (no signals, no _process) but it is what
+	# reddens test_game_lifecycle_hygiene's orphan-delta assertion on any machine
+	# whose config has a scenario selected. Free it explicitly.
+	loader.free()
 
 	scenario_option.clear()
 
@@ -101,10 +106,24 @@ func _populate_scenarios():
 	print("[PreGameSetup] Loaded %d scenarios" % available_scenarios.size())
 
 func _update_scenario_description(index: int):
-	"""Update the scenario description label"""
-	if index >= 0 and index < available_scenarios.size():
-		var scenario = available_scenarios[index]
-		scenario_description.text = scenario.get("description", "No description available")
+	"""Update the scenario description label, and WARN when the pick costs the board.
+
+	Pip's ruling 2026-07-31: scenarios stay playable, but a scenario run is locked
+	out of the leaderboard (GameConfig.is_ranked_run) because scenario is not in the
+	board key -- Sandbox Mode's $10,000,000 opening would post turns-survived to the
+	same board as a Standard run. The player must be told AT THE MOMENT OF CHOICE,
+	not discover it at the game-over screen, so the warning rides on the description
+	label that already updates on every selection."""
+	if index < 0 or index >= available_scenarios.size():
+		return
+	var scenario = available_scenarios[index]
+	var desc: String = scenario.get("description", "No description available")
+	if String(scenario.get("id", "")).strip_edges().is_empty():
+		scenario_description.text = desc
+		scenario_description.remove_theme_color_override("font_color")
+		return
+	scenario_description.text = desc + "\n[!] NOT RANKED -- a run on this scenario does not go on the leaderboard. Scenarios change the starting position, so those scores cannot be compared. Pick Standard Game to play for the board."
+	scenario_description.add_theme_color_override("font_color", Color(1.0, 0.75, 0.25))
 
 func _setup_button_icons():
 	"""Replace button text/emoji with icons where available"""

--- a/godot/tests/unit/test_endgame_score_isolation.gd
+++ b/godot/tests/unit/test_endgame_score_isolation.gd
@@ -19,6 +19,7 @@ const UNREACHABLE := "https://10.255.255.1"  # unroutable: connect never complet
 
 var _prev_optin: bool
 var _prev_asked: bool
+var _prev_scenario: String
 
 func before_each():
 	# Isolate the outbox file per test.
@@ -30,8 +31,14 @@ func before_each():
 	_prev_asked = GameConfig.leaderboard_consent_asked
 	GameConfig.submit_scores_global = true
 	GameConfig.leaderboard_consent_asked = true
+	# RANKED RUN, pinned explicitly. GameConfig is an autoload reading the real user
+	# config, so on a machine with a scenario selected these tests were asserting
+	# against an UNRANKED run (2026-07-31). A test must state the state it needs.
+	_prev_scenario = GameConfig.scenario_id
+	GameConfig.scenario_id = ""
 
 func after_each():
+	GameConfig.scenario_id = _prev_scenario
 	GameConfig.submit_scores_global = _prev_optin
 	GameConfig.leaderboard_consent_asked = _prev_asked
 	if FileAccess.file_exists(LeaderboardSync.OUTBOX_PATH):

--- a/godot/tests/unit/test_game_over_remote_isolation.gd
+++ b/godot/tests/unit/test_game_over_remote_isolation.gd
@@ -15,6 +15,7 @@ var _prev_base: String
 var _prev_token: String
 var _prev_optin: bool
 var _prev_asked: bool
+var _prev_scenario: String
 
 func before_each():
 	_prev_enabled = LeaderboardSync.enabled
@@ -25,6 +26,12 @@ func before_each():
 	# Default these tests to an explicitly opted-in player (identity-consent
 	# ruling 2026-07-26); individual tests override where they test decline.
 	GameConfig.leaderboard_consent_asked = true
+	# RANKED RUN, pinned explicitly. GameConfig is an autoload that loads the real
+	# user config, so on a machine with a scenario selected these tests were asserting
+	# against an UNRANKED run and failing for a reason that had nothing to do with
+	# remote isolation (2026-07-31). A test must state the state it needs.
+	_prev_scenario = GameConfig.scenario_id
+	GameConfig.scenario_id = ""
 	if FileAccess.file_exists(LeaderboardSync.OUTBOX_PATH):
 		DirAccess.remove_absolute(LeaderboardSync.OUTBOX_PATH)
 
@@ -32,6 +39,7 @@ func after_each():
 	LeaderboardSync.enabled = _prev_enabled
 	LeaderboardSync.base_url = _prev_base
 	LeaderboardSync.token = _prev_token
+	GameConfig.scenario_id = _prev_scenario
 	GameConfig.submit_scores_global = _prev_optin
 	GameConfig.leaderboard_consent_asked = _prev_asked
 	if FileAccess.file_exists(LeaderboardSync.OUTBOX_PATH):

--- a/tools/reset_player_state.py
+++ b/tools/reset_player_state.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Reset this machine's P(Doom) player state to a genuine first-launch experience.
+
+WHY THIS EXISTS (2026-07-31, league day). Pip's local config had carried
+`scenario_id="crisis"` and `difficulty=2` for an unknown length of time. Two things
+followed, and neither announced itself:
+
+  1. A recorded "playtest of the league build" was actually a playtest of Crisis Mode
+     (doom starting at 65, year 2020). It validated a configuration no league player
+     would run.
+  2. Four endgame tests went red on this machine and green in CI, because the GameConfig
+     autoload reads the real user config and the tests never pinned what they needed.
+
+Dev state leaking into what is supposed to be a fresh-player observation is the same
+silent-wrongness family as everything else in issue #1027: it looked right.
+
+USE IT before any recorded playtest, any pre-release ceremony run, and any "does a new
+player understand this screen" check -- i.e. every time the loop comes round again.
+
+    python tools/reset_player_state.py            # show what WOULD be cleared
+    python tools/reset_player_state.py --apply    # back up, then clear
+    python tools/reset_player_state.py --apply --keep-identity
+    python tools/reset_player_state.py --restore  # undo the most recent --apply
+
+DRY RUN BY DEFAULT, matching intelligent_ascii_converter.py's posture after #773 --
+a destructive tool that fires on a bare invocation is a trap.
+
+NOTHING IS DELETED. --apply moves the whole user-data directory into a timestamped
+backup beside it, so any run can be recovered with --restore or by hand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from datetime import datetime
+from pathlib import Path
+
+APP_NAME = "P(Doom)"
+BACKUP_PREFIX = "_backup_"
+
+# What a first-launch player has. Anything not listed here is state THEY would not have.
+FIRST_LAUNCH_KEEPS: tuple[str, ...] = ()
+
+# Cleared unless --keep-identity. These are the ones that change what the GAME does,
+# as opposed to merely what it remembers.
+BEHAVIOUR_BEARING = {
+    "config.cfg": "scenario_id / difficulty / seed / onboarding flags -- the 2026-07-31 trap",
+    "leaderboards": "local board files; stale entries make a fresh board look populated",
+    "saves": "a resumable save changes the first thing the player sees",
+    "achievements.json": "unlock state",
+    "install_id.txt": "install identity for the launch ping",
+    "keybinds.cfg": "rebinds a new player would not have",
+    "theme.cfg": "theme selection",
+    "flight_recorder": "prior session recordings",
+    "bug_reports": "prior reports + screenshots",
+    "ui_evolution": "UI telemetry",
+    "screenshots": "prior screenshots",
+    "scenarios": "user-installed scenario packs",
+    "shader_cache": "regenerated on launch; cleared so first-launch timing is honest",
+    "vulkan": "driver pipeline cache; same reason as shader_cache",
+    "logs": "prior logs",
+}
+
+IDENTITY_FILES = {"config.cfg", "install_id.txt"}
+
+
+def user_data_root() -> Path:
+    """Godot's user:// on this platform, for this app."""
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA")
+        if not base:
+            raise SystemExit("APPDATA is not set -- cannot locate Godot user data.")
+        return Path(base) / "Godot" / "app_userdata" / APP_NAME
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Godot" / "app_userdata" / APP_NAME
+    return Path.home() / ".local" / "share" / "godot" / "app_userdata" / APP_NAME
+
+
+def entries_to_clear(root: Path, keep_identity: bool) -> list[Path]:
+    out = []
+    for child in sorted(root.iterdir()):
+        if child.name.startswith(BACKUP_PREFIX):
+            continue  # never recurse into our own backups
+        if child.name in FIRST_LAUNCH_KEEPS:
+            continue
+        if keep_identity and child.name in IDENTITY_FILES:
+            continue
+        out.append(child)
+    return out
+
+
+def describe(root: Path, keep_identity: bool) -> int:
+    if not root.exists():
+        print("[OK] No user data at %s -- already a first launch." % root)
+        return 0
+    targets = entries_to_clear(root, keep_identity)
+    if not targets:
+        print("[OK] Nothing to clear at %s" % root)
+        return 0
+    print("Godot user data: %s" % root)
+    print("")
+    print("WOULD CLEAR %d item(s):" % len(targets))
+    for t in targets:
+        note = BEHAVIOUR_BEARING.get(t.name, "")
+        kind = "dir " if t.is_dir() else "file"
+        print("  [%s] %-22s %s" % (kind, t.name, ("-- " + note) if note else ""))
+    if keep_identity:
+        kept = sorted(n for n in IDENTITY_FILES if (root / n).exists())
+        if kept:
+            print("")
+            print("KEEPING (--keep-identity): %s" % ", ".join(kept))
+            print("  NOTE: config.cfg is where scenario_id lives. Keeping it keeps the trap.")
+    print("")
+    print("Nothing has changed. Re-run with --apply to back up and clear.")
+    return 0
+
+
+def apply(root: Path, keep_identity: bool) -> int:
+    if not root.exists():
+        print("[OK] No user data at %s -- already a first launch." % root)
+        return 0
+    targets = entries_to_clear(root, keep_identity)
+    if not targets:
+        print("[OK] Nothing to clear at %s" % root)
+        return 0
+
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup = root / (BACKUP_PREFIX + stamp)
+    backup.mkdir(parents=True, exist_ok=False)
+
+    for t in targets:
+        shutil.move(str(t), str(backup / t.name))
+        print("  moved %s" % t.name)
+
+    print("")
+    print("[OK] Cleared %d item(s). Backup: %s" % (len(targets), backup))
+    print("[OK] Next launch is a genuine first-launch experience.")
+    print("")
+    print("VERIFY BEFORE RECORDING -- the point of this script is that you check:")
+    print("  - pre-game screen shows Scenario = 'Standard Game'")
+    print("  - difficulty shows Standard and is disabled (#1058)")
+    print("  - the leaderboard screen is EMPTY for this board")
+    print("  - the first-launch welcome overlay appears")
+    print("")
+    print("Undo with: python tools/reset_player_state.py --restore")
+    return 0
+
+
+def restore(root: Path) -> int:
+    if not root.exists():
+        raise SystemExit("No user data directory at %s" % root)
+    backups = sorted(p for p in root.iterdir() if p.is_dir() and p.name.startswith(BACKUP_PREFIX))
+    if not backups:
+        raise SystemExit("No backups found in %s" % root)
+    newest = backups[-1]
+    print("Restoring from %s" % newest)
+    for child in sorted(newest.iterdir()):
+        dest = root / child.name
+        if dest.exists():
+            print("  SKIP %s (already present -- not overwriting)" % child.name)
+            continue
+        shutil.move(str(child), str(dest))
+        print("  restored %s" % child.name)
+    try:
+        newest.rmdir()
+    except OSError:
+        print("  (backup dir kept: it still holds skipped items)")
+    print("[OK] Restore complete.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Reset local P(Doom) player state to a first-launch experience.",
+    )
+    ap.add_argument("--apply", action="store_true", help="actually clear (default is a dry run)")
+    ap.add_argument("--restore", action="store_true", help="undo the most recent --apply")
+    ap.add_argument(
+        "--keep-identity",
+        action="store_true",
+        help="keep config.cfg + install_id.txt (WARNING: config.cfg carries scenario_id)",
+    )
+    args = ap.parse_args()
+
+    root = user_data_root()
+    if args.restore:
+        return restore(root)
+    if args.apply:
+        return apply(root, args.keep_identity)
+    return describe(root, args.keep_identity)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Found during the 15:07 pre-league sweep, ~90 minutes before the board opens. Pip's ruling at 15:29.

## The hole

#1058 locked **difficulty** to Standard this morning because difficulty appeared nowhere in the board key. The **scenario** dropdown three rows above it on the same pre-game screen was left fully live -- and scenario is not in the board key either (`get_board_version()` returns seed + ladder epoch, nothing else).

| Scenario | Opening position |
|---|---|
| Sandbox Mode | **$10,000,000**, 1000 compute, 500 research, 10 papers -- in-game text: *"Unlimited resources"* |
| Crisis Mode | $150k, doom already at **65**, starts 2020 |
| Bootstrap Mode | $500k, 200 compute, doom 40 |

A player picks Sandbox from a visible dropdown and posts turns-survived to the same `(weekly-2026-w31, L3)` board as everyone else, unmarked.

Not hypothetical: Pip's own config carried `scenario_id="crisis"`, so this morning's recorded 14-minute "playtest of the league build" was a playtest of Crisis Mode.

## The ruling: warned, not blocked

> "I want scenarios to lock you out of the board and for players to be warned about it explicitly when picking them. I have no problems with the scenario, the player just needs to be actively warned."

Told twice, and the second telling is **shown** rather than silent -- a score that simply never appears is precisely this week's failure mode (#1027).

1. `GameConfig.is_ranked_run()` -- single source of truth, a named accessor rather than an inline check so a future board-write site can't quietly forget it.
2. `pregame_setup` -- amber `[!] NOT RANKED` warning on the description label, at the moment of choice.
3. `game_over_screen` -- unranked runs skip the **local** board write as well as the remote POST, and say why on screen. Local matters: it is what the leaderboard screen renders.

Reversible the same way #1058 is, once the board can distinguish scenarios. **No board-key change** -- that surface is frozen per website #191.

## Also fixed: the red fast gate, which was a different bug

`test_game_lifecycle_hygiene` was attributed in the midday handover to #1050/#1051, with an open worry the leaked node was signal-connected (doubled doom ticks). GUT names it: `scenario_loader.gd`.

- **Inert, not connected** -- no signals, no `_ready`/`_process`, never added to the tree. The feared correctness bug was not there.
- **Old, not from this morning** -- #483 / PR #494.
- **Green in CI legitimately** -- `_apply_scenario_overrides` returns early before the allocation when no scenario is set, so it reddened only on machines with a scenario selected.

Freed explicitly at all three call sites.

## Tests that depended on the developer's own config

Four endgame tests asserted against whatever the `GameConfig` autoload had loaded from the real user config -- red here, green in CI. They now pin `scenario_id` in `before_each` and restore it in `after_each`.

## `tools/reset_player_state.py`

Dry run by default (#773 posture), backs up rather than deletes, `--restore` undoes it. For every recorded playtest and ceremony run from here.

## Verification

Fast gate: **1001 tests, 0 failures, 97/97 files collected** -- same count as #1051 reported, so nothing was silently dropped.

Not done: simulation tier not run (no simulation/economy/replay code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)