### PR TITLE
fix(office-floor): stop the server rack painting over the feed, and shrink the giant staff (#793)

### DIFF
--- a/godot/scenes/ui/office_floor/office_floor.tscn
+++ b/godot/scenes/ui/office_floor/office_floor.tscn
@@ -9,5 +9,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+clip_contents = true
 custom_minimum_size = Vector2(360, 260)
 script = ExtResource("1_officefloor")

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -1227,10 +1227,30 @@ func _setup_delta_chips() -> void:
 		chip.name = "DeltaChip_%s" % spec["key"]
 		chip.text = ""
 		chip.add_theme_font_size_override("font_size", 12)
+		chip.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 		chip.tooltip_text = "Change over the last turn"
 		var parent = anchor.get_parent()
-		parent.add_child(chip)
-		parent.move_child(chip, anchor.get_index() + 1)
+		# The doom readout's parent (main.tscn NumericDoomZone) is a CenterContainer,
+		# which centres EVERY child at its own minimum size -- so the chip landed
+		# exactly on top of the label and the two texts rendered through each other
+		# ("20.0%" + "(+0.9)" reading as garbage like "2099%" on the league recording).
+		# Money/compute/reputation sit in the TopBar HBox and were never affected.
+		# Give a CenterContainer anchor a real row to live in; every other parent
+		# (HBox/VBox) keeps the original sibling insert exactly as before.
+		if parent is CenterContainer:
+			var row := HBoxContainer.new()
+			row.name = "DeltaRow_%s" % spec["key"]
+			row.add_theme_constant_override("separation", 4)
+			row.alignment = BoxContainer.ALIGNMENT_CENTER
+			var at: int = anchor.get_index()
+			parent.remove_child(anchor)
+			parent.add_child(row)
+			parent.move_child(row, at)
+			row.add_child(anchor)
+			row.add_child(chip)
+		else:
+			parent.add_child(chip)
+			parent.move_child(chip, anchor.get_index() + 1)
 		_delta_labels[spec["key"]] = chip
 
 

--- a/godot/scripts/ui/office_floor/employee_sprite.gd
+++ b/godot/scripts/ui/office_floor/employee_sprite.gd
@@ -44,6 +44,20 @@ const ART_SUBJECT_H := 140.0                 # opaque subject height in that can
 const ART_FEET_Y := 158.0                    # bottom of the opaque bbox (the feet)
 const SPRITE_SCALE := Vector2(0.9, 0.9)      # ~= CHAR_TARGET_H / ART_SUBJECT_H
 
+# #793 (scale): CHAR_TARGET_H above is the REFERENCE height at the reference 64px tile.
+# The live WATCH strip is far too shallow for that -- a 128px worker in a ~244px-deep
+# room read as a giant, which is the scale half of #793. The owning OfficeFloor now
+# derives a room-proportionate height (OfficeFloor.char_target_height()) and pushes it
+# in here, so one worker is a fixed fraction of the ROOM rather than a fixed pixel
+# count. Default stays CHAR_TARGET_H, so a sprite constructed standalone (tests, the
+# sandbox harness) behaves exactly as before.
+var char_target_h: float = CHAR_TARGET_H:
+	set(value):
+		char_target_h = maxf(8.0, value)
+		_apply_art_transform()   # null-safe: the art nodes only exist after _ready()
+		if is_inside_tree():
+			queue_redraw()
+
 # Feet anchor: AnimatedSprite2D / Sprite2D are centre-anchored by default, while
 # props are feet-anchored (office_floor.gd _draw_prop), so characters floated.
 # Shift the texture up so the subject's feet sit on the node origin:
@@ -277,18 +291,23 @@ func _apply_art_transform() -> void:
 			var tex := _anim.sprite_frames.get_frame_texture(names[0], 0)
 			if tex != null and tex.get_height() < 100:
 				use_placeholder = true
+	# #793: derive from the live char_target_h rather than the baked-in constants, so
+	# the same art lands at whatever height the owning floor asked for. The feet
+	# OFFSETS are texture-space and so are unaffected by scale.
+	var real_scale := Vector2.ONE * (char_target_h / ART_SUBJECT_H)
+	var ph_scale := Vector2.ONE * (char_target_h / PLACEHOLDER_CANVAS_H)
 	if _anim:
-		_anim.scale = PLACEHOLDER_SCALE if use_placeholder else SPRITE_SCALE
+		_anim.scale = ph_scale if use_placeholder else real_scale
 		_anim.offset = PLACEHOLDER_FEET_OFFSET if use_placeholder else SPRITE_FEET_OFFSET
 	if _facing_sprite:
-		_facing_sprite.scale = SPRITE_SCALE
+		_facing_sprite.scale = real_scale
 		_facing_sprite.offset = SPRITE_FEET_OFFSET
 
 ## Radius of the walkable footprint around the feet (bounds clamping + wander
 ## targets). Tier 1: derived from the drawn height; tier 0: the blob radius.
 func _footprint_radius() -> float:
 	if tier == 1:
-		return FOOTPRINT_RATIO * CHAR_TARGET_H   # ~19px
+		return FOOTPRINT_RATIO * char_target_h   # ~0.15 of the DRAWN height
 	return BODY_RADIUS
 
 ## Rect the FEET may occupy inside `bounds`. Feet-anchored art extends UP from
@@ -297,7 +316,7 @@ func _footprint_radius() -> float:
 ## collapse to the vertical centre instead of inverting the clamp.
 func _feet_rect() -> Rect2:
 	var r := _footprint_radius()
-	var top_pad := CHAR_TARGET_H if tier == 1 else BODY_RADIUS
+	var top_pad := char_target_h if tier == 1 else BODY_RADIUS
 	var bottom_pad := FEET_BOTTOM_PAD if tier == 1 else BODY_RADIUS
 	var y_min := bounds.position.y + top_pad
 	var y_max := bounds.end.y - bottom_pad

--- a/godot/scripts/ui/office_floor/office_floor.gd
+++ b/godot/scripts/ui/office_floor/office_floor.gd
@@ -55,9 +55,43 @@ const FLOOR_TILE_SCALE := 2
 # authored proportions via PropCatalogue; PROP_TARGET_H remains the force-scale for any
 # texture drawn WITHOUT a manifest id (PropCatalogue's own fallback reproduces it too).
 const PROP_TARGET_H := 46.0                    # #770: props drawn larger (was 30) to match the bigger floor
-# One floor tile on screen: 32 px art displayed at FLOOR_TILE_SCALE (matches
-# OfficeEmployeeSprite.TILE_PX = 64). PropCatalogue heights are in tiles of this size.
+# REFERENCE tile size only: 32 px art displayed at FLOOR_TILE_SCALE (matches
+# OfficeEmployeeSprite.TILE_PX = 64). This is what the floor CONCRETE is tiled at,
+# and it is the unit PropCatalogue heights were authored against. It is NOT the
+# subject scale any more -- see _subject_tile_px() below and #793.
 const DISPLAY_TILE_PX := 32.0 * FLOOR_TILE_SCALE
+
+# --- #793 scale + #793 layering: how big a "tile" is for SUBJECTS (people, props) ---
+# The bug this replaces: subjects were scaled against DISPLAY_TILE_PX (64), so the
+# WATCH strip's ~244 px-deep floor was only 3.8 tiles deep while a worker is authored
+# at 2 tiles and the server cluster at 3.5. A 3.5-tile prop in a 3.8-tile room is a
+# prop the height of the room; a 2-tile worker is a giant standing in a cupboard.
+# The manifest is authored in TILES and is authoritative, so the on-screen tile must
+# shrink until the room contains a plausible number of them. ROOM_DEPTH_TILES is that
+# ruling: the floor is treated as this many tiles deep whatever pixel height the
+# layout hands us, so the view stays proportionate at any strip size.
+const ROOM_DEPTH_TILES := 6.0
+# A worker is authored 2 tiles tall (OfficeEmployeeSprite.CHAR_TARGET_H / TILE_PX).
+const CHAR_TILE_HEIGHT := 2.0
+# Clamps stop a degenerate layout pass (zero/absurd size) producing invisible or
+# screen-filling art before the first real resize lands.
+const SUBJECT_TILE_PX_MIN := 8.0
+const SUBJECT_TILE_PX_MAX := DISPLAY_TILE_PX
+
+# --- #793 layering: headroom above the floor ---------------------------------
+# Props are FEET-anchored and extend UPWARD. Before this, the floor rect's top edge
+# WAS the control's top edge, so any prop standing near the back wall necessarily
+# painted above the control -- and a Control does not clip its own _draw() by
+# default, so it landed on top of the feed panel above it in the WATCH VBox. The
+# floor now reserves a wall band at the top that back-wall props rise into.
+const HEADROOM_RATIO := 0.30
+# Where the server-cluster decor piece stands, as a fraction of the walkable floor.
+# Single source of truth: _draw() and _rebuild_blocked_rects() BOTH placed it and had
+# silently drifted apart in the making of this fix. x moved 0.12 -> 0.20 because the
+# rack is ~110 px wide when centred on its feet anchor, so at 0.12 the left half of it
+# hung off the control's left edge as well as over the feed above.
+const SERVER_DECOR_FRACTION := Vector2(0.20, 0.18)
+const WALL_COLOR := Color(0.12, 0.13, 0.15)
 const FLOOR_DIM := Color(0.62, 0.63, 0.66)     # tint floor/props muted so sprites + UI read over them
 
 @export var tier: int = 0: set = set_tier
@@ -152,6 +186,11 @@ var _style_tex_cache: Dictionary = {}   # variant manifest id -> Texture2D (load
 
 func _ready() -> void:
 	custom_minimum_size = Vector2(360, 260)
+	# #793 (layering): the floor's own rect is the ONLY thing it may paint. Set in code
+	# as well as in office_floor.tscn so a code-instantiated floor (tests, sandbox)
+	# carries the same guarantee, and so a future art/anchor change can never again
+	# reach out of this control and land on the feed panel above it in the WATCH VBox.
+	clip_contents = true
 	# #770: nearest-neighbor so the upscaled floor tile + props stay crisp pixel art
 	# (sprites already force NEAREST per-node; this covers the floor/prop draws here).
 	texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
@@ -274,18 +313,48 @@ func _on_resized() -> void:
 	# Keep everyone inside the new bounds; landmark footprints move with them.
 	var b := _bounds()
 	_rebuild_blocked_rects()
+	var ch := char_target_height()
 	for id in _sprites:
 		var spr: OfficeEmployeeSprite = _sprites[id]
 		spr.bounds = b
 		spr.blocked_rects = _blocked_rects
+		spr.char_target_h = ch
 	_relayout_desks()
 	queue_redraw()
 
-func _bounds() -> Rect2:
+## Control-space size to lay out against, falling back to the minimum size before the
+## first real layout pass (a zero-size Control would otherwise produce nonsense scales).
+func _layout_size() -> Vector2:
 	var s := size
 	if s.x < 40.0 or s.y < 40.0:
 		s = custom_minimum_size
-	return Rect2(Vector2(8, 8), s - Vector2(16, 16))
+	return s
+
+## Height of the back-wall band reserved ABOVE the walkable floor. Feet-anchored props
+## standing at the back of the room draw up into this band instead of out of the
+## control (#793). Nothing walks here; it is wall, not floor.
+func _headroom() -> float:
+	return _layout_size().y * HEADROOM_RATIO
+
+## The WALKABLE floor rect. Now starts BELOW the headroom band (#793).
+func _bounds() -> Rect2:
+	var s := _layout_size()
+	var head := _headroom()
+	return Rect2(Vector2(8, 8 + head), s - Vector2(16, 16 + head))
+
+## On-screen px of one authored tile for SUBJECTS (people + manifest props). Derived
+## from the floor depth so the room always reads as ROOM_DEPTH_TILES deep, whatever
+## height the WATCH column gives us. See the ROOM_DEPTH_TILES comment for the why.
+func _subject_tile_px() -> float:
+	var depth := _bounds().size.y
+	if depth <= 0.0:
+		return SUBJECT_TILE_PX_MIN
+	return clampf(depth / ROOM_DEPTH_TILES, SUBJECT_TILE_PX_MIN, SUBJECT_TILE_PX_MAX)
+
+## Target on-screen height of a worker, in px. Public so tests (and a future Pip
+## eyeball pass) can assert the person-to-room proportion without redoing the maths.
+func char_target_height() -> float:
+	return _subject_tile_px() * CHAR_TILE_HEIGHT
 
 ## Observability only (see godot/autoload/perf_log.gd): the Titan-phase scaling cliff this
 ## class's own doc comment flags above (hundreds of staff, one-sprite-each not viable) makes
@@ -302,6 +371,8 @@ func set_roster(snapshot: Array) -> void:
 	var sw := PerfLog.time_section("office_roster_rebuild", {"count": snapshot.size()})
 	var b := _bounds()
 	var z := _zones(b)
+	# #793: workers are sized against the ROOM, not against a fixed 64px tile.
+	var ch := char_target_height()
 	var seen: Dictionary = {}
 	var total := snapshot.size()
 	for i in range(total):
@@ -328,12 +399,14 @@ func set_roster(snapshot: Array) -> void:
 			var spr: OfficeEmployeeSprite = _sprites[id]
 			spr.bounds = b
 			spr.blocked_rects = _blocked_rects
+			spr.char_target_h = ch
 			spr.configure(cfg)
 		else:
 			var spr2: OfficeEmployeeSprite = EmployeeSpriteScript.new()
 			spr2.tier = tier
 			spr2.bounds = b
 			spr2.blocked_rects = _blocked_rects
+			spr2.char_target_h = ch
 			spr2.position = desk
 			add_child(spr2)
 			spr2.configure(cfg)
@@ -445,8 +518,7 @@ func _rebuild_blocked_rects() -> void:
 	var z := _zones(b)
 	_add_landmark_prop("water_cooler", z["water_pos"])
 	_add_landmark_prop("filing_cabinet", z["fridge_pos"])
-	_add_landmark_prop("server_cluster",
-		b.position + Vector2(b.size.x * 0.12, b.size.y * 0.18))
+	_add_landmark_prop("server_cluster", _server_decor_pos(b))
 	_blocked_rects.append_array(_extra_blocked_rects)
 
 func _add_landmark_prop(id: String, feet: Vector2) -> void:
@@ -491,7 +563,7 @@ func _approach_slots_at(landmark: Vector2) -> Array:
 		var subject_h := float(subj[1]) if subj.size() == 2 else 0.0
 		if subject_h <= 0.0:
 			return []
-		var scl := PropCatalogue.height_px(id, DISPLAY_TILE_PX) / subject_h
+		var scl := PropCatalogue.height_px(id, _subject_tile_px()) / subject_h
 		var out: Array = []
 		for o in offs:
 			out.append(landmark + (o as Vector2) * scl)
@@ -514,8 +586,9 @@ func _slot_free(slot: Vector2, requester_id: String) -> bool:
 # from the feet point (same convention as the sandbox occupancy pass, #907).
 func _footprint_rect(id: String, feet: Vector2) -> Rect2:
 	var fp := PropCatalogue.footprint(id)
-	var w := fp.x * DISPLAY_TILE_PX
-	var d := fp.y * DISPLAY_TILE_PX
+	var tile := _subject_tile_px()
+	var w := fp.x * tile
+	var d := fp.y * tile
 	return Rect2(feet - Vector2(w * 0.5, d), Vector2(w, d))
 
 func _relayout_desks() -> void:
@@ -544,6 +617,10 @@ func _zones(b: Rect2) -> Dictionary:
 		"water_pos":  b.position + Vector2(b.size.x - inset.x, inset.y),                 # top-right
 		"fridge_pos": b.position + Vector2(b.size.x - inset.x, b.size.y - inset.y),      # bottom-right
 	}
