### PR TITLE
feat(settings): rebuild as front card + operations board -- directions 5 and 1 as one screen (#1096)

### DIFF
--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -370,6 +370,12 @@ func set_setting(key: String, value, save_immediately: bool = false) -> void:
 			colorblind_mode = value
 		"show_hints":
 			show_hints = value
+		"show_rivals_feed":
+			# Settings-menu row for the WATCH feed's rival-intel preference. The WATCH
+			# screen's own filter button predates this case and writes the var + saves
+			# directly (main_ui._on_rivals_filter_changed); both paths land on the same
+			# persisted field.
+			show_rivals_feed = value
 		"submit_scores_global":
 			submit_scores_global = value
 		"send_launch_ping":

--- a/godot/scenes/settings_menu.tscn
+++ b/godot/scenes/settings_menu.tscn
@@ -36,180 +36,359 @@ grow_vertical = 2
 texture = ExtResource("3_overlay")
 stretch_mode = 1
 
-[node name="VBox" type="VBoxContainer" parent="."]
+[node name="FrontCard" type="CenterContainer" parent="."]
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -400.0
-offset_top = -300.0
-offset_right = 400.0
-offset_bottom = 300.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 20
 
-[node name="Title" type="Label" parent="VBox"]
+[node name="Card" type="PanelContainer" parent="FrontCard"]
+layout_mode = 2
+
+[node name="Margin" type="MarginContainer" parent="FrontCard/Card"]
+layout_mode = 2
+theme_override_constants/margin_left = 28
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 28
+theme_override_constants/margin_bottom = 24
+
+[node name="CardVBox" type="VBoxContainer" parent="FrontCard/Card/Margin"]
+custom_minimum_size = Vector2(480, 0)
+layout_mode = 2
+theme_override_constants/separation = 14
+
+[node name="Title" type="Label" parent="FrontCard/Card/Margin/CardVBox"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
-theme_override_font_sizes/font_size = 48
-text = "LABORATORY SETTINGS"
-horizontal_alignment = 1
+theme_override_font_sizes/font_size = 32
+text = "SETTINGS"
 
-[node name="Subtitle" type="Label" parent="VBox"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
-theme_override_font_sizes/font_size = 18
-text = "Configure Operations & Protocols"
-horizontal_alignment = 1
-
-[node name="HSeparator" type="HSeparator" parent="VBox"]
-layout_mode = 2
-
-[node name="Scroll" type="ScrollContainer" parent="VBox"]
-layout_mode = 2
-size_flags_vertical = 3
-horizontal_scroll_mode = 0
-vertical_scroll_mode = 2
-
-[node name="SettingsContainer" type="VBoxContainer" parent="VBox/Scroll"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-theme_override_constants/separation = 12
-
-[node name="AudioSettings" type="VBoxContainer" parent="VBox/Scroll/SettingsContainer"]
-layout_mode = 2
-theme_override_constants/separation = 8
-
-[node name="AudioLabel" type="Label" parent="VBox/Scroll/SettingsContainer/AudioSettings"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
-theme_override_font_sizes/font_size = 20
-text = "Audio Settings"
-
-[node name="MasterVolumeRow" type="HBoxContainer" parent="VBox/Scroll/SettingsContainer/AudioSettings"]
+[node name="VolumeRow" type="HBoxContainer" parent="FrontCard/Card/Margin/CardVBox"]
 layout_mode = 2
 theme_override_constants/separation = 15
 
-[node name="Label" type="Label" parent="VBox/Scroll/SettingsContainer/AudioSettings/MasterVolumeRow"]
-custom_minimum_size = Vector2(250, 0)
+[node name="Label" type="Label" parent="FrontCard/Card/Margin/CardVBox/VolumeRow"]
+custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
-text = "Master Volume:"
+text = "Volume"
 
-[node name="Slider" type="HSlider" parent="VBox/Scroll/SettingsContainer/AudioSettings/MasterVolumeRow"]
-custom_minimum_size = Vector2(300, 0)
+[node name="Slider" type="HSlider" parent="FrontCard/Card/Margin/CardVBox/VolumeRow"]
+custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 size_flags_horizontal = 3
+size_flags_vertical = 4
 max_value = 100.0
 value = 50.0
 
-[node name="ValueLabel" type="Label" parent="VBox/Scroll/SettingsContainer/AudioSettings/MasterVolumeRow"]
+[node name="ValueLabel" type="Label" parent="FrontCard/Card/Margin/CardVBox/VolumeRow"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
 text = "50%"
 
-[node name="SFXVolumeRow" type="HBoxContainer" parent="VBox/Scroll/SettingsContainer/AudioSettings"]
+[node name="MusicRow" type="HBoxContainer" parent="FrontCard/Card/Margin/CardVBox"]
 layout_mode = 2
 theme_override_constants/separation = 15
 
-[node name="Label" type="Label" parent="VBox/Scroll/SettingsContainer/AudioSettings/SFXVolumeRow"]
-custom_minimum_size = Vector2(250, 0)
+[node name="Label" type="Label" parent="FrontCard/Card/Margin/CardVBox/MusicRow"]
+custom_minimum_size = Vector2(160, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
-text = "Sound Effects Volume:"
+text = "Music"
 
-[node name="Slider" type="HSlider" parent="VBox/Scroll/SettingsContainer/AudioSettings/SFXVolumeRow"]
-custom_minimum_size = Vector2(300, 0)
+[node name="Slider" type="HSlider" parent="FrontCard/Card/Margin/CardVBox/MusicRow"]
+custom_minimum_size = Vector2(200, 0)
 layout_mode = 2
 size_flags_horizontal = 3
-max_value = 100.0
-value = 50.0
-
-[node name="ValueLabel" type="Label" parent="VBox/Scroll/SettingsContainer/AudioSettings/SFXVolumeRow"]
-custom_minimum_size = Vector2(50, 0)
-layout_mode = 2
-theme_override_font_sizes/font_size = 16
-text = "50%"
-
-[node name="MusicVolumeRow" type="HBoxContainer" parent="VBox/Scroll/SettingsContainer/AudioSettings"]
-layout_mode = 2
-theme_override_constants/separation = 15
-
-[node name="Label" type="Label" parent="VBox/Scroll/SettingsContainer/AudioSettings/MusicVolumeRow"]
-custom_minimum_size = Vector2(250, 0)
-layout_mode = 2
-theme_override_font_sizes/font_size = 16
-text = "Music Volume:"
-
-[node name="Slider" type="HSlider" parent="VBox/Scroll/SettingsContainer/AudioSettings/MusicVolumeRow"]
-custom_minimum_size = Vector2(300, 0)
-layout_mode = 2
-size_flags_horizontal = 3
+size_flags_vertical = 4
 max_value = 100.0
 value = 15.0
 
-[node name="ValueLabel" type="Label" parent="VBox/Scroll/SettingsContainer/AudioSettings/MusicVolumeRow"]
+[node name="ValueLabel" type="Label" parent="FrontCard/Card/Margin/CardVBox/MusicRow"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
 text = "15%"
 
-[node name="HSeparator2" type="HSeparator" parent="VBox/Scroll/SettingsContainer"]
+[node name="FullscreenRow" type="HBoxContainer" parent="FrontCard/Card/Margin/CardVBox"]
 layout_mode = 2
 
-[node name="GraphicsSettings" type="VBoxContainer" parent="VBox/Scroll/SettingsContainer"]
+[node name="Label" type="Label" parent="FrontCard/Card/Margin/CardVBox/FullscreenRow"]
 layout_mode = 2
-theme_override_constants/separation = 8
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Fullscreen"
 
-[node name="GraphicsLabel" type="Label" parent="VBox/Scroll/SettingsContainer/GraphicsSettings"]
+[node name="CheckBox" type="CheckButton" parent="FrontCard/Card/Margin/CardVBox/FullscreenRow"]
+layout_mode = 2
+
+[node name="HintsRow" type="HBoxContainer" parent="FrontCard/Card/Margin/CardVBox"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="FrontCard/Card/Margin/CardVBox/HintsRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Gameplay hints"
+
+[node name="CheckBox" type="CheckButton" parent="FrontCard/Card/Margin/CardVBox/HintsRow"]
+layout_mode = 2
+
+[node name="ColorblindRow" type="HBoxContainer" parent="FrontCard/Card/Margin/CardVBox"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="FrontCard/Card/Margin/CardVBox/ColorblindRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Colorblind mode"
+
+[node name="CheckBox" type="CheckButton" parent="FrontCard/Card/Margin/CardVBox/ColorblindRow"]
+layout_mode = 2
+tooltip_text = "Adds patterns and symbols alongside colors for better visibility"
+
+[node name="HSeparator" type="HSeparator" parent="FrontCard/Card/Margin/CardVBox"]
+layout_mode = 2
+
+[node name="AllProtocolsButton" type="Button" parent="FrontCard/Card/Margin/CardVBox"]
+custom_minimum_size = Vector2(0, 48)
+layout_mode = 2
+theme_override_font_sizes/font_size = 18
+text = ">> ALL PROTOCOLS"
+
+[node name="AllProtocolsCaption" type="Label" parent="FrontCard/Card/Margin/CardVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 12
+text = "sound detail, display, privacy, intros, rival feed, experiments"
+
+[node name="KeybindingsButton" type="Button" parent="FrontCard/Card/Margin/CardVBox"]
+custom_minimum_size = Vector2(0, 48)
+layout_mode = 2
+theme_override_font_sizes/font_size = 18
+text = ">> KEYBINDINGS"
+
+[node name="HSeparator2" type="HSeparator" parent="FrontCard/Card/Margin/CardVBox"]
+layout_mode = 2
+
+[node name="FooterRow" type="HBoxContainer" parent="FrontCard/Card/Margin/CardVBox"]
+layout_mode = 2
+theme_override_constants/separation = 20
+
+[node name="BackButton" type="Button" parent="FrontCard/Card/Margin/CardVBox/FooterRow"]
+custom_minimum_size = Vector2(150, 48)
+layout_mode = 2
+theme_override_font_sizes/font_size = 18
+text = "Back"
+
+[node name="SavedLabel" type="Label" parent="FrontCard/Card/Margin/CardVBox/FooterRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 12
+text = "changes save automatically"
+horizontal_alignment = 2
+vertical_alignment = 1
+
+[node name="Board" type="MarginContainer" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 48
+theme_override_constants/margin_top = 28
+theme_override_constants/margin_right = 48
+theme_override_constants/margin_bottom = 24
+
+[node name="BoardVBox" type="VBoxContainer" parent="Board"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="HeaderRow" type="HBoxContainer" parent="Board/BoardVBox"]
+layout_mode = 2
+
+[node name="BoardTitle" type="Label" parent="Board/BoardVBox/HeaderRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
+theme_override_font_sizes/font_size = 28
+text = "LAB OPERATIONS // SETTINGS"
+
+[node name="VersionLabel" type="Label" parent="Board/BoardVBox/HeaderRow"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 14
+text = "v0.0.0"
+vertical_alignment = 1
+
+[node name="AutosaveNote" type="Label" parent="Board/BoardVBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 12
+text = "changes apply immediately and are saved -- there is no Apply button"
+
+[node name="HSeparator" type="HSeparator" parent="Board/BoardVBox"]
+layout_mode = 2
+
+[node name="Columns" type="HBoxContainer" parent="Board/BoardVBox"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 40
+
+[node name="Col1" type="VBoxContainer" parent="Board/BoardVBox/Columns"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 10
+
+[node name="AudioHeader" type="Label" parent="Board/BoardVBox/Columns/Col1"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
-text = "Graphics Settings"
+text = "AUDIO"
 
-[node name="FullscreenRow" type="HBoxContainer" parent="VBox/Scroll/SettingsContainer/GraphicsSettings"]
+[node name="MasterLabelRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col1"]
 layout_mode = 2
-theme_override_constants/separation = 15
 
-[node name="Label" type="Label" parent="VBox/Scroll/SettingsContainer/GraphicsSettings/FullscreenRow"]
-custom_minimum_size = Vector2(250, 0)
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col1/MasterLabelRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Master"
+
+[node name="ValueLabel" type="Label" parent="Board/BoardVBox/Columns/Col1/MasterLabelRow"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
-text = "Fullscreen:"
+text = "50%"
 
-[node name="CheckBox" type="CheckButton" parent="VBox/Scroll/SettingsContainer/GraphicsSettings/FullscreenRow"]
+[node name="MasterSlider" type="HSlider" parent="Board/BoardVBox/Columns/Col1"]
+layout_mode = 2
+max_value = 100.0
+value = 50.0
+
+[node name="SFXLabelRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col1"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col1/SFXLabelRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Effects"
+
+[node name="ValueLabel" type="Label" parent="Board/BoardVBox/Columns/Col1/SFXLabelRow"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
+text = "50%"
 
-[node name="HSeparator3" type="HSeparator" parent="VBox/Scroll/SettingsContainer"]
+[node name="SFXSlider" type="HSlider" parent="Board/BoardVBox/Columns/Col1"]
+layout_mode = 2
+max_value = 100.0
+value = 50.0
+
+[node name="MusicLabelRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col1"]
 layout_mode = 2
 
-[node name="GameplaySettings" type="VBoxContainer" parent="VBox/Scroll/SettingsContainer"]
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col1/MusicLabelRow"]
 layout_mode = 2
-theme_override_constants/separation = 8
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Music"
 
-[node name="GameplayLabel" type="Label" parent="VBox/Scroll/SettingsContainer/GameplaySettings"]
+[node name="ValueLabel" type="Label" parent="Board/BoardVBox/Columns/Col1/MusicLabelRow"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "15%"
+
+[node name="MusicSlider" type="HSlider" parent="Board/BoardVBox/Columns/Col1"]
+layout_mode = 2
+max_value = 100.0
+value = 15.0
+
+[node name="HSeparator" type="HSeparator" parent="Board/BoardVBox/Columns/Col1"]
+layout_mode = 2
+
+[node name="DisplayHeader" type="Label" parent="Board/BoardVBox/Columns/Col1"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
-text = "Gameplay Settings"
+text = "DISPLAY"
 
-[node name="DifficultyRow" type="HBoxContainer" parent="VBox/Scroll/SettingsContainer/GameplaySettings"]
+[node name="FullscreenRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col1"]
 layout_mode = 2
-theme_override_constants/separation = 15
 
-[node name="Label" type="Label" parent="VBox/Scroll/SettingsContainer/GameplaySettings/DifficultyRow"]
-custom_minimum_size = Vector2(250, 0)
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col1/FullscreenRow"]
 layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Fullscreen"
+
+[node name="CheckBox" type="CheckButton" parent="Board/BoardVBox/Columns/Col1/FullscreenRow"]
+layout_mode = 2
+
+[node name="Col2" type="VBoxContainer" parent="Board/BoardVBox/Columns"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 10
+
+[node name="OperationsHeader" type="Label" parent="Board/BoardVBox/Columns/Col2"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
+theme_override_font_sizes/font_size = 20
+text = "OPERATIONS"
+
+[node name="IntrosRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col2"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col2/IntrosRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Play story intros"
+
+[node name="CheckBox" type="CheckButton" parent="Board/BoardVBox/Columns/Col2/IntrosRow"]
+layout_mode = 2
+
+[node name="HintsRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col2"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col2/HintsRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Show gameplay hints"
+tooltip_text = "Show onboarding help: the getting-started hint and the first-launch welcome overlay."
+
+[node name="CheckBox" type="CheckButton" parent="Board/BoardVBox/Columns/Col2/HintsRow"]
+layout_mode = 2
+
+[node name="RivalsRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col2"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col2/RivalsRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Rival intel in the WATCH feed"
+tooltip_text = "Show rival-lab intel lines in the WATCH feed. Also toggleable on the WATCH screen itself."
+
+[node name="CheckBox" type="CheckButton" parent="Board/BoardVBox/Columns/Col2/RivalsRow"]
+layout_mode = 2
+
+[node name="DifficultyRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col2"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col2/DifficultyRow"]
+layout_mode = 2
+size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
 text = "Research Intensity:"
 
-[node name="OptionButton" type="OptionButton" parent="VBox/Scroll/SettingsContainer/GameplaySettings/DifficultyRow"]
+[node name="OptionButton" type="OptionButton" parent="Board/BoardVBox/Columns/Col2/DifficultyRow"]
 custom_minimum_size = Vector2(200, 40)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
@@ -221,27 +400,25 @@ popup/item_1/id = 1
 popup/item_2/text = "Hard"
 popup/item_2/id = 2
 
-[node name="UISettings" type="VBoxContainer" parent="VBox/Scroll/SettingsContainer"]
+[node name="HSeparator" type="HSeparator" parent="Board/BoardVBox/Columns/Col2"]
 layout_mode = 2
-theme_override_constants/separation = 8
 
-[node name="UILabel" type="Label" parent="VBox/Scroll/SettingsContainer/UISettings"]
+[node name="InterfaceHeader" type="Label" parent="Board/BoardVBox/Columns/Col2"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
-text = "UI Settings"
+text = "INTERFACE"
 
-[node name="ThemeRow" type="HBoxContainer" parent="VBox/Scroll/SettingsContainer/UISettings"]
+[node name="ThemeRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col2"]
 layout_mode = 2
-theme_override_constants/separation = 15
 
-[node name="Label" type="Label" parent="VBox/Scroll/SettingsContainer/UISettings/ThemeRow"]
-custom_minimum_size = Vector2(250, 0)
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col2/ThemeRow"]
 layout_mode = 2
+size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 16
-text = "Visual Theme:"
+text = "Visual theme"
 
-[node name="ThemeDropdown" type="OptionButton" parent="VBox/Scroll/SettingsContainer/UISettings/ThemeRow"]
+[node name="ThemeDropdown" type="OptionButton" parent="Board/BoardVBox/Columns/Col2/ThemeRow"]
 custom_minimum_size = Vector2(200, 40)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
@@ -252,157 +429,140 @@ popup/item_1/id = 1
 popup/item_2/text = "High Contrast"
 popup/item_2/id = 2
 
-[node name="HSeparator4" type="HSeparator" parent="VBox/Scroll/SettingsContainer"]
+[node name="UILayoutRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col2"]
 layout_mode = 2
 
-[node name="AccessibilitySettings" type="VBoxContainer" parent="VBox/Scroll/SettingsContainer"]
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col2/UILayoutRow"]
 layout_mode = 2
-theme_override_constants/separation = 8
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Proposed UI layout (experimental)"
+tooltip_text = "A/B test: proposed PLAN/WATCH (grouped actions, operations gantt, reclaimed space). Applies on next game load."
 
-[node name="AccessibilityLabel" type="Label" parent="VBox/Scroll/SettingsContainer/AccessibilitySettings"]
+[node name="CheckBox" type="CheckButton" parent="Board/BoardVBox/Columns/Col2/UILayoutRow"]
+layout_mode = 2
+
+[node name="UILayoutCaption" type="Label" parent="Board/BoardVBox/Columns/Col2"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 12
+text = "applies on next game load"
+
+[node name="HSeparator2" type="HSeparator" parent="Board/BoardVBox/Columns/Col2"]
+layout_mode = 2
+
+[node name="AccessHeader" type="Label" parent="Board/BoardVBox/Columns/Col2"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
-text = "Accessibility"
+text = "ACCESS"
 
-[node name="ColorblindRow" type="HBoxContainer" parent="VBox/Scroll/SettingsContainer/AccessibilitySettings"]
+[node name="ColorblindRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col2"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col2/ColorblindRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 16
+text = "Colorblind mode"
+
+[node name="CheckBox" type="CheckButton" parent="Board/BoardVBox/Columns/Col2/ColorblindRow"]
+layout_mode = 2
+tooltip_text = "Adds patterns and symbols alongside colors for better visibility"
+
+[node name="ColorblindCaption" type="Label" parent="Board/BoardVBox/Columns/Col2"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 12
+text = "patterns + symbols alongside colors"
+
+[node name="Col3" type="VBoxContainer" parent="Board/BoardVBox/Columns"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 10
+
+[node name="DisclosureHeader" type="Label" parent="Board/BoardVBox/Columns/Col3"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
+theme_override_font_sizes/font_size = 20
+text = "DISCLOSURE"
+
+[node name="LeaderboardRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col3"]
 layout_mode = 2
 theme_override_constants/separation = 15
 
-[node name="Label" type="Label" parent="VBox/Scroll/SettingsContainer/AccessibilitySettings/ColorblindRow"]
-custom_minimum_size = Vector2(250, 0)
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col3/LeaderboardRow"]
 layout_mode = 2
-theme_override_font_sizes/font_size = 16
-text = "Colorblind Mode:"
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 15
+text = "Submit scores to the global leaderboard -- shares player + lab name publicly. Opt-in."
+autowrap_mode = 3
 
-[node name="CheckBox" type="CheckButton" parent="VBox/Scroll/SettingsContainer/AccessibilitySettings/ColorblindRow"]
+[node name="CheckBox" type="CheckButton" parent="Board/BoardVBox/Columns/Col3/LeaderboardRow"]
 layout_mode = 2
-theme_override_font_sizes/font_size = 16
-tooltip_text = "Adds patterns and symbols alongside colors for better visibility"
+size_flags_vertical = 0
 
-[node name="HSeparator5" type="HSeparator" parent="VBox/Scroll/SettingsContainer"]
+[node name="LaunchPingRow" type="HBoxContainer" parent="Board/BoardVBox/Columns/Col3"]
+layout_mode = 2
+theme_override_constants/separation = 15
+
+[node name="Label" type="Label" parent="Board/BoardVBox/Columns/Col3/LaunchPingRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_font_sizes/font_size = 15
+text = "Anonymous launch ping -- counts installs; no personal data."
+autowrap_mode = 3
+
+[node name="CheckBox" type="CheckButton" parent="Board/BoardVBox/Columns/Col3/LaunchPingRow"]
+layout_mode = 2
+size_flags_vertical = 0
+
+[node name="HSeparator" type="HSeparator" parent="Board/BoardVBox/Columns/Col3"]
 layout_mode = 2
 
-[node name="KeyboardShortcuts" type="VBoxContainer" parent="VBox/Scroll/SettingsContainer"]
-layout_mode = 2
-theme_override_constants/separation = 8
-
-[node name="KeyboardLabel" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts"]
+[node name="ControlsHeader" type="Label" parent="Board/BoardVBox/Columns/Col3"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 20
-text = "Keyboard Shortcuts"
+text = "CONTROLS"
 
-[node name="ShortcutsGrid" type="GridContainer" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts"]
+[node name="KeybindingsButton" type="Button" parent="Board/BoardVBox/Columns/Col3"]
+custom_minimum_size = Vector2(0, 48)
 layout_mode = 2
-theme_override_constants/h_separation = 30
-theme_override_constants/v_separation = 4
-columns = 2
+theme_override_font_sizes/font_size = 18
+text = ">> KEYBINDINGS"
 
-[node name="Key1" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
+[node name="KeybindCaption" type="Label" parent="Board/BoardVBox/Columns/Col3"]
 layout_mode = 2
-theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
-theme_override_font_sizes/font_size = 14
-text = "[1-9]"
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 12
+text = "edit all bindings and profiles"
 
-[node name="Desc1" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 14
-text = "Select action"
-
-[node name="Key2" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
-theme_override_font_sizes/font_size = 14
-text = "[Space/Enter]"
-
-[node name="Desc2" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 14
-text = "End turn"
-
-[node name="Key3" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
-theme_override_font_sizes/font_size = 14
-text = "[Esc]"
-
-[node name="Desc3" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 14
-text = "Cancel / Pause menu"
-
-[node name="Key4" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
-theme_override_font_sizes/font_size = 14
-text = "[Q/W/E/R]"
-
-[node name="Desc4" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 14
-text = "Dialog options"
-
-[node name="Key5" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
-theme_override_font_sizes/font_size = 14
-text = "[F5]"
-
-[node name="Desc5" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 14
-text = "Quick save"
-
-[node name="Key6" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
-theme_override_font_sizes/font_size = 14
-text = "[N]"
-
-[node name="Desc6" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 14
-text = "Bug report"
-
-[node name="Key7" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_colors/font_color = Color(0.9, 0.95, 1, 1)
-theme_override_font_sizes/font_size = 14
-text = "[F9]"
-
-[node name="Desc7" type="Label" parent="VBox/Scroll/SettingsContainer/KeyboardShortcuts/ShortcutsGrid"]
-layout_mode = 2
-theme_override_font_sizes/font_size = 14
-text = "Quick load"
-
-[node name="Spacer" type="Control" parent="VBox"]
+[node name="HSeparator2" type="HSeparator" parent="Board/BoardVBox"]
 layout_mode = 2
 
-[node name="ButtonRow" type="HBoxContainer" parent="VBox"]
+[node name="FooterRow" type="HBoxContainer" parent="Board/BoardVBox"]
 layout_mode = 2
 theme_override_constants/separation = 20
-alignment = 1
 
-[node name="ApplyButton" type="Button" parent="VBox/ButtonRow"]
-custom_minimum_size = Vector2(150, 50)
+[node name="FrontCardButton" type="Button" parent="Board/BoardVBox/FooterRow"]
+custom_minimum_size = Vector2(200, 48)
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_font_sizes/font_size = 20
-text = "Apply"
+theme_override_font_sizes/font_size = 18
+text = "<< FRONT CARD"
 
-[node name="BackButton" type="Button" parent="VBox/ButtonRow"]
-custom_minimum_size = Vector2(150, 50)
+[node name="FooterHint" type="Label" parent="Board/BoardVBox/FooterRow"]
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_font_sizes/font_size = 20
-text = "Back"
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 12
+text = "[ESC] front card"
+vertical_alignment = 1
 
-[connection signal="value_changed" from="VBox/Scroll/SettingsContainer/AudioSettings/MasterVolumeRow/Slider" to="." method="_on_master_volume_changed"]
-[connection signal="value_changed" from="VBox/Scroll/SettingsContainer/AudioSettings/SFXVolumeRow/Slider" to="." method="_on_sfx_volume_changed"]
-[connection signal="value_changed" from="VBox/Scroll/SettingsContainer/AudioSettings/MusicVolumeRow/Slider" to="." method="_on_music_volume_changed"]
-[connection signal="toggled" from="VBox/Scroll/SettingsContainer/GraphicsSettings/FullscreenRow/CheckBox" to="." method="_on_fullscreen_toggled"]
-[connection signal="item_selected" from="VBox/Scroll/SettingsContainer/GameplaySettings/DifficultyRow/OptionButton" to="." method="_on_difficulty_changed"]
-[connection signal="toggled" from="VBox/Scroll/SettingsContainer/AccessibilitySettings/ColorblindRow/CheckBox" to="." method="_on_colorblind_toggled"]
-[connection signal="pressed" from="VBox/ButtonRow/ApplyButton" to="." method="_on_apply_pressed"]
-[connection signal="pressed" from="VBox/ButtonRow/BackButton" to="." method="_on_back_pressed"]
+[node name="SavedLabel" type="Label" parent="Board/BoardVBox/FooterRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 12
+text = "changes save automatically"
+horizontal_alignment = 2
+vertical_alignment = 1

--- a/godot/scripts/ui/settings_menu.gd
+++ b/godot/scripts/ui/settings_menu.gd
@@ -1,50 +1,92 @@
 extends Control
-## Settings Menu - Comprehensive settings management using GameConfig
+## Settings -- two views in one scene (Pip's ruling 2026-08-02, memo #1096:
+## "settings directions 1 and 5 proceed, diegetic deferred").
+##
+## FRONT CARD (Direction 5, THE FIRST FIVE MINUTES): the five controls nearly
+## every early settings visit is for -- volume, music, fullscreen, hints,
+## colorblind -- on one small centered card, plus exactly one door.
+##
+## OPERATIONS BOARD (Direction 1): behind the ">> ALL PROTOCOLS" door. Every
+## remaining control on one dense three-column board, zero navigation, nothing
+## scrolls, so nothing can hide below a fold (the old screen buried six shipped
+## sections behind a mis-flagged Spacer -- see docs/design/SETTINGS_MENU_OPTIONS.md
+## section 0). Columns group by the player's question: my machine / my game /
+## my data + my hands.
+##
+## PERSISTENCE MODEL -- there is no Apply button. Every control applies live
+## (unchanged) and now also SAVES via a debounced timer plus a flush on exit.
+## The old model applied live but persisted only on Apply, so Back-without-Apply
+## silently reverted on next launch -- the exact silent-wrongness flavour league
+## week taught us to fear. One honest rule, stated on screen.
+##
+## The duplicated controls (volume/music/fullscreen/hints/colorblind exist on
+## both views) share one handler each and are re-read from GameConfig on every
+## view switch, so the two views cannot disagree while visible.
 
-# UI References
-@onready var master_volume_slider = $VBox/Scroll/SettingsContainer/AudioSettings/MasterVolumeRow/Slider
-@onready var master_volume_label = $VBox/Scroll/SettingsContainer/AudioSettings/MasterVolumeRow/ValueLabel
-@onready var sfx_volume_slider = $VBox/Scroll/SettingsContainer/AudioSettings/SFXVolumeRow/Slider
-@onready var sfx_volume_label = $VBox/Scroll/SettingsContainer/AudioSettings/SFXVolumeRow/ValueLabel
-@onready var music_volume_slider = $VBox/Scroll/SettingsContainer/AudioSettings/MusicVolumeRow/Slider
-@onready var music_volume_label = $VBox/Scroll/SettingsContainer/AudioSettings/MusicVolumeRow/ValueLabel
-# NOTE: there is no Graphics Quality control. GameConfig.graphics_quality still
-# exists and still persists, but apply_graphics_settings() has never done
-# anything with it ("TODO: Apply graphics quality settings"), so the dropdown
-# that used to sit here was a Low/Medium/High choice with no effect whatsoever.
-# It was removed 2026-08-01 rather than left rendering a lie. Fullscreen below
-# is real (DisplayServer.window_set_mode) and stays.
-@onready var fullscreen_checkbox = $VBox/Scroll/SettingsContainer/GraphicsSettings/FullscreenRow/CheckBox
-@onready var difficulty_option = $VBox/Scroll/SettingsContainer/GameplaySettings/DifficultyRow/OptionButton
-@onready var theme_dropdown = $VBox/Scroll/SettingsContainer/UISettings/ThemeRow/ThemeDropdown
-@onready var colorblind_checkbox = $VBox/Scroll/SettingsContainer/AccessibilitySettings/ColorblindRow/CheckBox
+const KEYBIND_SCENE := "res://scenes/keybind_screen.tscn"
 
-# Built programmatically (no .tscn row): global-leaderboard opt-out (default ON).
-var global_leaderboard_checkbox: CheckButton = null
+# How long after the last change before the config is written. Sliders fire
+# value_changed continuously while dragging; this coalesces a drag into one write.
+const SAVE_DEBOUNCE_SECONDS := 0.75
 
-# Built programmatically (no .tscn row): anonymous launch-ping opt-out (#799).
-# Honest label -- the ping carries a random install UUID + version + OS only.
-var launch_ping_checkbox: CheckButton = null
+# --- Front card (Direction 5) ---
+@onready var front_card: Control = $FrontCard
+@onready var fc_volume_slider: HSlider = $FrontCard/Card/Margin/CardVBox/VolumeRow/Slider
+@onready var fc_volume_label: Label = $FrontCard/Card/Margin/CardVBox/VolumeRow/ValueLabel
+@onready var fc_music_slider: HSlider = $FrontCard/Card/Margin/CardVBox/MusicRow/Slider
+@onready var fc_music_label: Label = $FrontCard/Card/Margin/CardVBox/MusicRow/ValueLabel
+@onready var fc_fullscreen_checkbox: CheckButton = $FrontCard/Card/Margin/CardVBox/FullscreenRow/CheckBox
+@onready var fc_hints_checkbox: CheckButton = $FrontCard/Card/Margin/CardVBox/HintsRow/CheckBox
+@onready var fc_colorblind_checkbox: CheckButton = $FrontCard/Card/Margin/CardVBox/ColorblindRow/CheckBox
+@onready var all_protocols_button: Button = $FrontCard/Card/Margin/CardVBox/AllProtocolsButton
+@onready var fc_keybindings_button: Button = $FrontCard/Card/Margin/CardVBox/KeybindingsButton
+@onready var back_button: Button = $FrontCard/Card/Margin/CardVBox/FooterRow/BackButton
+@onready var fc_saved_label: Label = $FrontCard/Card/Margin/CardVBox/FooterRow/SavedLabel
 
-# Built programmatically (no .tscn row): story-intro toggle (#801). The reversible
-# ESCAPE HATCH for the "auto-flip on player signal + reversible settings toggle" pattern
-# (see GameConfig.play_intros): a hold-to-skip auto-flips play_intros off; this re-enables.
-var play_intros_checkbox: CheckButton = null
+# --- Operations board (Direction 1) ---
+@onready var board: Control = $Board
+@onready var version_label: Label = $Board/BoardVBox/HeaderRow/VersionLabel
+@onready var board_master_slider: HSlider = $Board/BoardVBox/Columns/Col1/MasterSlider
+@onready var board_master_label: Label = $Board/BoardVBox/Columns/Col1/MasterLabelRow/ValueLabel
+@onready var board_sfx_slider: HSlider = $Board/BoardVBox/Columns/Col1/SFXSlider
+@onready var board_sfx_label: Label = $Board/BoardVBox/Columns/Col1/SFXLabelRow/ValueLabel
+@onready var board_music_slider: HSlider = $Board/BoardVBox/Columns/Col1/MusicSlider
+@onready var board_music_label: Label = $Board/BoardVBox/Columns/Col1/MusicLabelRow/ValueLabel
+@onready var board_fullscreen_checkbox: CheckButton = $Board/BoardVBox/Columns/Col1/FullscreenRow/CheckBox
+@onready var board_intros_checkbox: CheckButton = $Board/BoardVBox/Columns/Col2/IntrosRow/CheckBox
+@onready var board_hints_checkbox: CheckButton = $Board/BoardVBox/Columns/Col2/HintsRow/CheckBox
+@onready var board_rivals_checkbox: CheckButton = $Board/BoardVBox/Columns/Col2/RivalsRow/CheckBox
+@onready var difficulty_option: OptionButton = $Board/BoardVBox/Columns/Col2/DifficultyRow/OptionButton
+@onready var theme_dropdown: OptionButton = $Board/BoardVBox/Columns/Col2/ThemeRow/ThemeDropdown
+@onready var board_ui_layout_checkbox: CheckButton = $Board/BoardVBox/Columns/Col2/UILayoutRow/CheckBox
+@onready var board_colorblind_checkbox: CheckButton = $Board/BoardVBox/Columns/Col2/ColorblindRow/CheckBox
+@onready var board_leaderboard_checkbox: CheckButton = $Board/BoardVBox/Columns/Col3/LeaderboardRow/CheckBox
+@onready var board_launch_ping_checkbox: CheckButton = $Board/BoardVBox/Columns/Col3/LaunchPingRow/CheckBox
+@onready var board_keybindings_button: Button = $Board/BoardVBox/Columns/Col3/KeybindingsButton
+@onready var front_card_button: Button = $Board/BoardVBox/FooterRow/FrontCardButton
+@onready var board_saved_label: Label = $Board/BoardVBox/FooterRow/SavedLabel
 
-# Section header labels for icon integration
-@onready var audio_label = $VBox/Scroll/SettingsContainer/AudioSettings/AudioLabel
-@onready var graphics_label = $VBox/Scroll/SettingsContainer/GraphicsSettings/GraphicsLabel
-@onready var gameplay_label = $VBox/Scroll/SettingsContainer/GameplaySettings/GameplayLabel
-@onready var ui_label = $VBox/Scroll/SettingsContainer/UISettings/UILabel
-@onready var accessibility_label = $VBox/Scroll/SettingsContainer/AccessibilitySettings/AccessibilityLabel
-@onready var keyboard_label = $VBox/Scroll/SettingsContainer/KeyboardShortcuts/KeyboardLabel
-@onready var back_button: Button = $VBox/ButtonRow/BackButton
+# Debounced-save state. _dirty means "applied live but not yet on disk"; the
+# window where that is true is at most SAVE_DEBOUNCE_SECONDS + the exit flush.
+var _dirty: bool = false
+var _save_timer: Timer = null
+
 
 func _ready():
-	print("[SettingsMenu] Initializing...")
+	print("[SettingsMenu] Initializing (front card + operations board)...")
 
-	# Load settings from GameConfig singleton
-	update_ui_from_game_config()
+	_save_timer = Timer.new()
+	_save_timer.one_shot = true
+	_save_timer.wait_time = SAVE_DEBOUNCE_SECONDS
+	_save_timer.timeout.connect(_on_save_timer_timeout)
+	add_child(_save_timer)
+
+	version_label.text = "v%s  board %s" % [
+		GameConfig.get_current_version(), GameConfig.get_board_version()]
+
+	_refresh_controls()
+	_setup_section_icons()
+	_connect_signals()
 
 	# Scene-reentry run-killer family (sibling of #979): reached mid-run (dev-overlay jump,
 	# or any future nav) with the run still live and unfinished in the GameManager autoload.
@@ -53,40 +95,53 @@ func _ready():
 	if back_button != null and _live_run_active():
 		back_button.text = "[BACK TO GAME]"
 
-	# Add icons to section headers
-	_setup_section_icons()
 
-	# Add the global-leaderboard opt-out under Gameplay (built in code, not the .tscn)
-	_add_global_leaderboard_toggle()
-	# Add the anonymous launch-ping opt-out right below it (#799)
-	_add_launch_ping_toggle()
+func _connect_signals():
+	# Duplicated controls share one handler each; the hidden view is re-synced by
+	# _refresh_controls() on every view switch, never inside a handler.
+	fc_volume_slider.value_changed.connect(_on_master_volume_changed)
+	board_master_slider.value_changed.connect(_on_master_volume_changed)
+	fc_music_slider.value_changed.connect(_on_music_volume_changed)
+	board_music_slider.value_changed.connect(_on_music_volume_changed)
+	board_sfx_slider.value_changed.connect(_on_sfx_volume_changed)
+	fc_fullscreen_checkbox.toggled.connect(_on_fullscreen_toggled)
+	board_fullscreen_checkbox.toggled.connect(_on_fullscreen_toggled)
+	fc_hints_checkbox.toggled.connect(_on_show_hints_toggled)
+	board_hints_checkbox.toggled.connect(_on_show_hints_toggled)
+	fc_colorblind_checkbox.toggled.connect(_on_colorblind_toggled)
+	board_colorblind_checkbox.toggled.connect(_on_colorblind_toggled)
 
-	# Add the story-intro toggle under Gameplay (built in code, not the .tscn)
-	_add_play_intros_toggle()
-	# Add the "Show gameplay hints" onboarding toggle under Gameplay (issue #720)
-	_add_show_hints_toggle()
-
-	# Add the experimental A/B UI layout toggle under UI (built in code, not the .tscn)
-	_add_ui_layout_toggle()
-
-	# Connect theme dropdown
+	board_intros_checkbox.toggled.connect(_on_play_intros_toggled)
+	board_rivals_checkbox.toggled.connect(_on_rivals_feed_toggled)
+	board_ui_layout_checkbox.toggled.connect(_on_ui_layout_toggled)
+	board_leaderboard_checkbox.toggled.connect(_on_global_leaderboard_toggled)
+	board_launch_ping_checkbox.toggled.connect(_on_launch_ping_toggled)
 	theme_dropdown.item_selected.connect(_on_theme_changed)
 
-	# Set current theme
-	var themes = ThemeManager.get_available_themes()
-	for i in range(themes.size()):
-		if themes[i] == ThemeManager.current_theme:
-			theme_dropdown.selected = i
-			break
+	# Research Intensity: issue #1084 owns this row's write path (the #1058 league-lock
+	# contradiction). _on_difficulty_changed is kept byte-identical to the pre-rebuild
+	# handler on purpose; only the debounced save is attached as a SEPARATE connection
+	# so the rebuild does not alter what the handler itself does.
+	difficulty_option.item_selected.connect(_on_difficulty_changed)
+	difficulty_option.item_selected.connect(func(_index: int): _schedule_save())
+
+	all_protocols_button.pressed.connect(_show_board)
+	front_card_button.pressed.connect(_show_front_card)
+	fc_keybindings_button.pressed.connect(_open_keybindings)
+	board_keybindings_button.pressed.connect(_open_keybindings)
+	back_button.pressed.connect(_on_back_pressed)
+
 
 func _setup_section_icons():
-	"""Add icons to settings section headers"""
-	_add_icon_to_label(audio_label, IconLoader.get_settings_icon("audio"))
-	_add_icon_to_label(graphics_label, IconLoader.get_settings_icon("graphics"))
-	_add_icon_to_label(gameplay_label, IconLoader.get_settings_icon("gameplay"))
-	_add_icon_to_label(ui_label, IconLoader.get_settings_icon("theme"))
-	_add_icon_to_label(accessibility_label, IconLoader.get_settings_icon("accessibility"))
-	_add_icon_to_label(keyboard_label, IconLoader.get_settings_icon("controls"))
+	"""Add icons to the board's section headers (same IconLoader set the old
+	single-column screen used; DISCLOSURE has no matching icon and stays bare)."""
+	_add_icon_to_label($Board/BoardVBox/Columns/Col1/AudioHeader, IconLoader.get_settings_icon("audio"))
+	_add_icon_to_label($Board/BoardVBox/Columns/Col1/DisplayHeader, IconLoader.get_settings_icon("graphics"))
+	_add_icon_to_label($Board/BoardVBox/Columns/Col2/OperationsHeader, IconLoader.get_settings_icon("gameplay"))
+	_add_icon_to_label($Board/BoardVBox/Columns/Col2/InterfaceHeader, IconLoader.get_settings_icon("theme"))
+	_add_icon_to_label($Board/BoardVBox/Columns/Col2/AccessHeader, IconLoader.get_settings_icon("accessibility"))
+	_add_icon_to_label($Board/BoardVBox/Columns/Col3/ControlsHeader, IconLoader.get_settings_icon("controls"))
+
 
 func _add_icon_to_label(label: Label, icon: Texture2D):
 	"""Replace a label with an HBox containing icon + label"""
@@ -96,11 +151,9 @@ func _add_icon_to_label(label: Label, icon: Texture2D):
 	var parent = label.get_parent()
 	var index = label.get_index()
 
-	# Create container
 	var hbox = HBoxContainer.new()
 	hbox.add_theme_constant_override("separation", 8)
 
-	# Create icon
 	var icon_rect = TextureRect.new()
 	icon_rect.texture = icon
 	icon_rect.custom_minimum_size = Vector2(24, 24)
@@ -108,209 +161,216 @@ func _add_icon_to_label(label: Label, icon: Texture2D):
 	icon_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	hbox.add_child(icon_rect)
 
-	# Clone label properties to new label
 	var new_label = Label.new()
 	new_label.text = label.text
 	new_label.add_theme_color_override("font_color", label.get_theme_color("font_color"))
 	new_label.add_theme_font_size_override("font_size", label.get_theme_font_size("font_size"))
 	hbox.add_child(new_label)
 
-	# Replace in parent
 	parent.remove_child(label)
 	parent.add_child(hbox)
 	parent.move_child(hbox, index)
 	label.queue_free()
 
-func update_ui_from_game_config():
-	"""Update all UI elements to reflect GameConfig settings"""
-	master_volume_slider.value = GameConfig.master_volume
-	master_volume_label.text = "%d%%" % GameConfig.master_volume
 
-	sfx_volume_slider.value = GameConfig.sfx_volume
-	sfx_volume_label.text = "%d%%" % GameConfig.sfx_volume
+## Re-read every control from GameConfig / ThemeManager. Uses the no-signal
+## setters: this is a display sync, not a player change -- it must not mark the
+## config dirty or re-fire handlers.
+func _refresh_controls():
+	fc_volume_slider.set_value_no_signal(GameConfig.master_volume)
+	board_master_slider.set_value_no_signal(GameConfig.master_volume)
+	fc_volume_label.text = "%d%%" % GameConfig.master_volume
+	board_master_label.text = "%d%%" % GameConfig.master_volume
 
-	music_volume_slider.value = GameConfig.music_volume
-	music_volume_label.text = "%d%%" % GameConfig.music_volume
+	board_sfx_slider.set_value_no_signal(GameConfig.sfx_volume)
+	board_sfx_label.text = "%d%%" % GameConfig.sfx_volume
 
-	fullscreen_checkbox.button_pressed = GameConfig.fullscreen
+	fc_music_slider.set_value_no_signal(GameConfig.music_volume)
+	board_music_slider.set_value_no_signal(GameConfig.music_volume)
+	fc_music_label.text = "%d%%" % GameConfig.music_volume
+	board_music_label.text = "%d%%" % GameConfig.music_volume
+
+	fc_fullscreen_checkbox.set_pressed_no_signal(GameConfig.fullscreen)
+	board_fullscreen_checkbox.set_pressed_no_signal(GameConfig.fullscreen)
+	fc_hints_checkbox.set_pressed_no_signal(GameConfig.show_hints)
+	board_hints_checkbox.set_pressed_no_signal(GameConfig.show_hints)
+	fc_colorblind_checkbox.set_pressed_no_signal(GameConfig.colorblind_mode)
+	board_colorblind_checkbox.set_pressed_no_signal(GameConfig.colorblind_mode)
+
+	board_intros_checkbox.set_pressed_no_signal(GameConfig.play_intros)
+	board_rivals_checkbox.set_pressed_no_signal(GameConfig.show_rivals_feed)
+	board_ui_layout_checkbox.set_pressed_no_signal(GameConfig.ui_layout == "proposed")
+	# Identity consent renders its EFFECTIVE state: un-consented (never asked) shows
+	# OFF even if a legacy config persisted submit_scores_global=true from the old
+	# default-ON era (privacy ruling 2026-07-26).
+	board_leaderboard_checkbox.set_pressed_no_signal(
+		GameConfig.submit_scores_global and GameConfig.leaderboard_consent_asked)
+	board_launch_ping_checkbox.set_pressed_no_signal(GameConfig.send_launch_ping)
+
 	difficulty_option.selected = GameConfig.difficulty
-	colorblind_checkbox.button_pressed = GameConfig.colorblind_mode
+
+	var themes = ThemeManager.get_available_themes()
+	for i in range(themes.size()):
+		if themes[i] == ThemeManager.current_theme:
+			theme_dropdown.selected = i
+			break
+
+
+# --- View switching (the Direction 5 door onto the Direction 1 board) ---
+
+func _show_board():
+	_refresh_controls()
+	front_card.visible = false
+	board.visible = true
+
+
+func _show_front_card():
+	_refresh_controls()
+	board.visible = false
+	front_card.visible = true
+
+
+# --- Debounced autosave (replaces the Apply button) ---
+
+func _schedule_save():
+	_dirty = true
+	_set_saved_text("saving...")
+	_save_timer.start()  # restarts if already running -- coalesces a slider drag
+
+
+func _on_save_timer_timeout():
+	if not _dirty:
+		return
+	GameConfig.save_config()
+	_dirty = false
+	_set_saved_text("[OK] saved")
+
+
+## Write immediately if anything is pending. Called on every exit path so a
+## change can never be lost to navigation -- the failure the Apply button caused.
+func _flush_save():
+	if not _dirty:
+		return
+	_save_timer.stop()
+	GameConfig.save_config()
+	_dirty = false
+	_set_saved_text("[OK] saved")
+
+
+func _exit_tree():
+	# Backstop for exits that bypass _on_back_pressed (scene swaps, quit).
+	_flush_save()
+
+
+func _set_saved_text(status_text: String):
+	if fc_saved_label != null:
+		fc_saved_label.text = status_text
+	if board_saved_label != null:
+		board_saved_label.text = status_text
+
+
+# --- Handlers (apply live via GameConfig, then schedule the save) ---
 
 func _on_master_volume_changed(value: float):
-	"""Handle master volume slider change"""
-	master_volume_label.text = "%d%%" % int(value)
-	# Update GameConfig (will apply to audio bus automatically)
+	fc_volume_label.text = "%d%%" % int(value)
+	board_master_label.text = "%d%%" % int(value)
 	GameConfig.set_setting("master_volume", int(value), false)
+	_schedule_save()
+
 
 func _on_sfx_volume_changed(value: float):
-	"""Handle SFX volume slider change"""
-	sfx_volume_label.text = "%d%%" % int(value)
-	# Update GameConfig (will apply when SFX bus is implemented)
+	board_sfx_label.text = "%d%%" % int(value)
 	GameConfig.set_setting("sfx_volume", int(value), false)
+	_schedule_save()
+
 
 func _on_music_volume_changed(value: float):
-	"""Handle Music volume slider change"""
-	music_volume_label.text = "%d%%" % int(value)
-	# Update GameConfig (will apply to Music bus automatically)
+	fc_music_label.text = "%d%%" % int(value)
+	board_music_label.text = "%d%%" % int(value)
 	GameConfig.set_setting("music_volume", int(value), false)
+	_schedule_save()
+
 
 func _on_fullscreen_toggled(pressed: bool):
-	"""Handle fullscreen checkbox toggle"""
 	print("[SettingsMenu] Fullscreen: ", pressed)
 	GameConfig.set_setting("fullscreen", pressed, false)
+	_schedule_save()
+
 
 func _on_difficulty_changed(index: int):
 	"""Handle difficulty dropdown change"""
 	print("[SettingsMenu] Difficulty changed to: ", ["Easy", "Standard", "Hard"][index])
 	GameConfig.set_setting("difficulty", index, false)
 
-func _add_global_leaderboard_toggle():
-	"""Append the global-leaderboard IDENTITY-CONSENT toggle to the Gameplay section
-	(privacy ruling 2026-07-26). Submitting shares player + lab name + score, so it
-	is an explicit opt-in: shown OFF until the player has actually made the choice
-	(consent_asked), and flipping the toggle here COUNTS as that explicit choice.
-	LeaderboardSync.should_submit reads both flags. Reversible any time."""
-	var gameplay = get_node_or_null("VBox/Scroll/SettingsContainer/GameplaySettings")
-	if gameplay == null:
-		return
-	var row = HBoxContainer.new()
-	var label = Label.new()
-	label.text = "Submit scores to global leaderboard (shares player + lab name)"
-	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	row.add_child(label)
-	global_leaderboard_checkbox = CheckButton.new()
-	# Display the EFFECTIVE state: un-consented (never asked) renders OFF even if a
-	# legacy config persisted submit_scores_global=true from the old default-ON era.
-	global_leaderboard_checkbox.button_pressed = (
-		GameConfig.submit_scores_global and GameConfig.leaderboard_consent_asked
-	)
-	global_leaderboard_checkbox.toggled.connect(_on_global_leaderboard_toggled)
-	row.add_child(global_leaderboard_checkbox)
-	gameplay.add_child(row)
-
-func _on_global_leaderboard_toggled(pressed: bool):
-	"""Identity-consent toggle: flipping it IS the explicit one-time choice, so it
-	also marks consent as asked (no game-over prompt afterwards)."""
-	print("[SettingsMenu] Submit scores to global leaderboard: ", pressed)
-	GameConfig.leaderboard_consent_asked = true
-	GameConfig.set_setting("submit_scores_global", pressed, false)
-	NotificationManager.info("Global leaderboard submission " + ("enabled" if pressed else "disabled"))
-
-func _add_launch_ping_toggle():
-	"""Append the 'Anonymous launch ping' opt-out under Gameplay (#799).
-	Honestly labelled: one event on boot with a random install UUID + version + OS,
-	nothing else (UpdateCheck.build_ping_body is the whitelist). Default ON.
-	DECOUPLED from the leaderboard toggle above (coordinator ruling 2026-07-26,
-	flagged in PR #942 for Pip's veto): that toggle now means IDENTITY consent,
-	and the ping carries no identity, so only THIS toggle gates it
-	(UpdateCheck.should_send_ping). The update CHECK is separate again and
-	carries no identifiers at all, so it sits behind no toggle."""
-	var gameplay = get_node_or_null("VBox/Scroll/SettingsContainer/GameplaySettings")
-	if gameplay == null:
-		return
-	var row = HBoxContainer.new()
-	var label = Label.new()
-	label.text = "Anonymous launch ping (counts installs; no personal data)"
-	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	row.add_child(label)
-	launch_ping_checkbox = CheckButton.new()
-	launch_ping_checkbox.button_pressed = GameConfig.send_launch_ping
-	launch_ping_checkbox.toggled.connect(_on_launch_ping_toggled)
-	row.add_child(launch_ping_checkbox)
-	gameplay.add_child(row)
-
-func _on_launch_ping_toggled(pressed: bool):
-	"""Handle the anonymous launch-ping opt-out toggle (#799)."""
-	print("[SettingsMenu] Anonymous launch ping: ", pressed)
-	GameConfig.set_setting("send_launch_ping", pressed, false)
-	NotificationManager.info("Anonymous launch ping " + ("enabled" if pressed else "disabled"))
-
-func _add_play_intros_toggle():
-	"""Append a 'Play story intros' toggle to the Gameplay section (#801). Reversible escape
-	hatch: hold-to-skip auto-flips play_intros off; this lets the player turn intros back on."""
-	var gameplay = get_node_or_null("VBox/Scroll/SettingsContainer/GameplaySettings")
-	if gameplay == null:
-		return
-	var row = HBoxContainer.new()
-	var label = Label.new()
-	label.text = "Play story intros"
-	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	row.add_child(label)
-	play_intros_checkbox = CheckButton.new()
-	play_intros_checkbox.button_pressed = GameConfig.play_intros
-	play_intros_checkbox.toggled.connect(_on_play_intros_toggled)
-	row.add_child(play_intros_checkbox)
-	gameplay.add_child(row)
-
-func _on_play_intros_toggled(pressed: bool):
-	"""Handle story-intro opt-in/out toggle"""
-	print("[SettingsMenu] Play story intros: ", pressed)
-	GameConfig.set_setting("play_intros", pressed, false)
-	NotificationManager.info("Story intros " + ("enabled" if pressed else "disabled"))
-
-var show_hints_checkbox: CheckButton = null
-
-func _add_show_hints_toggle():
-	"""Append a 'Show gameplay hints' toggle to the Gameplay section (issue #720).
-	Master switch for onboarding help surfaces (getting-started hint + first-launch
-	welcome overlay). Respects the player's choice (GameConfig.show_hints). Default ON."""
-	var gameplay = get_node_or_null("VBox/Scroll/SettingsContainer/GameplaySettings")
-	if gameplay == null:
-		return
-	var row = HBoxContainer.new()
-	var label = Label.new()
-	label.text = "Show gameplay hints"
-	label.tooltip_text = "Show onboarding help: the getting-started hint and the first-launch welcome overlay."
-	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	row.add_child(label)
-	show_hints_checkbox = CheckButton.new()
-	show_hints_checkbox.button_pressed = GameConfig.show_hints
-	show_hints_checkbox.toggled.connect(_on_show_hints_toggled)
-	row.add_child(show_hints_checkbox)
-	gameplay.add_child(row)
 
 func _on_show_hints_toggled(pressed: bool):
-	"""Handle the show-gameplay-hints toggle (issue #720)."""
+	"""Master switch for onboarding help surfaces (issue #720)."""
 	print("[SettingsMenu] Show gameplay hints: ", pressed)
 	GameConfig.set_setting("show_hints", pressed, false)
 	NotificationManager.info("Gameplay hints " + ("enabled" if pressed else "disabled"))
+	_schedule_save()
 
-var ui_layout_checkbox: CheckButton = null
 
-func _add_ui_layout_toggle():
-	"""Append a 'Proposed UI layout (experimental)' toggle to the UI section. A/B scaffolding
-	(UI_PROPOSALS_2026-07-22): OFF = classic PLAN/WATCH; ON = the proposed grouped-hand + gantt +
-	reclaim assembly. Applies on the next game load; the in-game F9 hotkey flips it live."""
-	var ui_section = get_node_or_null("VBox/Scroll/SettingsContainer/UISettings")
-	if ui_section == null:
-		return
-	var row = HBoxContainer.new()
-	var label = Label.new()
-	label.text = "Proposed UI layout (experimental)"
-	label.tooltip_text = "A/B test: proposed PLAN/WATCH (grouped actions, operations gantt, reclaimed space). Applies on next game load."
-	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	row.add_child(label)
-	ui_layout_checkbox = CheckButton.new()
-	ui_layout_checkbox.button_pressed = (GameConfig.ui_layout == "proposed")
-	ui_layout_checkbox.toggled.connect(_on_ui_layout_toggled)
-	row.add_child(ui_layout_checkbox)
-	ui_section.add_child(row)
+func _on_colorblind_toggled(pressed: bool):
+	print("[SettingsMenu] Colorblind mode: ", pressed)
+	GameConfig.set_setting("colorblind_mode", pressed, false)
+	NotificationManager.info("Colorblind mode " + ("enabled" if pressed else "disabled"))
+	_schedule_save()
+
+
+func _on_play_intros_toggled(pressed: bool):
+	"""Reversible escape hatch (#801): hold-to-skip auto-flips play_intros off;
+	this toggle turns intros back on."""
+	print("[SettingsMenu] Play story intros: ", pressed)
+	GameConfig.set_setting("play_intros", pressed, false)
+	NotificationManager.info("Story intros " + ("enabled" if pressed else "disabled"))
+	_schedule_save()
+
+
+func _on_rivals_feed_toggled(pressed: bool):
+	"""Rival-intel lines in the WATCH feed. The WATCH screen's own filter button is
+	the other UI for the same persisted preference (GameConfig.show_rivals_feed);
+	a live run picks a change here up on its next feed rebuild, not instantly."""
+	print("[SettingsMenu] Rival intel feed: ", pressed)
+	GameConfig.set_setting("show_rivals_feed", pressed, false)
+	NotificationManager.info("Rival intel feed " + ("shown" if pressed else "hidden"))
+	_schedule_save()
+
 
 func _on_ui_layout_toggled(pressed: bool):
-	"""Handle the proposed-UI-layout toggle."""
+	"""A/B scaffolding (UI_PROPOSALS_2026-07-22): OFF = classic PLAN/WATCH; ON = the
+	proposed grouped-hand + gantt + reclaim assembly. Applies on next game load."""
 	var layout = "proposed" if pressed else "classic"
 	print("[SettingsMenu] UI layout: ", layout)
 	GameConfig.set_setting("ui_layout", layout, false)
 	NotificationManager.info("Proposed UI layout " + ("enabled" if pressed else "disabled") + " (applies on next game load)")
+	_schedule_save()
 
-func _on_colorblind_toggled(pressed: bool):
-	"""Handle colorblind mode toggle"""
-	print("[SettingsMenu] Colorblind mode: ", pressed)
-	GameConfig.set_setting("colorblind_mode", pressed, false)
-	NotificationManager.info("Colorblind mode " + ("enabled" if pressed else "disabled"))
+
+func _on_global_leaderboard_toggled(pressed: bool):
+	"""Identity-consent toggle (privacy ruling 2026-07-26): flipping it IS the explicit
+	one-time choice, so it also marks consent as asked (no game-over prompt afterwards).
+	LeaderboardSync.should_submit reads both flags. Reversible any time."""
+	print("[SettingsMenu] Submit scores to global leaderboard: ", pressed)
+	GameConfig.leaderboard_consent_asked = true
+	GameConfig.set_setting("submit_scores_global", pressed, false)
+	NotificationManager.info("Global leaderboard submission " + ("enabled" if pressed else "disabled"))
+	_schedule_save()
+
+
+func _on_launch_ping_toggled(pressed: bool):
+	"""Anonymous launch-ping opt-out (#799). DECOUPLED from the identity toggle above
+	(coordinator ruling 2026-07-26): the ping carries no identity, so only this toggle
+	gates it (UpdateCheck.should_send_ping)."""
+	print("[SettingsMenu] Anonymous launch ping: ", pressed)
+	GameConfig.set_setting("send_launch_ping", pressed, false)
+	NotificationManager.info("Anonymous launch ping " + ("enabled" if pressed else "disabled"))
+	_schedule_save()
+
 
 func _on_theme_changed(index: int):
-	"""Handle theme dropdown change"""
+	"""ThemeManager persists to its own cfg file inside apply_theme(), so no
+	debounced save is scheduled here -- GameConfig does not own this value."""
 	var themes = ThemeManager.get_available_themes()
 	if index < themes.size():
 		var theme_name = themes[index]
@@ -318,19 +378,19 @@ func _on_theme_changed(index: int):
 		ThemeManager.apply_theme(theme_name)
 		NotificationManager.info("Theme changed to " + ThemeManager.themes[theme_name].display_name)
 
-func _on_apply_pressed():
-	"""Handle Apply button press - save all settings"""
-	print("[SettingsMenu] Saving settings to disk...")
-	GameConfig.save_config()
-	print("[SettingsMenu] Settings saved successfully!")
 
-	# Show confirmation feedback
-	NotificationManager.success("Settings saved successfully!")
+# --- Navigation ---
+
+func _open_keybindings():
+	"""The real keybind editor (profiles + rebinding). Replaces the old static
+	shortcuts grid, which advertised [F5] Quick save / [F9] Quick load -- neither
+	binding exists; the grid was stale text posing as documentation."""
+	_flush_save()
+	SceneTransition.go_to(KEYBIND_SCENE)
+
 
 func _on_back_pressed():
-	"""Handle Back button press"""
-	# Ask if user wants to save unsaved changes
-	# For now, just return (changes are applied in real-time anyway)
+	_flush_save()
 
 	if _live_run_active():
 		# Scene-reentry run-killer family (sibling of #979): a live, unfinished run is
@@ -350,8 +410,12 @@ func _live_run_active() -> bool:
 	"""True when a real, unfinished run is sitting live in the GameManager autoload."""
 	return GameManager.is_initialized and GameManager.state != null and not GameManager.state.game_over
 
+
 func _input(event: InputEvent):
-	"""Handle keyboard shortcuts"""
+	"""ESC walks back out the way the player came in: board -> front card -> leave."""
 	if event is InputEventKey and event.pressed and not event.echo:
 		if event.keycode == KEY_ESCAPE:
-			_on_back_pressed()
+			if board.visible:
+				_show_front_card()
+			else:
+				_on_back_pressed()

--- a/godot/tests/unit/test_audio_defaults_and_settings_layout.gd
+++ b/godot/tests/unit/test_audio_defaults_and_settings_layout.gd
@@ -103,64 +103,155 @@ func test_every_tier_bed_still_resolves():
 				"tier %d stem missing: %s" % [tier, stem["path"]])
 
 ## ---- 3. The settings screen ----
+##
+## Rebuilt 2026-08-02 per Pip's ruling (#1096): Direction 5 front card (the five
+## first-five-minutes controls) + Direction 1 operations board behind the
+## ">> ALL PROTOCOLS" door. The old single scrolling column is gone, so the old
+## fold-geometry assertions are restated against the new structure: the INTENT
+## each test guards is unchanged and named in its comment.
 
 func _build_settings_menu() -> Control:
 	var menu: Control = load(SETTINGS_MENU_SCENE).instantiate()
 	add_child_autofree(menu)
 	return menu
 
-func test_graphics_section_rows_are_visible_without_scrolling():
-	# THE DEFECT. VBox is anchor-centred with fixed +-400/+-300 offsets, so it is
-	# 800x600 at any window size and this measurement is screen-independent.
-	# Scroll and Spacer both carried size_flags_vertical = 3, so they split the
-	# leftover height evenly and the scroll viewport came out near 179 px -- just
-	# enough for the three audio sliders and the "Graphics Settings" header, and
-	# nothing else. Collapsing the (unused) Spacer hands that space back.
+func test_front_card_is_the_default_view():
+	# Direction 5's bet: a drive-by adjuster lands on five controls, not a wall.
 	var menu := _build_settings_menu()
+	await get_tree().process_frame
+	assert_true((menu.get_node("FrontCard") as Control).visible,
+		"the front card is the default view")
+	assert_false((menu.get_node("Board") as Control).visible,
+		"the operations board opens only through the ALL PROTOCOLS door")
+
+func test_nothing_can_hide_below_a_fold():
+	# THE ORIGINAL DEFECT, restated. Six shipped sections spent weeks invisible
+	# below the fold of a half-starved ScrollContainer. The rebuild's answer is
+	# structural: no scroll region exists anywhere in the scene, so there is no
+	# fold for a control to hide behind.
+	var menu := _build_settings_menu()
+	assert_null(_find_scroll(menu),
+		"no ScrollContainer in settings -- nothing scrolls, nothing hides")
+
+func _find_scroll(node: Node) -> Node:
+	if node is ScrollContainer:
+		return node
+	for child in node.get_children():
+		var hit := _find_scroll(child)
+		if hit != null:
+			return hit
+	return null
+
+func test_front_card_serves_the_five_first_minute_intents():
+	# Volume, music, fullscreen, hints, colorblind: the five intents nearly every
+	# early settings visit is one of (SETTINGS_MENU_OPTIONS.md, Direction 5).
+	var menu := _build_settings_menu()
+	var card := "FrontCard/Card/Margin/CardVBox"
+	for row in ["VolumeRow", "MusicRow", "FullscreenRow", "HintsRow", "ColorblindRow"]:
+		assert_not_null(menu.get_node_or_null(card + "/" + row),
+			"front card must carry %s" % row)
+	assert_not_null(menu.get_node_or_null(card + "/AllProtocolsButton"),
+		"the one door to everything else must exist")
+
+func test_board_carries_the_full_inventory():
+	# Direction 1's promise: EVERY remaining control visible at once on the board,
+	# so a privacy sweep or a settings audit is one glance, zero navigation.
+	var menu := _build_settings_menu()
+	var expectations := {
+		"Board/BoardVBox/Columns/Col1/MasterSlider": "master volume",
+		"Board/BoardVBox/Columns/Col1/SFXSlider": "sfx volume",
+		"Board/BoardVBox/Columns/Col1/MusicSlider": "music volume",
+		"Board/BoardVBox/Columns/Col1/FullscreenRow": "fullscreen",
+		"Board/BoardVBox/Columns/Col2/IntrosRow": "story intros",
+		"Board/BoardVBox/Columns/Col2/HintsRow": "gameplay hints",
+		"Board/BoardVBox/Columns/Col2/RivalsRow": "rival intel feed (new: was WATCH-screen-only)",
+		"Board/BoardVBox/Columns/Col2/DifficultyRow": "research intensity (write path owned by #1084)",
+		"Board/BoardVBox/Columns/Col2/ThemeRow": "visual theme",
+		"Board/BoardVBox/Columns/Col2/UILayoutRow": "UI layout A/B",
+		"Board/BoardVBox/Columns/Col2/ColorblindRow": "colorblind mode",
+		"Board/BoardVBox/Columns/Col3/LeaderboardRow": "leaderboard identity consent",
+		"Board/BoardVBox/Columns/Col3/LaunchPingRow": "anonymous launch ping",
+		"Board/BoardVBox/Columns/Col3/KeybindingsButton": "keybindings jump-off",
+	}
+	for path in expectations:
+		assert_not_null(menu.get_node_or_null(path),
+			"board must show %s (%s)" % [expectations[path], path])
+
+func test_board_fits_the_frame_without_overflow():
+	# The no-scroll bet only holds if the board actually FITS. Geometry check at
+	# the design viewport; smaller test windows can't judge this fairly, so they
+	# skip loudly instead of passing vacuously.
+	var menu := _build_settings_menu()
+	menu.call("_show_board")
 	await get_tree().process_frame
 	await get_tree().process_frame
 
-	var scroll: ScrollContainer = menu.get_node("VBox/Scroll")
-	var section := "VBox/Scroll/SettingsContainer/GraphicsSettings"
-	var header: Node = menu.get_node(section)
-	assert_not_null(header, "Graphics section must exist")
+	var vp := menu.get_viewport_rect()
+	if vp.size.x < 1280 or vp.size.y < 720:
+		pass_test("viewport %s too small to judge the 1080p board layout" % vp.size)
+		return
 
-	var row: Control = menu.get_node(section + "/FullscreenRow")
-	assert_true(scroll.get_global_rect().encloses(row.get_global_rect()),
-		"Fullscreen row must be inside the scroll viewport (scroll=%s row=%s)" % [
-			scroll.get_global_rect(), row.get_global_rect()])
-
-func test_graphics_section_is_not_an_empty_header():
-	# Stated separately from the geometry so the intent survives a future
-	# relayout: whatever the rects end up being, the section must have content.
-	var menu := _build_settings_menu()
-	await get_tree().process_frame
-	var section: Node = menu.get_node("VBox/Scroll/SettingsContainer/GraphicsSettings")
-	var rows := 0
-	for child in section.get_children():
-		if child is HBoxContainer:
-			rows += 1
-	assert_gt(rows, 0, "a section header with no rows under it is worse than no section")
-
-func test_scrollbar_is_always_visible():
-	# The list is longer than the viewport even after the fix, and it always will
-	# be. SHOW_ALWAYS (2) is the affordance that says so; on AUTO the dark-theme
-	# bar is easy to miss, which is half of why the cut-off section read as empty.
-	var menu := _build_settings_menu()
-	var scroll: ScrollContainer = menu.get_node("VBox/Scroll")
-	assert_eq(scroll.vertical_scroll_mode, ScrollContainer.SCROLL_MODE_SHOW_ALWAYS,
-		"settings list must advertise that it scrolls")
+	var board: Control = menu.get_node("Board")
+	for path in ["Board/BoardVBox/Columns/Col1/FullscreenRow",
+			"Board/BoardVBox/Columns/Col3/KeybindingsButton",
+			"Board/BoardVBox/FooterRow"]:
+		var row: Control = menu.get_node(path)
+		assert_true(board.get_global_rect().encloses(row.get_global_rect()),
+			"%s must sit inside the board frame (board=%s row=%s)" % [
+				path, board.get_global_rect(), row.get_global_rect()])
 
 func test_no_dead_graphics_quality_control():
 	# GameConfig.graphics_quality is still declared and still persists, but
 	# apply_graphics_settings() carries a TODO and does nothing with it. A
 	# Low/Medium/High dropdown wired to that is a control that lies. Guard both
-	# halves: the row is gone, and the handler that fed it is gone.
+	# halves: no such row anywhere in either view, and no handler to feed one.
 	var menu := _build_settings_menu()
-	assert_null(menu.get_node_or_null("VBox/Scroll/SettingsContainer/GraphicsSettings/QualityRow"),
+	assert_null(menu.find_child("QualityRow", true, false),
 		"do not re-add a quality dropdown until apply_graphics_settings() honours it")
 	assert_false(menu.has_method("_on_graphics_quality_changed"),
 		"handler for a control that does nothing must not linger")
+
+func test_apply_button_is_dead_and_autosave_replaces_it():
+	# The old model applied every change live but persisted only on Apply, so
+	# Back-without-Apply silently reverted on next launch -- settings that "worked"
+	# until the player restarted. The rebuild's rule: no Apply button anywhere,
+	# a debounced save on change, and a flush on every exit path.
+	var menu := _build_settings_menu()
+	await get_tree().process_frame
+	assert_null(menu.find_child("ApplyButton", true, false),
+		"there is no Apply button; saving is not the player's job")
+	assert_false(menu.has_method("_on_apply_pressed"), "Apply handler must be gone")
+
+	var src := FileAccess.get_file_as_string(SETTINGS_MENU_SCRIPT)
+	assert_string_contains(src, "func _exit_tree():",
+		"an exit backstop must exist so navigation can never discard changes")
+	assert_string_contains(src, "_flush_save()",
+		"exits must flush the debounced save")
+
+	# Mechanism check without touching any real setting value: scheduling arms
+	# the timer and marks dirty; disarm afterwards so autofree cannot write the
+	# machine's real user://config.cfg from a test.
+	menu.call("_schedule_save")
+	assert_true(bool(menu.get("_dirty")), "a change must mark the config dirty")
+	var timer: Timer = menu.get("_save_timer")
+	assert_false(timer.is_stopped(), "a change must arm the debounced save timer")
+	timer.stop()
+	menu.set("_dirty", false)
+
+func test_stale_shortcuts_grid_is_gone():
+	# The static grid advertised [F5] Quick save / [F9] Quick load; no F5 binding
+	# exists and F9 is a debug-only layout flip. Stale text posing as documentation
+	# -- the silent-wrongness flavour league week taught us to fear. The real,
+	# self-maintaining keybind screen is linked from BOTH views instead.
+	var menu := _build_settings_menu()
+	assert_null(menu.find_child("ShortcutsGrid", true, false),
+		"the hand-maintained shortcuts grid must stay dead (it drifted from reality)")
+	assert_null(menu.find_child("KeyboardShortcuts", true, false),
+		"no static keyboard-reference section; the keybind screen is the truth")
+	assert_not_null(menu.get_node_or_null("FrontCard/Card/Margin/CardVBox/KeybindingsButton"),
+		"front card must link the real keybind screen")
+	assert_not_null(menu.get_node_or_null("Board/BoardVBox/Columns/Col3/KeybindingsButton"),
+		"board must link the real keybind screen")
 
 func test_fullscreen_toggle_is_wired_to_something_real():
 	# The row that survived has to actually work. GameConfig.apply_graphics_settings()


### PR DESCRIPTION
## The failure that earned this

The settings screen Pip called "pretty amateur" (2026-08-01 playtest) carried three
instances of silent wrongness:

1. **Apply was a data-loss trap.** Every control applied live but persisted only on
   Apply, so Back-without-Apply silently reverted everything on next launch. The
   standard player mental model ("it changed, so it's saved") lost data here.
2. **The Keyboard Shortcuts grid was stale.** It advertised `[F5] Quick save` /
   `[F9] Quick load`; no F5 binding exists anywhere and F9 is a debug-only layout
   flip. Hand-copied documentation drifting from reality.
3. **The layout shape that hid six shipped sections below a scroll fold** (defused by
   PR #1095) was still the screen's architecture.

## What this builds

Pip's ruling (memo #1096, `docs/SPOKEN_RULINGS_2026-08-02_playtest-and-cards.md`
section 4): **"settings directions 1 and 5 proceed, diegetic deferred until a designer
is hired."** Spec: `docs/design/SETTINGS_MENU_OPTIONS.md`.

Directions 5 and 1 are built as **one scene with a deliberate relationship** -- 5 is the
front, 1 is what sits behind the door:

- **FRONT CARD (Direction 5)** -- default view. Volume, music, fullscreen, gameplay
  hints, colorblind: the five intents nearly every early settings visit is one of, on a
  small centered card. One door: `>> ALL PROTOCOLS` (captioned "sound detail, display,
  privacy, intros, rival feed, experiments"), plus `>> KEYBINDINGS`.
- **OPERATIONS BOARD (Direction 1)** -- behind the door, same scene (a visibility
  toggle, no scene navigation). Every remaining control on one dense three-column
  board grouped by the player's question: Col 1 my machine (AUDIO, DISPLAY), Col 2 my
  game (OPERATIONS, INTERFACE, ACCESS), Col 3 my data + my hands (DISCLOSURE, CONTROLS).
  Header strip carries version + board epoch; **no ScrollContainer exists anywhere in
  the scene**, so no control can ever hide below a fold again. DISCLOSURE gives the
  privacy pair (identity consent, launch ping) their own header and honest sentences
  instead of burying them under "Gameplay". ESC walks back out the way you came:
  board -> front card -> leave.

The duplicated controls (the front-card five also appear on the board, which must stay
a complete audit surface) share one handler each and are re-read from GameConfig on
every view switch.

## Apply: killed, replaced with persist-on-change

Chose **persist-on-change** (0.75s debounced save + flush on every exit path,
`_exit_tree` backstop) over "make Back explicit about discarding" because a discard
dialog keeps the trap open for ESC/alt-F4/window-close exits and adds a modal nobody
reads. Both views state the rule on screen: "changes save automatically", flipping to
"[OK] saved" after a write. The debounce coalesces a slider drag into one disk write.

## Also in here

- **Stale shortcuts grid DELETED**; both views link the real keybind screen
  (profiles + rebinding -- self-maintaining, cannot drift).
- **New board row: "Rival intel in the WATCH feed"** (`show_rivals_feed`) -- a
  persisted preference that previously had UI only on the WATCH screen filter button.
  Adds the missing `set_setting` case in `game_config.gd`. Known seam: a change made
  here mid-run applies on the next feed rebuild, not instantly (nothing listens to
  `config_changed`; the settings screen is normally reached from welcome, so this is
  theoretical outside the dev-overlay jump).
- Live-run reentry guard preserved byte-for-byte (`[BACK TO GAME]` relabel,
  `pending_resume` routing).

## What this deliberately does NOT do

- **Does NOT reinstate the graphics-quality dropdown** (removed in #1095;
  `apply_graphics_settings()` still carries a TODO and reads nothing). A test guards
  against its return until it is wired.
- **Does NOT touch the difficulty write path.** MERGE-ORDER NOTE: the Research
  Intensity row MOVED into the board's OPERATIONS column, but `_on_difficulty_changed`
  is byte-identical to the pre-rebuild handler and the debounced save is attached as a
  separate signal connection. Issue #1084 (`feat/alpha-tools-and-difficulty-lock` lane)
  owns that row's behaviour; whichever lands second will conflict in
  `settings_menu.gd`/`settings_menu.tscn` and should keep #1084's semantics for the
  row. The spec's shared assumption was to remove the row entirely -- left for #1084
  to decide.
- **Does NOT build Direction 3** (diegetic lab floor) -- deferred by ruling until a
  designer is hired.
- **Does NOT put the common early settings on the pause screen** -- Pip's "great
  pickup" from the same capture is a different surface (the pause menu already has
  inline audio sliders); follow-up work.
- **Does NOT fix keybind_screen's Back**, which returns to welcome even when entered
  from settings -- pre-existing seam, worth a small follow-up (return-to-caller).

## Tests

Fast gate in the worktree: **1035 tests / 0 failures / 101 files** vs main baseline
**1031 / 0 / 101** (+4 net). Five old fold-geometry tests hardcoding the dead node
tree were replaced by nine guards restating the same intents against the new
structure: front card default + five intents present, full board inventory (14 named
controls), board fits its frame at the 1080p design viewport, no scroll region
anywhere, no quality control, Apply dead + autosave mechanism armed, stale grid dead.

**Honest limit: tests prove structure and wiring, not that the screen looks right.**
Column balance, card proportions, header icon rendering, and how the board reads at a
glance need Pip's eyes on a running build (preview worktree + `--import` pass per the
usual visual-pass flow).

## What needs Pip's eyes

1. The board's three-column balance and density at 1080p (and any window size he
   actually plays at -- the board is anchored full-rect, not fixed 800x600).
2. Front-card wording: "Volume" (master) vs "Music" split, and the ALL PROTOCOLS
   caption line.
3. Whether "saving... / [OK] saved" footer feedback is enough, or he wants the
   Direction-1 wireframe's "saved 3s ago" timestamp.
4. The persist-on-change ruling itself (vs explicit-discard Back) -- argued above,
   reversible in one function if he disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
