### PR TITLE
fix(art): unblock 605 approved assets -- promotion map, resolver, loud gate (#1093)

### DIFF
--- a/tests/test_art_promotion_pipeline.py
+++ b/tests/test_art_promotion_pipeline.py
@@ -1,0 +1,283 @@
+"""Tests for tools/art_review/apply_review.py -- destination map + resolver.
+
+Guards the promotion gate against the silent-wrongness failure family
+(issues #1027 / #1075 / #1093): an approved (keep) asset must either be
+promotable, or explicitly held, or FAIL LOUDLY -- never silently skipped.
+
+Pure logic: temp-dir fixtures for the resolver, live-tree invariants for the
+maps (a new art_generated/<category> batch with no destination mapping fails
+here at commit time, not at promote time).
+"""
+
+import importlib.util
+import io
+import shutil
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "tools" / "art_review" / "apply_review.py"
+
+_spec = importlib.util.spec_from_file_location("apply_review", MODULE_PATH)
+apply_review = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(apply_review)
+
+
+def _make_asset(asset_id, art_root, verdict="keep"):
+    return apply_review.Asset(asset_id, verdict, "", [], Path(art_root))
+
+
+class TestPxCategory(unittest.TestCase):
+    """_px_category: batch-dir overrides beat tokens beat the 'cat' fallback."""
+
+    def test_prefix_overrides(self):
+        cat = apply_review._px_category
+        self.assertEqual(cat("icon_hires/main_navigation/icon_menu_512"), "icon_hires")
+        # gen_cat_doom contains 'cat' but the batch dir pins it to icons.
+        self.assertEqual(cat("iconset_2026-07-21/gen_cat_doom_128"), "icons")
+        self.assertEqual(cat("settings_bg_2026-07-21/gen_bg_warm_ochre_512"), "backgrounds")
+        self.assertEqual(cat("cats_incoming/office_cat_base"), "cats")
+
+    def test_prop_family_tokens(self):
+        cat = apply_review._px_category
+        for seg in ("props", "objects", "chairs", "kitchen", "windows", "environment"):
+            self.assertEqual(cat(f"pixellab_2026-07-21-rerolls/{seg}/thing_1"), "props", seg)
+
+    def test_character_family_tokens(self):
+        cat = apply_review._px_category
+        self.assertEqual(
+            cat("pixellab_2026-07-19/characters/worker_x/rotations/east"), "characters"
+        )
+        self.assertEqual(cat("pixellab_2026-07-21-rerolls/founder/founder_back_1"), "characters")
+        self.assertEqual(cat("pixellab_2026-07-21-rerolls/cosmetics/hat_medium_1"), "characters")
+
+    def test_tilesets_cats_icons(self):
+        cat = apply_review._px_category
+        self.assertEqual(cat("pixellab_2026-07-19/tilesets/floor_1"), "tilesets")
+        self.assertEqual(cat("pixellab_2026-07-21-rerolls/cats/cat_purple_1"), "cats")
+        self.assertEqual(cat("pixellab_2026-07-17/reroll/icons/icon_1"), "icons")
+
+    def test_cat_fallback_and_batch_default(self):
+        cat = apply_review._px_category
+        self.assertEqual(cat("pixellab_2026-07-16/cat_walk_cat1/walk_east_0"), "cats")
+        # loose files at the 2026-07-16 batch root are character style probes.
+        self.assertEqual(cat("pixellab_2026-07-16/18-Hat-tall"), "characters")
+
+    def test_unknown_is_none(self):
+        self.assertIsNone(apply_review._px_category("mystery_batch/loose_file"))
+
+
+class TestDestMaps(unittest.TestCase):
+    """Map invariants -- these are what make regressions loud."""
+
+    def test_every_destination_is_under_godot_assets(self):
+        for cat, rule in {**apply_review.GEN_DEST, **apply_review.PX_DEST}.items():
+            if isinstance(rule, apply_review.Hold):
+                self.assertTrue(rule.reason, f"{cat}: Hold must carry a reason")
+                continue
+            dests = [rule] if isinstance(rule, str) else [d for _, d in rule]
+            for d in dests:
+                self.assertTrue(
+                    d.startswith("godot/assets/"), f"{cat}: {d} not under godot/assets/"
+                )
+
+    def test_every_art_generated_batch_on_disk_is_mapped(self):
+        """LIVE-TREE INVARIANT: a new art_generated/<category> dir with no
+        GEN_DEST entry fails here -- the gap surfaces at commit time."""
+        gen_root = REPO_ROOT / "art_generated"
+        self.assertTrue(gen_root.is_dir(), "art_generated/ missing from repo")
+        for d in sorted(p for p in gen_root.iterdir() if p.is_dir()):
+            self.assertIn(
+                d.name,
+                apply_review.GEN_DEST,
+                f"art_generated/{d.name} has no GEN_DEST mapping: add a destination "
+                "or an explicit Hold(reason) in tools/art_review/apply_review.py",
+            )
+
+    def test_px_dest_categories_cover_all_tokens(self):
+        for token, cat in apply_review.PX_TOKEN_CATEGORY.items():
+            self.assertIn(cat, apply_review.PX_DEST, f"token {token} -> unmapped {cat}")
+        for prefix, cat in apply_review.PX_PREFIX_CATEGORY.items():
+            self.assertIn(cat, apply_review.PX_DEST, f"prefix {prefix} -> unmapped {cat}")
+        for batch, cat in apply_review.PX_BATCH_DEFAULT_CATEGORY.items():
+            self.assertIn(cat, apply_review.PX_DEST, f"batch {batch} -> unmapped {cat}")
+
+    def test_icon_hires_is_explicitly_held(self):
+        """icon_hires is the issue #787 bloat class: promoting it must be an
+        explicit ruling, never a default."""
+        self.assertIsInstance(apply_review.PX_DEST["icon_hires"], apply_review.Hold)
+
+    def test_tilesets_destination_exists_in_game_tree(self):
+        """Guards the office_floor/tiles -> office_floor/tilesets fix: the
+        destination must be a dir the game actually uses."""
+        rel = apply_review.PX_DEST["tilesets"]
+        self.assertEqual(rel, "godot/assets/office_floor/tilesets")
+        self.assertTrue((REPO_ROOT / rel).is_dir(), f"{rel} does not exist")
+
+
+class TestGenDestRel(unittest.TestCase):
+    def test_round3_rerolls_split_routing(self):
+        f = apply_review._gen_dest_rel
+        self.assertEqual(
+            f("round3_rerolls", "dossier_fresh_grad_a"), "godot/assets/portraits/generated"
+        )
+        self.assertEqual(
+            f("round3_rerolls", "painterly_fresh_grad_a"), "godot/assets/portraits/generated"
+        )
+        self.assertEqual(f("round3_rerolls", "acquire_startup_r3"), "godot/assets/icons/generated")
+
+    def test_unknown_category_is_none(self):
+        self.assertIsNone(apply_review._gen_dest_rel("no_such_category", "x"))
+
+    def test_plain_categories_pass_through(self):
+        self.assertEqual(
+            apply_review._gen_dest_rel("ui_icons", "anything"), "godot/assets/icons/generated"
+        )
+
+
+class _TmpArtRoot(unittest.TestCase):
+    """Fixture: a throwaway art root with art_source/ + art_generated/."""
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="art_review_test_"))
+        self.addCleanup(shutil.rmtree, self.root, True)
+
+    def _write(self, rel, size=16):
+        p = self.root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "wb") as fh:
+            fh.write(b"\x89PNG")
+            fh.seek(size - 1)
+            fh.write(b"\x00")
+        return p
+
+
+class TestPxResolver(_TmpArtRoot):
+    def test_exact_file_relpath(self):
+        self._write("art_source/batch/props/desk_1.png")
+        a = _make_asset("px:batch/props/desk_1.png", self.root)
+        self.assertIsNone(a.error)
+        self.assertEqual(len(a.sources), 1)
+
+    def test_extensionless_relpath_resolves_to_png(self):
+        """The review app writes single-PNG relpaths WITHOUT .png -- the 550
+        'no file/dir at ...' skips of 2026-07/08 were exactly this."""
+        self._write("art_source/batch/props/desk_1.png")
+        a = _make_asset("px:batch/props/desk_1", self.root)
+        self.assertIsNone(a.error)
+        self.assertEqual(a.sources[0].name, "desk_1.png")
+
+    def test_rotation_dir_relpath(self):
+        self._write("art_source/batch/characters/worker/rotations/east.png")
+        self._write("art_source/batch/characters/worker/rotations/west.png")
+        a = _make_asset("px:batch/characters/worker/rotations", self.root)
+        self.assertIsNone(a.error)
+        self.assertEqual([s.name for s in a.sources], ["east.png", "west.png"])
+
+    def test_art_root_relative_form(self):
+        self._write("art_source/batch/props/desk_1.png")
+        a = _make_asset("px:art_source/batch/props/desk_1", self.root)
+        self.assertIsNone(a.error)
+
+    def test_missing_reports_every_candidate(self):
+        a = _make_asset("px:batch/props/ghost", self.root)
+        self.assertIsNotNone(a.error)
+        # precise failure: all four tried paths are named, no guessing.
+        self.assertEqual(a.error.count("ghost"), 4)
+        self.assertIn("ghost.png", a.error)
+
+    def test_px_dest_name_preserves_identity_subdirs(self):
+        """cat1/walk_east_0 and cat2/walk_east_0 are DIFFERENT assets -- the
+        destination must keep the distinguishing sub-path."""
+        p1 = self._write("art_source/pixellab_2026-07-16/cat_walk_cat1/walk_east_0.png")
+        p2 = self._write("art_source/pixellab_2026-07-16/cat_walk_cat2/walk_east_0.png")
+        a1 = _make_asset("px:pixellab_2026-07-16/cat_walk_cat1/walk_east_0", self.root)
+        a2 = _make_asset("px:pixellab_2026-07-16/cat_walk_cat2/walk_east_0", self.root)
+        self.assertEqual(a1.dest_name(p1), "cat_walk_cat1/walk_east_0.png")
+        self.assertEqual(a2.dest_name(p2), "cat_walk_cat2/walk_east_0.png")
+
+    def test_px_dest_name_strips_category_token_not_structure(self):
+        p = self._write("art_source/pixellab_2026-07-19/characters/worker_x/rotations/east.png")
+        a = _make_asset("px:pixellab_2026-07-19/characters/worker_x/rotations/east", self.root)
+        # 'characters' (the category token) is dropped; worker identity kept.
+        self.assertEqual(a.dest_name(p), "worker_x/rotations/east.png")
+
+
+class TestGenSizeCap(_TmpArtRoot):
+    def test_picks_largest_size_under_the_git_cap(self):
+        cap = apply_review.MAX_PROMOTE_BYTES
+        self._write("art_generated/ui_icons/v1/icon_x_v1_64.png", size=1024)
+        self._write("art_generated/ui_icons/v1/icon_x_v1_512.png", size=2048)
+        self._write("art_generated/ui_icons/v1/icon_x_v1_1024.png", size=cap + 1)
+        a = _make_asset("gen:ui_icons:icon_x:v1", self.root)
+        self.assertIsNone(a.error)
+        self.assertEqual(a.promote_file.name, "icon_x_v1_512.png")
+        self.assertEqual(a.best_file.name, "icon_x_v1_1024.png")
+        self.assertTrue(a.size_capped)
+        self.assertEqual(a.promotion_status()[0], "promotable")
+
+    def test_nothing_under_cap_is_blocked_not_silent(self):
+        cap = apply_review.MAX_PROMOTE_BYTES
+        self._write("art_generated/ui_icons/v1/icon_y_v1_1024.png", size=cap + 1)
+        a = _make_asset("gen:ui_icons:icon_y:v1", self.root)
+        self.assertEqual(a.promotion_status()[0], "blocked-size")
+
+
+class TestPromotionGate(_TmpArtRoot):
+    def test_unmapped_category_is_blocked_and_report_fails(self):
+        self._write("art_generated/new_batch_2099/v1/thing_v1_512.png")
+        a = _make_asset("gen:new_batch_2099:thing:v1", self.root)
+        self.assertEqual(a.promotion_status()[0], "blocked-unmapped")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = apply_review.action_report([a])
+        self.assertEqual(rc, 1, "report must exit nonzero when a keep is blocked")
+        self.assertIn("[FAIL]", buf.getvalue())
+
+    def test_unresolved_source_is_blocked(self):
+        a = _make_asset("px:batch/props/missing_thing", self.root)
+        self.assertEqual(a.promotion_status()[0], "blocked-unresolved")
+
+    def test_held_does_not_fail_the_gate(self):
+        self._write("art_source/icon_hires/guide/icon_help_512.png")
+        a = _make_asset("px:icon_hires/guide/icon_help_512", self.root)
+        self.assertEqual(a.promotion_status()[0], "held")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = apply_review.action_report([a])
+        self.assertEqual(rc, 0, "explicit Hold is a legitimate outcome, not a failure")
+
+    def test_both_variants_kept_is_contested_not_overwritten(self):
+        """v1 and v2 collapse onto one game filename (variant marker is
+        stripped) -- promoting both would let the last copy silently win."""
+        self._write("art_generated/ui_icons/v1/icon_z_v1_512.png")
+        self._write("art_generated/ui_icons/v1/icon_z_v2_512.png")
+        a1 = _make_asset("gen:ui_icons:icon_z:v1", self.root)
+        a2 = _make_asset("gen:ui_icons:icon_z:v2", self.root)
+        buckets, n_blocked, contested = apply_review._promotion_gate([a1, a2])
+        self.assertEqual(len(buckets["contested"]), 2)
+        self.assertEqual(len(buckets["promotable"]), 0)
+        self.assertEqual(len(contested), 1)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = apply_review.action_report([a1, a2])
+        self.assertEqual(rc, 1)
+
+    def test_clean_keep_promotes_and_dry_run_reports_bytes(self):
+        self._write("art_generated/ui_icons/v1/icon_ok_v1_512.png", size=4096)
+        a = _make_asset("gen:ui_icons:icon_ok:v1", self.root)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = apply_review.action_promote([a], dry_run=True)
+        out = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("would copy 1 file(s)", out)
+        self.assertIn("icon_ok_512.png", out)  # variant marker stripped
+        # dry-run must not create anything.
+        self.assertFalse((self.root / "godot").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_art_promotion_pipeline.py
+++ b/tests/test_art_promotion_pipeline.py
@@ -249,21 +249,49 @@ class TestPromotionGate(_TmpArtRoot):
             rc = apply_review.action_report([a])
         self.assertEqual(rc, 0, "explicit Hold is a legitimate outcome, not a failure")
 
-    def test_both_variants_kept_is_contested_not_overwritten(self):
-        """v1 and v2 collapse onto one game filename (variant marker is
-        stripped) -- promoting both would let the last copy silently win."""
+    def test_both_variants_kept_ship_at_distinct_paths(self):
+        """Pip ruled 2026-08-03: "Keep both, you pick naming variant."
+
+        The guarantee under test is UNCHANGED from when this asserted a contested
+        failure -- NO SILENT OVERWRITE. What changed is the resolution: instead of
+        refusing, the highest variant claims the plain name and earlier ones carry
+        their marker, so both ship at distinct paths.
+        """
         self._write("art_generated/ui_icons/v1/icon_z_v1_512.png")
         self._write("art_generated/ui_icons/v1/icon_z_v2_512.png")
         a1 = _make_asset("gen:ui_icons:icon_z:v1", self.root)
         a2 = _make_asset("gen:ui_icons:icon_z:v2", self.root)
         buckets, n_blocked, contested = apply_review._promotion_gate([a1, a2])
-        self.assertEqual(len(buckets["contested"]), 2)
-        self.assertEqual(len(buckets["promotable"]), 0)
-        self.assertEqual(len(contested), 1)
-        buf = io.StringIO()
-        with redirect_stdout(buf):
-            rc = apply_review.action_report([a1, a2])
-        self.assertEqual(rc, 1)
+        self.assertEqual(contested, {}, "variant collision must resolve, not block")
+        self.assertEqual(len(buckets["promotable"]), 2, "both variants ship")
+        self.assertEqual(len(buckets["contested"]), 0)
+
+        dests = set()
+        for a in (a1, a2):
+            for src in a.promote_sources():
+                dests.add(a.dest_dir() / a.dest_name(src, a.keep_variant_in_name))
+        self.assertEqual(len(dests), 2, "distinct destinations -- nothing overwrites")
+        names = sorted(d.name for d in dests)
+        # HIGHEST variant takes the plain name the game already references.
+        self.assertEqual(names, ["icon_z_512.png", "icon_z_v1_512.png"])
+
+    def test_implicit_v1_gets_its_marker_inserted(self):
+        """v1 files carry NO _v1_ marker (icon_y_512.png), so "keep the marker" is
+        a no-op for them and the collision would survive. The loser must have the
+        marker INSERTED before the size token. This is the bug that made the first
+        implementation of Pip's ruling silently ineffective."""
+        self._write("art_generated/ui_icons/v1/icon_y_512.png")  # v1, no marker
+        self._write("art_generated/ui_icons/v1/icon_y_v2_512.png")
+        a1 = _make_asset("gen:ui_icons:icon_y:v1", self.root)
+        a2 = _make_asset("gen:ui_icons:icon_y:v2", self.root)
+        buckets, _n, contested = apply_review._promotion_gate([a1, a2])
+        self.assertEqual(contested, {})
+        names = sorted(
+            a.dest_name(src, a.keep_variant_in_name)
+            for a in (a1, a2)
+            for src in a.promote_sources()
+        )
+        self.assertEqual(names, ["icon_y_512.png", "icon_y_v1_512.png"])
 
     def test_clean_keep_promotes_and_dry_run_reports_bytes(self):
         self._write("art_generated/ui_icons/v1/icon_ok_v1_512.png", size=4096)

--- a/tools/art_review/apply_review.py
+++ b/tools/art_review/apply_review.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import json
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -184,6 +185,12 @@ class Asset:
         self.category = None
         self.base_id = None  # gen only
         self.variant = None  # gen only
+        # Set by resolve_contested() when a sibling variant claims the plain
+        # filename; keeps this asset's _vN marker so both can ship (Pip, 2026-08-03).
+        self.keep_variant_in_name = False
+        # Set by resolve_contested() for px assets whose filename collides
+        # across BATCHES; carries the losing batch's date (e.g. '20260719').
+        self.batch_suffix = ""
         self.relpath = None  # px only
         self.pipeline = None  # "gpt" | "pixellab"
         self.sources = []  # list[Path] of resolved existing PNGs
@@ -310,15 +317,46 @@ class Asset:
             )
         return ("promotable", rule)
 