+
+# Feet point of the server-cluster decor piece for a given floor rect.
+func _server_decor_pos(b: Rect2) -> Vector2:
+	return b.position + Vector2(b.size.x * SERVER_DECOR_FRACTION.x, b.size.y * SERVER_DECOR_FRACTION.y)
 
 # A couple of table centres in the central band (kept clear of the corner landmarks).
 func _table_centers(b: Rect2) -> Array:
@@ -582,7 +659,7 @@ func _build_floor_tile() -> Texture2D:
 
 # Draw a prop texture with its feet anchor at `at`, dimmed to match the floor.
 # #907 integration: when `id` has a manifest entry (PropCatalogue) the prop keeps its
-# AUTHORED proportions -- scaled so the opaque subject spans height_px(id, DISPLAY_TILE_PX)
+# AUTHORED proportions -- scaled so the opaque subject spans height_px(id, _subject_tile_px())
 # and anchored at the manifest anchor_px (subject feet) instead of the texture's
 # bottom-centre (which drifted with transparent padding). Without an id / entry it falls
 # back to the legacy PROP_TARGET_H force-scale, so unknown textures render like before.
@@ -598,7 +675,7 @@ func _draw_prop(tex: Texture2D, at: Vector2, id: String = "") -> void:
 		var subject_h := float(subj[1]) if subj.size() == 2 else src.y
 		if subject_h <= 0.0:
 			subject_h = src.y
