### PR TITLE
fix(ui): achievement toast -- kill the giant purple rectangle

### DIFF
--- a/godot/autoload/notification_manager.gd
+++ b/godot/autoload/notification_manager.gd
@@ -38,18 +38,25 @@ func show_notification(message: String, type: NotificationType = NotificationTyp
 func _create_notification(data: Dictionary):
 	var notif_panel = _build_notification_panel(data)
 
-	# Add to root
-	get_tree().root.add_child(notif_panel)
-
-	# Position at top-right, offset by number of active notifications
+	# Position off-screen right BEFORE entering the tree, so the settle frame
+	# below never flashes an unpositioned panel at (0, 0).
 	var offset_y = 20 + (active_notifications.size() * 90)
 	notif_panel.position = Vector2(
 		get_viewport().get_visible_rect().size.x + 400,  # Start off-screen right
 		offset_y
 	)
 
+	# Add to root
+	get_tree().root.add_child(notif_panel)
+
 	# Track it
 	active_notifications.append(notif_panel)
+
+	# v0.13.2 giant-purple-toast fix: collapse any degenerate first-layout
+	# inflation before the panel becomes visible (see _settle_toast_size).
+	await _settle_toast_size(notif_panel)
+	if not is_instance_valid(notif_panel):
+		return
 
 	# Slide in animation
 	var slide_in_pos = Vector2(
@@ -60,8 +67,16 @@ func _create_notification(data: Dictionary):
 	var tween = create_tween()
 	tween.tween_property(notif_panel, "position", slide_in_pos, SLIDE_DURATION).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
 
-	# Wait, then slide out
-	await get_tree().create_timer(data["duration"]).timeout
+	# Wait out the duration, or leave early if the player clicks the toast.
+	var waited := 0.0
+	while waited < float(data["duration"]):
+		await get_tree().create_timer(0.1).timeout
+		waited += 0.1
+		if not is_instance_valid(notif_panel):
+			active_notifications.erase(notif_panel)
+			return
+		if bool(notif_panel.get_meta("dismiss_early", false)):
+			break
 
 	var slide_out_pos = Vector2(
 		get_viewport().get_visible_rect().size.x + 400,
@@ -84,10 +99,33 @@ func _create_notification(data: Dictionary):
 	if notification_queue.size() > 0:
 		_create_notification(notification_queue.pop_front())
 
+## Settle a toast back to its content size after the first layout tick.
+##
+## WHY (the v0.13.2 "giant purple rectangle" bug): the message Label autowraps
+## (WORD_SMART breaks words that do not fit the line). On the FIRST layout pass
+## the label's width can measure as ~zero, so a 36-char message wraps one glyph
+## per line and reports a ~950px minimum height; the PanelContainer inflates to
+## fit. Because the toast is a ROOT-level Control (child of the Window, not of
+## any container), nothing ever re-lays it out when the minimum collapses on
+## the next pass -- Controls keep their current size when their minimum
+## shrinks -- so the inflated size stuck for the toast's whole 5s lifetime.
+## One frame later the label has its real width, so resetting to the combined
+## minimum yields the correct compact size (including legit multi-line wraps).
+func _settle_toast_size(panel: Control) -> void:
+	await get_tree().process_frame
+	if is_instance_valid(panel):
+		panel.reset_size()
+
+## Click-to-dismiss: any mouse press on the toast ends its wait loop early.
+func _on_toast_gui_input(event: InputEvent, panel: Control) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		panel.set_meta("dismiss_early", true)
+
 ## Build notification panel
 func _build_notification_panel(data: Dictionary) -> PanelContainer:
 	var panel = PanelContainer.new()
 	panel.custom_minimum_size = Vector2(400, 70)
+	panel.gui_input.connect(_on_toast_gui_input.bind(panel))
 
 	# Style the panel
 	var style = StyleBoxFlat.new()
@@ -112,15 +150,20 @@ func _build_notification_panel(data: Dictionary) -> PanelContainer:
 	var hbox = HBoxContainer.new()
 	hbox.add_theme_constant_override("separation", 10)
 
-	# Icon
+	# Icon -- tinted to the type's border colour so the chrome reads deliberate
 	var icon_label = Label.new()
 	icon_label.text = _get_notification_icon(data["type"])
 	icon_label.add_theme_font_size_override("font_size", 24)
+	icon_label.add_theme_color_override("font_color", _get_notification_border_color(data["type"]))
 	hbox.add_child(icon_label)
 
-	# Message
+	# Message. The pinned minimum width keeps the autowrap measurement sane:
+	# without it, a degenerate ~zero-width first pass wraps one glyph per line
+	# (see _settle_toast_size). 330 fits inside the 400px panel minus margins,
+	# icon and separation, so it never widens the toast.
 	var message_label = Label.new()
 	message_label.text = data["message"]
+	message_label.custom_minimum_size = Vector2(330, 0)
 	message_label.add_theme_font_size_override("font_size", ThemeManager.get_font_size("body"))
 	message_label.add_theme_color_override("font_color", Color.WHITE)
 	message_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -141,7 +184,10 @@ func _get_notification_color(type: NotificationType) -> Color:
 		NotificationType.ERROR:
 			return ThemeManager.get_color("error").darkened(0.3)
 		NotificationType.ACHIEVEMENT:
-			return Color(0.5, 0.3, 0.8, 0.95)  # Purple
+			# Recognition register: dark leather + amber, matching the Liability
+			# Ledger chrome (ledger_screen.gd) and the #743 menu palette. The old
+			# debug-looking Color(0.5, 0.3, 0.8) purple is retired.
+			return Color(0.16, 0.11, 0.07, 0.97)
 		_:
 			return ThemeManager.get_color("panel")
 
@@ -155,7 +201,7 @@ func _get_notification_border_color(type: NotificationType) -> Color:
 		NotificationType.ERROR:
 			return ThemeManager.get_color("error")
 		NotificationType.ACHIEVEMENT:
-			return Color(0.8, 0.5, 1.0)
+			return Color(0.91, 0.64, 0.24)  # house amber (menu register, #743)
 		_:
 			return ThemeManager.get_color("accent")
 

--- a/godot/tests/unit/test_notification_manager.gd
+++ b/godot/tests/unit/test_notification_manager.gd
@@ -1,0 +1,77 @@
+extends GutTest
+## Regression tests for the achievement toast presentation (the v0.13.2
+## "giant unstyled purple rectangle" bug).
+##
+## Shipped failure: the ACHIEVEMENT toast rendered as a flat violet panel
+## ~400x950 covering the right third of the screen. Mechanism: the autowrap
+## message Label measured at ~zero width on the first layout pass (one glyph
+## per line -> ~950px minimum height), the PanelContainer inflated to fit,
+## and -- being a ROOT-level Control with no parent container -- nothing ever
+## re-laid it out when the minimum collapsed a frame later. These tests pin
+## both halves of the fix plus the palette swap away from debug purple.
+
+var _nm = null
+
+
+func before_each():
+	_nm = get_node_or_null("/root/NotificationManager")
+
+
+func _build_achievement_panel() -> PanelContainer:
+	return _nm._build_notification_panel({
+		"message": "Achievement -- Personnel File Opened",
+		"type": _nm.NotificationType.ACHIEVEMENT,
+	})
+
+
+func test_settle_collapses_inflated_toast():
+	# The persistence half of the bug: a root-level Control keeps a bogus
+	# inflated size forever unless something resets it. Simulate the shipped
+	# degenerate first pass, then assert _settle_toast_size collapses it.
+	assert_not_null(_nm, "NotificationManager autoload should exist")
+	var panel := _build_achievement_panel()
+	get_tree().root.add_child(panel)
+	panel.size = Vector2(400, 950)  # what v0.13.2 actually rendered
+	await _nm._settle_toast_size(panel)
+	assert_lte(panel.size.y, 120.0,
+		"toast must settle back to content height, not keep the inflated 950px")
+	assert_lte(panel.size.x, 410.0, "toast width should stay ~400px")
+	panel.queue_free()
+
+
+func test_achievement_toast_minimum_is_compact():
+	# The measurement half: with the wrap width pinned, the real shipped
+	# message must never report a near-screen-height minimum.
+	assert_not_null(_nm, "NotificationManager autoload should exist")
+	var panel := _build_achievement_panel()
+	get_tree().root.add_child(panel)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var min_size: Vector2 = panel.get_combined_minimum_size()
+	assert_lte(min_size.y, 120.0,
+		"a one-line achievement toast should be ~70px tall, not screen-height")
+	panel.queue_free()
+
+
+func test_achievement_palette_is_amber_leather_not_debug_purple():
+	# Presentation contract: achievement chrome uses the warm ledger register
+	# (dark leather bg, amber border), not the retired violet placeholder.
+	assert_not_null(_nm, "NotificationManager autoload should exist")
+	var bg: Color = _nm._get_notification_color(_nm.NotificationType.ACHIEVEMENT)
+	var border: Color = _nm._get_notification_border_color(_nm.NotificationType.ACHIEVEMENT)
+	assert_gt(bg.r, bg.b,
+		"achievement background should read warm (r > b), not violet (was r 0.5 < b 0.8)")
+	assert_lt(bg.get_luminance(), 0.25, "achievement background should stay dark")
+	assert_gt(border.r, border.b, "achievement border should be amber, not lilac")
+
+
+func test_toast_click_requests_early_dismiss():
+	assert_not_null(_nm, "NotificationManager autoload should exist")
+	var panel := _build_achievement_panel()
+	var click := InputEventMouseButton.new()
+	click.button_index = MOUSE_BUTTON_LEFT
+	click.pressed = true
+	_nm._on_toast_gui_input(click, panel)
+	assert_true(bool(panel.get_meta("dismiss_early", false)),
+		"a mouse press on the toast should flag it for early dismissal")
+	panel.free()

--- a/godot/tests/unit/test_notification_manager.gd.uid
+++ b/godot/tests/unit/test_notification_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://belnxqbnygi27


### PR DESCRIPTION
## The failure

The shipped v0.13.2 build renders an achievement unlock as a flat violet panel roughly 400x950 design-px anchored to the right screen edge -- occluding the doom gauge, the build banner and part of the event feed. Evidence: frame f006_54s of the 2026-07-31 league-night recording. Pixel measurement of that frame ties the rect to `NotificationManager`'s ACHIEVEMENT toast conclusively: the 4px lighter-purple left border `(0.8, 0.5, 1.0)` runs the full 950px height, the fill matches `Color(0.5, 0.3, 0.8, 0.95)`, the width and right-edge position match the coded 400px / 20px-from-right slide-in, and the text is the toast's exact `"* Achievement -- Personnel File Opened"`.

## The mechanism

Two stacked defects, both in `godot/autoload/notification_manager.gd`:

1. **Degenerate first-pass autowrap measurement.** The message Label uses `AUTOWRAP_WORD_SMART`, which breaks words that do not fit the line. On the first layout pass the label can measure at ~zero width, so the 36-char message wraps one glyph per line: ~36 lines x ~26px + 20px margins = ~956px minimum height -- matching the measured ~957 design-px rect. The PanelContainer inflates to fit.
2. **Root-level Controls never shrink back.** The toast is a direct child of the root Window -- no parent container ever re-lays it out, and a Control keeps its current size when its minimum later collapses. So the inflated size stuck for the toast's whole 5s lifetime.

Headless GUT never hits the degenerate measurement (the same panel settles at 400x70 there), which is why the suite never caught it.

The colour was simply a hardcoded debug purple that never got themed.

## The fix (presentation only)

- `_settle_toast_size()`: one frame after entering the tree (while still off-screen), reset the panel to its combined minimum. Kills the sticky inflation for every toast type.
- Pin the message label's wrap width (330px inside the 400px panel) so multi-line minimums are measured at a sane width.
- ACHIEVEMENT palette: dark leather bg `(0.16, 0.11, 0.07)` + house amber border `(0.91, 0.64, 0.24)` -- the Liability Ledger / #743 menu register. Icons now tint to the type's border colour.
- Click-to-dismiss: the panel already swallowed clicks; a press now ends the toast early instead of being eaten.

**Not done:** no redesign of the achievement or notification systems, no stacking/duration changes, no theme-resource extraction (that is the #743 theme lane).

## Verification

- `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`: **1005 tests, 0 failures** (includes 4 new regression tests in `tests/unit/test_notification_manager.gd`, one of which forces the shipped 400x950 state and asserts the settle step collapses it).
- **Could not verify visually**: no live render available from this session. The geometry diagnosis rests on pixel measurement of the recording; the fix rests on the settle test. A quick in-game check (unlock any achievement, e.g. first hire) is the remaining human step.
- Flake disclosure: one full-gate run showed 3 failures in `test_leaderboard_view_bounded` (short read / parse error on a `user://leaderboards` file -- this machine shares the real game's user dir). They reproduced neither in isolation nor on re-run, and on a clean main run the same suite passed 1001/1001; their code path is disjoint from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)