-    def dest_name(self, src: Path):
-        """Destination path RELATIVE to dest_dir (may contain subdirs for px)."""
+    def dest_name(self, src: Path, keep_variant: bool = False):
+        """Destination path RELATIVE to dest_dir (may contain subdirs for px).
+
+        keep_variant: retain the _vN marker instead of stripping it. Used to
+        resolve CONTESTED destinations, where two kept variants of one base would
+        otherwise collapse onto a single game filename and the last copy would
+        silently overwrite the rest.
+
+        Pip's ruling 2026-08-03 on the 35 contested keeps: "Keep both, you pick
+        naming variant." The scheme: the HIGHEST variant claims the plain name, so
+        whatever the game already references keeps working and the newest art is
+        what players see; every earlier variant keeps its _vN suffix and ships
+        alongside, available but unreferenced.
+
+        Deterministic on purpose -- no per-asset judgement, so re-running promote
+        cannot shuffle which variant is "current". Note the earlier variants are
+        packed-but-unreferenced, exactly the class ADR-0019 exists to end; they
+        stay until the demand manifest can rule on them (see #1109).
+        """
         # generated: strip the _<variant> suffix for a clean game path
         # (matches promote_assets.py convention: art id vN -> base name).
         if self.kind == "gen":
             stem = src.stem  # e.g. icon_doom_v2_1024
             marker = f"_{self.variant}_"