-		var scl_m := PropCatalogue.height_px(id, DISPLAY_TILE_PX) / subject_h
+		var scl_m := PropCatalogue.height_px(id, _subject_tile_px()) / subject_h
 		var anchor := PropCatalogue.anchor(id)
 		if anchor == PropCatalogue.ANCHOR_UNSET:
 			anchor = Vector2(src.x * 0.5, src.y)   # no anchor data -> texture bottom-centre
@@ -632,6 +709,9 @@ func _draw_landmark_prop(id: String, default_tex: Texture2D, at: Vector2) -> voi
 func _draw() -> void:
 	var b := _bounds()
 	draw_rect(Rect2(Vector2.ZERO, size), Color(0.09, 0.10, 0.11))       # room
+	# #793: the reserved headroom band reads as BACK WALL, not as void. Nothing walks
+	# here; it is the space feet-anchored back-of-room props rise into.
+	draw_rect(Rect2(Vector2.ZERO, Vector2(size.x, b.position.y)), WALL_COLOR)
 	# Floor: tile the promoted concrete Wang base tile if available, else a flat fill.
 	if _floor_tile != null:
 		draw_texture_rect(_floor_tile, b, true, FLOOR_DIM)               # tiled concrete
@@ -653,20 +733,21 @@ func _draw() -> void:
 	# props stand in for the water/fridge markers + add a server-cluster decor piece; the
 	# window strip + cat corner stay procedural (cat art deferred to the #758 identity pass).
 	var z := _zones(b)
