### PR TITLE
fix(release): route CI exports through build_release.py's freshness proof (#1069)

### DIFF
--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -157,7 +157,28 @@ jobs:
           fi
           echo "SUCCESS All validation checks passed!"
 
-      - name: Build all platforms
+      # Issue #1069: the exports are routed through tools/build_release.py
+      # (one preset at a time, inside build_all_platforms.py), so CI inherits
+      # the SAME discipline a local cut gets: rm -rf godot/.godot before each
+      # export (defeats the stale .godot/exported cache that burned ~12 cycles
+      # in v0.11.0), a unique freshness-marker file, and post-export PROOF the
+      # marker landed inside the .pck/zip. If the marker is missing, the
+      # platform build exits non-zero and its outputs are discarded.
+      #
+      # The three platform builds are SEQUENTIAL and MUST STAY sequential:
+      # every build_release.py run deletes godot/.godot, so splitting this
+      # into parallel matrix jobs sharing a workspace (or parallel processes)
+      # would corrupt the import caches mid-export.
+      #
+      # Failure policy (ruled in #1069): Windows or Linux failing fails this
+      # job -- nothing is packaged, nothing publishes. macOS is BEST-EFFORT
+      # (issue #1071: the GodotSteam .framework loses its Versions/Current
+      # symlink on non-mac checkouts, so its export can fail through no fault
+      # of the tagged source): a macOS failure emits a warning annotation,
+      # drops the macOS assets, and lets Windows/Linux publish -- then the
+      # verify-release-urls alias check (PDoom.app.zip must answer 200) turns
+      # the run RED. Loud, but not blocking.
+      - name: Build all platforms (via tools/build_release.py, freshness-proven)
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
         run: |
@@ -165,23 +186,30 @@ jobs:
           echo "Building P(Doom) $VERSION for all platforms..."
           python scripts/build_all_platforms.py --version "$VERSION" --godot-path "$(which godot)"
 
+      # Required platform: an empty artifact here means the freshness-proven
+      # build silently vanished -- fail loudly, never publish.
       - name: Upload Windows build
         uses: actions/upload-artifact@v7
         with:
           name: build-windows
           path: builds/windows/${{ github.event.inputs.version || github.ref_name }}/
+          if-no-files-found: error
 
       - name: Upload Linux build
         uses: actions/upload-artifact@v7
         with:
           name: build-linux
           path: builds/linux/${{ github.event.inputs.version || github.ref_name }}/
+          if-no-files-found: error
 
+      # Best-effort platform (issue #1071): the dir is empty when the macOS
+      # export failed; warn and continue so Windows/Linux still publish.
       - name: Upload macOS build
         uses: actions/upload-artifact@v7
         with:
           name: build-mac
           path: builds/mac/${{ github.event.inputs.version || github.ref_name }}/
+          if-no-files-found: warn
 
   generate-feeds:
     name: Generate Release Feeds & Metadata