-            if marker in stem:
-                stem = stem.replace(marker, "_", 1)
+            if not keep_variant:
+                if marker in stem:
+                    stem = stem.replace(marker, "_", 1)
+                return stem + src.suffix
+            # Disambiguating this asset from a sibling variant. NOTE v1 is
+            # IMPLICIT in the file convention -- v1 files carry no _v1_ marker at
+            # all (button_hire_hover_512.png), so "keep the marker" is a no-op for
+            # them and the collision survives. Insert it before the trailing size
+            # token instead, which is what makes both variants nameable.
+            if marker not in stem:
+                head, sep, tail = stem.rpartition("_")
+                stem = (
+                    f"{head}_{self.variant}_{tail}"
+                    if sep and tail.isdigit()
+                    else f"{stem}_{self.variant}"
+                )
             return stem + src.suffix
         # pixellab: the leaf filename alone is NOT the identity -- e.g.
         # cat_walk_cat1/walk_east_0 vs cat_walk_cat2/walk_east_0 are different
@@ -332,7 +370,14 @@ class Asset:
         ]
         if not self._target_is_dir and parts:
             parts = parts[:-1]  # last segment names the file itself; use src.name
-        return "/".join(parts + [src.name]) if parts else src.name
+        name = src.name
+        if self.batch_suffix:
+            # Two BATCHES produced the same filename (e.g. the 07-19 original and
+            # its 07-21 reroll). Pip ruled both ship, so the older batch carries a
+            # date suffix and the newer keeps the plain name the game references.
+            stem, dot, ext = name.rpartition(".")
+            name = "%s_%s%s%s" % (stem or name, self.batch_suffix, dot, ext)
+        return "/".join(parts + [name]) if parts else name
 
 
 def _looks_like_size_stem(path: Path, base_id: str):