-	# window strip (top wall). Dev-hook: if a promoted wall texture was supplied via
-	# set_wall_strip_texture() it tiles across a slightly taller strip; default (null)
-	# draws the original flat blue rect unchanged.
+	# window strip -- now drawn ON the back wall (in the headroom band) rather than on
+	# the first row of floor, which is where a window actually is. Dev-hook: if a
+	# promoted wall texture was supplied via set_wall_strip_texture() it tiles across a
+	# slightly taller strip; default (null) draws the flat blue rect.
+	var wall_y: float = b.position.y - _headroom() * 0.55
 	if _wall_strip_tex != null:
-		draw_texture_rect(_wall_strip_tex, Rect2(Vector2(b.position.x + 6, b.position.y + 2), Vector2(b.size.x - 12, 12)), true, FLOOR_DIM)
+		draw_texture_rect(_wall_strip_tex, Rect2(Vector2(b.position.x + 6, wall_y), Vector2(b.size.x - 12, 12)), true, FLOOR_DIM)
 	else:
-		draw_rect(Rect2(Vector2(b.position.x + 6, b.position.y + 2), Vector2(b.size.x - 12, 5)), Color(0.45, 0.6, 0.75, 0.45))
+		draw_rect(Rect2(Vector2(b.position.x + 6, wall_y), Vector2(b.size.x - 12, 5)), Color(0.45, 0.6, 0.75, 0.45))
 	draw_circle(z["cat_pos"], 9.0, Color(0.9, 0.5, 0.7, 0.4))            # cat corner (pink)
 	# #907: landmark props render manifest-scaled/anchored, style-variant-aware.
 	_draw_landmark_prop("water_cooler", PROP_WATER_COOLER, z["water_pos"])          # top-right
 	_draw_water_bubbles(z["water_pos"])                                             # #913 juice
 	_draw_landmark_prop("filing_cabinet", PROP_FILING_CABINET, z["fridge_pos"])     # bottom-right
