### PR TITLE
fix(release): public build wore the DEV BUILD banner, stale and clipped (#1067)

### DIFF
--- a/godot/scripts/core/build_info.gd
+++ b/godot/scripts/core/build_info.gd
@@ -13,8 +13,10 @@ class_name BuildInfo
 ## The pure readers here are unit-tested (test_dev_build_indicator.gd); the on-screen
 ## badge (dev_build_badge.gd) still needs a human eye.
 
-## Master switch for the DEV BUILD indicators. On by default in dev; flip to false
-## for a clean release cut (or gate on OS.is_debug_build() via is_dev_build()).
+## Manual kill-switch for the DEV BUILD indicators. Leave true: the real gate is
+## is_dev_build() below, which ALSO requires a debug run, so a release-template
+## export is never a "dev build" no matter what this const says. Flip false only
+## to force the indicators off even in a dev checkout.
 const DEV_BUILD := true
 
 ## res:// text file written by tools/write_build_stamp.py. Not a Godot resource, so
@@ -47,9 +49,18 @@ static func get_commit() -> String:
 static func get_build_date() -> String:
 	return String(_read_stamp().get("date", ""))
 
-## True while this build should show the DEV BUILD indicators.
+## True while this run should show the DEV BUILD indicators (badge, dev overlay,
+## flight recorder, perf log -- everything that gates on this function).
+##
+## Discriminator: OS.is_debug_build() (same signal as OS.has_feature("debug")) is
+## true in the editor AND in a debug-template export, and false ONLY in a
+## release-template export -- exactly the set of builds players download.
+## OS.has_feature("editor") is deliberately NOT used: it is false in an exported
+## debug build, which would misclassify tester debug exports as public releases.
+## Before this gate existed the const above shipped as-is, so the public v0.13.2
+## release showed the amber DEV BUILD banner on every screen (issue #1067).
 static func is_dev_build() -> bool:
-	return DEV_BUILD
+	return DEV_BUILD and OS.is_debug_build()
 
 # --- Live git identity (L1 follow-up: the stamp went stale and cost a playtest) --------
 #
@@ -123,7 +134,18 @@ static func get_stamp() -> String:
 		return "%s (stamp)" % date
 	return "unstamped"
 
-## One-line badge text for the corner indicator, e.g.
-## "DEV BUILD  v0.11.0  -  fd60eb6 - 2026-07-11". Always non-empty.
+## One-line badge text for the corner indicator. Dev/debug runs get the loud form
+## with the full stamp; exported release builds get a dignified version-only form
+## (players read "DEV BUILD" on a downloaded release as "I have the wrong file" --
+## issue #1067). Always non-empty either way.
 static func get_badge_text() -> String:
+	return get_dev_badge_text() if is_dev_build() else get_release_badge_text()
+
+## Dev form, e.g. "DEV BUILD  v0.11.0  -  fd60eb6 - 2026-07-11 (stamp)".
+static func get_dev_badge_text() -> String:
 	return "DEV BUILD  v%s  -  %s" % [GameConfig.CURRENT_VERSION, get_stamp()]
+
+## Release form: just the version, e.g. "v0.13.2". Keeps the support value ("which
+## build are you running?") without the scary label or the git plumbing.
+static func get_release_badge_text() -> String:
+	return "v%s" % GameConfig.CURRENT_VERSION

--- a/godot/scripts/ui/dev_build_badge.gd
+++ b/godot/scripts/ui/dev_build_badge.gd
@@ -1,70 +1,109 @@
 extends CanvasLayer
 class_name DevBuildBadge
-## Always-visible "DEV BUILD" corner badge (playtester couldn't tell which build he ran).
+## Corner build-identity badge, pinned top-right on every screen.
 ##
-## A high-contrast amber-on-dark badge pinned to the top-right corner, drawn on its own
-## CanvasLayer so it floats over everything on both the main game screen and the
-## welcome/loading screen. Shows GameConfig.CURRENT_VERSION plus the per-commit build
-## stamp from BuildInfo (git short hash + date) so a tester can confirm the exact build.
+## Two faces, decided by BuildInfo.is_dev_build():
+##   - Dev/debug runs (editor, debug-template exports): the loud amber "DEV BUILD"
+##     badge with the full git stamp, so a playtester can confirm exactly which
+##     build he is running.
+##   - Exported release builds: a quiet version-only label ("v0.13.2"). The public
+##     v0.13.2 release shipped the amber banner to players, who read it as "I have
+##     the wrong file" (issue #1067) -- releases keep the support value (which build
+##     is this?) without the scare.
 ##
-## Gated on BuildInfo.is_dev_build(): if that constant is flipped false for a release
-## cut, the badge instances but hides itself. On-screen look still needs a human eye.
+## Layout: the panel's RIGHT edge is pinned to the viewport's right edge and its
+## width is computed from the content, growing leftward -- so it can never run off
+## the right edge. (The old code positioned the panel's LEFT edge at a fixed
+## -360 px offset and let the panel take its natural width to the right; any stamp
+## text wider than ~352 px overflowed the screen and clipped mid-word, which is
+## exactly what the shipped v0.13.2 did.) If the window is narrower than the text,
+## the label ellipsizes instead of overflowing the left edge.
 ##
 ## Usage: `add_child(DevBuildBadge.new())` from any screen's _ready().
 
 ## High layer so the badge sits above normal UI and other CanvasLayers (e.g. overlays).
 const BADGE_LAYER := 200
 
+## Gap kept between the badge and the screen edges.
+const EDGE_MARGIN := 8.0
+
+var _panel: PanelContainer
+var _label: Label
+
 func _ready() -> void:
 	layer = BADGE_LAYER
-	if not BuildInfo.is_dev_build():
-		visible = false
-		return
-	_build_badge()
+	_build_badge(BuildInfo.is_dev_build())
+	get_viewport().size_changed.connect(_fit_to_viewport)
+	_fit_to_viewport()
 
-func _build_badge() -> void:
-	# Anchor a container to the top-right corner of the viewport.
-	var anchor := Control.new()
-	anchor.name = "DevBadgeAnchor"
-	anchor.anchor_left = 1.0
-	anchor.anchor_right = 1.0
-	anchor.anchor_top = 0.0
-	anchor.anchor_bottom = 0.0
-	anchor.offset_left = -360.0
-	anchor.offset_top = 8.0
-	anchor.offset_right = -8.0
-	anchor.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(anchor)
-
-	# The badge panel -- dark translucent base with a bright glowing amber border for
-	# an unmissable "not a real build" read.
-	var panel := PanelContainer.new()
-	panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	panel.size_flags_horizontal = Control.SIZE_SHRINK_END
+func _build_badge(dev: bool) -> void:
+	_panel = PanelContainer.new()
+	_panel.name = "BuildBadgePanel"
+	_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	# Pin the RIGHT edge; _fit_to_viewport() sets offset_left so the panel grows
+	# leftward from there and the right edge can never be crossed.
+	_panel.anchor_left = 1.0
+	_panel.anchor_right = 1.0
+	_panel.anchor_top = 0.0
+	_panel.anchor_bottom = 0.0
+	_panel.offset_right = -EDGE_MARGIN
+	_panel.offset_top = EDGE_MARGIN
+	_panel.grow_horizontal = Control.GROW_DIRECTION_BEGIN
 
 	var style := StyleBoxFlat.new()
-	style.bg_color = Color(0.12, 0.10, 0.02, 0.88)
-	style.border_color = Color(1.0, 0.72, 0.0, 1.0)  # bright amber "glow" edge
-	style.set_border_width_all(3)
-	style.set_corner_radius_all(6)
-	style.content_margin_left = 12
-	style.content_margin_right = 12
-	style.content_margin_top = 6
-	style.content_margin_bottom = 6
-	# Soft outer shadow to fake a glow around the badge.
-	style.shadow_color = Color(1.0, 0.72, 0.0, 0.35)
-	style.shadow_size = 6
-	panel.add_theme_stylebox_override("panel", style)
-	anchor.add_child(panel)
+	_label = Label.new()
+	_label.name = "BuildBadgeLabel"
+	_label.text = BuildInfo.get_badge_text()
+	_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
 
-	var label := Label.new()
-	label.name = "DevBadgeLabel"
-	label.text = BuildInfo.get_badge_text()
-	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-	label.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	label.add_theme_font_size_override("font_size", 15)
-	label.add_theme_color_override("font_color", Color(1.0, 0.82, 0.25))
-	# Dark outline so the amber text stays legible over any background (menu art, etc.).
-	label.add_theme_color_override("font_outline_color", Color(0, 0, 0, 0.9))
-	label.add_theme_constant_override("outline_size", 4)
-	panel.add_child(label)
+	if dev:
+		# Dark translucent base with a bright glowing amber border for an
+		# unmissable "not a real build" read.
+		style.bg_color = Color(0.12, 0.10, 0.02, 0.88)
+		style.border_color = Color(1.0, 0.72, 0.0, 1.0)  # bright amber "glow" edge
+		style.set_border_width_all(3)
+		style.set_corner_radius_all(6)
+		style.content_margin_left = 12
+		style.content_margin_right = 12
+		style.content_margin_top = 6
+		style.content_margin_bottom = 6
+		# Soft outer shadow to fake a glow around the badge.
+		style.shadow_color = Color(1.0, 0.72, 0.0, 0.35)
+		style.shadow_size = 6
+		_label.add_theme_font_size_override("font_size", 15)
+		_label.add_theme_color_override("font_color", Color(1.0, 0.82, 0.25))
+	else:
+		# Release: quiet, small, no border, no glow -- an identity tag, not a warning.
+		style.bg_color = Color(0.05, 0.06, 0.09, 0.5)
+		style.set_border_width_all(0)
+		style.set_corner_radius_all(4)
+		style.content_margin_left = 8
+		style.content_margin_right = 8
+		style.content_margin_top = 3
+		style.content_margin_bottom = 3
+		_label.add_theme_font_size_override("font_size", 12)
+		_label.add_theme_color_override("font_color", Color(0.72, 0.75, 0.80, 0.9))
+
+	# Dark outline so the text stays legible over any background (menu art, etc.).
+	_label.add_theme_color_override("font_outline_color", Color(0, 0, 0, 0.9))
+	_label.add_theme_constant_override("outline_size", 4 if dev else 3)
+
+	_panel.add_theme_stylebox_override("panel", style)
+	_panel.add_child(_label)
+	add_child(_panel)
+
+## Size the panel to its content, clamped to the viewport width, right edge pinned.
+## When the window is narrower than the text, switch the label to ellipsis trimming
+## (which releases the label's minimum-width claim) so the badge shrinks to fit
+## instead of running off the LEFT edge.
+func _fit_to_viewport() -> void:
+	if _panel == null or _label == null:
+		return
+	_label.text_overrun_behavior = TextServer.OVERRUN_NO_TRIMMING
+	var need := _panel.get_combined_minimum_size().x
+	var max_w := get_viewport().get_visible_rect().size.x - 2.0 * EDGE_MARGIN
+	if need > max_w:
+		_label.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+		need = max_w
+	_panel.offset_left = _panel.offset_right - need

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -316,8 +316,8 @@ func _ready():
 	instruments.add_child(_inflight_hiring_box)
 	instruments.move_child(_inflight_hiring_box, instruments.queue_panel.get_index() + 1)
 
-	# Always-visible DEV BUILD corner badge so a playtester can confirm exactly which
-	# build he's running (version + git stamp). Draws on its own CanvasLayer over the UI.
+	# Build-identity corner badge: loud DEV BUILD + git stamp in dev/debug runs, quiet
+	# version-only label in exported release builds (issue #1067). Own CanvasLayer.
 	add_child(DevBuildBadge.new())
 
 	# DEV MODE overlay (backslash) -- full state readout + dev controls, on its own CanvasLayer.

--- a/godot/scripts/ui/welcome_screen.gd
+++ b/godot/scripts/ui/welcome_screen.gd
@@ -82,8 +82,8 @@ func _ready():
 	load_game_button.visible = false
 	load_game_button.disabled = true
 
-	# Always-visible DEV BUILD corner badge (version + git stamp) so a playtester can
-	# confirm which build he's on right from the welcome/loading screen.
+	# Build-identity corner badge: loud DEV BUILD + git stamp in dev/debug runs, quiet
+	# version-only label in exported release builds (issue #1067).
 	add_child(DevBuildBadge.new())
 
 	# Quiet launch notices next to the version label (#799 update check, #939

--- a/godot/tests/unit/test_dev_build_indicator.gd
+++ b/godot/tests/unit/test_dev_build_indicator.gd
@@ -9,15 +9,41 @@ func test_build_stamp_reader_returns_non_empty():
 	# Even with no stamp file, the reader degrades to "unstamped" rather than blank.
 	assert_ne(BuildInfo.get_stamp(), "", "Build stamp must never be empty")
 
-func test_badge_text_includes_version_and_dev_marker():
-	var text := BuildInfo.get_badge_text()
+func test_dev_badge_text_includes_version_and_dev_marker():
+	var text := BuildInfo.get_dev_badge_text()
 	assert_ne(text, "", "Badge text must never be empty")
-	assert_string_contains(text, "DEV BUILD", "Badge must read as a dev build")
+	assert_string_contains(text, "DEV BUILD", "Dev badge must read as a dev build")
 	assert_string_contains(text, GameConfig.CURRENT_VERSION,
 		"Badge must show the current version so the tester can confirm the build")
 
+func test_release_badge_text_is_version_only():
+	# Issue #1067: the public v0.13.2 release showed "DEV BUILD" on every screen and
+	# players read it as "I downloaded the wrong file". The release form must carry
+	# the version (support value) and nothing scary.
+	var text := BuildInfo.get_release_badge_text()
+	assert_string_contains(text, GameConfig.CURRENT_VERSION,
+		"Release badge still identifies the version")
+	assert_false(text.contains("DEV BUILD"),
+		"Release badge must never read as a dev build")
+
+func test_badge_text_matches_run_kind():
+	# get_badge_text() must pick the form that matches this run's is_dev_build().
+	if BuildInfo.is_dev_build():
+		assert_eq(BuildInfo.get_badge_text(), BuildInfo.get_dev_badge_text(),
+			"Dev runs get the loud DEV BUILD form")
+	else:
+		assert_eq(BuildInfo.get_badge_text(), BuildInfo.get_release_badge_text(),
+			"Release builds get the quiet version-only form")
+
 func test_is_dev_build_returns_bool():
 	assert_typeof(BuildInfo.is_dev_build(), TYPE_BOOL, "is_dev_build() should return a bool")
+
+func test_is_dev_build_requires_debug_run():
+	# The load-bearing formula (issue #1067): a release-template export, where
+	# OS.is_debug_build() is false, can NEVER be a dev build regardless of the
+	# DEV_BUILD const. In this test environment (editor/debug) both sides are true.
+	assert_eq(BuildInfo.is_dev_build(), BuildInfo.DEV_BUILD and OS.is_debug_build(),
+		"is_dev_build() must AND the manual switch with the debug-run discriminator")
 
 func test_open_ledger_keybind_registered_on_L():
 	assert_true(KeybindManager.keybinds.has("open_ledger"),

--- a/scripts/build_all_platforms.py
+++ b/scripts/build_all_platforms.py
@@ -90,6 +90,31 @@ class MultiPlatformBuilder:
 
         return None
 
+    def _stamp_build(self) -> bool:
+        """Refresh godot/build_stamp.txt so it names the commit actually being built.
+
+        The committed stamp is structurally always stale: it is written BY a build
+        and committed AFTER it, so the value at any SHA describes the PREVIOUS
+        build. Only re-stamping at export time can make it right. build_release.py
+        (local builds) already does this; this method mirrors it for the CI path
+        (enhanced-release.yml -> this script), which previously shipped whatever
+        stamp happened to be committed -- the public v0.13.2 release displayed
+        fd60eb6 / 2026-07-11 from a dead feature branch (issue #1067).
+
+        Runs tools/write_build_stamp.py, which stamps from `git rev-parse HEAD`
+        of the checked-out ref. Blocking: a stale provenance display is the very
+        defect this exists to prevent, so failure fails the build loudly.
+        """
+        stamp_tool = self.repo_root / "tools" / "write_build_stamp.py"
+        if not stamp_tool.exists():
+            print(f"[ERROR] Missing {stamp_tool} -- the build would ship a stale stamp")
+            return False
+        result = subprocess.run([sys.executable, str(stamp_tool)], check=False)
+        if result.returncode != 0:
+            print("[ERROR] write_build_stamp.py failed -- refusing to ship a stale-stamped build")
+            return False
+        return True
+
     def _update_export_paths(self):
         """Update export_presets.cfg with current version paths."""
         export_presets = self.godot_dir / "export_presets.cfg"
@@ -159,6 +184,11 @@ class MultiPlatformBuilder:
         print("\n" + "=" * 60)
         print("P(Doom) Multi-Platform Build")
         print("=" * 60)
+
+        # Stamp BEFORE any export so the packed godot/build_stamp.txt names this
+        # ref, not whatever a previous build committed (issue #1067).
+        if not self._stamp_build():
+            return False
 
         # Update export paths first
         self._update_export_paths()


### PR DESCRIPTION
## The failure

The shipped v0.13.2 public release displays, on every screen including the main menu, an amber banner clipped mid-word at the right screen edge:

```
DEV BUILD  v0.13.2  -  fd60eb6  -  2026-07-11  (stam
```

Caught on a recorded playthrough. Three stacked defects; this PR fixes all three. References #1067 (squash-merge does not fire closes-keywords here -- close it manually after merge).

## 1. "DEV BUILD" on a public release

`BuildInfo.is_dev_build()` was a bare `const DEV_BUILD := true`, so every export -- release templates included -- counted as a dev build. It is now `DEV_BUILD and OS.is_debug_build()`.

**Why `OS.is_debug_build()`**: same signal as `OS.has_feature("debug")` -- true in the editor AND in debug-template exports, false ONLY in a release-template export, which is exactly the set of builds players download. `OS.has_feature("editor")` was rejected: it is false in an exported DEBUG build, which would misclassify tester debug exports as public releases.

Release builds now show a quiet version-only corner label (`v0.13.2`) instead of nothing -- the badge exists because a playtester could not tell builds apart, and that support value holds for players filing bug reports. The gate change also auto-disables the dev overlay, flight recorder, UI evolution recorder and perf log in release exports (they all gate on `is_dev_build()`).

## 2. Stale stamp (the #1067 mechanism)

`fd60eb6 / 2026-07-11` was a dead feature branch; the release was built from `868c784e` on main on 2026-07-31. The stamp is written BY a build and committed AFTER it, so the committed value at any SHA is structurally always the PREVIOUS build's -- only an export-time rewrite can be right. `tools/build_release.py` (local) already re-stamps; the CI path (`enhanced-release.yml` -> `scripts/build_all_platforms.py`) called nothing. `build_all_platforms.py` now runs `tools/write_build_stamp.py` against the checked-out ref before any export, and fails the build loudly if stamping fails.

## 3. Clipping

The old badge anchored a fixed-width (352 px) plain `Control` by its LEFT edge and parented the `PanelContainer` to it -- a plain Control applies no container layout, so the panel rendered at its natural content width rightward past the screen edge. The panel is now pinned by its RIGHT edge and grows leftward, width computed from content and clamped to the viewport on every resize; when the window is narrower than the text the label ellipsizes instead of overflowing the left edge. Right-edge overflow is now geometrically impossible.

## Deliberately not done

- No workflow YAML edit -- the stamp call lives in `build_all_platforms.py` so every caller of the multi-platform script (CI or manual) stamps, not just today's one workflow.
- `godot/build_stamp.txt` content untouched -- stays tracked (exported fallback needs a real `res://` file) and stays one-build-behind at any commit by construction; correctness now comes from the export-time rewrite.
- `write_build_stamp.py` still records `branch=HEAD` on a detached tag checkout; the badge renders only commit+date, branch is informational.

## Not verifiable from here

An actual CI release render. The release-template branch of `is_dev_build()` and the CI stamping only manifest in a real exported release from the workflow -- the next tag cut should eyeball the corner label and the `build_stamp.txt` inside the zip.

## Tests

`python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **1004 tests, 0 failures**. Badge tests extended: release form carries the version and never "DEV BUILD"; `get_badge_text()` picks the form matching the run kind; `is_dev_build()` ANDs the manual switch with the debug discriminator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