@@ -473,8 +518,67 @@ def _contested(promotables):
     for a in promotables:
         dest_dir = a.dest_dir()
         for src in a.promote_sources():
-            claims.setdefault(dest_dir / a.dest_name(src), []).append(a)
+            claims.setdefault(dest_dir / a.dest_name(src, a.keep_variant_in_name), []).append(a)
     return {d: ass for d, ass in claims.items() if len(ass) > 1}
+
+
+def _batch_date(asset):
+    """The YYYYMMDD embedded in a px asset's batch dir, or "" if absent."""
+    first = Path(asset.relpath).as_posix().split("/")[0]
+    m = re.search(r"(\d{4})-(\d{2})-(\d{2})", first)
+    return "".join(m.groups()) if m else ""
+
+
+def _variant_rank(asset):
+    """Sort key for picking which variant claims the plain filename.
+
+    'v12' must beat 'v2', so compare the trailing integer numerically and fall
+    back to the raw string when a variant is not vN-shaped.
+    """
+    raw = asset.variant or ""
+    m = re.search(r"(\d+)$", raw)
+    return (1, int(m.group(1))) if m else (0, 0)
+
+
+def resolve_contested(contested):
+    """Assign per-asset variant-suffix flags so BOTH variants can ship.
+
+    Pip's ruling 2026-08-03: "Keep both, you pick naming variant."
+
+    Scheme: within each contested destination the HIGHEST variant keeps the plain
+    name; every earlier one retains its _vN suffix. That means whatever the game
+    already references keeps resolving, the newest art is what players see, and no
+    copy can silently overwrite another.
+
+    Deterministic by construction -- re-running promote cannot shuffle which
+    variant is "current", which matters because a shuffling filename would be a
+    silent content change with a green build.
+
+    Returns the number of assets given a suffix.
+    """
+    suffixed = 0
+    for _dest, assets in contested.items():
+        gen = [a for a in assets if a.kind == "gen" and a.variant]
+        if len(gen) >= 2:
+            gen.sort(key=_variant_rank)
+            for a in gen[:-1]:
+                a.keep_variant_in_name = True
+                suffixed += 1
+            continue
+
+        # px: same leaf filename produced by two different BATCH dirs -- the
+        # 07-19 originals against their 07-21 rerolls. Newest batch keeps the
+        # plain name (it is the improvement, and the game already points at it);
+        # older batches carry their date. Same determinism rule as variants.
+        px = [a for a in assets if a.kind == "px" and a.relpath]
+        if len(px) >= 2 and len({_batch_date(a) for a in px}) == len(px):
+            px.sort(key=_batch_date)
+            for a in px[:-1]:
+                a.batch_suffix = _batch_date(a)
+                suffixed += 1
+            continue
+        continue  # not a shape we can resolve automatically; flag for a human
+    return suffixed
 
 
 def _promotion_gate(keeps):
@@ -490,6 +594,11 @@ def _promotion_gate(keeps):
     for a in keeps:
         buckets[a.promotion_status()[0]].append(a)
     contested = _contested(buckets["promotable"])
+    # Pip ruled 2026-08-03 that BOTH variants ship, so resolve collisions by
+    # suffixing all but the highest variant, then recompute. Anything still
+    # contested after this is NOT a variant collision and still needs a human.
+    if contested and resolve_contested(contested):
+        contested = _contested(buckets["promotable"])
     if contested:
         losers = []
         seen = set()
@@ -640,7 +749,7 @@ def action_promote(assets, dry_run):
         # under-cap source PNG. Over-cap files are NEVER copied -- pre-commit
         # check-added-large-files (--maxkb=1000) would reject the commit.
         for src in a.promote_sources():
-            dst = dest_dir / a.dest_name(src)
+            dst = dest_dir / a.dest_name(src, a.keep_variant_in_name)
             rel_src = _rel(src, a.art_root)
             rel_dst = _rel(dst, a.art_root)
             if dry_run:

--- a/tools/art_review/apply_review.py
+++ b/tools/art_review/apply_review.py
@@ -7,8 +7,9 @@ The review app writes a verdict-state file (default
     gen:<category>:<base_id>:<variant>   generated art, file lives at
         <art-root>/art_generated/<category>/v1/<base_id>_<variant>_<size>.png
     px:<relpath>                         pixellab art, file/dir lives at
-        <art-root>/art_source/<relpath>  (relpath may point at a single PNG or a
-        rotation directory of PNGs)
+        <art-root>/art_source/<relpath>  (relpath may point at a single PNG, a
+        rotation directory of PNGs, or -- the review app's usual form -- a PNG
+        path WITHOUT its .png extension; the resolver tries all of these)
 
 Each value is ``{verdict, note, tags, updated_at}`` with verdict in
 {keep, iterate, discard} (the review app's v2 tri-state). Legacy files still
@@ -25,10 +26,20 @@ Verdict semantics:
 
 Three actions, all supporting --dry-run and --art-root (default "."):
 
-    report    Count + list keep/iterate/discard verdicts. Discards are surfaced
-              WITH their notes as a brief-reconsideration list.
-    promote   Copy each KEEP asset's PNG (largest size for generated art) into
-              the correct godot/assets/ destination, creating dirs as needed.
+    report    Count + list keep/iterate/discard verdicts, PLUS the promotion
+              gate: promotable vs blocked vs held counts for every KEEP.
+              EXITS NONZERO if any KEEP is blocked (unmapped category,
+              unresolvable source, or nothing under the 1MB git cap) -- an
+              approved asset that cannot move is a pipeline bug and must fail
+              at review time, not surface silently at promote time
+              (silent-wrongness family: issues #1027 / #1075). Discards are
+              surfaced WITH their notes as a brief-reconsideration list.
+    promote   Copy each KEEP asset's PNG (largest size that fits the 1MB git
+              cap, for generated art) into the correct godot/assets/
+              destination, creating dirs as needed. Files over the cap are
+              NEVER copied (pre-commit check-added-large-files --maxkb=1000
+              would reject the commit anyway; docs/art/ART_MASTERS_POLICY.md).
+              Exits nonzero if any KEEP was blocked.
     reroll    Emit tools/assets/manifests/reroll_<YYYY-MM-DD>.json describing each
               ITERATE asset (id, category, source_file, note, original_prompt),
               split by pipeline (gpt vs pixellab) to feed the next generation run.
@@ -51,25 +62,97 @@ from pathlib import Path
 # --- category -> godot/assets destination map ------------------------------
 # Keyed by the asset's category. For generated art the category is the
 # art_generated/<category> subdir (== the manifest's asset_type). For pixellab
-# art the category is derived from the relpath (props/characters/tilesets/cats).
+# art the category is derived from the relpath (see _px_category).
+#
+# A mapping value is one of:
+#   str                     destination dir under the art root
+#   list[(prefix, str)]     per-base_id-prefix routing, first match wins,
+#                           "" as catch-all (round3_rerolls mixes action
+#                           icons with dossier/painterly portraits)
+#   Hold(reason)            EXPLICITLY not-for-promotion. Reviewed art that
+#                           must NOT enter godot/ -- Godot packs the entire
+#                           godot/ tree into the .pck (issue #787), so a
+#                           wrong destination silently bloats the build.
+#
+# INVARIANT (enforced by report's promotion gate + tests/test_art_promotion_pipeline.py):
+# every category that can appear in review_state.json MUST resolve to a str or
+# a Hold. An unmapped category is a loud failure, never a silent skip.
+
+
+class Hold:
+    """Explicit not-for-promotion marker: a legitimate mapping outcome."""
+
+    def __init__(self, reason):
+        self.reason = reason
+
+
 GEN_DEST = {
     "game_icons": "godot/assets/icons/generated",
     "ui_icons": "godot/assets/icons/generated",
+    "action_icons_missing": "godot/assets/icons/generated",
+    "iconset_round2": "godot/assets/icons/generated",
+    "core_resource_icons": "godot/assets/icons/generated",
+    "round3_rerolls": [
+        ("dossier_", "godot/assets/portraits/generated"),
+        ("painterly_", "godot/assets/portraits/generated"),
+        ("", "godot/assets/icons/generated"),
+    ],
+    "researcher_portraits_pilot": "godot/assets/portraits/generated",
     "hero_banners": "godot/assets/images/heroes",
+    "round3_rerolls_banners": "godot/assets/images/heroes",
     "screen_backgrounds": "godot/assets/images/backgrounds",
     "env_scenes": "godot/assets/images/scenes",
+    "scene_art_wave2": "godot/assets/images/scenes",
     "terminal_textures": "godot/assets/textures/generated",
     "env_textures": "godot/assets/textures/generated",
+    "crt_frame_overlay": "godot/assets/textures/generated",
     "ui_frames": "godot/assets/ui/frames",
 }
 PX_DEST = {
     "props": "godot/assets/office_floor/props",
     "characters": "godot/assets/office_floor/characters",
-    "tilesets": "godot/assets/office_floor/tiles",
+    # was office_floor/tiles -- no such dir exists; the game's tilesets live
+    # in godot/assets/office_floor/tilesets (latent wrong-destination fix).
+    "tilesets": "godot/assets/office_floor/tilesets",
     "cats": "godot/assets/cats/generated",
+    "icons": "godot/assets/icons/generated",
+    "backgrounds": "godot/assets/images/backgrounds",
+    "icon_hires": Hold(
+        "hi-res icon source variants (issue #787 bloat class): the game references "
+        "sized icons already in godot/assets/icons; re-importing ~318 files (~52MB) "
+        "needs Pip's explicit ruling"
+    ),
 }
-# pixellab category tokens we recognise inside a relpath, in priority order.
-PX_CATEGORY_TOKENS = ["props", "characters", "tilesets", "cats"]
+# first-path-segment overrides: batch dirs whose names would fool the token
+# scan (e.g. iconset_2026-07-21's gen_cat_doom_* must NOT land in cats/).
+PX_PREFIX_CATEGORY = {
+    "icon_hires": "icon_hires",
+    "iconset_2026-07-21": "icons",
+    "settings_bg_2026-07-21": "backgrounds",
+    "cats_incoming": "cats",
+}
+# relpath segment -> category (any segment, first match in path order).
+PX_TOKEN_CATEGORY = {
+    "props": "props",
+    "objects": "props",
+    "chairs": "props",
+    "kitchen": "props",
+    "windows": "props",
+    "environment": "props",
+    "characters": "characters",
+    "founder": "characters",
+    "cosmetics": "characters",
+    "tilesets": "tilesets",
+    "cats": "cats",
+    "icons": "icons",
+}
+# batch dirs whose ROOT-level loose files are character style probes.
+PX_BATCH_DEFAULT_CATEGORY = {"pixellab_2026-07-16": "characters"}
+
+# git art cap: pre-commit check-added-large-files runs with --maxkb=1000 and
+# docs/art/ART_MASTERS_POLICY.md forbids >1MB art in git. Anything bigger can
+# NEVER be committed, so promote must never copy it into godot/.
+MAX_PROMOTE_BYTES = 1000 * 1024
 
 DEFAULT_STATE = "tools/art_review/review_state.json"
 MANIFEST_DIR = "tools/assets/manifests"
@@ -104,7 +187,9 @@ class Asset:
         self.relpath = None  # px only
         self.pipeline = None  # "gpt" | "pixellab"
         self.sources = []  # list[Path] of resolved existing PNGs
-        self.promote_file = None  # Path chosen to promote (largest for gen)
+        self.promote_file = None  # Path chosen to promote (largest UNDER-CAP for gen)
+        self.best_file = None  # largest file regardless of cap (reroll reporting)
+        self.size_capped = False  # True if the cap forced a smaller pick than best
         self.error = None
         self._parse()
 
@@ -144,21 +229,28 @@ class Asset:
             self.error = f"no file matching {gen_dir}/{pattern}"
             return
         self.sources = matches
-        self.promote_file = _largest_by_size(matches)
+        self.best_file = _largest_by_size(matches)
+        fits = [m for m in matches if m.stat().st_size <= MAX_PROMOTE_BYTES]
+        self.promote_file = _largest_by_size(fits) if fits else None
+        self.size_capped = bool(fits) and self.promote_file != self.best_file
 
     def _parse_px(self):
         self.relpath = self.id[len("px:") :]
         # relpath may be given relative to art_source/ (natural) or relative to
-        # the art-root (includes the leading art_source/). Try both.
-        candidates = [
-            self.art_root / "art_source" / self.relpath,
-            self.art_root / self.relpath,
-        ]
+        # the art-root (includes the leading art_source/). The review app also
+        # writes single-PNG relpaths WITHOUT the .png extension. Try, in order:
+        # each base as-is (file or rotation dir), then base + ".png".
+        candidates = []
+        for base in (self.art_root / "art_source" / self.relpath, self.art_root / self.relpath):
+            candidates.append(base)
+            candidates.append(base.with_name(base.name + ".png"))
         target = next((c for c in candidates if c.exists()), None)
         if target is None:
-            self.error = f"no file/dir at {candidates[0]} (or {candidates[1]})"
+            tried = "; ".join(str(c) for c in candidates)
+            self.error = f"no file/dir at any of: {tried}"
             return
-        if target.is_dir():
+        self._target_is_dir = target.is_dir()
+        if self._target_is_dir:
             self.sources = sorted(target.glob("*.png"))
             if not self.sources:
                 self.error = f"directory {target} has no PNGs"
@@ -166,21 +258,60 @@ class Asset:
         else:
             self.sources = [target]
         self.category = _px_category(self.relpath)
-        # promote copies every source PNG for px (rotation sets stay together);
-        # promote_file holds the first for single-file reporting convenience.
-        self.promote_file = self.sources[0]
+        # promote copies every under-cap source PNG for px (rotation sets stay
+        # together); promote_file holds the first for reporting convenience.
+        self.best_file = self.sources[0]
+        fits = [s for s in self.sources if s.stat().st_size <= MAX_PROMOTE_BYTES]
+        self.promote_file = fits[0] if fits else None
+        self.size_capped = bool(fits) and len(fits) != len(self.sources)
 
-    # -- destination directory for a promote --
-    def dest_dir(self):
+    # -- destination mapping for a promote --
+    def dest_rule(self):
+        """Raw mapping outcome: a destination str, a Hold, or None (unmapped)."""
         if self.kind == "gen":
-            rel = GEN_DEST.get(self.category)
-        elif self.kind == "px":
-            rel = PX_DEST.get(self.category) if self.category else None
-        else:
-            rel = None
-        return (self.art_root / rel) if rel else None
+            return _gen_dest_rel(self.category, self.base_id)
+        if self.kind == "px":
+            return PX_DEST.get(self.category) if self.category else None
+        return None
+
+    def dest_dir(self):
+        rel = self.dest_rule()
+        return (self.art_root / rel) if isinstance(rel, str) else None
+
+    def promote_sources(self):
+        """Source files promote would copy: all under-cap PNGs for px, the
+        largest under-cap size for gen. Empty if nothing fits the git cap."""
+        if self.kind == "gen":
+            return [self.promote_file] if self.promote_file else []
+        return [s for s in self.sources if s.stat().st_size <= MAX_PROMOTE_BYTES]
+
+    def promotion_status(self):
+        """Classify a KEEP asset for the promotion gate.
+
+        Returns (status, detail) with status one of:
+          promotable          -> detail = destination rel path
+          held                -> detail = Hold reason (explicit not-for-promotion)
+          blocked-unresolved  -> detail = resolution error (pipeline bug)
+          blocked-unmapped    -> detail = missing category mapping (pipeline bug)
+          blocked-size        -> detail = nothing fits the 1MB git cap
+        """
+        if self.error:
+            return ("blocked-unresolved", self.error)
+        rule = self.dest_rule()
+        if rule is None:
+            return ("blocked-unmapped", f"no destination for category {self.category!r}")
+        if isinstance(rule, Hold):
+            return ("held", rule.reason)
+        if not self.promote_sources():
+            return (
+                "blocked-size",
+                "every candidate file exceeds the 1MB git cap "
+                "(docs/art/ART_MASTERS_POLICY.md; pre-commit --maxkb=1000)",
+            )
+        return ("promotable", rule)
 
     def dest_name(self, src: Path):
+        """Destination path RELATIVE to dest_dir (may contain subdirs for px)."""
         # generated: strip the _<variant> suffix for a clean game path
         # (matches promote_assets.py convention: art id vN -> base name).
         if self.kind == "gen":
@@ -189,7 +320,19 @@ class Asset:
             if marker in stem:
                 stem = stem.replace(marker, "_", 1)
             return stem + src.suffix
-        return src.name
+        # pixellab: the leaf filename alone is NOT the identity -- e.g.
+        # cat_walk_cat1/walk_east_0 vs cat_walk_cat2/walk_east_0 are different
+        # cats. Preserve the relpath below the batch dir (dropping segments
+        # that merely repeat this asset's category token), mirroring the
+        # existing per-set dirs under godot/assets/office_floor/.
+        parts = [
+            seg
+            for seg in Path(self.relpath).as_posix().split("/")[1:]
+            if PX_TOKEN_CATEGORY.get(seg) != self.category
+        ]
+        if not self._target_is_dir and parts:
+            parts = parts[:-1]  # last segment names the file itself; use src.name
+        return "/".join(parts + [src.name]) if parts else src.name
 
 
 def _looks_like_size_stem(path: Path, base_id: str):
@@ -216,14 +359,40 @@ def _largest_by_size(paths):
 
 
 def _px_category(relpath: str):
+    """Category for a pixellab relpath. Precedence: batch-dir override,
+    then segment tokens, then the loose "cat" fallback, then batch default."""
     parts = Path(relpath).as_posix().split("/")
-    for token in PX_CATEGORY_TOKENS:
-        if token in parts:
-            return token
+    if parts and parts[0] in PX_PREFIX_CATEGORY:
+        return PX_PREFIX_CATEGORY[parts[0]]
+    for seg in parts:
+        if seg in PX_TOKEN_CATEGORY:
+            return PX_TOKEN_CATEGORY[seg]
     # loose fallback: any segment containing "cat" -> cats
     if any("cat" in seg for seg in parts):
         return "cats"
+    if parts and parts[0] in PX_BATCH_DEFAULT_CATEGORY:
+        return PX_BATCH_DEFAULT_CATEGORY[parts[0]]
     return None
+
+
+def _gen_dest_rel(category, base_id):
+    """Destination for a generated-art category: str, Hold, or None.
+    List rules route by base_id prefix, first match wins ("" = catch-all)."""
+    rule = GEN_DEST.get(category)
+    if rule is None or isinstance(rule, (str, Hold)):
+        return rule
+    for prefix, dest in rule:
+        if (base_id or "").startswith(prefix):
+            return dest
+    return None
+
+
+def _fmt_rule(rule):
+    if isinstance(rule, Hold):
+        return "[NOT FOR PROMOTION] " + rule.reason
+    if isinstance(rule, str):
+        return rule
+    return "; ".join("{} -> {}".format(p or "*", d) for p, d in rule)
 
 
 # --- review_state.json loading ---------------------------------------------
@@ -282,6 +451,59 @@ def build_prompt_index(art_root: Path):
 
 
 # --- actions ----------------------------------------------------------------
+STATUS_FLAG = {
+    "promotable": "",
+    "held": "  [HELD]",
+    "blocked-unresolved": "  [UNRESOLVED]",
+    "blocked-unmapped": "  [NO-DEST]",
+    "blocked-size": "  [OVER-1MB]",
+}
+BLOCKED_STATUSES = ("blocked-unmapped", "blocked-unresolved", "blocked-size")
+
+
+def _contested(promotables):
+    """Destinations claimed by more than one promotable KEEP.
+
+    dest_name strips the variant marker (art id vN -> base name), so keeping
+    BOTH v1 and v2 of a base makes them collapse onto ONE game path -- the
+    last copy would silently win. Returns {dest Path: [Asset, ...]} for every
+    contested destination.
+    """
+    claims = {}
+    for a in promotables:
+        dest_dir = a.dest_dir()
+        for src in a.promote_sources():
+            claims.setdefault(dest_dir / a.dest_name(src), []).append(a)
+    return {d: ass for d, ass in claims.items() if len(ass) > 1}
+
+
+def _promotion_gate(keeps):
+    """Bucket KEEP assets by promotion status.
+
+    Returns (buckets, n_blocked, contested) where buckets adds a "contested"
+    bucket (assets whose destination collides with another keep's -- pulled
+    OUT of promotable), n_blocked counts per-asset pipeline bugs, and
+    contested is the {dest: [assets]} collision map.
+    """
+    buckets = {s: [] for s in STATUS_FLAG}
+    buckets["contested"] = []
+    for a in keeps:
+        buckets[a.promotion_status()[0]].append(a)
+    contested = _contested(buckets["promotable"])
+    if contested:
+        losers = []
+        seen = set()
+        for ass in contested.values():
+            for a in ass:
+                if id(a) not in seen:
+                    seen.add(id(a))
+                    losers.append(a)
+        buckets["contested"] = losers
+        buckets["promotable"] = [a for a in buckets["promotable"] if id(a) not in seen]
+    n_blocked = sum(len(buckets[s]) for s in BLOCKED_STATUSES)
+    return buckets, n_blocked, contested
+
+
 def action_report(assets):
     groups = {v: [] for v in VERDICTS}
     for a in assets:
@@ -293,11 +515,67 @@ def action_report(assets):
         )
     )
     print("  keep    -> promote     iterate -> regenerate (reroll)     discard -> rethink brief")