-	_draw_landmark_prop("server_cluster", PROP_SERVER,
-		b.position + Vector2(b.size.x * 0.12, b.size.y * 0.18))                     # top-left decor
+	_draw_landmark_prop("server_cluster", PROP_SERVER, _server_decor_pos(b))       # back-left decor
 
 # Pass-3 organic bubbles (#913 evolved): draw whichever emitters are mid-burst
 # right now. Two emitters on incommensurate timers (constants above) each rise
@@ -674,7 +755,7 @@ func _draw() -> void:
 # a short 3-frame burst; between bursts the jug is still. Pure function of the
 # emitter clock -- sparse, never visibly repeating, no RNG.
 func _draw_water_bubbles(feet: Vector2) -> void:
-	var h := PropCatalogue.height_px("water_cooler", DISPLAY_TILE_PX)
+	var h := PropCatalogue.height_px("water_cooler", _subject_tile_px())
 	if h <= 0.0:
 		return
 	var rise := h * 0.05                                   # px climbed per frame

--- a/godot/tests/unit/test_office_floor_paint_bounds.gd
+++ b/godot/tests/unit/test_office_floor_paint_bounds.gd
@@ -1,0 +1,121 @@
+extends GutTest
+## #793 (layering + scale): locks the two invariants that the v0.13.2 league recording
+## broke at 00:54 -- the office-floor server rack painting ON TOP of the feed text, and
+## a worker sprite drawn nearly as tall as the room was deep.
+##
+## WHAT THIS CAN AND CANNOT PROVE. These are ARITHMETIC assertions over the rects the
+## renderer computes, not pixel checks: a headless test cannot see a frame. They prove
+## the drawn geometry stays inside the control and that the person/room ratio is sane.
+## They CANNOT prove the result looks right. That still needs a human looking at it.
+
+const OfficeFloorScene := preload("res://scenes/ui/office_floor/office_floor.tscn")
+
+# The size WatchScreen actually gives the floor (watch_screen.gd sets height 260 and
+# EXPAND_FILL for the width; 360 is the floor's own custom_minimum_size width).
+const LIVE_SIZE := Vector2(360, 260)
+
+var _floor: OfficeFloor
+
+
+func before_each() -> void:
+	_floor = _sized_floor(LIVE_SIZE)
+
+
+## A floor pinned to an exact pixel size. The scene root is anchored full-rect, so a
+## bare instance adopts the VIEWPORT size when parented outside a container -- pinning
+## the anchors top-left is what makes `size` actually stick.
+func _sized_floor(px: Vector2) -> OfficeFloor:
+	var f: OfficeFloor = OfficeFloorScene.instantiate()
+	add_child_autofree(f)
+	f.set_anchors_preset(Control.PRESET_TOP_LEFT)
+	f.custom_minimum_size = Vector2.ZERO
+	f.size = px
+	return f
+
+
+func test_floor_clips_its_own_painting() -> void:
+	# The structural guarantee. A Control does NOT clip its own _draw() by default, and
+	# the floor is the LAST sibling in the WATCH VBox, so anything it paints above its
+	# own rect lands on the feed panel. clip_contents makes the rect authoritative
+	# whatever a future art/anchor/scale change does.
+	assert_true(_floor.clip_contents,
+		"OfficeFloor must clip_contents so it can never paint over the feed above it")
+
+
+func test_floor_reserves_headroom_above_the_walkable_floor() -> void:
+	# Feet-anchored props extend UPWARD. If the walkable floor's top edge is the
+	# control's top edge, a prop at the back wall must paint outside the control --
+	# that is the defect, expressed as geometry.
+	var b: Rect2 = _floor._bounds()
+	assert_gt(b.position.y, 8.0,
+		"walkable floor must start below a back-wall headroom band, not at the control top")
+	assert_lt(b.size.y, LIVE_SIZE.y,
+		"the walkable floor is a subset of the control, not the whole of it")
+
+
+func test_every_landmark_prop_paints_inside_the_control() -> void:
+	# The actual regression: server_cluster is 3.5 authored tiles tall and stands at
+	# 18% depth. At the old 64px subject tile that was 224px of art rising out of a
+	# 260px control, ~178px of it above the top edge and over the feed.
+	var b: Rect2 = _floor._bounds()
+	var z: Dictionary = _floor._zones(b)
+	var placements := {
+		"water_cooler": z["water_pos"],
+		"filing_cabinet": z["fridge_pos"],
+		"server_cluster": _floor._server_decor_pos(b),
+	}
+	var control := Rect2(Vector2.ZERO, LIVE_SIZE)
+	for id in placements.keys():
+		var rect: Rect2 = _prop_draw_rect(String(id), placements[id])
+		assert_true(control.encloses(rect),
+			"%s draw rect %s must fit inside the control %s" % [id, rect, control])
+
+
+func test_worker_is_a_person_in_a_room_not_a_giant() -> void:
+	# The scale half of #793. The recording showed a worker about as tall as the floor
+	# was deep. A person should read as a modest fraction of the room's depth.
+	var depth: float = _floor._bounds().size.y
+	var h: float = _floor.char_target_height()
+	assert_gt(h, 0.0, "worker target height must be positive")
+	var ratio := h / depth
+	assert_lt(ratio, 0.40, "a worker must be well under half the room's depth (was ~0.52)")
+	assert_gt(ratio, 0.15, "...but still big enough to read as a person, not a speck")
+
+
+func test_worker_sprites_receive_the_room_proportionate_height() -> void:
+	# The floor must PUSH its derived height into the sprites; a sprite left on the
+	# 128px reference default is the bug back again.
+	_floor.set_tier(1)
+	_floor.set_roster([
+		{"id": "a", "name": "Ellis Wilson", "specialization": "safety"},
+		{"id": "b", "name": "Second Person", "specialization": "capabilities"},
+	])
+	var found := 0
+	for child in _floor.get_children():
+		if child is OfficeEmployeeSprite:
+			found += 1
+			assert_almost_eq(child.char_target_h, _floor.char_target_height(), 0.01,
+				"each sprite is sized against the room, not the 64px reference tile")
+	assert_eq(found, 2, "both roster members rendered a sprite")
+
+
+func test_subject_scale_tracks_the_room_size() -> void:
+	# Responsiveness: halve the strip, the subjects halve too, so the proportion
+	# survives any layout Pip lands on.
+	var tall: float = _floor.char_target_height()
+	var short: float = _sized_floor(Vector2(360, 130)).char_target_height()
+	assert_lt(short, tall, "a shorter strip yields shorter people")
+
+
+## Reproduce _draw_prop's manifest branch: the rect the renderer will actually paint.
+func _prop_draw_rect(id: String, feet: Vector2) -> Rect2:
+	var e: Dictionary = PropCatalogue.get_entry(id)
+	assert_false(e.is_empty(), "%s must be manifested for this test to mean anything" % id)
+	var subj: Array = e.get("subject_px", [])
+	var canvas: Array = e.get("canvas_px", [])
+	var src := Vector2(float(canvas[0]), float(canvas[1]))
+	var scl: float = PropCatalogue.height_px(id, _floor._subject_tile_px()) / float(subj[1])
+	var anchor: Vector2 = PropCatalogue.anchor(id)
+	if anchor == PropCatalogue.ANCHOR_UNSET:
+		anchor = Vector2(src.x * 0.5, src.y)
+	return Rect2(feet - anchor * scl, src * scl)

