### PR TITLE
fix(release): derive export filename from the preset, and publish the Linux alias (#1072, #1068)

### DIFF
--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -364,6 +364,30 @@ jobs:
         run: |
           python scripts/verify_release_urls.py --file "public/releases/${RELEASE_VERSION}.json"
 
+      # The step above only checks URLs the FEED lists, and the feed lists
+      # versioned zips only. The website's download buttons are a second,
+      # independent path: fixed strings against releases/latest/download/<name>.
+      # That is exactly how #1068 hid -- the feed check passed green on every
+      # release while the site's Linux button 404'd, because the unversioned
+      # PDoom-Linux.zip alias was never published and never checked. Assert the
+      # aliases exist ON THIS TAG (deterministic; `latest` may not have flipped
+      # yet, and a prerelease never becomes Latest at all).
+      - name: Verify the unversioned platform aliases were published
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
+        run: |
+          fail=0
+          for asset in PDoom-Windows.zip PDoom-Linux.zip PDoom.app.zip; do
+            url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_VERSION}/${asset}"
+            code=$(curl -sIL -o /dev/null -w '%{http_code}' "$url")
+            echo "  $code  $url"
+            if [ "$code" != "200" ]; then
+              echo "::error::Unversioned alias asset missing: ${asset} (HTTP ${code}). The website download button for this platform will 404."
+              fail=1
+            fi
+          done
+          exit $fail
+
       - name: Sweep committed feed index for rotted entries (report-only)
         # Report-only on purpose: an OLD entry going 404 (e.g. a release that
         # was later deleted, like v0.9.0) is a separate, non-urgent cleanup

--- a/docs/RELEASE_PLATFORMS.md
+++ b/docs/RELEASE_PLATFORMS.md
@@ -146,36 +146,37 @@ python tools/build_release.py --preset "Linux/X11" --output builds/linux
 python tools/build_release.py --preset "macOS" --output builds/mac
 ```
 
-Pass `--output` explicitly on every platform. The reason is mechanical: the tool
-hardcodes its output filename as `PDoom.exe` regardless of preset
-(`exe_path = out_dir / "PDoom.exe"`), so three presets sharing one output
-directory would overwrite each other's artifact silently. Separate directories
-make that impossible.
+Separate `--output` directories per platform are still the recommended habit,
+but they are no longer load-bearing. **Both hazards this section used to warn
+about are FIXED (issue #1072).**
 
-### Two consequences of that hardcoded filename, flagged as predictions
+### What changed, and what it means for the three cut commands
 
-Neither was tested here -- the constraint on the session that wrote this sheet
-was that a build was already running and must not be collided with. Both are
-read off the source and should be confirmed the first time all three are cut:
+- **The output filename now comes from the preset**, read out of that preset's
+  own `export_path` in `godot/export_presets.cfg`
+  (`output_name_for_preset()` in `tools/build_release.py`). Windows lands as
+  `PDoom.exe`, Linux as `PDoom.x86_64`, macOS as `PDoom.app.zip` -- the same
+  names a manual editor export produces, because it is the same source of truth.
+  No rename step, and three presets sharing one output directory can no longer
+  silently overwrite each other. Unit-covered in
+  `tests/test_build_release_paths.py`, including a check against the real
+  `export_presets.cfg` so the derivation cannot drift.
+- **The freshness check now descends into zip containers** (`find_marker()`).
+  The old raw-byte scan could not see the marker's filename inside a macOS
+  `.app.zip`, because it lives in a *compressed* `.pck` entry rather than in the
+  zip's plaintext central directory -- a false FAILURE waiting to happen. The
+  check now searches zip entry names and then entry contents. It was NOT
+  weakened: a zip genuinely lacking the marker still fails, and `--no-clean` is
+  still the wrong answer to a `[BUILD-VERIFY]` failure.
 
-- **Linux:** the export lands as `builds/linux/PDoom.exe` plus
-  `builds/linux/PDoom.pck`. Renaming the binary to `PDoom.x86_64` before zipping
-  is expected to be safe, because Godot resolves the pack from the executable's
-  basename with its extension stripped (`PDoom.exe` and `PDoom.x86_64` both
-  resolve to `PDoom.pck`). *Expected, not proven.* Rename, then have a human on
-  Linux launch it before shipping. Also set the executable bit -- a Windows
-  filesystem carries no mode bits, so a zip built on Windows can ship a Linux
-  binary that will not execute.
-- **macOS:** the export is a single `.app.zip` and the tool will write it named
-  `PDoom.exe`. It must be renamed to `PDoom.app.zip` (or the shipped asset name)
-  afterwards. More seriously, **the freshness check may report a false FAILURE
-  here**: the check scans the raw bytes of the output file for the marker token,
-  and inside a `.app.zip` the marker's filename lives in a *compressed* `.pck`
-  entry rather than in the zip's plaintext central directory. A macOS
-  `[BUILD-VERIFY]` failure is therefore ambiguous in a way the Windows one is
-  not. Do not wave it through and do not "fix" it with `--no-clean`; establish
-  which it is (e.g. by unzipping and grepping the extracted pack) and record the
-  answer here so the next person does not re-derive it.
+Still true, still unproven, still a job for a human on the relevant machine:
+
+- **Linux:** Godot resolves the pack from the executable's basename with its
+  extension stripped, so `PDoom.x86_64` pairs with `PDoom.pck`. Set the
+  executable bit -- a Windows filesystem carries no mode bits, so a zip built on
+  Windows can ship a Linux binary that will not execute.
+- **macOS:** no macOS build has ever been verified to RUN (issue #1071). That
+  needs a person with a Mac, not code.
 
 ---
 
@@ -283,11 +284,14 @@ runner) plus an Apple Developer account. Until then, every macOS release ships
 with a friction step and that should be stated in the release body rather than
 discovered.
 
-### Linux: no launch proof, and two mechanical traps
+### Linux: no launch proof, and one remaining mechanical trap
 
-Covered in section 2 -- the `PDoom.exe` filename and the missing executable bit.
-Both are the kind of thing that is obvious to whoever launches it and invisible
-to whoever built it on Windows.
+The wrong-filename trap is closed (issue #1072 -- the binary now lands as
+`PDoom.x86_64`, from the preset). What remains is the **missing executable
+bit**: a Windows filesystem carries no mode bits, so a zip packaged on Windows
+can ship a Linux binary that will not execute. That is the kind of thing that is
+obvious to whoever launches it and invisible to whoever built it on Windows.
+No Linux build has ever been verified to run.
 
 ---
 
@@ -333,9 +337,26 @@ Recommended asset set per release, so both paths stay alive:
 
 ```
 PDoom-Windows-v<X.Y.Z>.zip      PDoom-Windows.zip       (alias -- the button)