+
+    # -- promotion gate: a keep that cannot move is a pipeline bug, and it
+    # must fail HERE, at review time -- not silently at promote time
+    # (silent-wrongness family, issues #1027 / #1075).
+    keeps = groups["keep"]
+    buckets, n_blocked, contested = _promotion_gate(keeps)
+    n_bytes = sum(f.stat().st_size for a in buckets["promotable"] for f in a.promote_sources())
+    print("\n== promotion gate (keeps only) ==")
+    print(
+        "promotable: {} of {} keeps ({:.1f} MB would enter godot/assets)".format(
+            len(buckets["promotable"]), len(keeps), n_bytes / 1e6
+        )
+    )
+    print(
+        "held (explicit not-for-promotion): {}    contested-destination: {}    "
+        "blocked: {} (unmapped-category={} unresolved-source={} over-size-cap={})".format(
+            len(buckets["held"]),
+            len(buckets["contested"]),
+            n_blocked,
+            len(buckets["blocked-unmapped"]),
+            len(buckets["blocked-unresolved"]),
+            len(buckets["blocked-size"]),
+        )
+    )
+    if buckets["held"]:
+        reasons = {}
+        for a in buckets["held"]:
+            reasons.setdefault(a.promotion_status()[1], []).append(a)
+        for reason, items in reasons.items():
+            print(f"  held x{len(items)}: {reason}")
+    if contested:
+        print(
+            "\n[FAIL] {} destination path(s) contested by {} keeps -- multiple kept "
+            "variants collapse onto one game filename (variant marker is stripped); "
+            "the last copy would silently overwrite the rest. Un-keep all but one "
+            "variant per base, or rule on a naming change:".format(
+                len(contested), len(buckets["contested"])
+            )
+        )
+        for dest, ass in sorted(contested.items(), key=lambda kv: str(kv[0]))[:15]:
+            ids = ", ".join(a.id for a in ass)
+            print(f"  {dest.name}  <-  {ids}")
+        if len(contested) > 15:
+            print(f"  ... and {len(contested) - 15} more contested destination(s)")
+    if n_blocked:
+        print("\n[FAIL] {} approved asset(s) cannot be promoted -- pipeline bug:".format(n_blocked))
+        for status in BLOCKED_STATUSES:
+            rollup = {}
+            for a in buckets[status]:
+                key = a.promotion_status()[1] if status != "blocked-unresolved" else a.category
+                rollup.setdefault(key, []).append(a)
+            for key, items in sorted(rollup.items(), key=lambda kv: -len(kv[1])):
+                print(f"  {status} x{len(items)}: {key}  (e.g. {items[0].id})")
+        print("  fix the map/resolver in tools/art_review/apply_review.py; this report")
+        print("  exits nonzero until every keep is promotable or explicitly held.")
+
     for v in VERDICTS:
         print(f"\n-- {v} ({len(groups[v])}) --")
         for a in groups[v]:
