### PR TITLE
fix(ui): the office cat was a magenta checkerboard in every shipped build, not one flaky JPG (#796)

### DIFF
--- a/godot/scripts/data/contributor_manager.gd
+++ b/godot/scripts/data/contributor_manager.gd
@@ -124,9 +124,12 @@ func get_cat_image_for_doom_level(doom_percentage: float) -> String:
 	var image_path_png = "res://assets/cats/%s/%s.png" % [cat_image_base, variant_name]
 	var image_path_svg = "res://assets/cats/%s/%s.svg" % [cat_image_base, variant_name]
 
-	if FileAccess.file_exists(image_path_png):
+	# ResourceLoader.exists(), not FileAccess.file_exists() -- see #796. The .png/
+	# .svg sources are stripped from the exported .pck and replaced by imported
+	# .ctex, so FileAccess answers "missing" for artwork that is present.
+	if ResourceLoader.exists(image_path_png):
 		return image_path_png
-	elif FileAccess.file_exists(image_path_svg):
+	elif ResourceLoader.exists(image_path_svg):
 		return image_path_svg
 	else:
 		push_warning("Contributor cat image not found: " + image_path_png + ", using default")
@@ -140,7 +143,8 @@ func get_default_cat_image(doom_percentage: float) -> String:
 	var png_path = "res://assets/cats/default/%s.png" % variant_name
 	var svg_path = "res://assets/cats/default/%s.svg" % variant_name
 
-	if FileAccess.file_exists(png_path):
+	# ResourceLoader.exists(), not FileAccess.file_exists() -- see #796.
+	if ResourceLoader.exists(png_path):
 		return png_path
 	else:
 		return svg_path  # Use SVG placeholder

--- a/godot/scripts/ui/office_cat.gd
+++ b/godot/scripts/ui/office_cat.gd
@@ -59,8 +59,19 @@ func set_cat_image(image_path: String) -> void:
 
 	current_cat_image = image_path
 
-	# Load texture
-	if FileAccess.file_exists(image_path):
+	# Load texture.
+	#
+	# MUST be ResourceLoader.exists(), NEVER FileAccess.file_exists() (issue #796).
+	# Godot's exporter does not put the source .jpg in the .pck at all -- it ships
+	# only the imported texture (.godot/imported/<name>.jpg-<md5>.ctex) plus the
+	# .import metadata that points at it. FileAccess reads the packed file table
+	# literally, so file_exists("res://assets/cats/simple/web-arwen.jpg") is FALSE
+	# for EVERY cat in a shipped build even though the artwork is right there.
+	# ResourceLoader goes through the import system and resolves the .ctex.
+	# The rest of this project already uses ResourceLoader.exists() for exactly
+	# this (music_manager, portrait_library, resource_bar, fanfare_popup, ...);
+	# office_cat was the last holdout.
+	if ResourceLoader.exists(image_path):
 		var texture = load(image_path) as Texture2D
 		if texture:
 			cat_texture.texture = texture
@@ -73,11 +84,20 @@ func set_cat_image(image_path: String) -> void:
 		use_placeholder()
 
 ## Use placeholder when image is missing
+##
+## Defence in depth for #796. The old body assigned a PlaceholderTexture2D, which
+## is not a real texture -- the renderer substitutes its missing-texture fill, and
+## what the player saw on screen was a magenta/black checkerboard the size of the
+## cat panel. That is the single loudest "this software is broken" signal a game
+## can show, and it was showing for a purely cosmetic optional asset.
+##
+## If a cat ever goes missing again, fail QUIETLY: a muted swatch that reads as
+## "no photo" rather than as a rendering fault. The push_warning() above is where
+## a developer is meant to learn about it, not the player's screen.
 func use_placeholder() -> void:
-	# Create a simple colored rectangle as placeholder
-	var placeholder_texture = PlaceholderTexture2D.new()
-	placeholder_texture.size = Vector2(256, 256)
-	cat_texture.texture = placeholder_texture
+	var img := Image.create(64, 64, false, Image.FORMAT_RGBA8)
+	img.fill(Color(0.16, 0.17, 0.20, 1.0))
+	cat_texture.texture = ImageTexture.create_from_image(img)
 
 ## Cycle to next cat (for future feature: click to cycle)
 func cycle_contributor() -> void:

--- a/godot/tests/unit/test_office_cat_assets.gd
+++ b/godot/tests/unit/test_office_cat_assets.gd
@@ -1,0 +1,119 @@
+extends GutTest
+## Guards the office cat against issue #796, where every cat in the SHIPPED build
+## rendered as the engine's magenta/black missing-texture checkerboard while the
+## artwork sat correctly imported in the pack the whole time.
+##
+## The mechanism, because it decides what these tests can and cannot prove:
+## Godot's exporter does NOT put the source .jpg into the .pck. It ships the
+## imported texture (.godot/imported/<name>.jpg-<md5>.ctex) plus the .import file
+## that points at it. FileAccess reads the packed file table literally and answers
+## "no such file" for res://assets/cats/simple/web-arwen.jpg; ResourceLoader goes
+## through the import system and resolves the .ctex. office_cat.gd guarded its
+## load() with FileAccess.file_exists(), so the guard failed for all eight cats in
+## every exported build and the placeholder path ran every single time.
+##
+## HONEST LIMITATION -- READ BEFORE TRUSTING A GREEN RUN.
+## These tests run against the SOURCE TREE, where the .jpg files are on disk and
+## FileAccess.file_exists() therefore returns true. They CANNOT reproduce the
+## export-only failure, and they cannot prove a texture reaches a screen. Only a
+## human looking at a cat in an exported build proves that. What they do buy:
+## (1) the eight referenced assets exist and decode, and (2) the guard in
+## office_cat.gd does not regress to FileAccess, which is the actual defect and is
+## invisible to any behavioural test run from the editor.
+
+const OFFICE_CAT_SCRIPT_PATH := "res://scripts/ui/office_cat.gd"
+
+# Eight cats shipped in v0.13.2. Floored so a refactor that empties CAT_NAMES
+# cannot pass this file vacuously.
+const MIN_CATS := 8
+
+
+func _cat_names() -> Dictionary:
+	var script: GDScript = load(OFFICE_CAT_SCRIPT_PATH)
+	assert_not_null(script, "could not load " + OFFICE_CAT_SCRIPT_PATH)
+	var consts: Dictionary = script.get_script_constant_map()
+	assert_true(consts.has("CAT_NAMES"), "office_cat.gd no longer defines CAT_NAMES")
+	return consts.get("CAT_NAMES", {})
+
+
+func _cat_path_prefix() -> String:
+	var script: GDScript = load(OFFICE_CAT_SCRIPT_PATH)
+	var consts: Dictionary = script.get_script_constant_map()
+	return str(consts.get("CAT_IMAGES_PATH", ""))
+
+
+func test_cat_roster_is_not_empty():
+	var names := _cat_names()
+	assert_true(
+		names.size() >= MIN_CATS,
+		"expected at least %d office cats, found %d" % [MIN_CATS, names.size()]
+	)
+
+
+func test_every_cat_resolves_through_resource_loader():
+	# ResourceLoader.exists() is the check that is TRUE in both the editor and an
+	# exported build. If this fails, the asset is genuinely gone or was renamed.
+	var prefix := _cat_path_prefix()
+	assert_ne(prefix, "", "office_cat.gd no longer defines CAT_IMAGES_PATH")
+	for file_name in _cat_names().keys():
+		var path: String = prefix + str(file_name)
+		assert_true(
+			ResourceLoader.exists(path),
+			"cat asset does not resolve through the import system: " + path
+		)
+
+
+func test_every_cat_loads_as_a_texture():
+	var prefix := _cat_path_prefix()
+	for file_name in _cat_names().keys():
+		var path: String = prefix + str(file_name)
+		var tex := load(path) as Texture2D
+		assert_not_null(tex, "cat asset did not load as Texture2D: " + path)
+		if tex != null:
+			assert_true(
+				tex.get_width() > 0 and tex.get_height() > 0,
+				"cat texture decoded to a zero-sized image: " + path
+			)
+
+
+func test_guard_does_not_regress_to_file_access():
+	# The #796 defect is invisible from the editor, so this asserts on the SOURCE.
+	# Same spirit as the check_scene_nav / no-emoji source gates: the failure mode
+	# only exists in a shipped artifact, so the source is where it must be caught.
+	var f := FileAccess.open(OFFICE_CAT_SCRIPT_PATH, FileAccess.READ)
+	assert_not_null(f, "could not read " + OFFICE_CAT_SCRIPT_PATH)
+	if f == null:
+		return
+	var src := f.get_as_text()
+	f.close()
+
+	assert_false(
+		src.contains("FileAccess.file_exists(image_path)"),
+		"office_cat.gd guards its texture load with FileAccess.file_exists(), which is"
+		+ " ALWAYS FALSE in an exported build for an imported asset -- this is the exact"
+		+ " regression that shipped the magenta checkerboard in #796. Use"
+		+ " ResourceLoader.exists() instead."
+	)
+	assert_true(
+		src.contains("ResourceLoader.exists(image_path)"),
+		"office_cat.gd should gate its texture load on ResourceLoader.exists(image_path)"
+	)
+
+
+func test_placeholder_is_a_real_texture_not_the_engine_checkerboard():
+	# Defence in depth: even when a cat IS missing, the fallback must be a real
+	# ImageTexture. PlaceholderTexture2D is not a real texture and the renderer
+	# substitutes its missing-texture fill -- the magenta/black checkerboard the
+	# player actually saw.
+	var script: GDScript = load(OFFICE_CAT_SCRIPT_PATH)
+	assert_not_null(script, "could not load " + OFFICE_CAT_SCRIPT_PATH)
+	var f := FileAccess.open(OFFICE_CAT_SCRIPT_PATH, FileAccess.READ)
+	if f == null:
+		return
+	var src := f.get_as_text()
+	f.close()
+	assert_false(
+		src.contains("PlaceholderTexture2D.new()"),
+		"office_cat.gd fallback uses PlaceholderTexture2D, which renders as the engine's"
+		+ " missing-texture checkerboard. Build a muted ImageTexture instead (#796)."
+	)

--- a/godot/tests/unit/test_office_cat_assets.gd.uid
+++ b/godot/tests/unit/test_office_cat_assets.gd.uid
@@ -1,0 +1,1 @@
+uid://b77dy8kn4ff1t


### PR DESCRIPTION
Closes #796.

## The failure that earned this

At 54s in the recorded v0.13.2 playthrough a bright magenta/black checkerboard --
Godot's missing-texture fill -- sits in the office panel with **"Arwen & Chuck"**
captioned underneath, while the feed cheerfully reports `A Stray Cat Appears!` and
`Cat adopted! Your researchers' morale improves slightly.` Pip, live on the
recording: *"Get the cat. The cat's blopped out."*

The feature worked. The event fired. The morale bonus applied. Only the picture
failed, and it failed in the loudest possible way -- a checkerboard is the single
most "this software is broken" thing a game can put on screen, and it was doing it
for a purely decorative optional asset.

## Why #796's diagnosis was wrong

The issue is titled *"Office cat 'Missy' (web-missy.jpg) does not render"* and
reasons from a v0.12.0 sighting: 1 of 8 cats broken, so re-import that one JPG.

The caption in the new recording reads **"Arwen & Chuck", not "Missy"**. That is
the tell. `select_random_cat()` picks with `randi() % 8`, so a defect that hits
ALL eight presents as a DIFFERENT single cat every time you look -- and reads as
"one flaky asset" to anyone who looks once. Two observations, two different cats,
one cause.

The per-file theory does not survive contact with the files either: all eight
`.import` files are byte-identical apart from the uid/md5, all eight JPGs are on
disk at healthy sizes, and all eight import cleanly.

## The actual mechanism

Godot's exporter **does not put the source `.jpg` into the `.pck` at all.** It
ships the imported texture plus the `.import` metadata that points at it. Parsing
the shipped `builds/PDoom-v0.13.0-windows/PDoom.pck` directory confirms it exactly:

| entry | in pck? | size |
|---|---|---|
| `.godot/imported/web-arwen-chuck.jpg-56916b9a...ctex` | **present** | 306,970 |
| `.godot/imported/web-missy.jpg-3aaf71dc...ctex` | **present** | 404,112 |
| (all 8 `.ctex`) | **present** | 306KB - 474KB each |
| `assets/cats/simple/web-*.jpg.import` (all 8) | **present** | ~200 B each |
| `assets/cats/simple/web-*.jpg` | **ABSENT (0 of 8)** | -- |

`office_cat.gd:63` guarded its `load()` with:

```gdscript
if FileAccess.file_exists(image_path):
```

`FileAccess` reads the packed file table literally. It has no idea the import
system exists. For `res://assets/cats/simple/web-arwen-chuck.jpg` it answers "no
such file" -- **correctly**, that path really is not in the pack -- and the guard
falls through to `use_placeholder()` for every cat, in every exported build, on
every run. The artwork was sitting in the `.pck` the whole time, fully imported,
300KB of it, never once asked for by a name the pack could answer to.

Second half of the ugliness: `use_placeholder()` assigned a `PlaceholderTexture2D`,
which is not a real texture, so the renderer substitutes its missing-texture fill.
That is where the magenta came from. A missing decorative photo was being rendered
with the engine's diagnostic for a broken asset pipeline.

This is the #1027 proxy-detachment shape again. *"The file is on disk and
imported"* is a cheap and usually-faithful proxy for *"the game can load it"*, and
the export step is precisely where the two come apart. Nothing was watching the
join -- and the symptom, a random cat each time, actively disguised the scope.

## The fix, and the class

`ResourceLoader.exists()` resolves through the import system and is true in both
the editor and an exported build. It is already this project's house convention:
`music_manager`, `scene_transition`, `portrait_library`, `resource_bar`,
`fanfare_popup`, `action_bar_renderer`, `office_floor` and `worker_variant_pool`
all use it. `office_cat` was the last holdout guarding an imported asset with
`FileAccess`.

Swept **every** `FileAccess.file_exists()` call in `godot/` for the same class:

| site | verdict |
|---|---|
| `scripts/ui/office_cat.gd:63` (`.jpg`) | **FIXED** -- the shipped defect |
| `scripts/data/contributor_manager.gd:127/129/143` (`.png`/`.svg`) | **FIXED** -- same bug exactly. Currently **dead code** (nothing outside the file references `ContributorManager`; not an autoload), so it broke nothing -- but a loaded gun for whoever revives the contributor-cat feature. |
| `icon_loader`, `whats_new_modal`, `anchored_overlay`, `rivals`, `definition`/`scenario`/`timeline` loaders, `balance`, `event_service`, `achievements` | **OK** -- all guard `res://data/*.json`. JSON is not an imported type; it is packed verbatim. Verified in the pck: `icon_mapping.json` 15,143 B, `patch_notes.json` 3,304 B, `contributors.json` 92 B. Correct as-is. |
| `office_floor/office_sandbox.gd` (8 sites) | **OK** -- absolute `art_source` paths via `Image.load()`, an editor-only dev tool outside `res://`. No export exposure. |
| `addons/gut/*` | **N/A** -- vendored. `collected_script.gd::_remap_path` already implements the equivalent workaround for `.gd.remap`, which is a neat independent confirmation of the mechanism. |

Also hardened the fallback: `use_placeholder()` now builds a muted dark
`ImageTexture` instead of a `PlaceholderTexture2D`. If a cat ever does go missing
again it should read as "no photo" to the player and shout in `push_warning()` to
the developer, not paint a rendering fault across the office.

## Tests -- and what they do not prove

`tests/unit/test_office_cat_assets.gd`, 5 new tests. Full fast gate:

```
1006 tests, 0 failures, 98/98 files collected
python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300
```

**Be clear about what that proves: not much about the actual bug.** These tests run
against the source tree, where the `.jpg` files are on disk and the OLD broken
`FileAccess` guard would also have passed. No test in the editor can reproduce an
export-only packing behaviour, and no test anywhere proves a texture reached a
screen.

So two of the five assert on the **source** of `office_cat.gd` -- that the guard is
`ResourceLoader.exists(image_path)` and not `FileAccess.file_exists(image_path)`,
and that the fallback is not `PlaceholderTexture2D` -- in the same spirit as the
`check_scene_nav` and no-emoji source gates, which exist for the same reason: the
failure only exists in a shipped artifact, so the source is where it must be
caught. The other three assert the eight assets resolve and decode, which catches
a rename or a dropped file.

**THE ONLY REAL PROOF IS A HUMAN SEEING A CAT IN AN EXPORTED BUILD.** That has not
happened yet. Please do not treat #796 as closed until it has.

## Review notes

- No asset was moved, added or removed. The fix is a reference repair, as intended.
- No `.import` churn staged. The one `.uid` in the diff is the new test script's,
  per the Godot 4 convention that `.uid` files are tracked.
- The `.pck` evidence above came from parsing `builds/PDoom-v0.13.0-windows/PDoom.pck`
  (v0.13.0, one patch behind the recorded v0.13.2; the cat assets and
  `office_cat.gd` are unchanged between them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