--- a/godot/tests/unit/test_office_floor_paint_bounds.gd.uid
+++ b/godot/tests/unit/test_office_floor_paint_bounds.gd.uid
@@ -1,0 +1,1 @@
+uid://c33klsepqpeo8

--- a/godot/tests/unit/test_office_walker_separation.gd
+++ b/godot/tests/unit/test_office_walker_separation.gd
@@ -178,11 +178,17 @@ func _make_floor_with_idle_worker_and_cat() -> Array:
 	add_child_autofree(f)
 	f.set_roster([{"id": 0, "name": "A", "loyalty": 8}])
 	var spr: OfficeEmployeeSprite = f._sprites[0]
-	spr.position = Vector2(180, 150)
+	# #793: place the pair relative to the floor's OWN walkable rect rather than at a
+	# hardcoded (180, 150). The floor now reserves a back-wall headroom band, so a
+	# hardcoded point can land in the wall and get clamped, which swamps the few px of
+	# separation travel this test is measuring. Deriving the spot keeps the test about
+	# separation whatever the bounds become.
+	var mid: Vector2 = f._bounds().get_center()
+	spr.position = mid
 	var cat := Node2D.new()
 	cat.add_to_group(OfficeFloor.CAT_GROUP)
 	f.add_child(cat)
-	cat.position = Vector2(186, 150)          # rendering inside the worker
+	cat.position = mid + Vector2(6, 0)        # rendering inside the worker
 	return [f, spr, cat]
 
 


