### PR TITLE
feat(month-review): show what CHANGED, and let SPACE open the door (A1/A4/A10/B1/B2/B3)

### DIFF
--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -26,6 +26,21 @@ var day_tick_seconds: float = 0.2
 # deliberately NOT serialized (a loaded game just shows "flat" on its first review). Never
 # read by the simulation, so it cannot touch determinism.
 var _rival_cap_snapshot: Dictionary = {}
+
+## A4 (playtest 2026-08-01): the month review showed LEVELS the HUD already shows. To show
+## MOVEMENT instead it needs two readings per stat.
+##   _month_stat_snapshot -- the reading taken at the last month boundary, i.e. the START of
+##                           the month now being reviewed. Empty before the first boundary.
+##   _last_tick_stats     -- the reading taken immediately BEFORE each day tick. At the moment
+##                           the boundary tick reports "month_open", this still holds the LAST
+##                           DAY of the old month. That matters: the boundary tick has already
+##                           run MonthController._open_plan_month(), which charges the NEW
+##                           month's office rent -- reading state.money at review time would
+##                           book next month's rent against last month's funds delta, every
+##                           month, in the same direction.
+## Display-only. Nothing here feeds the sim, so determinism/replay are untouched.
+var _month_stat_snapshot: Dictionary = {}
+var _last_tick_stats: Dictionary = {}
 # Synthetic month-review dialog id -- intercepted by resolve_event before any engine path.
 const MONTH_REVIEW_EVENT_ID := "__month_review__"
 
@@ -76,6 +91,8 @@ func start_new_game(game_seed: String = "", force: bool = false):
 	month_playback_active = false
 	_release_game_objects()
 	_rival_cap_snapshot.clear()  # fresh drift baseline for the new run
+	_month_stat_snapshot.clear()  # A4: no month has elapsed yet, so there is no movement to show
+	_last_tick_stats.clear()
 
 	state = GameState.new(game_seed)
 	# Early-game org-form choice (DQ-19): copy the pregame selection onto the pure state
@@ -728,6 +745,10 @@ func _run_month_playback() -> void:
 		await get_tree().create_timer(day_tick_seconds).timeout
 		if not month_playback_active or state == null or state.game_over:
 			break
+		# A4: last reading BEFORE the tick. If this tick turns out to be the boundary, this is
+		# the true end-of-month state -- captured before _open_plan_month charges the new
+		# month's rent. See the _last_tick_stats declaration.
+		_last_tick_stats = _capture_month_stats()
 		var r: Dictionary = month_controller.advance_tick()
 		game_state_updated.emit(state.to_dict())
 		for item in r.get("feed", []):
@@ -767,18 +788,116 @@ func _finish_month_playback() -> void:
 	month_playback_active = false
 	var label := Clock.month_label(state.turn, state.start_year, state.start_month, state.start_day)
 	var attention_now: int = state.month_plan.available() if state.month_plan else 0
+
+	# A4: end-of-month reading is the pre-boundary tick where we have one; a run resumed from a
+	# save (or a boundary reached without ticking) falls back to the live state.
+	var end_stats: Dictionary = _last_tick_stats if not _last_tick_stats.is_empty() else _capture_month_stats()
+
+	# A1 (Pip, [3:45]): "funds is good, but I CAN SEE THAT UP HERE, so this is NOT FRESH
+	# INFORMATION." The Funds/Doom/Staff LEVEL line is gone -- the top bar owns funds, the doom
+	# meter owns doom, the roster owns staff. What the HUD cannot show is what MOVED over the
+	# month, so that is all this block prints, and only for stats that actually moved.
+	var body := "%s begins.\n\nAttention: %d fresh decisions this month (last month's unspent reserve evaporated -- no banking).%s%s" % [
+		label, attention_now,
+		_build_month_movement_section(_month_stat_snapshot, end_stats),
+		_build_rivals_review_section()]
+
 	var review := {
 		"id": MONTH_REVIEW_EVENT_ID,
 		"name": "Month Review -- %s" % label,
-		"description": "%s begins.\n\nAttention: %d fresh decisions this month (last month's unspent reserve evaporated -- no banking).\nFunds: %s   |   Doom: %.1f%%   |   Staff: %d%s\n\nQueue this month's actions, then End Turn to play the month out." % [
-			label, attention_now, GameConfig.format_money(state.money), state.doom, state.get_total_staff(),
-			_build_rivals_review_section()],
+		"description": "%s\n\nQueue this month's actions, then End Turn to play the month out." % body,
 		"type": "popup",
 		"options": [
 			{"id": "begin_planning", "text": "Begin planning %s" % label, "costs": {}, "effects": {}}
 		],
 	}