--- a/docs/RELEASE_PLATFORMS.md
+++ b/docs/RELEASE_PLATFORMS.md
@@ -178,6 +178,21 @@ Still true, still unproven, still a job for a human on the relevant machine:
 - **macOS:** no macOS build has ever been verified to RUN (issue #1071). That
   needs a person with a Mac, not code.
 
+### CI parity (issue #1069)
+
+The release workflow (`.github/workflows/enhanced-release.yml` ->
+`scripts/build_all_platforms.py`) used to run a raw `godot --export-release`
+per platform: no cache nuke, no freshness marker, no proof -- the release path
+routed around the tool built after the v0.11.0 stale-cache disaster. Since
+issue #1069, `build_all_platforms.py` delegates every export to
+`tools/build_release.py` (sequentially, for the same never-concurrently reason
+as above), so CI artifacts carry the same `[BUILD-VERIFY]` marker proof in the
+workflow log that a local cut prints. Failure policy, ruled there: Windows or
+Linux failing fails the job and publishes nothing; macOS is best-effort
+(issue #1071) -- its failure drops the macOS assets and the
+`verify-release-urls` alias check turns the run red AFTER Windows/Linux
+publish. Loud, not blocking.
+
 ---
 
 ## 3. THE RELEASE CHECKLIST

--- a/scripts/build_all_platforms.py
+++ b/scripts/build_all_platforms.py
@@ -2,8 +2,26 @@
 """
 Build P(Doom) for all platforms (Windows, Linux, macOS).
 
-This script automates Godot exports for all configured platforms,
-making it easy to create releases for distribution.
+This script orchestrates per-platform exports and packages the distribution
+zips. Since issue #1069 the EXPORT itself is delegated to
+tools/build_release.py, one preset at a time, so CI and local cuts share ONE
+build discipline: rm -rf godot/.godot before the export (defeats the stale
+.godot/exported cache that burned ~12 cycles in v0.11.0), a unique
+freshness-marker file, and post-export PROOF that the marker landed inside the
+exported .pck/zip. This script previously ran a raw `godot --export-release`,
+which had none of that -- the release path routed around the tool built to
+prevent the disaster.
+
+The per-platform builds are SEQUENTIAL BY DESIGN and must stay that way:
+every build_release.py invocation deletes godot/.godot, so parallel exports
+would destroy each other's import caches mid-flight.
+
+macOS is BEST-EFFORT (issue #1071): the GodotSteam .framework loses its
+Versions/Current symlink on non-mac checkouts, so the macOS export can fail
+through no fault of the tagged source. A macOS failure is reported LOUDLY and
+its outputs are discarded (never package an unproven artifact), but it does
+not block Windows and Linux from shipping. Windows or Linux failing fails the
+whole build, and nothing is packaged.
 
 Usage:
     python scripts/build_all_platforms.py --version v0.10.1
@@ -36,6 +54,16 @@ class MultiPlatformBuilder:
         "libgodotsteam.linux.template_release.x86_64.so",
         "libsteam_api.so",
     ]
+
+    # Platforms a release MUST ship. macOS is deliberately absent: issue #1071
+    # (the GodotSteam .framework's Versions/Current symlink does not survive a
+    # non-mac checkout, so the macOS export can fail through no fault of the
+    # tagged source). The ruling (issue #1069): a macOS failure must be LOUD
+    # and its outputs discarded, but it must not block Windows and Linux from
+    # publishing. The release workflow's alias check (PDoom.app.zip must
+    # answer 200) then turns the run red AFTER Windows/Linux publish -- a
+    # visible failure, not a silent one.
+    REQUIRED_PLATFORMS = {"Windows", "Linux"}
 
     def __init__(
         self, version: str, godot_path: Optional[str] = None, project_path: Optional[Path] = None
@@ -151,90 +179,143 @@ class MultiPlatformBuilder:
 
         print(f"[+] Updated export paths to version {self.version}")
 
-    def export_platform(self, preset_name: str, platform_name: str) -> bool:
-        """Export for a specific platform."""
-        print(f"\n[*] Building {platform_name}...")
-
-        cmd = [
-            str(self.godot_exe),
-            "--headless",
-            "--export-release",
+    def _build_release_cmd(self, preset_name: str, build_dir: Path) -> list:
+        """Command line for one tools/build_release.py invocation."""
+        return [
+            sys.executable,
+            str(self.repo_root / "tools" / "build_release.py"),
+            "--preset",
             preset_name,
-            "--path",
+            "--output",
+            str(build_dir),
+            "--godot-path",
+            str(self.godot_exe),
+            "--project",
             str(self.godot_dir),
         ]
 
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    def export_platform(self, preset_name: str, platform_name: str, build_dir: Path) -> bool:
+        """Export one platform VIA tools/build_release.py (issue #1069).
 
-            if result.returncode == 0:
-                print(f"[SUCCESS] {platform_name} build completed successfully")
-                return True
-            else:
-                print(f"[ERROR] {platform_name} build failed:")
-                print(f"  stdout: {result.stdout}")
-                print(f"  stderr: {result.stderr}")
-                return False
+        build_release.py is the single build discipline: it nukes godot/.godot
+        (stale .godot/exported cache defeat), stamps the build, exports, and
+        exits non-zero unless a unique freshness marker is PROVEN present in
+        the exported .pck/zip. The output filename comes from the preset's own
+        export_path (issue #1072), so --output <dir> is all we pass.
+        """
+        print(f"\n[*] Building {platform_name} via tools/build_release.py ...")
+
+        cmd = self._build_release_cmd(preset_name, build_dir)
+        try:
+            # Deliberately NOT capture_output: the [BUILD-VERIFY] marker proof
+            # must be readable in the CI log, or the proof proves nothing to
+            # anyone auditing the run.
+            result = subprocess.run(cmd, check=False)
         except Exception as e:
             print(f"[ERROR] Exception during {platform_name} build: {e}")
-            return False
+            result = None
+
+        if result is not None and result.returncode == 0:
+            print(f"[SUCCESS] {platform_name} build completed and freshness-verified")
+            return True
+
+        code = result.returncode if result is not None else "exception"
+        print(f"[ERROR] {platform_name} build failed (build_release.py exit: {code})")
+        # A build_release.py failure can happen AFTER the export wrote files
+        # (e.g. the freshness check missed). Clear the output dir so a stale
+        # or unverified artifact can never be packaged or uploaded.
+        if build_dir.exists():
+            shutil.rmtree(build_dir, ignore_errors=True)
+            build_dir.mkdir(parents=True, exist_ok=True)
+            print(f"[*] Cleared {build_dir} -- no unverified artifact may be packaged")
+        return False
 
     def build_all(self) -> bool:
-        """Build for all platforms."""
+        """Build all platforms via tools/build_release.py, then package zips.
+
+        Returns True iff every REQUIRED platform (Windows, Linux) exported,
+        proved its freshness marker, and packaged. macOS is best-effort: its
+        failure is loud but non-blocking (see REQUIRED_PLATFORMS).
+        """
         print("\n" + "=" * 60)
-        print("P(Doom) Multi-Platform Build")
+        print("P(Doom) Multi-Platform Build (via tools/build_release.py)")
         print("=" * 60)
 
         # Stamp BEFORE any export so the packed godot/build_stamp.txt names this
         # ref, not whatever a previous build committed (issue #1067).
+        # build_release.py re-stamps per invocation (same HEAD, idempotent);
+        # this early call also fails fast if the stamp tool is broken.
         if not self._stamp_build():
             return False
 
         # Update export paths first
         self._update_export_paths()
 
-        # Create build directories
-        for platform in ["windows", "linux", "mac"]:
-            build_dir = self.repo_root / "builds" / platform / self.version
-            build_dir.mkdir(parents=True, exist_ok=True)
-            print(f"[+] Created build directory: {build_dir}")
-
         platforms = [
-            ("Windows Desktop", "Windows"),
-            ("Linux/X11", "Linux"),
-            ("macOS", "macOS"),
+            ("Windows Desktop", "Windows", "windows"),
+            ("Linux/X11", "Linux", "linux"),
+            ("macOS", "macOS", "mac"),
         ]
 
         results = {}
-        for preset_name, platform_name in platforms:
-            results[platform_name] = self.export_platform(preset_name, platform_name)
+        # SEQUENTIAL ON PURPOSE: every build_release.py run deletes
+        # godot/.godot to defeat the stale-export cache, so parallel exports
+        # would destroy each other's import caches mid-flight. Do not
+        # "optimize" this loop into concurrent builds.
+        for preset_name, platform_name, platform_key in platforms:
+            build_dir = self.repo_root / "builds" / platform_key / self.version
+            build_dir.mkdir(parents=True, exist_ok=True)
+            print(f"[+] Build directory: {build_dir}")
+            results[platform_name] = self.export_platform(preset_name, platform_name, build_dir)
 
         # Print summary
         print("\n" + "=" * 60)
         print("Build Summary")
         print("=" * 60)
 
-        all_success = True
         for platform, success in results.items():
             status = "[SUCCESS]" if success else "[FAILED]"
-            print(f"  {status} {platform}")
-            if not success:
-                all_success = False
+            tier = "" if platform in self.REQUIRED_PLATFORMS else " (best-effort, issue #1071)"
+            print(f"  {status} {platform}{tier}")
 
-        if all_success:
-            print(f"\n[SUCCESS] All platforms built successfully for {self.version}")
+        required_failed = [
+            p for p, ok in results.items() if not ok and p in self.REQUIRED_PLATFORMS
+        ]
+        best_effort_failed = [
+            p for p, ok in results.items() if not ok and p not in self.REQUIRED_PLATFORMS
+        ]
 
-            # Create distribution ZIPs
-            zip_success = self.zip_builds()
-            if not zip_success:
-                print("\n[ERROR] ZIP packaging failed -- refusing to ship incomplete zips")
-                all_success = False
+        if required_failed:
+            print(f"\n[ERROR] Required platform build(s) failed: {', '.join(required_failed)}")
+            print(
+                "[ERROR] Refusing to package ANYTHING -- a half-built release is worse than none."
+            )
+            return False
 
-            print(f"\nBuilds location: {self.repo_root / 'builds'}")
-        else:
-            print("\n[WARNING] Some builds failed. Check errors above.")
+        for p in best_effort_failed:
+            print(f"\n[WARNING] Best-effort platform FAILED: {p} (issue #1071).")
+            print("          Its assets will be MISSING from this release. The release")
+            print("          workflow's alias check (PDoom.app.zip must answer 200) will")
+            print("          turn the run red after Windows/Linux publish -- that red is")
+            print("          the intended loud signal, not a flake.")
+            # GitHub Actions annotation: visible on the run summary page even
+            # though this step exits 0. Plain print noise in a local run.
+            print(
+                f"::warning::{p} build failed (best-effort, issue #1071); "
+                "its release assets will be missing and verify-release-urls will fail."
+            )
 
-        return all_success
+        # Create distribution ZIPs for the platforms that built and verified.
+        zip_success = self.zip_builds()
+        if not zip_success:
+            print("\n[ERROR] ZIP packaging failed -- refusing to ship incomplete zips")
+            return False
+
+        print(
+            f"\n[SUCCESS] Required platforms built, verified fresh, and packaged for {self.version}"
+        )
+        print(f"\nBuilds location: {self.repo_root / 'builds'}")
+        return True
 
     def _release_note(self, platform_key: str) -> Optional[Path]:
         """Per-platform HOW-TO-RUN template shipped inside each zip."""
@@ -358,10 +439,17 @@ class MultiPlatformBuilder:
         # (verified against the CI-built v0.13.1 asset). Verify that, add
         # HOW-TO-RUN.txt beside the .app inside the zip, then copy to the
         # versioned name.
+        #
+        # BEST-EFFORT (issues #1069/#1071): a macOS packaging problem must not
+        # block Windows/Linux from shipping, but a broken bundle must never
+        # ship either -- so on ANY problem the macOS zips are DELETED (loudly)
+        # and `success` is left alone. The missing PDoom.app.zip asset then
+        # turns the release workflow's alias check red.
         mac_dir = self.repo_root / "builds" / "mac" / self.version
         old_mac_zip = mac_dir / "PDoom.app.zip"
         new_mac_zip = mac_dir / f"PDoom-macOS-{self.version}.zip"
         if old_mac_zip.exists():
+            mac_ok = True
             try:
                 with zipfile.ZipFile(old_mac_zip, "a", zipfile.ZIP_DEFLATED) as zf:
                     names = zf.namelist()
@@ -371,23 +459,40 @@ class MultiPlatformBuilder:
                             "[ERROR] macOS .app bundle has no Contents/Frameworks/ -- "
                             "GodotSteam GDExtension was not embedded by the export"
                         )
-                        success = False
+                        mac_ok = False
                     else:
                         print(f"[INFO] macOS bundle embeds {len(frameworks)} Frameworks/ entries")
                     note = self._release_note("macos")
                     if note is None:
-                        success = False
+                        mac_ok = False
                     elif "HOW-TO-RUN.txt" not in names:
                         zf.write(note, "HOW-TO-RUN.txt")
                         print("    + HOW-TO-RUN.txt (added beside the .app inside the zip)")
 
-                # Copy (overwrite) so the versioned zip matches the updated one
-                shutil.copy2(old_mac_zip, new_mac_zip)
-                size_mb = new_mac_zip.stat().st_size / (1024 * 1024)
-                print(f"[SUCCESS] Created {new_mac_zip.name} ({size_mb:.1f} MB)")
+                if mac_ok:
+                    # Copy (overwrite) so the versioned zip matches the updated one
+                    shutil.copy2(old_mac_zip, new_mac_zip)
+                    size_mb = new_mac_zip.stat().st_size / (1024 * 1024)
+                    print(f"[SUCCESS] Created {new_mac_zip.name} ({size_mb:.1f} MB)")
             except Exception as e:
                 print(f"[ERROR] Failed to package macOS ZIP: {e}")
-                success = False
+                mac_ok = False
+
+            if not mac_ok:
+                for stale in (old_mac_zip, new_mac_zip):
+                    if stale.exists():
+                        stale.unlink()
+                        print(f"[*] Deleted {stale.name} -- a broken macOS bundle must not ship")
+                print("[WARNING] macOS packaging failed (best-effort); its assets are dropped.")
+                print(
+                    "::warning::macOS packaging failed (best-effort, issue #1071); "
+                    "PDoom.app.zip will be missing and verify-release-urls will fail."
+                )
+        else:
+            print(
+                "[INFO] No macOS PDoom.app.zip present -- skipping macOS packaging "
+                "(best-effort platform; expected when the macOS export failed, issue #1071)"
+            )
 
         return success
 

--- a/tests/test_build_all_platforms.py
+++ b/tests/test_build_all_platforms.py
@@ -1,0 +1,165 @@
+# !/usr/bin/env python3
+"""Unit tests for scripts/build_all_platforms.py orchestration (issue #1069).
+
+The defect these lock down: the CI release path used to run a raw
+`godot --export-release` with none of tools/build_release.py's discipline
+(cache nuke, freshness marker, marker-in-pack proof), so the binary a
+developer proved locally was never the binary players downloaded. The fix
+delegates every per-platform export to build_release.py; these tests pin:
+
+- the delegation command actually routes through tools/build_release.py
+- Windows/Linux are REQUIRED, macOS is best-effort (issue #1071 ruling)
+- a failed platform's output dir is cleared, so a stale or unverified
+  artifact can never be packaged or uploaded
+- a required-platform failure aborts before any packaging; a macOS-only
+  failure does not block Windows/Linux
+"""
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import build_all_platforms  # noqa: E402  (deliberate late import; sys.path just set)
+
+
+def make_builder(repo_root: Path, version: str = "v9.9.9"):
+    """Builder instance without __init__ (which requires a real Godot exe)."""
+    b = build_all_platforms.MultiPlatformBuilder.__new__(build_all_platforms.MultiPlatformBuilder)
+    b.version = version
+    b.version_num = version.lstrip("v")
+    b.repo_root = repo_root
+    b.godot_dir = repo_root / "godot"
+    b.godot_exe = repo_root / "godot_exe"
+    return b
+
+
+class TestRequiredPlatforms(unittest.TestCase):
+    def test_windows_and_linux_are_required(self):
+        self.assertIn("Windows", build_all_platforms.MultiPlatformBuilder.REQUIRED_PLATFORMS)
+        self.assertIn("Linux", build_all_platforms.MultiPlatformBuilder.REQUIRED_PLATFORMS)
+
+    def test_macos_is_best_effort(self):
+        # The #1069 ruling: macOS (issue #1071) must not block Windows/Linux
+        # from publishing. If macOS ever becomes required, change this test
+        # deliberately, not by accident.
+        self.assertNotIn("macOS", build_all_platforms.MultiPlatformBuilder.REQUIRED_PLATFORMS)
+
+
+class TestBuildReleaseCmd(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.repo = Path(self._tmp.name)
+        self.builder = make_builder(self.repo)
+
+    def test_command_routes_through_build_release(self):
+        cmd = self.builder._build_release_cmd("Windows Desktop", self.repo / "out")
+        self.assertEqual(cmd[0], sys.executable)
+        self.assertEqual(Path(cmd[1]).name, "build_release.py")
+        self.assertEqual(Path(cmd[1]).parent.name, "tools")
+
+    def test_command_carries_preset_output_godot_and_project(self):
+        out_dir = self.repo / "builds" / "linux" / "v9.9.9"
+        cmd = self.builder._build_release_cmd("Linux/X11", out_dir)
+        for flag, value in [
+            ("--preset", "Linux/X11"),
+            ("--output", str(out_dir)),
+            ("--godot-path", str(self.builder.godot_exe)),
+            ("--project", str(self.builder.godot_dir)),
+        ]:
+            with self.subTest(flag=flag):
+                self.assertIn(flag, cmd)
+                self.assertEqual(cmd[cmd.index(flag) + 1], value)
+
+    def test_command_never_weakens_the_discipline(self):
+        # --no-clean would skip the cache nuke; --keep-marker litters the
+        # project. Neither has any business in the release path.
+        cmd = self.builder._build_release_cmd("macOS", self.repo / "out")
+        self.assertNotIn("--no-clean", cmd)
+        self.assertNotIn("--keep-marker", cmd)
+
+
+class TestExportPlatform(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.repo = Path(self._tmp.name)
+        self.builder = make_builder(self.repo)
+        self.build_dir = self.repo / "builds" / "windows" / "v9.9.9"
+        self.build_dir.mkdir(parents=True)
+
+    def test_success_returns_true_and_keeps_outputs(self):
+        artifact = self.build_dir / "PDoom.exe"
+        artifact.write_bytes(b"exe")
+        with mock.patch.object(
+            build_all_platforms.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 0),
+        ):
+            ok = self.builder.export_platform("Windows Desktop", "Windows", self.build_dir)
+        self.assertTrue(ok)
+        self.assertTrue(artifact.exists())
+
+    def test_failure_clears_the_output_dir(self):
+        # A build_release.py failure can happen AFTER the export wrote files
+        # (freshness miss). Nothing left behind may be packaged or uploaded.
+        stale = self.build_dir / "PDoom.app.zip"
+        stale.write_bytes(b"stale unverified export")
+        with mock.patch.object(
+            build_all_platforms.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 1),
+        ):
+            ok = self.builder.export_platform("macOS", "macOS", self.build_dir)
+        self.assertFalse(ok)
+        self.assertFalse(stale.exists())
+        self.assertTrue(self.build_dir.exists())
+        self.assertEqual(list(self.build_dir.iterdir()), [])
+
+
+class TestBuildAllFailurePolicy(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.repo = Path(self._tmp.name)
+        self.builder = make_builder(self.repo)
+        self.builder._stamp_build = mock.Mock(return_value=True)
+        self.builder._update_export_paths = mock.Mock()
+        self.builder.zip_builds = mock.Mock(return_value=True)
+
+    def _fake_exports(self, outcomes):
+        def fake(preset_name, platform_name, build_dir):
+            return outcomes[platform_name]
+
+        self.builder.export_platform = mock.Mock(side_effect=fake)
+
+    def test_macos_failure_does_not_block_the_release(self):
+        self._fake_exports({"Windows": True, "Linux": True, "macOS": False})
+        self.assertTrue(self.builder.build_all())
+        self.builder.zip_builds.assert_called_once()
+
+    def test_required_platform_failure_packages_nothing(self):
+        # A half-built release is worse than none: no zips, exit non-zero.
+        self._fake_exports({"Windows": True, "Linux": False, "macOS": True})
+        self.assertFalse(self.builder.build_all())
+        self.builder.zip_builds.assert_not_called()
+
+    def test_all_green_still_green(self):
+        self._fake_exports({"Windows": True, "Linux": True, "macOS": True})
+        self.assertTrue(self.builder.build_all())
+        self.builder.zip_builds.assert_called_once()
+
+    def test_zip_failure_fails_the_build(self):
+        self._fake_exports({"Windows": True, "Linux": True, "macOS": True})
+        self.builder.zip_builds = mock.Mock(return_value=False)
+        self.assertFalse(self.builder.build_all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1069.

## What this does

`scripts/build_all_platforms.py` no longer runs a raw `godot --export-release`. Every per-platform export is delegated to `tools/build_release.py` (`export_platform()` -> `_build_release_cmd()`), so the CI release path now inherits the exact discipline a local cut gets:

1. `rm -rf godot/.godot` before the export -- defeats the stale `.godot/exported` cache that burned ~12 cycles in v0.11.0 (the reason `build_release.py` exists; its docstring records the cost).
2. A unique freshness-marker file dropped into the project.
3. Post-export PROOF the marker's filename landed inside the exported `.pck`/zip, or the platform build exits non-zero.

The `[BUILD-VERIFY][PASS]` block (marker token, where it was found, output path) is streamed uncaptured into the CI log, so a workflow run is auditable the same way a local cut is. One build path, one discipline -- option 1 from the issue.

The workflow's build step command is UNCHANGED (`python scripts/build_all_platforms.py --version ... --godot-path ...`); the routing happens inside the script, so local invocations of `build_all_platforms.py` get the same guarantee.

## Sequencing

The three platform builds are SEQUENTIAL BY CONSTRUCTION (one script, one loop) and must stay that way: every `build_release.py` run deletes `godot/.godot`, so parallel exports would destroy each other's import caches mid-flight. Stated in the workflow comment, the script docstring, and the loop comment, so nobody "optimizes" it into a matrix. Cost: three full import passes per release instead of one (some extra minutes of CI). That is the price of the proof.

## Ruling: macOS failure behaviour (issues #1069 / #1071)

macOS is **best-effort**; Windows and Linux are **required** (`REQUIRED_PLATFORMS`).

- **Windows or Linux fails (export, freshness, or packaging): the job fails and NOTHING is packaged or published.** A half-built release is worse than none.
- **macOS fails: loud but non-blocking.** `::warning::` annotation on the run, macOS assets dropped, Windows/Linux publish -- and then the existing `verify-release-urls` alias check (PDoom.app.zip must answer 200) turns the run RED after publish. A mac-less release is impossible to mistake for a healthy one, without holding the two platforms players actually use hostage to a checkout defect.

Why not block on macOS: #1071 shows the macOS export can fail through no fault of the tagged source (the GodotSteam `.framework` loses its `Versions/Current` symlink on non-mac checkouts; codesign then fails), and no macOS build has ever been verified to run anyway. Why not let it silently succeed: on ANY macOS failure (export non-zero, freshness miss, packaging problem) the outputs are DELETED before packaging, so a stale or unverified macOS artifact can never ship quietly.

Corollary to state plainly: the FIRST tag after this merges may publish without macOS assets (locally the macOS export exits non-zero per #1071; its CI exit code is unproven -- the near-identical asset sizes in #1071 suggest CI has been shipping the same broken bundle with exit 0). If that red run happens, it is #1071 becoming visible, not a regression of this PR.

## Safety detail worth knowing

A `build_release.py` failure can happen AFTER the export wrote files (that is what a freshness miss is). On any platform failure the platform's output dir is cleared (`export_platform()`), so `zip_builds()` and the upload steps can never pick up an unverified artifact. Windows/Linux artifact uploads now carry `if-no-files-found: error`; macOS carries `warn`.

## Relationship to #1099 (merged) and #1110 (open)

- Built ON #1099, not around it: the delegation only works because `build_release.py` now derives the output filename from the preset's `export_path` (`PDoom.exe` / `PDoom.x86_64` / `PDoom.app.zip`) and `find_marker()` descends into the macOS `.app.zip`. Nothing from #1099 is undone; `tools/build_release.py` is untouched here.
- No collision with #1110: that PR rewrites the manifest step in the `create-release-manifest` job; this PR touches only the `build-godot` job and `scripts/build_all_platforms.py`. Artifact names (`build-windows`/`build-linux`/`build-mac`), zip locations (`builds/<platform>/<version>/`), and asset names are all unchanged, so #1110's `pattern: build-*` hashing and `scripts/generate_release_manifest.py` keep working. One interaction to know: if macOS fails best-effort, the `build-mac` artifact is empty/absent and the manifest will simply carry no macOS asset hashes. #1110's hash claim ("what CI uploaded is what you got") now composes with this PR's claim ("CI packed the right bits") -- which is the prerequisite its design doc names.
- Asset contract intact: `releases/latest/download/PDoom-Windows.zip` / `PDoom.app.zip` / `PDoom-Linux.zip` (#1068) still resolve from the next cut, produced by the same `zip_builds()` code as before.

## Tests

- NEW `tests/test_build_all_platforms.py` (11 tests): delegation command routes through `tools/build_release.py` with `--preset/--output/--godot-path/--project` and never `--no-clean`/`--keep-marker`; Windows+Linux required / macOS best-effort pinned; failed platform's output dir cleared; macOS-only failure returns success while a required failure aborts before `zip_builds()`.
- `python -m unittest tests.test_build_all_platforms tests.test_build_release_paths`: 30/30 pass.
- Workflow YAML parses (`yaml.safe_load`).
- Godot fast gate: 1072 tests, 0 failures, 104/104 files -- exactly baseline; no `.gd` touched.

## What remains UNPROVEN until the next real tag

**The end-to-end release path has not been executed.** This machine cannot run the workflow, and `tools/build_release.py` was deliberately not run locally (it `rm -rf`s `godot/.godot` while other agents share the machine). Specifically unproven until a tag is cut: the delegation on ubuntu-latest with `setup-godot`'s binary, the macOS export's actual CI exit code, the per-run import cost, and the empty-`build-mac` artifact interaction with downstream jobs. The first tag after this merges should be watched end to end, and its published `PDoom-Windows.zip` downloaded and played for [Gate 4] check 5 -- the issue's own mitigation-turned-policy.

Refs #1069, #1099, #1071, #1068, #1110.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