### PR DESCRIPTION
## The failure that earned this

In the v0.13.2 league recording, at 00:54, an isometric server-rack sprite from
the WATCH office floor is drawn **on top of the event feed**, obscuring several
lines of "Feed -- the month as it happens". In the same frame Ellis Wilson stands
about as tall as the office floor is deep.

Both are one geometry mistake with two faces. Neither is a `z_index` problem.

## Mechanism

1. `WatchScreen` is a `VBoxContainer`: `MessageScroll` (the feed), then the
   `OfficeFloor` below it. Later siblings draw on top, so anything the floor
   paints above its own rect lands on the feed. That is correct and expected --
   the floor simply must not paint outside its rect.
2. It did. `_bounds()` returned `Rect2(8, 8, w-16, h-16)`: the walkable floor's
   top edge **was** the control's top edge. No wall band, no headroom. Props are
   feet-anchored and extend *upward*; the server cluster stands at 18% depth,
   i.e. at the back wall. Any prop of nonzero height standing there **must**
   paint above the control. Inevitable, not a tuning accident.
3. How far above: `PropCatalogue` authors heights in TILES; `server_cluster` is
   3.5 tiles, converted at `DISPLAY_TILE_PX = 64` = 224px of rack in a 244px-deep
   floor. Feet at `8 + 0.18*244 = 52`, so the draw rect started at `y = -178`.
   178px of server rack sitting on the feed.
4. Godot did not stop it because **`Control.clip_contents` defaults to false** --
   a Control's own `_draw()` is not clipped to its rect unless you ask.