+	# A10: the review is also the WATCH feed's permanent record, so dismissing the popup costs
+	# the player nothing and months can be compared by scrolling back. Emitted BEFORE the popup
+	# so the feed line exists even if the popup is torn down by some other path.
+	_log_month_review_to_feed(review.get("name", ""), body)
 	event_triggered.emit(review)
+
+	# The new month has begun; this reading is the baseline the NEXT review measures against.
+	_month_stat_snapshot = _capture_month_stats()
+
+
+func _capture_month_stats() -> Dictionary:
+	"""A4: the three headline stats, read off live state. Display-only, no RNG, no writes."""
+	if state == null:
+		return {}
+	return {
+		"money": float(state.money),
+		"doom": float(state.doom),
+		"staff": int(state.get_total_staff()),
+	}
+
+
+func _build_month_movement_section(start_stats: Dictionary, end_stats: Dictionary) -> String:
+	"""A4: start -> end movement for the month just played. Returns "" when there is no
+	baseline (first month of a run, or a freshly loaded save) or when nothing moved -- a
+	'Funds unchanged' line would be exactly the non-fresh information A1 deleted.
+
+	Doom is reported as BAND movement only, never a number and never per-cause. ADR-0015 makes
+	doom a computed consequence of world state, so a printed per-source delta would be a lie
+	about how doom works; per-cause attribution stays behind the paid doom-breakdown instrument
+	(ADR-0001, spending-buys-sight). A start/end band comparison is world-state display, using
+	ThemeManager's canonical band labels -- the same non-color channel the HUD already uses."""
+	if start_stats.is_empty() or end_stats.is_empty():
+		return ""
+	var lines: Array[String] = []
+
+	var money_start := float(start_stats.get("money", 0.0))
+	var money_end := float(end_stats.get("money", 0.0))
+	if not is_equal_approx(money_start, money_end):
+		var money_delta := money_end - money_start
+		lines.append("  Funds   %s -> %s   (%s%s)" % [
+			GameConfig.format_money(money_start), GameConfig.format_money(money_end),
+			"+" if money_delta > 0.0 else "-", GameConfig.format_money(abs(money_delta))])
+
+	var staff_start := int(start_stats.get("staff", 0))
+	var staff_end := int(end_stats.get("staff", 0))
+	if staff_start != staff_end:
+		lines.append("  Staff   %d -> %d   (%s%d)" % [
+			staff_start, staff_end, "+" if staff_end > staff_start else "-", abs(staff_end - staff_start)])
+
+	var doom_move := _doom_band_movement(float(start_stats.get("doom", 0.0)), float(end_stats.get("doom", 0.0)))
+	if doom_move != "":
+		lines.append("  Doom    %s" % doom_move)
+
+	if lines.is_empty():
+		return ""
+	return "\n\nLast month's movement:\n" + "\n".join(lines)
+
+
+func _doom_band_movement(doom_start: float, doom_end: float) -> String:
+	"""A4/ADR-0015: band crossing only. "" when the band did not change -- an unchanged band is
+	already legible on the doom meter, so printing it would re-open the A1 complaint."""
+	var band_start := ThemeManager.get_doom_band_index(doom_start)
+	var band_end := ThemeManager.get_doom_band_index(doom_end)
+	if band_start == band_end:
+		return ""
+	var direction := "crossed up" if band_end > band_start else "eased down"
+	return "%s -> %s   (%s)" % [
+		ThemeManager.get_doom_status_label(doom_start), ThemeManager.get_doom_status_label(doom_end),
+		direction]
+
+
+func _log_month_review_to_feed(review_name: String, body: String) -> void:
+	"""A10 (Pip, [3:49] "it's actually just kind of popping up and blocking the screen"): half
+	of why the modal feels bad is that dismissing it DESTROYS the only copy. Mirror every
+	review into the WATCH feed so closing it is free and past months stay comparable.
+
+	Channel "review" is new and unfiltered -- the existing toggles suppress only "flavour"
+	(the arxiv flood) and "rivals" (the intel toggle), so a review can never be silently
+	hidden. This is a palliative for the blocking complaint, not the fix: A5 (review as a
+	panel, or docked into the plan screen) is the structural answer and is NOT in this PR."""
+	var block := "[color=cyan]== %s ==[/color]" % review_name
+	for raw_line in body.split("\n"):
+		var line := String(raw_line).strip_edges()
+		if line == "":
+			continue
+		block += "\n[color=gray]  %s[/color]" % line
+	action_executed.emit({"success": true, "channel": "review", "message": block})
 
 
 func _build_rivals_review_section() -> String:
@@ -866,6 +985,11 @@ func load_saved_game(path: String = SaveLoad.QUICKSAVE_PATH, force: bool = false
 	# turn_manager on every load.
 	_release_game_objects()
 	_rival_cap_snapshot.clear()  # drift baseline restarts from the loaded snapshot
+	# A4: the movement baseline is NOT serialized (display-only). A loaded run therefore shows
+	# no movement block on its first review, then resumes normally -- degrade quietly rather
+	# than print a delta measured against a month the player did not play.
+	_month_stat_snapshot.clear()
+	_last_tick_stats.clear()
 	state = loaded
 	# Scenario custom events live as node meta (Issue #483), not in state
 	# serialization -- re-attach them from the pack recorded in the envelope.

--- a/godot/scripts/ui/event_dialog.gd
+++ b/godot/scripts/ui/event_dialog.gd
@@ -82,6 +82,32 @@ static func format_cost_summary(costs: Dictionary) -> String:
 		return " (Free)"
 	return " (%s)" % ", ".join(parts)
 
+
+## Teal of the bottom bar's END TURN button (scenes/main.tscn:378). The month loop's two
+## forward doors must look like siblings -- see is_navigation_popup below.
+const PRIMARY_TEAL := Color(0.118, 0.765, 0.702, 1.0)
+
+
+static func is_navigation_popup(event: Dictionary) -> bool:
+	"""True when this popup is a DOOR, not a decision: exactly one option, costing nothing.
+
+	B2/B3 (playtest 2026-08-01, [4:55]): the month review is a generic event, so its single
+	'Begin planning August 2017' option was wearing crisis-option chrome -- the letter-menu
+	prefix `[Q]` (an arbitrary index into dialog_key_labels) and the ` (Free)` cost suffix, a
+	price tag on a door that was never for sale. Neither communicates anything when there is
+	no choice to weigh, and the dark-gray option styling reads half-disabled next to the teal
+	END TURN.
+
+	Free-ness is decided by asking format_cost_summary what it WOULD have printed, so this
+	predicate can never disagree with the chrome it suppresses."""
+	var options = event.get("options", [])
+	if not (options is Array) or options.size() != 1:
+		return false
+	var only = options[0]
+	if not (only is Dictionary):
+		return false
+	return format_cost_summary(only.get("costs", {})) == " (Free)"
+
 func _show_next_event() -> void:
 	"""Show the next event in queue (sequential presentation)"""
 	if event_queue.is_empty():
@@ -202,6 +228,12 @@ func _show_next_event() -> void:
 	var buttons = []  # Store buttons for keyboard access
 	var dialog_key_labels = ["Q", "W", "E", "R", "A", "S", "D", "F", "Z"]
 
+	# B2/B3: a one-costless-option popup is navigation, not deliberation. Its button drops the
+	# letter-menu prefix and the "(Free)" price tag, hints the key the player actually reaches
+	# for, and takes primary-action styling. The letter key still WORKS (MainUI's key map is
+	# positional) -- it is only unadvertised.
+	var is_navigation := is_navigation_popup(event)
+
 	for option in options:
 		var choice_id = option.get("id", "")
 		var choice_text = option.get("text", "")
@@ -213,8 +245,15 @@ func _show_next_event() -> void:
 
 		# Add keyboard hint (LETTERS not numbers) + inline cost summary (#510)
 		var key_label = dialog_key_labels[button_index] if button_index < dialog_key_labels.size() else ""
-		btn.text = "[%s] %s%s" % [key_label, choice_text, format_cost_summary(costs)]
-		btn.custom_minimum_size = Vector2(500, 45)
+		if is_navigation:
+			btn.text = "%s   [SPACE]" % choice_text
+			btn.custom_minimum_size = Vector2(520, 54)
+			btn.add_theme_font_size_override("font_size", 16)
+			btn.add_theme_color_override("font_color", PRIMARY_TEAL)
+			btn.add_theme_color_override("font_hover_color", Color(1, 1, 1, 1))
+		else:
+			btn.text = "[%s] %s%s" % [key_label, choice_text, format_cost_summary(costs)]
+			btn.custom_minimum_size = Vector2(500, 45)
 
 		# Add button border for better definition
 		var button_style = StyleBoxFlat.new()
@@ -228,11 +267,19 @@ func _show_next_event() -> void:
 		button_style.corner_radius_top_right = 4
 		button_style.corner_radius_bottom_right = 4
 		button_style.corner_radius_bottom_left = 4
+		if is_navigation:
+			# Primary action: teal-on-dark, teal border. Deliberately NOT a flat teal fill --
+			# the label text sits on this panel and a saturated block would out-shout the
+			# review it is meant to close.
+			button_style.bg_color = Color(0.07, 0.20, 0.19, 1.0)
+			button_style.border_color = PRIMARY_TEAL
 		btn.add_theme_stylebox_override("normal", button_style)
 
 		# Hover state
 		var button_style_hover = button_style.duplicate()
 		button_style_hover.bg_color = Color(0.3, 0.3, 0.3, 1.0)  # Lighter on hover
+		if is_navigation:
+			button_style_hover.bg_color = PRIMARY_TEAL
 		btn.add_theme_stylebox_override("hover", button_style_hover)
 
 		# Affordability DISPLAY (grey-out + tooltip). This is player information, not
@@ -291,6 +338,14 @@ func _show_next_event() -> void:
 
 	# Mark this as an event dialog to prevent ESC from closing it (issue #452)
 	dialog.set_meta("is_event_dialog", true)
+
+	# B1 (Pip, [4:55]-[5:03]): "maybe a space bar or something as well -- maybe not enter, if
+	# enter is going to be the commit turn thing, we don't want people doing that accidentally."
+	# MainUI._input blocks SPACE and ENTER outright while any dialog is up (correct: it stops an
+	# accidental end-turn/commit landing on a crisis). This meta is the narrow, opt-in exception:
+	# a costless one-option navigation popup declares that SPACE means "go through the door".
+	# ENTER carries no such flag anywhere and stays inert by design.
+	dialog.set_meta("space_advances", is_navigation)
 
 	# #877: pin the root-level blocker to the panel's lifetime, so ANY teardown path takes the
 	# blocker with it -- the same idiom main_ui._present_modal_dialog uses for its barrier.

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -538,6 +538,17 @@ func _input(event: InputEvent):
 			# else: key isn't a choice for this dialog (e.g. R on a 3-option event).
 			# Fall through to ESC handling; other keys are blocked below. No scary log.
 
+			# B1: SPACE advances a one-costless-option NAVIGATION popup (the month review).
+			# Checked before the block-everything branch below, and only for dialogs that
+			# opted in via the "space_advances" meta -- see dialog_key_advances().
+			if dialog_key_advances(active_dialog, event.keycode) and not active_dialog_buttons.is_empty():
+				var nav_btn = active_dialog_buttons[0]
+				if nav_btn != null and is_instance_valid(nav_btn) and not nav_btn.disabled:
+					print("[MainUI] *** SPACE advancing navigation dialog: %s ***" % nav_btn.text)
+					nav_btn.pressed.emit()
+					get_viewport().set_input_as_handled()
+					return
+
 			# ESC key: only close submenu dialogs (hiring, fundraising), NOT event dialogs
 			# Event dialogs must be completed to prevent soft-lock (issue #452)
 			if event.keycode == KEY_ESCAPE:
@@ -649,6 +660,23 @@ func _dialog_button_index_for_key(keycode: int) -> int:
 		return keycode - KEY_1
 	var letter_keys = [KEY_Q, KEY_W, KEY_E, KEY_R, KEY_A, KEY_S, KEY_D, KEY_F, KEY_Z]
 	return letter_keys.find(keycode)
+
+static func dialog_key_advances(dialog: Control, keycode: int) -> bool:
+	"""B1: does this key advance THIS dialog past the block-all rule in _input?
+
+	Only SPACE, and only on a dialog that opted in via the "space_advances" meta
+	(EventDialog sets it for a one-costless-option navigation popup -- the month review).
+	ENTER returns false unconditionally and there is no meta that can change that: Pip's
+	[5:03] ruling is that ENTER is the commit-plan key and must not be trainable as a
+	dismiss-the-popup reflex, or players will commit turns by muscle memory.
+
+	Static + parameterised on purpose -- it is the whole decision, so it is unit-testable
+	without instantiating the 3k-line MainUI or a live input stack."""
+	if keycode != KEY_SPACE:
+		return false
+	if dialog == null or not is_instance_valid(dialog):
+		return false
+	return bool(dialog.get_meta("space_advances", false))
 
 func _trigger_action_by_index(index: int):
 	"""Trigger action button by its index (for keyboard shortcuts)"""

--- a/godot/tests/unit/test_month_review_movement.gd
+++ b/godot/tests/unit/test_month_review_movement.gd
@@ -1,0 +1,123 @@
+extends GutTest
+## A1/A4 (recorded playtest 2026-08-01, [3:45]) -- the month review shows CHANGE, not STATE.
+##
+## The failure Pip named: "funds is good, but I CAN SEE THAT UP HERE, so this is NOT FRESH
+## INFORMATION." The review printed `Funds: $84,200 | Doom: 31.2% | Staff: 3` -- three numbers
+## the top bar, the doom meter and the roster already show, every month, unchanged in meaning.
+##
+## The replacement is start -> end movement, and ONLY for stats that moved: an unchanged stat
+## is exactly the non-fresh information A1 deleted, so printing "Funds unchanged" would
+## re-open the complaint in different words.
+##
+## Doom is band movement only (ADR-0015: doom is computed from world state, so a printed
+## per-source number would misrepresent how it works; per-cause attribution stays behind the
+## paid doom-breakdown instrument, ADR-0001). These tests pin that no doom PERCENTAGE ever
+## reaches this string.
+
+const GameManagerScript := preload("res://scripts/game_manager.gd")
+
+
+func _gm() -> Node:
+	var gm: Node = GameManagerScript.new()
+	autofree(gm)
+	return gm
+
+
+func _stats(money: float, doom: float, staff: int) -> Dictionary:
+	return {"money": money, "doom": doom, "staff": staff}
+
+
+# --- no baseline -> no block ------------------------------------------------------------
+
+func test_no_baseline_yields_no_movement_block() -> void:
+	# Month 1 of a run, and any run resumed from a save (the baseline is display-only and is
+	# deliberately not serialized). Degrade to silence rather than print a delta measured
+	# against a month the player did not play.
+	assert_eq(_gm()._build_month_movement_section({}, _stats(100.0, 10.0, 2)), "")
+	assert_eq(_gm()._build_month_movement_section(_stats(100.0, 10.0, 2), {}), "")
+
+
+func test_a_month_where_nothing_moved_prints_nothing() -> void:
+	var same := _stats(84200.0, 31.2, 3)
+	assert_eq(_gm()._build_month_movement_section(same, same.duplicate()), "",
+		"an unchanged stat is precisely the non-fresh information A1 deleted")
+
+
+# --- funds ------------------------------------------------------------------------------
+
+func test_funds_render_as_start_to_end_with_a_signed_delta() -> void:
+	var out: String = _gm()._build_month_movement_section(
+		_stats(102000.0, 10.0, 3), _stats(84200.0, 10.0, 3))
+	assert_string_contains(out, "Funds")
+	assert_string_contains(out, "->", "movement is a start -> end statement, not a level")
+	assert_string_contains(out, "(-", "a month that lost money must read as a LOSS")
+
+
+func test_funds_gain_is_signed_positive() -> void:
+	var out: String = _gm()._build_month_movement_section(
+		_stats(10000.0, 10.0, 3), _stats(25000.0, 10.0, 3))
+	assert_string_contains(out, "(+")
+
+
+func test_unchanged_funds_are_omitted_while_another_stat_moved() -> void:
+	var out: String = _gm()._build_month_movement_section(
+		_stats(50000.0, 10.0, 3), _stats(50000.0, 10.0, 5))
+	assert_false(out.contains("Funds"), "only stats that MOVED earn a line")
+	assert_string_contains(out, "Staff")
+
+
+# --- staff ------------------------------------------------------------------------------
+
+func test_staff_growth_and_loss_are_signed() -> void:
+	var grew: String = _gm()._build_month_movement_section(
+		_stats(1.0, 10.0, 3), _stats(1.0, 10.0, 4))
+	assert_string_contains(grew, "(+1)")
+	var shrank: String = _gm()._build_month_movement_section(
+		_stats(1.0, 10.0, 4), _stats(1.0, 10.0, 2))
+	assert_string_contains(shrank, "(-2)")
+
+
+# --- doom: bands only, never numbers ------------------------------------------------------
+
+func test_doom_inside_one_band_prints_nothing() -> void:
+	var low := 1.0
+	var slightly_higher := 2.0
+	assert_eq(ThemeManager.get_doom_band_index(low), ThemeManager.get_doom_band_index(slightly_higher),
+		"test precondition: these two doom values must share a band")
+	assert_eq(_gm()._doom_band_movement(low, slightly_higher), "",
+		"drift within a band is already on the doom meter -- not fresh information")
+
+
+func test_doom_band_crossing_is_reported_with_direction() -> void:
+	assert_true(ThemeManager.get_doom_band_index(5.0) < ThemeManager.get_doom_band_index(95.0),
+		"test precondition: 5%% and 95%% doom must be different bands")
+	var up: String = _gm()._doom_band_movement(5.0, 95.0)
+	assert_string_contains(up, "crossed up")
+	assert_string_contains(up, ThemeManager.get_doom_status_label(95.0))
+	var down: String = _gm()._doom_band_movement(95.0, 5.0)
+	assert_string_contains(down, "eased down")
+
+
+func test_doom_movement_never_prints_a_percentage() -> void:
+	# ADR-0015 guard. A regression that reintroduced a raw number here would look harmless
+	# and would quietly re-assert the retired "single source-destination number bump" model.
+	for pair in [[5.0, 95.0], [95.0, 5.0], [31.2, 62.7]]:
+		var out: String = _gm()._doom_band_movement(float(pair[0]), float(pair[1]))
+		assert_false(out.contains("%"), "no doom percentage may reach the review: got '%s'" % out)
+
+
+func test_movement_block_never_prints_a_doom_percentage() -> void:
+	var out: String = _gm()._build_month_movement_section(
+		_stats(102000.0, 5.0, 3), _stats(84200.0, 95.0, 4))
+	assert_false(out.contains("%"), "got '%s'" % out)
+
+
+# --- A1: the deleted level line stays deleted ---------------------------------------------
+
+func test_the_old_state_level_line_is_gone_from_the_source() -> void:
+	# Source scan, same idiom as test_action_bar_renderer: the point of A1 is that this exact
+	# construction never comes back. A behavioural assertion cannot see it, because the string
+	# is only assembled inside a live month boundary.
+	var src: String = FileAccess.get_file_as_string("res://scripts/game_manager.gd")
+	assert_false(src.contains("Funds: %s   |   Doom:"),
+		"the HUD owns funds/doom/staff levels -- the review owns what CHANGED ([3:45])")

--- a/godot/tests/unit/test_month_review_movement.gd.uid
+++ b/godot/tests/unit/test_month_review_movement.gd.uid
@@ -1,0 +1,1 @@
+uid://cvskg8whbb6rf

--- a/godot/tests/unit/test_month_review_navigation.gd
+++ b/godot/tests/unit/test_month_review_navigation.gd
@@ -1,0 +1,118 @@
+extends GutTest
+## B1/B2/B3 (recorded playtest 2026-08-01, [4:55]-[5:03]) -- the month review's forward door.
+##
+## The failure: MainUI._input blocks SPACE and ENTER outright whenever any dialog is up. That
+## rule is correct for a crisis window (it stops an accidental end-turn/commit landing on a
+## decision), but the month review is not a decision -- it is a door with one costless option.
+## So the two keys every player reaches for did nothing, and the key that DID work (Q) worked
+## only because "Begin planning..." happened to be button 0 in the letter map. Pip found Q by
+## accident. His ruling: "maybe a space bar or something as well -- maybe not enter, if enter
+## is going to be the commit turn thing, we don't want people doing that accidentally."
+##
+## This suite asserts the ROUTING and the CHROME SUPPRESSION -- both are behaviour, not
+## appearance. Nothing here proves the screen LOOKS right; only Pip's eyes can do that.
+
+
+# --- EventDialog.is_navigation_popup: which popups are doors? --------------------------------
+
+func _popup(options: Array) -> Dictionary:
+	return {"id": "x", "name": "X", "type": "popup", "options": options}
+
+
+func test_single_costless_option_is_a_navigation_popup() -> void:
+	var ev := _popup([{"id": "begin_planning", "text": "Begin planning August 2017", "costs": {}}])
+	assert_true(EventDialog.is_navigation_popup(ev), "one free option is a door, not a decision")
+
+
+func test_missing_costs_key_is_still_a_navigation_popup() -> void:
+	# The review builder writes costs:{}, but an option Dictionary with no costs key at all
+	# renders identically (" (Free)"), so it must classify identically.
+	var ev := _popup([{"id": "ok", "text": "Continue"}])
+	assert_true(EventDialog.is_navigation_popup(ev))
+
+
+func test_zero_valued_costs_are_still_free() -> void:
+	# format_cost_summary drops non-positive entries, so this option renders " (Free)". The
+	# predicate is defined in terms of what format_cost_summary WOULD print precisely so the
+	# two can never disagree about what chrome is being suppressed.
+	var ev := _popup([{"id": "ok", "text": "Continue", "costs": {"money": 0, "attention": 0}}])
+	assert_true(EventDialog.is_navigation_popup(ev))
+
+
+func test_priced_single_option_is_not_navigation() -> void:
+	var ev := _popup([{"id": "pay", "text": "Pay the fine", "costs": {"money": 20000}}])
+	assert_false(EventDialog.is_navigation_popup(ev),
+		"a single option that COSTS something is still a decision -- keep its cost chrome")
+
+
+func test_multi_option_event_is_not_navigation() -> void:
+	# A crisis window with a free out must keep its [Q]/[W] letter menu: with two options the
+	# letters are the only way to say WHICH one a key press picks.
+	var ev := _popup([
+		{"id": "handle", "text": "Handle it", "costs": {"attention": 2}},
+		{"id": "ignore", "text": "Ignore it", "costs": {}},
+	])
+	assert_false(EventDialog.is_navigation_popup(ev))
+
+
+func test_zero_option_popup_is_not_navigation() -> void:
+	assert_false(EventDialog.is_navigation_popup(_popup([])))
+
+
+func test_navigation_predicate_agrees_with_the_chrome_it_suppresses() -> void:
+	# The chrome being suppressed is exactly this string. If the "(Free)" wording ever changes,
+	# this pins that is_navigation_popup changes with it rather than silently classifying
+	# every popup as priced (which would quietly restore the [Q] and the price tag).
+	assert_eq(EventDialog.format_cost_summary({}), " (Free)")
+
+
+# main_ui.gd deliberately has NO class_name (it would form a coupling cycle with
+# EventResultPresenter, see that file's header), so reach the static through the script
+# resource rather than adding a class_name to a 3k-line monolith just to test it.
+const MainUIScript := preload("res://scripts/ui/main_ui.gd")
+
+
+# --- MainUIScript.dialog_key_advances: SPACE yes, ENTER no -----------------------------------------
+
+func _dialog(space_advances: bool) -> Control:
+	var d := Control.new()
+	d.set_meta("space_advances", space_advances)
+	autofree(d)
+	return d
+
+
+func test_space_advances_an_opted_in_dialog() -> void:
+	assert_true(MainUIScript.dialog_key_advances(_dialog(true), KEY_SPACE))
+
+
+func test_enter_never_advances_even_an_opted_in_dialog() -> void:
+	# Pip's [5:03] ruling, and the load-bearing half of it: ENTER is the commit-plan binding
+	# (main_ui _input, KEY_ENTER -> _on_commit_plan_button_pressed). If dismissing a monthly
+	# popup trained ENTER as a "next" reflex, players would commit turns by muscle memory.
+	# There is deliberately NO meta that can turn this true.
+	assert_false(MainUIScript.dialog_key_advances(_dialog(true), KEY_ENTER))
+
+
+func test_space_does_not_advance_a_crisis_dialog() -> void:
+	# A window/event dialog never sets the meta, so SPACE stays blocked there -- the original
+	# accidental-end-turn protection is untouched for every dialog that is a real decision.
+	assert_false(MainUIScript.dialog_key_advances(_dialog(false), KEY_SPACE))
+
+
+func test_space_does_not_advance_a_dialog_with_no_meta_at_all() -> void:
+	var d := Control.new()
+	autofree(d)
+	assert_false(MainUIScript.dialog_key_advances(d, KEY_SPACE),
+		"opt-in must default to OFF for every dialog that predates this flag")
+
+
+func test_null_dialog_is_safe() -> void:
+	assert_false(MainUIScript.dialog_key_advances(null, KEY_SPACE))
+
+
+func test_other_keys_do_not_advance() -> void:
+	# Only SPACE is promoted. ESC keeps its own path (modal_stack.handle_escape, #452/#877)
+	# and Q keeps working through the positional letter map -- neither routes through here.
+	for key in [KEY_ESCAPE, KEY_Q, KEY_A, KEY_1, KEY_TAB]:
+		assert_false(MainUIScript.dialog_key_advances(_dialog(true), key),
+			"key %d must not be promoted past the dialog key block" % key)

--- a/godot/tests/unit/test_month_review_navigation.gd.uid
+++ b/godot/tests/unit/test_month_review_navigation.gd.uid
@@ -1,0 +1,1 @@
+uid://daufd1fgr6mc6


### PR DESCRIPTION

Pip ruled the whole month-review pack on 2026-08-02 (#1096): "month-review A1-A10 and
B1-B5 with A6 deferred." This is the unambiguous, low-risk half. The structural half and
the data-capture half are named below and deliberately NOT here.

Lead with the failures, because each change is one.

-- A1. The review told him things he was already looking at. --

At [3:45], reading `Funds: $84,200 | Doom: 31.2% | Staff: 3`: "funds is good, but I CAN
SEE THAT UP HERE, so this is NOT FRESH INFORMATION." He is right, and it is worse than
redundant: a screen that opens every month and spends its best line restating the top bar
teaches the player that the screen is skippable. The level line is deleted. The top bar
owns funds, the doom meter owns doom, the roster owns staff.

-- A4. What the HUD cannot show is MOVEMENT, so that is now all the review prints. --

`Funds $102,000 -> $84,200 (-$17,800)`, `Staff 3 -> 4 (+1)`, and doom as BAND movement.
Only stats that actually moved get a line: "Funds unchanged" would be exactly the
non-fresh information A1 just deleted, in different words. A quiet month therefore prints
no movement block at all, which is the honest output and is the accepted cost the options
doc flagged (the review gets thinner before A2/A3 give it new content).

Doom is band-only -- `ELEVATED -> HIGH (crossed up)`, via ThemeManager's canonical band
labels, the same non-color channel the HUD already uses. No percentage, no per-cause
attribution. ADR-0015 makes doom a computed consequence of world state, so a printed
per-source number would assert the retired "single source-destination number bump" model;
per-cause attribution stays behind the paid doom-breakdown instrument (ADR-0001,
spending-buys-sight). A start/end band comparison is world-state display and is legal.
Two tests pin that no "%" can ever reach that string.

The measurement point is not obvious and is the one genuinely subtle thing here.
MonthController.advance_tick() runs _open_plan_month() -- which charges the NEW month's
office rent -- BEFORE _finish_month_playback() builds the review. Reading state.money at
render time would therefore book next month's rent against last month's funds delta,
every month, in the same direction, and it would look plausible. So the end-of-month
reading is taken immediately BEFORE each day tick (_last_tick_stats); when a tick turns
out to be the boundary, that reading is the true last day of the old month. The baseline
for the NEXT review is taken after the popup is built. Both readings are display-only:
no RNG, no writes, determinism and replay untouched.

The movement baseline is not serialized. A loaded save shows no movement block on its
first review and resumes normally -- degrade quietly rather than print a delta measured
against a month the player did not play.

-- A10. Dismissing the review destroyed the only copy of it. --

[3:49] "it's actually just kind of popping up and blocking the screen." Half of why
blocking feels bad is the read-now-or-lose-it pressure: the popup was the sole copy.
Every review now also lands in the WATCH feed as a compact block, so closing it costs
nothing and months can be compared by scrolling back. New channel "review", which the
existing feed filters cannot suppress (they hide only "flavour", the arxiv flood, and
"rivals", the intel toggle) -- a review can never be silently swallowed.

This is a palliative, not the fix. A5 -- the review as a dismissible panel, or docked into
the plan screen so it informs the decisions it is about -- is the structural answer and is
not in this PR.

-- B1. The two keys every player tries first did nothing. --

main_ui.gd's _input blocks SPACE and ENTER outright whenever any dialog is up. That rule
is correct and stays: it stops an accidental end-turn or commit landing on a crisis
window. But no exception existed for a popup that is not a decision, so the month review
-- a door with one costless option -- ate both keys, and the key that DID work (Q) worked
only because "Begin planning..." happened to be button 0 in the letter map. Pip found Q by
accident at [4:55].

His ruling at [4:55]-[5:03]: "maybe a space bar or something as well -- maybe not enter,
if enter is going to be the commit turn thing, we don't want people doing that
accidentally." Implemented exactly. EventDialog sets a "space_advances" meta on a
one-costless-option popup; MainUI.dialog_key_advances() promotes SPACE past the block for
that dialog and nothing else. ENTER returns false unconditionally and there is no meta
that can change it -- if dismissing a monthly popup trained ENTER as a "next" reflex,
players would start committing turns by muscle memory, which is the exact accident he
named. SPACE is also semantically consistent: outside dialogs SPACE already means "advance
the loop".

dialog_key_advances is static and takes the dialog and the keycode, so the whole decision
is unit-testable without instantiating the 3k-line MainUI or a live input stack.

-- B2. The door had a price tag. --

It rendered `[Q] Begin planning August 2017 (Free)`. The `(Free)` is
format_cost_summary({}), a deliberate 2026-07-24 fix for crisis OPTIONS where a blank cost
read as ambiguous -- correct there, nonsense on navigation. The `[Q]` is an arbitrary index
into dialog_key_labels, not a considered binding. Both are suppressed for a
one-costless-option popup and replaced with the key the player actually reaches for:
`Begin planning August 2017   [SPACE]`. Free-ness is decided by asking format_cost_summary
what it WOULD have printed, so the predicate can never drift from the chrome it suppresses
(there is a test pinning that too). The letter key still WORKS -- it is only unadvertised.

-- B3. The forward door looked half-disabled. --

Dark-gray 500x45, identical to any event option, while the loop's other primary action
(END TURN) is teal and 16px. The two doors of the month loop did not look like siblings,
and a dark-gray button next to grayed-out unaffordable options reads as disabled. The
navigation button now takes the END TURN teal (0.118, 0.765, 0.702 -- lifted from
scenes/main.tscn), 16px, 520x54, teal border on a dark teal fill. Deliberately not a flat
teal block: the review text sits on the same panel and a saturated fill would out-shout
the thing it is meant to close.

-- What this PR does NOT do, and why --

A2, A3 and A9 are NOT here even though Pip approved them. They all need a pre-reset
snapshot first: MonthPlan.begin_month() RESETS attention_spent, attention_reserved,
reserve_used, hours_spent and kind_spent one call before the review renders. His [3:24]
"I don't see what my unspent reserve here WAS" is not a layout gap -- the number does not
exist at render time. That is a data-capture change with its own save/load and ordering
questions, and it belongs in its own PR where it can be reviewed as one. A2's snapshot is
the substrate A3 and A9 render from, so they follow it.

A6 (the month as a headline) is deferred by Pip's own ruling.
A5b (docking the review into the plan screen) and B5 (deleting the button) are structural.
A7/A8 (introducing rivals before reporting them) is issue #1088, a separate lane.
B4 (putting the fresh Attention number on the door) was not in scope for this pass.

-- Verification --

Fast gate in this worktree: 1031 tests / 101 files before, 1055 tests / 103 files after,
0 failures both times. The +24 are the two new suites: test_month_review_navigation.gd
(SPACE/ENTER routing and the navigation-popup predicate -- routing is behaviour, so it is
testable) and test_month_review_movement.gd (movement rendering, the omit-unchanged rule,
and the ADR-0015 no-percentage guard).

Honest limit: nothing here proves the screen LOOKS right. The teal weighting, the thinner
body and the [SPACE] hint need Pip's eyes in a running build.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