-            loc = a.error if a.error else str(a.promote_file)
-            flag = "  [UNRESOLVED]" if a.error else ""
+            loc = a.error if a.error else str(a.promote_file or a.best_file)
+            flag = STATUS_FLAG.get(a.promotion_status()[0], "") if a.verdict == "keep" else ""
             print(f"  {a.id}{flag}")
             print(f"      pipeline={a.pipeline} category={a.category} -> {loc}")
             if a.note:
@@ -315,6 +593,13 @@ def action_report(assets):
             note = a.note.strip() if a.note else "(no note given)"
             print(f"  - {a.id}")
             print(f"      {note}")
+    n_gate_fail = n_blocked + len(buckets["contested"])
+    if n_gate_fail:
+        print(
+            f"\n[FAIL] promotion gate: {n_blocked} keep(s) blocked, "
+            f"{len(buckets['contested'])} contested (see gate summary above)."
+        )
+        return 1
     return 0
 
 
@@ -323,43 +608,71 @@ def action_promote(assets, dry_run):
     print("== promote KEEP assets ==")
     print("category -> destination map in use:")
     for k, v in sorted(GEN_DEST.items()):
-        print(f"  gen  {k:<20} -> {v}")
+        print(f"  gen  {k:<28} -> {_fmt_rule(v)}")
     for k, v in sorted(PX_DEST.items()):
-        print(f"  px   {k:<20} -> {v}")
+        print(f"  px   {k:<28} -> {_fmt_rule(v)}")
     print()
     if not keeps:
         print("no keep verdicts -- nothing to promote.")
         return 0
-    n_copied = n_skipped = 0
+    _, _, contested = _promotion_gate(keeps)
+    contested_ids = {a.id for ass in contested.values() for a in ass}
+    n_copied = n_skipped = n_held = n_capped = n_contested = 0
+    n_bytes = 0
     for a in keeps:
-        if a.error:
-            print(f"SKIP {a.id}: {a.error}")
+        status, detail = a.promotion_status()
+        if status == "held":
+            print(f"HOLD {a.id}: {detail}")
+            n_held += 1
+            continue
+        if status in BLOCKED_STATUSES:
+            print(f"SKIP {a.id}: {detail}")
             n_skipped += 1
+            continue
+        if a.id in contested_ids:
+            print(f"CONTEST {a.id}: destination filename claimed by another keep (see report)")
+            n_contested += 1
             continue
         dest_dir = a.dest_dir()
-        if dest_dir is None:
-            print(f"SKIP {a.id}: no destination for category {a.category!r}")
-            n_skipped += 1
-            continue
-        # generated: one file (largest). pixellab: every source PNG.
-        srcs = [a.promote_file] if a.kind == "gen" else a.sources
-        for src in srcs:
+        if a.size_capped:
+            n_capped += 1
+        # generated: one file (largest under the git cap). pixellab: every
+        # under-cap source PNG. Over-cap files are NEVER copied -- pre-commit
+        # check-added-large-files (--maxkb=1000) would reject the commit.
+        for src in a.promote_sources():
             dst = dest_dir / a.dest_name(src)
             rel_src = _rel(src, a.art_root)
             rel_dst = _rel(dst, a.art_root)
             if dry_run:
                 print(f"DRY  {rel_src}  ->  {rel_dst}")
             else:
-                dest_dir.mkdir(parents=True, exist_ok=True)
+                dst.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(src, dst)
                 print(f"COPY {rel_src}  ->  {rel_dst}")
             n_copied += 1
+            n_bytes += src.stat().st_size
     verb = "would copy" if dry_run else "copied"
-    print(f"\n{verb} {n_copied} file(s); skipped {n_skipped} asset(s).")
+    print(
+        f"\n{verb} {n_copied} file(s), {n_bytes / 1e6:.1f} MB into godot/assets; "
+        f"skipped {n_skipped} asset(s); contested {n_contested} asset(s); "
+        f"held {n_held} asset(s)."
+    )
+    if n_capped:
+        print(
+            f"size cap: {n_capped} asset(s) had their largest file over the 1MB git cap; "
+            "the largest UNDER-cap size was chosen instead (masters stay in art_generated/, "
+            "see docs/art/ART_MASTERS_POLICY.md)."
+        )
     print(
         "NOTE: run a Godot --import pass to register the new files "
         "(e.g. `godot --headless --path godot --import`). This tool does not."
     )
+    if n_skipped or n_contested:
+        print(
+            f"[FAIL] {n_skipped} keep(s) blocked, {n_contested} contested -- "
+            "run `report` for the gate summary."
+        )
+        return 1
     return 0
 
 
@@ -380,7 +693,9 @@ def action_reroll(assets, prompt_index, art_root, dry_run):
     }
     unresolved = 0
     for a in rerolls:
-        src = a.promote_file if a.promote_file else None
+        # reroll cares about the SOURCE, not the git cap: prefer the promote
+        # pick but fall back to the best (possibly over-cap) file.
+        src = a.promote_file or a.best_file
         entry = {
             "id": a.id,
             "category": a.category,
@@ -441,8 +756,11 @@ def build_parser():
         epilog="asset_id scheme:\n"
         "  gen:<category>:<base_id>:<variant>  -> art_generated/<category>/v1/"
         "<base_id>_<variant>_<size>.png\n"
-        "  px:<relpath>                        -> art_source/<relpath> (file or "
-        "rotation dir)\n\n"
+        "  px:<relpath>                        -> art_source/<relpath> (file, "
+        "rotation dir, or extensionless PNG path)\n\n"
+        "exit codes: nonzero from report/promote when any KEEP asset is blocked\n"
+        "(unmapped category / unresolvable source / nothing under the 1MB cap).\n"
+        "Explicit Hold (not-for-promotion) entries are reported but do not fail.\n\n"
         "examples:\n"
         "  python tools/art_review/apply_review.py report\n"
         "  python tools/art_review/apply_review.py promote --dry-run\n"
@@ -453,9 +771,10 @@ def build_parser():
     p.add_argument(
         "action",
         choices=["report", "promote", "reroll"],
-        help="report: counts+list (+ discard brief-reconsideration list); "
-        "promote: copy keeps into godot/assets; reroll: emit reroll_<date>.json "
-        "of ITERATE assets to regenerate (discards excluded).",
+        help="report: counts+list + promotion gate (fails if any keep is "
+        "blocked); promote: copy keeps into godot/assets (over-1MB files never "
+        "copied); reroll: emit reroll_<date>.json of ITERATE assets to "
+        "regenerate (discards excluded).",
     )
     p.add_argument(
         "--art-root",


### PR DESCRIPTION
Fixes the art-promotion delivery bug tracked in #1093; silent-wrongness guardrail per #951 (failure family #1027 / #1075).

## Before / after (real review_state.json, read-only dry runs)

| | before | after |
|---|---|---|
| `promote --dry-run` | would copy 202 file(s); skipped 605 | would copy 343 file(s), 57.8 MB; skipped 0; contested 146; held 318 |
| `report` | `keep=807` with no promotability info, exit 0 | promotion gate: promotable 343 / contested 146 / held 318 / blocked 0, exit 1 while contested>0 |

807 keeps = 343 promotable + 146 contested + 318 held + 0 blocked. **No art files were moved, copied, or deleted.** Pip runs promotion himself.

## Cause 1 -- unmapped categories (55 keeps)

New `GEN_DEST` entries (following the existing generated-art convention):

| category | destination |
|---|---|
| action_icons_missing, iconset_round2, core_resource_icons | `godot/assets/icons/generated` |
| round3_rerolls | split: `dossier_*` / `painterly_*` -> `godot/assets/portraits/generated`; rest -> `godot/assets/icons/generated` (the batch mixes action icons with dossier portraits) |
| researcher_portraits_pilot | `godot/assets/portraits/generated` |
| crt_frame_overlay | `godot/assets/textures/generated` |
| round3_rerolls_banners | `godot/assets/images/heroes` |
| scene_art_wave2 | `godot/assets/images/scenes` |

New px categories: `objects/chairs/kitchen/windows/environment -> office_floor/props`, `founder/cosmetics -> office_floor/characters`, `icons -> icons/generated`, `backgrounds -> images/backgrounds`, plus batch-dir overrides so `iconset_2026-07-21/gen_cat_doom_*` stops falling into `cats/` via the loose "cat" fallback.

**Explicit not-for-promotion (`Hold`)**: `icon_hires` (318 keeps, ~52 MB). This is the issue #787 hi-res-variant bloat class -- the game references sized icons already in `godot/assets/icons`, and Godot packs the whole tree into the `.pck`. Held with a reason string; reported, never silently skipped. Needs your ruling before anyone re-imports it.

**Latent wrong-destination fixed**: px `tilesets` mapped to `godot/assets/office_floor/tiles`, which does not exist; the game's tilesets live in `office_floor/tilesets`. It never fired only because every px asset failed resolution first.

## Cause 2 -- pixellab path resolution (550 keeps)

The review app writes single-PNG relpaths **without the `.png` extension** (`px:icon_hires/buttons_normal/button_hire_normal_128` -> `button_hire_normal_128.png`). All 550 skips were this one convention gap -- verified: 600/600 px entries resolve with the `+ ".png"` candidate; 0 required moving files. The resolver now tries, in order: `art_source/<rel>`, `art_source/<rel>.png`, `<rel>`, `<rel>.png` (file or rotation dir) and, on failure, reports every candidate it tried -- it never guesses.

Px destination names now keep the identifying sub-path below the batch dir (`cat_walk_cat1/walk_east_0.png` vs `cat_walk_cat2/walk_east_0.png`; `worker_x/rotations/east.png`), mirroring the per-set dirs already under `office_floor/`. The leaf filename alone silently collapsed different assets.

## The loud gate (the important half)

`report` now classifies every keep: **promotable / held (explicit Hold) / contested / blocked (unmapped-category, unresolved-source, over-size-cap)** and **exits nonzero when anything is blocked or contested** -- the gap surfaces at review time, not at promote time. `promote` prints the total MB entering `godot/assets`, refuses blocked and contested assets, and exits nonzero if any existed.

Two policy guards found real problems in the current data:

1. **Size cap**: promote never copies a file over 1 MB (pre-commit `check-added-large-files --maxkb=1000` would reject the commit anyway; `docs/art/ART_MASTERS_POLICY.md`). For generated art it now picks the largest size **under** the cap (87 assets were capped from 1024px to 512px; masters stay in `art_generated/`). Uncapped, the old "largest size" rule would have tried to commit ~382 MB of gen art, most files individually over the limit.
2. **Contested destinations**: the variant marker is stripped for game paths, so keeping BOTH v1 and v2 of a base collapses them onto one filename -- the old code let the last copy silently win (this bug was live inside the baseline 202). Now: nothing in a contested group is copied, every collision is listed, exit nonzero. 60 destinations / 146 keeps are contested in the real data (v1-vs-v2, and 8 props where the 07-19 original AND its 07-21 reroll are both kept).

## Tests

- `tests/test_art_promotion_pipeline.py`: 28 unit tests (pure logic, tmp-dir fixtures) covering the category rules, the split routing, the resolver candidates and error precision, the size cap, the Hold semantics, contested detection, and report/promote exit codes.
- Live-tree invariant: every `art_generated/<batch>` dir on disk must be in `GEN_DEST` (destination or explicit Hold) -- a new generation batch without a mapping fails the test suite at commit time.
- Godot fast gate: `1031 tests, 0 failures, 101/101 files` (baseline match).

## Needs Pip's ruling

1. **icon_hires** (318 keeps, ~52 MB): promote into the `.pck` or retire the verdicts? Held until ruled.
2. **146 contested keeps** (60 filenames): un-keep one variant per base in the review app, or rule on a naming scheme that ships both.
3. **57.8 MB payload**: even the clean promotable set adds ~58 MB to `godot/` (and the `.pck`). Fine under storage-is-cheap, but it is your call before running `promote` for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