5. The same 64px tile is why the people are giants: a worker is authored 2 tiles
   = 128px, in a room only `244/64 = 3.8` tiles deep. The manifest was not wrong;
   the room was too few tiles across for the tile size chosen in #770.

## What changed

- **`clip_contents = true`** on the OfficeFloor root (in `office_floor.tscn` and
  in `_ready()`). This is the guarantee, not the fix: the control's rect becomes
  authoritative, so no future art/anchor/scale change can reach out and land on
  the feed again.
- **`_bounds()` reserves a back-wall headroom band** (`HEADROOM_RATIO` 0.30).
  Back-wall props rise into wall -- which is where the top of a server rack
  actually is -- instead of out of the control. The band is drawn as wall, and
  the window strip moved off the first row of floor onto the wall.
- **Subject scale decoupled from the floor-art tile.** `DISPLAY_TILE_PX` still
  tiles the concrete and is still the unit the manifest was authored against, but
  people/props scale by `_subject_tile_px()`: the floor is treated as
  `ROOM_DEPTH_TILES` (6) deep whatever pixel height the layout gives it. At the
  live 360x260 strip: 27.7px tile, worker 55px (**33% of floor depth, was 52%**),
  rack 97px, and every landmark prop's draw rect lands wholly inside the control.
- **`OfficeEmployeeSprite.char_target_h`** is now an instance property (default
  `CHAR_TARGET_H`, so a standalone sprite is unchanged) that the owning floor
  pushes in on roster build and resize. Scale, footprint radius and feet-rect
  clamp all derive from it, so the view stays proportionate at any strip size.
- **`SERVER_DECOR_FRACTION`**: `_draw()` and `_rebuild_blocked_rects()` each
  hardcoded the rack's position and had already drifted into two copies. Now one
  constant. Its x moved `0.12 -> 0.20` because the rack is ~110px wide about its
  anchor, so at 0.12 its left half also hung off the control's left edge.

## Also in here: the "2099%" doom readout

Real, and separate. `main.tscn`'s `NumericDoomZone` is a **CenterContainer**, and
`_setup_delta_chips()` inserted the per-turn delta chip as a *sibling* of the
label inside it. A CenterContainer centres every child at its own minimum size,
so `"20.0%"` and `"(+0.9)"` were drawn through each other. Money/compute/
reputation live in the TopBar HBox and were never affected. The chip setup now
gives a CenterContainer anchor a real HBox row; every other parent keeps the
original sibling insert unchanged.

## What was NOT done, deliberately

The other half of #793 -- **every staff member rendering as the same character**
-- is untouched. That is an art/identity mapping problem (the `appearance_id`
seam and `WorkerVariantPool`), not a geometry one, and belongs in its own PR with
its own art review.

## Tests

`godot/tests/unit/test_office_floor_paint_bounds.gd` (new) asserts
`clip_contents`, that headroom exists, that all three landmark props' draw rects
are enclosed by the control at the live strip size, that the worker/room height
ratio sits between 0.15 and 0.40, that the floor pushes its derived height into
the sprites, and that a shorter strip yields shorter people.

`test_office_walker_separation.gd` was **edited, and should be read as an edit,
not a fix**: it placed a worker and cat at a hardcoded `(180, 150)`, which is now
inside the wall band and gets clamped, swamping the few pixels of separation
travel the test measures. It now derives the spot from the floor's own
`_bounds()` centre.

**Fast gate: 1007 tests, 0 failures, 98/98 files**
(`python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`).
Baseline on `origin/main` measured at 1001/0/97, so this adds 6 tests and breaks
nothing.

### Be clear about what that proves

It proves arithmetic about rects. **A headless test cannot see a frame**, so none
of it proves the office floor now *looks* right: whether 33% of room depth reads
as "a person in an office" or "a person in a slightly-too-big office", whether
the wall band reads as wall or as dead space, whether 55px of downscaled pixel
art still reads as a person at all. That needs a human looking at it, and it has
not been looked at. `ROOM_DEPTH_TILES` and `HEADROOM_RATIO` are the two dials to
turn if it is wrong.

### Incidental finding

`var at := anchor.get_index()` on an untyped variable is a hard **parse** error in
Godot 4 ("cannot infer the type"), and the repo's GDScript syntax gate passed it.
It surfaced only as 16 unrelated UI tests failing with `Nonexistent function
'new' in base 'GDScript'`. The syntax gate does not compile-check; `--check-only`
does. Possibly worth adding.

Refs #793

---
Generated with [Claude Code](https://claude.com/claude-code)