-PDoom-Linux-v<X.Y.Z>.zip        PDoom-Linux.zip         (alias -- add it; v0.13.1 had none)
+PDoom-Linux-v<X.Y.Z>.zip        PDoom-Linux.zip         (alias -- ADDED, issue #1068)
 PDoom-macOS-v<X.Y.Z>.zip        PDoom.app.zip           (alias, existing name -- keep it)
 ```
+
+**`PDoom-Linux.zip` is now produced automatically** by
+`scripts/build_all_platforms.py` (same `shutil.copy2` alias step Windows already
+had), and the release workflow's `verify-release-urls` job asserts all three
+alias assets exist on the tag before the run goes green. The website's Linux
+button pointed at `PDoom.x86_64`, which was never an asset -- the game repo
+publishes `PDoom-Linux.zip`, and the website repo repoints the button at that.
+A bare `PDoom.x86_64` would be the wrong thing to publish anyway: without the
+sibling `PDoom.pck` and the GodotSteam `.so` libraries it cannot run, which is
+exactly why the other two platforms ship zips.
+
+Note the shape of how #1068 hid: `verify_release_urls.py` only checks URLs the
+generated FEED lists, and the feed lists versioned zips only. So the "Verify
+Release Download URLs" job passed green on every release while the site's Linux
+button 404'd. The proxy ("the checked downloads work") had detached from the
+thing ("all the downloads people actually click work"). The new alias step is
+the missing half.
 
 Do not rename an existing alias to something tidier. The alias names are a
 contract with a fixed string in someone else's repository, and `[Gate 6]` check 3

--- a/scripts/build_all_platforms.py
+++ b/scripts/build_all_platforms.py
@@ -321,19 +321,34 @@ class MultiPlatformBuilder:
                 success = False
 
         # Linux: ZIP executable + pck + GodotSteam .so libs + HOW-TO-RUN
+        #
+        # The unversioned PDoom-Linux.zip alias is REQUIRED, not a nicety (issue
+        # #1068). The website's download buttons are fixed strings against
+        # releases/latest/download/<name>, which resolves only if the release
+        # flagged Latest carries an asset with exactly that name. Windows has had
+        # PDoom-Windows.zip and macOS has had PDoom.app.zip since the versioned-zip
+        # pipeline landed; Linux never got one, so the site's Linux button 404'd
+        # across every release and nobody noticed (a user who cannot download
+        # cannot report it in-game). A convention applied to two of three platforms
+        # is not a convention, it is two special cases.
         linux_dir = self.repo_root / "builds" / "linux" / self.version
         if linux_dir.exists():
-            zip_path = linux_dir / f"PDoom-Linux-{self.version}.zip"
+            zip_path_versioned = linux_dir / f"PDoom-Linux-{self.version}.zip"
+            zip_path_simple = linux_dir / "PDoom-Linux.zip"
             try:
                 if not self._zip_native_build(
                     linux_dir,
-                    zip_path,
+                    zip_path_versioned,
                     "PDoom.x86_64",
                     "*.so",
                     self.EXPECTED_LINUX_LIBS,
                     "linux",
                 ):
                     success = False
+
+                # Also create simple-named zip for website compatibility
+                shutil.copy2(zip_path_versioned, zip_path_simple)
+                print(f"[SUCCESS] Created {zip_path_simple.name} (copy for website)")
             except Exception as e:
                 print(f"[ERROR] Failed to create Linux ZIP: {e}")
                 success = False

--- a/tests/test_build_release_paths.py
+++ b/tests/test_build_release_paths.py
@@ -1,0 +1,222 @@
+# !/usr/bin/env python3
+"""Unit tests for tools/build_release.py output-name derivation (issue #1072).
+
+The defect these lock down: build_release.py used to compute
+`exe_path = out_dir / "PDoom.exe"` regardless of --preset, so Linux and macOS
+exports landed named PDoom.exe and three presets sharing one --output directory
+would silently overwrite each other -- in a tool whose whole purpose is proving
+which source produced which binary.
+
+The fix reads the filename from the preset's own export_path, so this file also
+checks against the REAL godot/export_presets.cfg, which is what makes the
+derivation unable to drift from a manual export.
+"""
+
+import io
+import sys
+import unittest
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import build_release  # noqa: E402  (deliberate late import; sys.path just set)
+
+# Trimmed but structurally faithful sample: quoted values, an [preset.N.options]
+# sub-section between presets (which must NOT be read as preset keys), and a
+# multi-line unindented dict value of the kind the real macOS preset carries
+# (this is why configparser cannot be used here).
+SAMPLE_CFG = """[preset.0]
+
+name="Windows Desktop"
+platform="Windows Desktop"
+runnable=true
+export_path="../builds/windows/v0.13.2/PDoom.exe"
+
+[preset.0.options]
+
+binary_format/embed_pck=false
+export_path="../builds/decoy/NOT_THIS.exe"
+
+[preset.1]
+
+name="Linux/X11"
+platform="Linux/X11"
+runnable=true
+export_path="../builds/linux/v0.13.2/PDoom.x86_64"
+
+[preset.1.options]
+
+binary_format/architecture="x86_64"
+
+[preset.2]
+
+name="macOS"
+platform="macOS"
+runnable=true
+export_path="../builds/mac/v0.13.2/PDoom.app.zip"
+
+[preset.2.options]
+
+application/copyright_localized={
+"en": "Copyright P(Doom)"
+}
+"""
+
+
+class TestParseExportPresets(unittest.TestCase):
+    def test_finds_all_top_level_presets_in_order(self):
+        presets = build_release.parse_export_presets(SAMPLE_CFG)
+        self.assertEqual([p["name"] for p in presets], ["Windows Desktop", "Linux/X11", "macOS"])
+
+    def test_ignores_options_subsections(self):
+        # A stray export_path inside [preset.0.options] must not leak into the
+        # preset -- otherwise a Godot config detail silently redirects the build.
+        presets = build_release.parse_export_presets(SAMPLE_CFG)
+        self.assertEqual(presets[0]["export_path"], "../builds/windows/v0.13.2/PDoom.exe")
+
+    def test_multiline_dict_value_does_not_break_parsing(self):
+        # configparser raises on the unindented continuation lines of
+        # application/copyright_localized; the line-wise scanner must not.
+        presets = build_release.parse_export_presets(SAMPLE_CFG)
+        self.assertEqual(presets[2]["export_path"], "../builds/mac/v0.13.2/PDoom.app.zip")
+
+    def test_empty_config_yields_no_presets(self):
+        self.assertEqual(build_release.parse_export_presets(""), [])
+
+
+class TestOutputNameForPreset(unittest.TestCase):
+    def test_each_platform_gets_its_own_filename(self):
+        for preset, expected in [
+            ("Windows Desktop", "PDoom.exe"),
+            ("Linux/X11", "PDoom.x86_64"),
+            ("macOS", "PDoom.app.zip"),
+        ]:
+            with self.subTest(preset=preset):
+                self.assertEqual(build_release.output_name_for_preset(SAMPLE_CFG, preset), expected)
+
+    def test_the_three_names_are_distinct(self):
+        # This is the actual bug: identical names meant a shared --output dir
+        # silently overwrote artifacts.
+        names = {
+            build_release.output_name_for_preset(SAMPLE_CFG, n)
+            for n in ("Windows Desktop", "Linux/X11", "macOS")
+        }
+        self.assertEqual(len(names), 3)
+
+    def test_windows_style_backslashes_in_export_path(self):
+        cfg = '[preset.0]\nname="Win"\nexport_path="..\\\\builds\\\\win\\\\PDoom.exe"\n'
+        self.assertEqual(build_release.output_name_for_preset(cfg, "Win"), "PDoom.exe")
+
+    def test_bare_filename_export_path(self):
+        cfg = '[preset.0]\nname="Win"\nexport_path="PDoom.exe"\n'
+        self.assertEqual(build_release.output_name_for_preset(cfg, "Win"), "PDoom.exe")
+
+    def test_unknown_preset_raises_and_lists_available(self):
+        with self.assertRaises(ValueError) as ctx:
+            build_release.output_name_for_preset(SAMPLE_CFG, "Nintendo Switch")
+        self.assertIn("Nintendo Switch", str(ctx.exception))
+        self.assertIn("Linux/X11", str(ctx.exception))
+
+    def test_empty_export_path_raises_rather_than_guessing(self):
+        cfg = '[preset.0]\nname="Web"\nexport_path=""\n'
+        with self.assertRaises(ValueError):
+            build_release.output_name_for_preset(cfg, "Web")
+
+    def test_missing_export_path_key_raises(self):
+        cfg = '[preset.0]\nname="Web"\nplatform="Web"\n'
+        with self.assertRaises(ValueError):
+            build_release.output_name_for_preset(cfg, "Web")
+
+
+class TestAgainstRealExportPresets(unittest.TestCase):
+    """The anti-drift half: derive from the config the build actually uses."""
+
+    def setUp(self):
+        cfg = REPO_ROOT / "godot" / "export_presets.cfg"
+        if not cfg.exists():
+            self.skipTest(f"no export_presets.cfg at {cfg}")
+        self.text = cfg.read_text(encoding="utf-8")
+
+    def test_real_presets_resolve_to_the_shipped_asset_names(self):
+        self.assertEqual(
+            build_release.output_name_for_preset(self.text, "Windows Desktop"), "PDoom.exe"
+        )
+        self.assertEqual(
+            build_release.output_name_for_preset(self.text, "Linux/X11"), "PDoom.x86_64"
+        )
+        self.assertEqual(build_release.output_name_for_preset(self.text, "macOS"), "PDoom.app.zip")
+
+    def test_no_two_real_presets_share_an_output_filename(self):
+        presets = build_release.parse_export_presets(self.text)
+        names = [
+            build_release.output_name_for_preset(self.text, p["name"])
+            for p in presets
+            if p.get("name") and p.get("export_path")
+        ]
+        self.assertEqual(len(names), len(set(names)), f"colliding output filenames: {names}")
+
+
+class TestFindMarker(unittest.TestCase):
+    """The zipped-bundle half (issue #1072): a macOS .app.zip hides the marker
+    filename inside a compressed entry, so a raw byte scan false-FAILS."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.token = b"buildstampdeadbeefcafe"
+
+    def test_plain_file_containing_marker(self):
+        p = self.tmp / "PDoom.pck"
+        p.write_bytes(b"\x00" * 100 + self.token + b"\x00" * 100)
+        self.assertIsNotNone(build_release.find_marker(p, self.token))
+
+    def test_plain_file_without_marker(self):
+        p = self.tmp / "PDoom.pck"
+        p.write_bytes(b"\x00" * 4096)
+        self.assertIsNone(build_release.find_marker(p, self.token))
+
+    def test_marker_straddling_a_chunk_boundary(self):
+        # The chunked scanner must carry a tail; a match split across two reads
+        # would otherwise be missed and reported as a stale build.
+        p = self.tmp / "PDoom.pck"
+        chunk = build_release._SCAN_CHUNK
+        head = b"\x00" * (chunk - len(self.token) // 2)
+        p.write_bytes(head + self.token + b"\x00" * 64)
+        self.assertIsNotNone(build_release.find_marker(p, self.token))
+
+    def test_zip_with_marker_only_inside_a_compressed_entry(self):
+        # The macOS shape: the marker's res:// filename lives in the bundled
+        # .pck, which is DEFLATEd, so it is absent from the zip's raw bytes.
+        inner = io.BytesIO()
+        inner.write(b"\x00" * 2048 + self.token + b"\x00" * 2048)
+        zip_path = self.tmp / "PDoom.app.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("PDoom.app/Contents/Resources/PDoom.pck", inner.getvalue())
+        self.assertNotIn(self.token, zip_path.read_bytes(), "test setup: token must be hidden")
+        found = build_release.find_marker(zip_path, self.token)
+        self.assertIsNotNone(found)
+        self.assertIn("PDoom.pck", found)
+
+    def test_zip_with_marker_as_an_entry_name(self):
+        zip_path = self.tmp / "PDoom.app.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(f"PDoom.app/{self.token.decode()}.gd", "extends Node\n")
+        found = build_release.find_marker(zip_path, self.token)
+        self.assertIsNotNone(found)
+        self.assertIn("zip entry name", found)
+
+    def test_zip_without_marker_still_reports_absent(self):
+        # The guarantee must not be weakened into always-passing.
+        zip_path = self.tmp / "PDoom.app.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("PDoom.app/Contents/Resources/PDoom.pck", b"\x00" * 4096)
+        self.assertIsNone(build_release.find_marker(zip_path, self.token))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -25,6 +25,21 @@ FRESHNESS-ANCHOR NOTE (why a marker FILE, not a grepped string):
     DO survive in the pack file table. So we anchor on a unique FILENAME, which is a
     reliable, encoding-independent freshness proof.
 
+OUTPUT-NAME NOTE (issue #1072):
+    The output FILENAME is read from the chosen preset's own `export_path` in
+    `godot/export_presets.cfg` (`PDoom.exe` / `PDoom.x86_64` / `PDoom.app.zip`), never
+    hardcoded. One source of truth, so this tool cannot produce a differently-named
+    artifact than a manual editor export, and three presets sharing one `--output`
+    directory can no longer silently overwrite each other.
+
+ZIPPED-BUNDLE NOTE (issue #1072):
+    The macOS preset emits a `.app.zip`. Its marker filename lives inside a COMPRESSED
+    zip entry (the bundled `.pck`), not in the zip's plaintext central directory, so a
+    raw byte scan of the container would report a FALSE freshness failure. The check
+    therefore descends into zip entries. It is never weakened to compensate: skipping
+    verification (or reaching for `--no-clean`) would discard the single guarantee this
+    tool exists to provide.
+
 RENDER-GATE LIMITATION:
     A clean, verified pack proves the RIGHT BITS shipped. It does NOT prove the game runs
     on a real GPU -- headless tooling never GPU-decodes textures or runs the release
@@ -40,12 +55,14 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 import subprocess
 import sys
 import uuid
-from pathlib import Path
-from typing import Optional
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Dict, List, Optional
 
 DEFAULT_GODOT_CANDIDATES = [
     Path("C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe"),
@@ -55,6 +72,121 @@ DEFAULT_GODOT_CANDIDATES = [
     Path("/usr/local/bin/godot"),
     Path("/Applications/Godot.app/Contents/MacOS/Godot"),
 ]
+
+
+# --- preset -> output filename (issue #1072) ---------------------------------
+# export_presets.cfg is INI-SHAPED BUT NOT INI: the macOS preset carries
+# multi-line unindented dict values (e.g. application/copyright_localized={...}),
+# which configparser rejects. So this scans line-wise for exactly the three
+# top-level `[preset.N]` keys we need and ignores everything else, including the
+# `[preset.N.options]` sub-sections.
+_SECTION_RE = re.compile(r"^\[(?P<section>[^\]]+)\]\s*$")
+_PRESET_SECTION_RE = re.compile(r"^preset\.\d+$")
+_QUOTED_KV_RE = re.compile(r'^(?P<key>name|platform|export_path)\s*=\s*"(?P<value>.*)"\s*$')
+
+
+def parse_export_presets(text: str) -> List[Dict[str, str]]:
+    """Parse export_presets.cfg into an ordered list of top-level preset dicts.
+
+    Each dict carries whichever of name/platform/export_path the preset declared.
+    """
+    presets: List[Dict[str, str]] = []
+    current: Optional[Dict[str, str]] = None
+    for raw_line in text.splitlines():
+        section = _SECTION_RE.match(raw_line.strip())
+        if section:
+            if _PRESET_SECTION_RE.match(section.group("section")):
+                current = {}
+                presets.append(current)
+            else:
+                # [preset.N.options] or anything else -- stop collecting.
+                current = None
+            continue
+        if current is None:
+            continue
+        kv = _QUOTED_KV_RE.match(raw_line.strip())
+        if kv:
+            current[kv.group("key")] = kv.group("value")
+    return presets
+
+
+def output_name_for_preset(text: str, preset_name: str) -> str:
+    """Return the output FILENAME the given preset exports to.
+
+    Derived from the preset's own `export_path`, so it cannot drift from what a
+    manual (editor or `--export-release`) export produces. Raises ValueError with
+    the available preset names if the preset is missing or has no export_path.
+    """
+    presets = parse_export_presets(text)
+    available = [p["name"] for p in presets if p.get("name")]
+    for preset in presets:
+        if preset.get("name") != preset_name:
+            continue
+        export_path = (preset.get("export_path") or "").strip()
+        if not export_path:
+            raise ValueError(
+                f"preset {preset_name!r} has an empty export_path in export_presets.cfg; "
+                "set one in the Godot export dialog so the output filename has a source."
+            )
+        # export_path is written with forward slashes by Godot; normalise anyway.
+        name = PurePosixPath(export_path.replace("\\", "/")).name
+        if not name:
+            raise ValueError(
+                f"preset {preset_name!r} export_path {export_path!r} has no filename component."
+            )
+        return name
+    raise ValueError(
+        f"preset {preset_name!r} not found in export_presets.cfg. Available: {available}"
+    )
+
+
+# --- freshness-marker search (issue #1072: zipped bundles) --------------------
+_SCAN_CHUNK = 1 << 20  # 1 MiB
+
+
+def _stream_contains(fh, needle: bytes) -> bool:
+    """Chunked substring search over a binary stream (packs are hundreds of MB).
+
+    Carries a needle-1 byte tail between chunks so a match straddling a chunk
+    boundary is still found.
+    """
+    overlap = len(needle) - 1
+    tail = b""
+    while True:
+        chunk = fh.read(_SCAN_CHUNK)
+        if not chunk:
+            return False
+        if needle in tail + chunk:
+            return True
+        tail = (tail + chunk)[-overlap:] if overlap else b""
+
+
+def find_marker(path: Path, needle: bytes) -> Optional[str]:
+    """Look for the freshness marker in `path`. Returns a human-readable location
+    (or None if absent).
+
+    For a zip container (the macOS `.app.zip`), the marker's res:// filename sits
+    inside a COMPRESSED entry -- the bundled `.pck` -- so scanning the container's
+    raw bytes would find nothing and report a false failure. Descend into the
+    entries instead: entry NAMES first (cheap), then entry CONTENTS.
+    """
+    if zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as zf:
+            infos = zf.infolist()
+            for info in infos:
+                if needle in info.filename.encode("utf-8", "replace"):
+                    return f"{path} (zip entry name: {info.filename})"
+            for info in infos:
+                if info.is_dir():
+                    continue
+                with zf.open(info) as entry:
+                    if _stream_contains(entry, needle):
+                        return f"{path} (inside zip entry: {info.filename})"
+        return None
+    with path.open("rb") as fh:
+        if _stream_contains(fh, needle):
+            return str(path)
+    return None
 
 
 def find_godot(explicit: Optional[str]) -> Path:
@@ -126,7 +258,20 @@ def main() -> int:
         else (repo_root / "builds" / args.preset.replace(" ", "_").lower())
     )
     out_dir.mkdir(parents=True, exist_ok=True)
-    exe_path = out_dir / "PDoom.exe"
+
+    # Output FILENAME comes from the preset's own export_path (issue #1072), so
+    # Linux gets PDoom.x86_64 and macOS gets PDoom.app.zip rather than all three
+    # landing as PDoom.exe and overwriting each other in a shared --output dir.
+    presets_cfg = project / "export_presets.cfg"
+    if not presets_cfg.exists():
+        fail(f"no export_presets.cfg under {project}")
+    try:
+        output_name = output_name_for_preset(presets_cfg.read_text(encoding="utf-8"), args.preset)
+    except ValueError as exc:
+        fail(str(exc))
+        raise SystemExit(1)  # unreachable; fail() exits
+    exe_path = out_dir / output_name
+    info(f"Output: {exe_path}   (filename from preset export_path)")
 
     dot_godot = project / ".godot"
 
@@ -204,18 +349,22 @@ def main() -> int:
             fail(f"export reported success but {exe_path} does not exist.")
 
         # ---- STEP 5: VERIFY the pack is fresh -----------------------------------
+        # A sibling .pck exists for Windows/Linux (PDoom.exe/PDoom.x86_64 both
+        # resolve to PDoom.pck); the macOS .app.zip embeds its pack instead, and
+        # find_marker() descends into the zip to reach it.
         pck_path = exe_path.with_suffix(".pck")
         search_targets = [p for p in (pck_path, exe_path) if p.exists()]
         needle = token.encode("ascii")
         found_in = None
         for tgt in search_targets:
-            data = tgt.read_bytes()
-            if needle in data:
-                found_in = tgt
+            found_in = find_marker(tgt, needle)
+            if found_in:
                 break
         if found_in is None:
             fail(
-                "FRESHNESS CHECK FAILED: marker '%s' NOT found in %s.\n"
+                "FRESHNESS CHECK FAILED: marker '%s' NOT found in %s\n"
+                "  (zip containers were searched entry-by-entry, so this is NOT the\n"
+                "  compressed-bundle false negative -- it is a real miss).\n"
                 "  The exported pack does NOT reflect the current working tree -- it was\n"
                 "  almost certainly served from a STALE .godot/exported cache. DO NOT SHIP.\n"
                 "  Re-run WITHOUT --no-clean." % (token, [str(t) for t in search_targets])
@@ -229,7 +378,7 @@ def main() -> int:
         print("[BUILD-VERIFY][PASS] pack is provably fresh.")
         print(f"  marker token : {token}")
         print(f"  found in     : {found_in}")
-        print(f"  exe          : {exe_path}")
+        print(f"  output       : {exe_path}")
         if pck_path.exists():
             print(f"  pck          : {pck_path}  ({size_mb:.1f} MB)")
         print(f"  mode         : {args.mode}")


### PR DESCRIPTION
Two release-pipeline defects. Both cheap now, both get expensive as patch cadence rises.

## FOR THE WEBSITE REPO -- the name to point at

**`PDoom-Linux.zip`**

```
https://github.com/PipFoweraker/pdoom1/releases/latest/download/PDoom-Linux.zip
```

That is the name `docs/RELEASE_PLATFORMS.md` already prescribed, and it matches the shape Windows already uses (`PDoom-Windows.zip`). It starts existing on the **next release cut** -- this PR changes the producer, not the already-published v0.13.2 assets. The current button points at `PDoom.x86_64`, which has never been an asset.

Why not publish a bare `PDoom.x86_64` to match the existing button? Because it would be a broken download: without the sibling `PDoom.pck` and the GodotSteam `.so` libraries it cannot run. That is exactly why the other two platforms ship zips.

## Fix 1 -- #1072: hardcoded output name

`tools/build_release.py` computed `exe_path = out_dir / "PDoom.exe"` regardless of `--preset`. Linux and macOS exports landed named `PDoom.exe` (observed: the Linux build landed at `builds/linux/x11/PDoom.exe`), and three presets sharing one `--output` would silently overwrite each other. For a tool whose entire purpose is proving which source produced which binary, a silent cross-platform overwrite is squarely against the point.

The filename now comes from the chosen preset's own `export_path` in `godot/export_presets.cfg` (`output_name_for_preset`). One source of truth that cannot drift from what a manual export produces; a hardcoded platform map would drift.

Implementation note worth knowing: `export_presets.cfg` is INI-*shaped* but not INI -- the macOS preset carries multi-line unindented dict values (`application/copyright_localized={...}`) that `configparser` rejects. So the parser is a line-wise scanner reading only top-level `[preset.N]` sections, deliberately ignoring `[preset.N.options]` (a stray `export_path` in the options sub-section must not redirect the build; there is a test for that).

### Adjacent, same pass: the zipped-bundle false failure

The freshness check grepped the output's raw bytes for the marker token. Inside a macOS `.app.zip` the marker filename sits in a **compressed** `.pck` entry, not the zip's plaintext central directory -- so it would have reported a FALSE FAILURE on macOS.

`find_marker()` now descends into zip containers: entry names first (cheap), then entry contents, streamed in 1 MiB chunks with a carry-over tail so a match straddling a chunk boundary is still found (packs are hundreds of MB).

**The check was not weakened.** A zip genuinely lacking the marker still fails loudly; `--no-clean` is still the wrong answer to a `[BUILD-VERIFY]` failure. There is a test asserting a marker-free zip still reports absent. That guarantee cost ~12 cycles in v0.11.0 to learn was necessary.

## Fix 2 -- #1068: the site's Linux download 404s

Measured against live v0.13.2: `PDoom-Windows.zip` 200, `PDoom.app.zip` 200, `PDoom.x86_64` **404**.

`scripts/build_all_platforms.py` now emits `PDoom-Linux.zip` alongside `PDoom-Linux-v<X.Y.Z>.zip`, using the same `shutil.copy2` alias step Windows already had. `enhanced-release.yml` already uploads `build-linux/**/*.zip`, so no upload-glob change is needed.

An asset-naming convention applied to two of three platforms is not a convention; it is two special cases.

## Why "Verify Release Download URLs" passed green on a dead URL

Cheap to see, so here it is. That job runs `scripts/verify_release_urls.py --file public/releases/<version>.json` -- it checks the URLs the generated **feed** lists, and the feed's `downloads` block lists **versioned** zips only (`PDoom-Linux-v0.13.2.zip`, which does resolve). The website's buttons are a second, independent path: fixed strings against `releases/latest/download/<name>`. Those unversioned aliases were never in the feed, so were never checked. The proxy ("the checked downloads work") had detached from the thing ("the downloads people actually click work").

Closed here: a blocking step that asserts all three alias assets exist. It checks **by tag**, not `latest`, deliberately -- `latest` may not have flipped yet when the job runs, and a prerelease never becomes Latest at all, so a `latest`-based check would be flaky in one direction and blind in the other.

I did not touch the feed generator to add `*_latest` URLs. That would have been the other way to close it, but it changes the feed schema the website consumes and would go stale against every already-published release (no old release has a Linux alias), fighting the `release-index-check` hook. Flagging as a possible follow-up, not doing it here.

## Tests

`tests/test_build_release_paths.py` -- 19 unit tests over the pure logic (`python -m unittest tests.test_build_release_paths`, all pass):

- preset parsing: ordering, the options-subsection trap, the multi-line dict value that breaks `configparser`
- name derivation: all three platforms, distinctness, Windows backslashes, bare filename, unknown preset, empty/missing `export_path`
- **against the real `godot/export_presets.cfg`**, so the derivation cannot drift from what ships
- `find_marker`: plain file hit/miss, chunk-boundary straddle, a real DEFLATEd zip whose token is provably absent from the container's raw bytes (the macOS shape), marker-as-entry-name, and marker-free zip still failing

Godot fast gate in the worktree, **1031 tests / 0 failures before and after** -- no delta, and none expected: no `.gd` was touched.

Also refreshed `docs/RELEASE_PLATFORMS.md`, which documented both defects as live hazards.

## Out of scope, deliberately

- **#1069** -- the release pipeline builds its own assets, bypassing `build_release.py`'s freshness proof. Bigger; needs a ruling from Pip on which of three options.
- **#1071** -- macOS never verified to run. Needs a human with a Mac, not code.

Refs #1072, #1068.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
