### PR TITLE
fix(art): second-pass promotion map -- all 327 blocked keeps resolve; unmapped batches refuse to index

### DIFF
--- a/tests/test_art_promotion_pipeline.py
+++ b/tests/test_art_promotion_pipeline.py
@@ -11,6 +11,7 @@ here at commit time, not at promote time).
 
 import importlib.util
 import io
+import json
 import shutil
 import tempfile
 import unittest
@@ -68,6 +69,44 @@ class TestPxCategory(unittest.TestCase):
     def test_unknown_is_none(self):
         self.assertIsNone(apply_review._px_category("mystery_batch/loose_file"))
 
+    def test_second_pass_prefix_overrides(self):
+        """The 2026-08-04 recurrence batches: every prefix added in the
+        second-pass fix routes where it was ruled to route."""
+        cat = apply_review._px_category
+        self.assertEqual(
+            cat("pixellab_2026-07-26_doom_overlays/arc/branching/idle"), "doom_overlays"
+        )
+        self.assertEqual(
+            cat("pixellab_2026-07-26_prop_grain_vanguard/native/door_scummy_native_r1"),
+            "px_probes",
+        )
+        self.assertEqual(cat("pixellab_2026-07-26_size_probe/whatever_probe_r1"), "px_probes")
+        self.assertEqual(cat("pixellab_2026-07-26_worker_rebase/worker_a/east"), "characters")
+        self.assertEqual(cat("pixellab_2026-07-27_t6_worker_diagonals/w/ne"), "characters")
+        self.assertEqual(
+            cat("pixellab_2026-07-27_worker_round2/worker_grey_black_f/animations/e/frame_000"),
+            "characters",
+        )
+        self.assertEqual(cat("dump_october_31_2025/hero-bg-2400w.webp"), "legacy_dump")
+
+    def test_vignette_batch_beats_cat_fallback(self):
+        """01_cat-in-the-alley contains 'cat': without the batch override the
+        loose fallback filed a 1536x1024 hero vignette under cats/generated
+        (latent wrong-destination, found 2026-08-04)."""
+        cat = apply_review._px_category
+        self.assertEqual(cat("vignettes_2026-07-28/01_cat-in-the-alley.png"), "vignettes")
+        self.assertEqual(cat("vignettes_2026-07-28/05_taxi-window-rain.png"), "vignettes")
+
+    def test_large_source_token_is_masters_hold(self):
+        """prop_rebase mixes promotable native/ art with 2x large_source
+        provenance in ONE batch: the token must split them."""
+        cat = apply_review._px_category
+        self.assertEqual(
+            cat("pixellab_2026-07-27_prop_rebase/large_source/desk_decent_r1.png"), "px_masters"
+        )
+        self.assertEqual(cat("pixellab_2026-07-27_prop_rebase/native/door_decent_r1.png"), "props")
+        self.assertIsInstance(apply_review.PX_DEST["px_masters"], apply_review.Hold)
+
 
 class TestDestMaps(unittest.TestCase):
     """Map invariants -- these are what make regressions loud."""
@@ -83,18 +122,79 @@ class TestDestMaps(unittest.TestCase):
                     d.startswith("godot/assets/"), f"{cat}: {d} not under godot/assets/"
                 )
 
+    IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp"}
+
+    def _has_images(self, d):
+        return any(f.suffix.lower() in self.IMAGE_EXTS for f in d.rglob("*") if f.is_file())
+
     def test_every_art_generated_batch_on_disk_is_mapped(self):
         """LIVE-TREE INVARIANT: a new art_generated/<category> dir with no
-        GEN_DEST entry fails here -- the gap surfaces at commit time."""
+        GEN_DEST entry fails here -- the gap surfaces at commit time.
+
+        KNOWN LIMIT (the 2026-08-04 recurrence): most of art_generated/ is
+        machine-local (untracked), so on CI this test only sees the tracked
+        legacy dirs and passes vacuously. The CI-real coverage lives in
+        test_every_review_state_id_is_mappable below; THIS test is the local
+        early-warning on the machine where new batches actually appear.
+        Dirs with no image files (logs/, velocity/, ...) cannot strand a
+        review and are exempt."""
         gen_root = REPO_ROOT / "art_generated"
         self.assertTrue(gen_root.is_dir(), "art_generated/ missing from repo")
         for d in sorted(p for p in gen_root.iterdir() if p.is_dir()):
+            if not self._has_images(d):
+                continue
             self.assertIn(
                 d.name,
                 apply_review.GEN_DEST,
                 f"art_generated/{d.name} has no GEN_DEST mapping: add a destination "
                 "or an explicit Hold(reason) in tools/art_review/apply_review.py",
             )
+
+    def test_every_art_source_image_on_disk_is_mappable(self):
+        """LIVE-TREE INVARIANT, px side (new, 2026-08-04): EVERY image file
+        under art_source/ must derive a category that PX_DEST maps (str or
+        Hold). Same CI limit as above -- untracked batches only exist on the
+        review machine, which is exactly where this needs to fire before the
+        gallery indexes them."""
+        src_root = REPO_ROOT / "art_source"
+        self.assertTrue(src_root.is_dir(), "art_source/ missing from repo")
+        bad = {}
+        for f in src_root.rglob("*"):
+            if not (f.is_file() and f.suffix.lower() in self.IMAGE_EXTS):
+                continue
+            rel = f.relative_to(src_root).as_posix()
+            if apply_review.dest_rule_for_id(f"px:{rel}") is None:
+                bad.setdefault(rel.split("/")[0], []).append(rel)
+        self.assertEqual(
+            bad,
+            {},
+            "art_source batches with unmappable images (add PX_PREFIX_CATEGORY "
+            "+ PX_DEST destination or Hold(reason)): "
+            + "; ".join(f"{k} x{len(v)} e.g. {v[0]}" for k, v in sorted(bad.items())),
+        )
+
+    def test_every_review_state_id_is_mappable(self):
+        """THE CI-VISIBLE INVARIANT (2026-08-04 structural fix): every asset
+        id in the TRACKED verdict store must map to a destination or an
+        explicit Hold, disk-free. art_generated/ and most of art_source/ only
+        exist on Pip's machine, so the on-disk sweeps above pass vacuously on
+        CI -- but review_state.json is in git, so the commit that lands a
+        review pass FAILS here until the map rules on every category it
+        touched. A review pass can no longer strand its own results on main."""
+        state_path = REPO_ROOT / "tools" / "art_review" / "review_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        bad = sorted(
+            aid
+            for aid, val in state.items()
+            if isinstance(val, dict) and apply_review.dest_rule_for_id(aid) is None
+        )
+        self.assertEqual(
+            bad,
+            [],
+            f"{len(bad)} review_state ids have no destination mapping "
+            f"(first few: {bad[:5]}) -- add a destination or Hold(reason) in "
+            "tools/art_review/apply_review.py",
+        )
 
     def test_px_dest_categories_cover_all_tokens(self):
         for token, cat in apply_review.PX_TOKEN_CATEGORY.items():
@@ -135,6 +235,84 @@ class TestGenDestRel(unittest.TestCase):
         self.assertEqual(
             apply_review._gen_dest_rel("ui_icons", "anything"), "godot/assets/icons/generated"
         )
+
+    def test_endgame_study_series_is_held(self):
+        """The eight 2026-08 endgame direction-study categories are concept
+        material, not game-ready derivatives (ADR-0019): all Hold."""
+        for cat in (
+            "endgame_concepts",
+            "endgame_concepts_gen2",
+            "crisp_sweep",
+            "treatment_sweep",
+            "new_subjects",
+            "wanasai_calls",
+            "doomfield_ladder",
+            "people_policy",
+        ):
+            self.assertIsInstance(
+                apply_review._gen_dest_rel(cat, "anything"), apply_review.Hold, cat
+            )
+
+    def test_audiodump_is_held(self):
+        self.assertIsInstance(apply_review.GEN_DEST["audiodump"], apply_review.Hold)
+
+    def test_scene_art_wave2_event_files_join_shipped_event_art(self):
+        """event_* must land in images/events beside the already-shipped
+        event_crisis_v1.webp etc. -- images/scenes would DUPLICATE those
+        bytes in the pack."""
+        f = apply_review._gen_dest_rel
+        self.assertEqual(f("scene_art_wave2", "event_crisis_v1"), "godot/assets/images/events")
+        self.assertEqual(f("scene_art_wave2", "office_wide_day"), "godot/assets/images/scenes")
+        self.assertEqual(f("scene_art_wave2", "records_vault"), "godot/assets/images/scenes")
+
+
+class TestDestRuleForId(unittest.TestCase):
+    """dest_rule_for_id: the disk-free mapping predicate shared by the report
+    gate, the gallery preflight and the review_state sweep."""
+
+    def test_gen_id(self):
+        self.assertEqual(
+            apply_review.dest_rule_for_id("gen:ui_icons:icon_x:v1"),
+            "godot/assets/icons/generated",
+        )
+
+    def test_px_id_with_and_without_art_source_prefix(self):
+        for aid in (
+            "px:pixellab_2026-07-19/characters/worker_x/rotations/east",
+            "px:art_source/pixellab_2026-07-19/characters/worker_x/rotations/east",
+        ):
+            self.assertEqual(
+                apply_review.dest_rule_for_id(aid),
+                "godot/assets/office_floor/characters",
+                aid,
+            )
+
+    def test_file_id_gen_side_routes_by_category_and_stem(self):
+        self.assertEqual(
+            apply_review.dest_rule_for_id(
+                "file:art_generated/scene_art_wave2/v1/event_board_v1.webp"
+            ),
+            "godot/assets/images/events",
+        )
+        self.assertEqual(
+            apply_review.dest_rule_for_id(
+                "file:art_generated/iconset_round2/v1/gen_cat_doom_8bit_v1_48.png"
+            ),
+            "godot/assets/icons/generated",
+        )
+
+    def test_file_id_px_side_uses_px_derivation(self):
+        self.assertEqual(
+            apply_review.dest_rule_for_id("file:art_source/cats_incoming/office_cat_base.png"),
+            "godot/assets/cats/generated",
+        )
+
+    def test_unmapped_and_malformed_are_none(self):
+        self.assertIsNone(apply_review.dest_rule_for_id("gen:no_such_category:x:v1"))
+        self.assertIsNone(apply_review.dest_rule_for_id("file:art_generated/no_such_cat/v1/x.png"))
+        self.assertIsNone(apply_review.dest_rule_for_id("px:mystery_batch/loose_file"))
+        self.assertIsNone(apply_review.dest_rule_for_id("gen:short"))
+        self.assertIsNone(apply_review.dest_rule_for_id("weird:thing"))
 
 
 class _TmpArtRoot(unittest.TestCase):
@@ -203,6 +381,55 @@ class TestPxResolver(_TmpArtRoot):
         a = _make_asset("px:pixellab_2026-07-19/characters/worker_x/rotations/east", self.root)
         # 'characters' (the category token) is dropped; worker identity kept.
         self.assertEqual(a.dest_name(p), "worker_x/rotations/east.png")
+
+
+class TestFileResolver(_TmpArtRoot):
+    """file:<relpath> -- the gallery's additive third id scheme, taught to
+    apply_review 2026-08-04 (the 30 'unresolved-source' keeps were all this:
+    webp scene art and 48/32px icons outside the gallery's gen: grammar)."""
+
+    def test_resolves_single_file_and_keeps_name_verbatim(self):
+        p = self._write("art_generated/scene_art_wave2/v1/event_crisis_v1.webp")
+        a = _make_asset("file:art_generated/scene_art_wave2/v1/event_crisis_v1.webp", self.root)
+        self.assertIsNone(a.error)
+        self.assertEqual(a.sources, [p])
+        self.assertEqual(a.promotion_status(), ("promotable", "godot/assets/images/events"))
+        # verbatim: v1/v2/v4 of one base are distinct kept assets; no
+        # variant-stripping collision is possible.
+        self.assertEqual(a.dest_name(p), "event_crisis_v1.webp")
+
+    def test_off_grid_size_stem_icon(self):
+        p = self._write("art_generated/iconset_round2/v1/gen_seal_dod_wax_v1_32.png")
+        a = _make_asset(
+            "file:art_generated/iconset_round2/v1/gen_seal_dod_wax_v1_32.png", self.root
+        )
+        self.assertIsNone(a.error)
+        self.assertEqual(a.promotion_status(), ("promotable", "godot/assets/icons/generated"))
+        self.assertEqual(a.dest_name(p), "gen_seal_dod_wax_v1_32.png")
+
+    def test_missing_file_is_blocked_unresolved(self):
+        a = _make_asset("file:art_generated/scene_art_wave2/v1/ghost.webp", self.root)
+        self.assertEqual(a.promotion_status()[0], "blocked-unresolved")
+        self.assertIn("ghost.webp", a.error)
+
+    def test_over_cap_file_is_blocked_size(self):
+        cap = apply_review.MAX_PROMOTE_BYTES
+        self._write("art_generated/scene_art_wave2/v1/office_huge.webp", size=cap + 1)
+        a = _make_asset("file:art_generated/scene_art_wave2/v1/office_huge.webp", self.root)
+        self.assertEqual(a.promotion_status()[0], "blocked-size")
+
+    def test_held_category_file_is_held(self):
+        self._write("art_generated/endgame_concepts/v1/study_x_v1.webp")
+        a = _make_asset("file:art_generated/endgame_concepts/v1/study_x_v1.webp", self.root)
+        self.assertEqual(a.promotion_status()[0], "held")
+
+    def test_unmapped_file_names_the_batch_dir(self):
+        self._write("art_generated/new_sweep_2099/v1/thing.webp")
+        a = _make_asset("file:art_generated/new_sweep_2099/v1/thing.webp", self.root)
+        status, detail = a.promotion_status()
+        self.assertEqual(status, "blocked-unmapped")
+        self.assertIn("art_generated/new_sweep_2099", detail)
+        self.assertIn("GEN_DEST", detail)
 
 
 class TestGenSizeCap(_TmpArtRoot):

--- a/tools/art_review/apply_review.py
+++ b/tools/art_review/apply_review.py
@@ -10,6 +10,12 @@ The review app writes a verdict-state file (default
         <art-root>/art_source/<relpath>  (relpath may point at a single PNG, a
         rotation directory of PNGs, or -- the review app's usual form -- a PNG
         path WITHOUT its .png extension; the resolver tries all of these)
+    file:<relpath-from-art-root>         build_full_gallery.py's additive
+        scheme for files no other scheme expresses (webp scene art, PNGs with
+        off-grid size stems, loose files outside a v1/ dir). Single file,
+        extension included; category derives from the path (art_generated/
+        <category>/... -> GEN_DEST, art_source/<batch>/... -> px derivation);
+        the destination filename is kept VERBATIM.
 
 Each value is ``{verdict, note, tags, updated_at}`` with verdict in
 {keep, iterate, discard} (the review app's v2 tri-state). Legacy files still
@@ -87,6 +93,19 @@ class Hold:
         self.reason = reason
 
 
+# The 2026-08 endgame art-direction exploration series is ONE lineage
+# (endgame_concepts -> gen2 -> crispness/treatment sweeps -> subject/people/
+# ladder probes): 1536x1024 opaque direction STUDIES, ~1.4MB each, most over
+# the git cap. They are Library reference material, not game-ready
+# derivatives (ADR-0019); the eventual production endgame batch promotes,
+# the studies never do. One shared Hold so the report rolls them up together.
+_ENDGAME_STUDY_HOLD = Hold(
+    "endgame art-direction study series (1536x1024 concept sweeps/probes/"
+    "ladder controls, tools/assets/manifests/endgame_concepts*.json lineage): "
+    "Library reference per ADR-0019, not game-ready derivatives -- promote "
+    "the eventual production endgame batch, never the studies"
+)
+
 GEN_DEST = {
     "game_icons": "godot/assets/icons/generated",
     "ui_icons": "godot/assets/icons/generated",
@@ -103,11 +122,29 @@ GEN_DEST = {
     "round3_rerolls_banners": "godot/assets/images/heroes",
     "screen_backgrounds": "godot/assets/images/backgrounds",
     "env_scenes": "godot/assets/images/scenes",
-    "scene_art_wave2": "godot/assets/images/scenes",
+    # event_* webps must land where the game's shipped event art already
+    # lives (godot/assets/images/events holds event_crisis_v1.webp etc.);
+    # routing them to images/scenes would DUPLICATE those bytes in the pack.
+    "scene_art_wave2": [
+        ("event_", "godot/assets/images/events"),
+        ("", "godot/assets/images/scenes"),
+    ],
     "terminal_textures": "godot/assets/textures/generated",
     "env_textures": "godot/assets/textures/generated",
     "crt_frame_overlay": "godot/assets/textures/generated",
     "ui_frames": "godot/assets/ui/frames",
+    "endgame_concepts": _ENDGAME_STUDY_HOLD,
+    "endgame_concepts_gen2": _ENDGAME_STUDY_HOLD,
+    "crisp_sweep": _ENDGAME_STUDY_HOLD,
+    "treatment_sweep": _ENDGAME_STUDY_HOLD,
+    "new_subjects": _ENDGAME_STUDY_HOLD,
+    "wanasai_calls": _ENDGAME_STUDY_HOLD,
+    "doomfield_ladder": _ENDGAME_STUDY_HOLD,
+    "people_policy": _ENDGAME_STUDY_HOLD,
+    # session recordings (mp4/mp3/transcripts + extracted frames) that live
+    # under art_generated/ on Pip's machine; the full gallery walks them, so
+    # they need an explicit mapping outcome. Never art, never packed.
+    "audiodump": Hold("session recordings and extracted video frames, not art"),
 }
 PX_DEST = {
     "props": "godot/assets/office_floor/props",
@@ -118,19 +155,54 @@ PX_DEST = {
     "cats": "godot/assets/cats/generated",
     "icons": "godot/assets/icons/generated",
     "backgrounds": "godot/assets/images/backgrounds",
+    # doom-generation particle/animation overlay sprites (64x64 RGBA idle +
+    # loop frames; art_source/pixellab_2026-07-26_doom_overlays/MANIFEST.md).
+    # Game-scale derivatives for the in-engine sprite-overlay candidate of
+    # docs/art/DOOM_OVERLAY.md ("doom is a layer, not a repaint"); the whole
+    # kept set is ~0.3MB. If the renderer lane rules for the shader pass
+    # instead, flip this to a Hold -- one line.
+    "doom_overlays": "godot/assets/effects/doom_overlays",
+    # seed-vignette stand-in heroes (docs/game-design/SEED_VIGNETTE_SPECS.md),
+    # already downscaled under the git cap; masters are archived per
+    # ART_MASTERS_POLICY (art_source/vignettes_2026-07-28/MANIFEST.md).
+    "vignettes": "godot/assets/images/vignettes",
     "icon_hires": Hold(
         "hi-res icon source variants (issue #787 bloat class): the game references "
         "sized icons already in godot/assets/icons; re-importing ~318 files (~52MB) "
         "needs Pip's explicit ruling"
     ),
+    "px_masters": Hold(
+        "2x large_source provenance masters: the kept game art is the "
+        "LANCZOS-downscaled native/ file (prop_rebase MANIFEST.md); a master "
+        "crossing into godot/ unchanged is a defect per ADR-0019"
+    ),
+    "px_probes": Hold(
+        "experiment/evidence probe batches (grain vanguard dial + "
+        "manifest-scale controls, size probes): their verdicts were executed "
+        "by the 2026-07-27 prop re-base regeneration; Library evidence, "
+        "not game art"
+    ),
+    "legacy_dump": Hold(
+        "October 2025 website/prototype dump (css, shaders, 2400w web hero): "
+        "pre-Godot reference material, never pack fodder"
+    ),
 }
 # first-path-segment overrides: batch dirs whose names would fool the token
-# scan (e.g. iconset_2026-07-21's gen_cat_doom_* must NOT land in cats/).
+# scan (e.g. iconset_2026-07-21's gen_cat_doom_* must NOT land in cats/, and
+# vignettes_2026-07-28's 01_cat-in-the-alley must NOT land in cats/ either).
 PX_PREFIX_CATEGORY = {
     "icon_hires": "icon_hires",
     "iconset_2026-07-21": "icons",
     "settings_bg_2026-07-21": "backgrounds",
     "cats_incoming": "cats",
+    "pixellab_2026-07-26_doom_overlays": "doom_overlays",
+    "pixellab_2026-07-26_prop_grain_vanguard": "px_probes",
+    "pixellab_2026-07-26_size_probe": "px_probes",
+    "pixellab_2026-07-26_worker_rebase": "characters",
+    "pixellab_2026-07-27_t6_worker_diagonals": "characters",
+    "pixellab_2026-07-27_worker_round2": "characters",
+    "vignettes_2026-07-28": "vignettes",
+    "dump_october_31_2025": "legacy_dump",
 }
 # relpath segment -> category (any segment, first match in path order).
 PX_TOKEN_CATEGORY = {
@@ -146,9 +218,17 @@ PX_TOKEN_CATEGORY = {
     "tilesets": "tilesets",
     "cats": "cats",
     "icons": "icons",
+    # 2x generate-large-then-downscale provenance dirs (prop_rebase and any
+    # future batch following the same convention) -- held, never promoted.
+    "large_source": "px_masters",
 }
-# batch dirs whose ROOT-level loose files are character style probes.
-PX_BATCH_DEFAULT_CATEGORY = {"pixellab_2026-07-16": "characters"}
+# batch dirs whose ROOT-level loose files are character style probes, plus
+# batches whose file names carry no routable token at all (prop_rebase
+# native/ files are bare prop names: desk_decent_r1.png).
+PX_BATCH_DEFAULT_CATEGORY = {
+    "pixellab_2026-07-16": "characters",
+    "pixellab_2026-07-27_prop_rebase": "props",
+}
 
 # git art cap: pre-commit check-added-large-files runs with --maxkb=1000 and
 # docs/art/ART_MASTERS_POLICY.md forbids >1MB art in git. Anything bigger can
@@ -210,8 +290,11 @@ class Asset:
             self.kind = "px"
             self.pipeline = "pixellab"
             self._parse_px()
+        elif self.id.startswith("file:"):
+            self.kind = "file"
+            self._parse_file()
         else:
-            self.error = "unrecognised asset_id prefix (expected gen: or px:)"
+            self.error = "unrecognised asset_id prefix (expected gen:, px: or file:)"
 
     def _parse_gen(self):
         # gen:<category>:<base_id>:<variant>  -- base_id may itself contain no
@@ -264,7 +347,7 @@ class Asset:
                 return
         else:
             self.sources = [target]
-        self.category = _px_category(self.relpath)
+        self.category = _px_category(_strip_art_source(self.relpath))
         # promote copies every under-cap source PNG for px (rotation sets stay
         # together); promote_file holds the first for reporting convenience.
         self.best_file = self.sources[0]
@@ -272,14 +355,30 @@ class Asset:
         self.promote_file = fits[0] if fits else None
         self.size_capped = bool(fits) and len(fits) != len(self.sources)
 
+    def _parse_file(self):
+        # file:<relpath-from-art-root> -- build_full_gallery.py's ADDITIVE id
+        # scheme for files no other scheme can express (webp scene art, PNGs
+        # whose size stem is outside the gallery's KNOWN_SIZES, loose files
+        # outside a v1/ dir). Always a single file, never a rotation dir.
+        self.relpath = self.id[len("file:") :]
+        self.pipeline = _FILE_PIPELINE.get(Path(self.relpath).as_posix().split("/")[0])
+        self.category, self.base_id = _file_category(self.relpath)
+        target = self.art_root / self.relpath
+        if not target.is_file():
+            self.error = f"no file at {target}"
+            return
+        self.sources = [target]
+        self.best_file = target
+        fits = target.stat().st_size <= MAX_PROMOTE_BYTES
+        self.promote_file = target if fits else None
+        self.size_capped = False
+
     # -- destination mapping for a promote --
     def dest_rule(self):
-        """Raw mapping outcome: a destination str, a Hold, or None (unmapped)."""
-        if self.kind == "gen":
-            return _gen_dest_rel(self.category, self.base_id)
-        if self.kind == "px":
-            return PX_DEST.get(self.category) if self.category else None
-        return None
+        """Raw mapping outcome: a destination str, a Hold, or None (unmapped).
+        Delegates to dest_rule_for_id so the report gate, the gallery
+        preflight and the coverage tests share ONE mapping logic."""
+        return dest_rule_for_id(self.id)
 
     def dest_dir(self):
         rel = self.dest_rule()
@@ -287,8 +386,9 @@ class Asset:
 
     def promote_sources(self):
         """Source files promote would copy: all under-cap PNGs for px, the
-        largest under-cap size for gen. Empty if nothing fits the git cap."""
-        if self.kind == "gen":
+        largest under-cap size for gen, the single file for file:. Empty if
+        nothing fits the git cap."""
+        if self.kind in ("gen", "file"):
             return [self.promote_file] if self.promote_file else []
         return [s for s in self.sources if s.stat().st_size <= MAX_PROMOTE_BYTES]
 
@@ -306,7 +406,10 @@ class Asset:
             return ("blocked-unresolved", self.error)
         rule = self.dest_rule()
         if rule is None:
-            return ("blocked-unmapped", f"no destination for category {self.category!r}")
+            # Name the BATCH DIRECTORY that needs the mapping, not just the
+            # category -- the fix (one GEN_DEST/PX_DEST line) must be obvious
+            # from the report alone (#1093 recurrence, 2026-08-04).
+            return ("blocked-unmapped", _unmapped_hint(self))
         if isinstance(rule, Hold):
             return ("held", rule.reason)
         if not self.promote_sources():
@@ -336,6 +439,13 @@ class Asset:
         packed-but-unreferenced, exactly the class ADR-0019 exists to end; they
         stay until the demand manifest can rule on them (see #1109).
         """
+        # file: ids ship their filename VERBATIM -- variants like
+        # event_crisis_v1.webp / event_crisis_v4.webp are distinct kept assets
+        # with no in-game plain-name convention to preserve, and verbatim
+        # names cannot collide with each other. (A same-name collision across
+        # subdirs would still surface as contested -- loud, never silent.)
+        if self.kind == "file":
+            return src.name
         # generated: strip the _<variant> suffix for a clean game path
         # (matches promote_assets.py convention: art id vN -> base name).
         if self.kind == "gen":
@@ -365,7 +475,7 @@ class Asset:
         # existing per-set dirs under godot/assets/office_floor/.
         parts = [
             seg
-            for seg in Path(self.relpath).as_posix().split("/")[1:]
+            for seg in _strip_art_source(self.relpath).split("/")[1:]
             if PX_TOKEN_CATEGORY.get(seg) != self.category
         ]
         if not self._target_is_dir and parts:
@@ -430,6 +540,89 @@ def _gen_dest_rel(category, base_id):
         if (base_id or "").startswith(prefix):
             return dest
     return None
+
+
+def _strip_art_source(relpath):
+    """px relpaths come in two spellings: relative to art_source/ (natural)
+    and relative to the art root. Category derivation must see the batch dir
+    as the FIRST segment either way."""
+    rel = Path(relpath).as_posix()
+    return rel[len("art_source/") :] if rel.startswith("art_source/") else rel
+
+
+# top-level dir of a file:<relpath> id -> reroll pipeline.
+_FILE_PIPELINE = {"art_generated": "gpt", "art_source": "pixellab"}
+
+
+def _file_category(relpath):
+    """(category, base_stem) for a file:<relpath-from-art-root> id.
+    art_generated/<category>/... reuses the GEN_DEST category (base_stem
+    feeds prefix-list routing); art_source/... reuses the px derivation."""
+    parts = Path(relpath).as_posix().split("/")
+    stem = Path(parts[-1]).stem
+    if parts[0] == "art_generated" and len(parts) >= 3:
+        return parts[1], stem
+    if parts[0] == "art_source" and len(parts) >= 3:
+        return _px_category("/".join(parts[1:])), stem
+    return None, stem
+
+
+def dest_rule_for_id(asset_id):
+    """Mapping outcome for an asset id WITHOUT touching the disk: a
+    destination str, a Hold, or None (unmapped).
+
+    This is the ONE mapping-coverage predicate, shared by the report's
+    promotion gate (Asset.dest_rule), build_full_gallery.py's preflight
+    (refuse to index a batch whose ids cannot map), and
+    tests/test_art_promotion_pipeline.py's review_state.json sweep. Keeping
+    it disk-free is what lets CI enforce it on the tracked state file even
+    though art_generated/ only exists on Pip's machine."""
+    if asset_id.startswith("gen:"):
+        parts = asset_id.split(":")
+        if len(parts) < 4:
+            return None
+        return _gen_dest_rel(parts[1], ":".join(parts[2:-1]))
+    if asset_id.startswith("px:"):
+        cat = _px_category(_strip_art_source(asset_id[len("px:") :]))
+        return PX_DEST.get(cat) if cat else None
+    if asset_id.startswith("file:"):
+        rel = asset_id[len("file:") :]
+        cat, stem = _file_category(rel)
+        if cat is None:
+            return None
+        if Path(rel).as_posix().split("/")[0] == "art_generated":
+            return _gen_dest_rel(cat, stem)
+        return PX_DEST.get(cat)
+    return None
+
+
+def _unmapped_hint(asset):
+    """Actionable blocked-unmapped detail: the batch dir that needs a
+    mapping and the exact structure to touch in THIS file."""
+    if asset.kind == "gen":
+        return (
+            f"art_generated/{asset.category} -- add GEN_DEST[{asset.category!r}] "
+            "(a godot/assets/... destination or Hold(reason))"
+        )
+    if asset.kind in ("px", "file") and asset.relpath:
+        rel = Path(asset.relpath).as_posix()
+        if asset.kind == "file" and rel.split("/")[0] == "art_generated":
+            cat = rel.split("/")[1] if len(rel.split("/")) > 1 else "?"
+            return (
+                f"art_generated/{cat} -- add GEN_DEST[{cat!r}] "
+                "(a godot/assets/... destination or Hold(reason))"
+            )
+        batch = _strip_art_source(rel).split("/")[0]
+        if asset.category:
+            return (
+                f"art_source/{batch} -- category {asset.category!r} has no "
+                f"PX_DEST entry (add a godot/assets/... destination or Hold(reason))"
+            )
+        return (
+            f"art_source/{batch} -- no category resolves; add "
+            f"PX_PREFIX_CATEGORY[{batch!r}] plus a PX_DEST destination or Hold(reason)"
+        )
+    return f"no destination for category {asset.category!r}"
 
 
 def _fmt_rule(rule):
@@ -823,6 +1016,10 @@ def action_reroll(assets, prompt_index, art_root, dry_run):
             manifest["gpt"].append(entry)
         elif a.kind == "px":
             manifest["pixellab"].append(entry)
+        elif a.kind == "file" and a.pipeline in ("gpt", "pixellab"):
+            # file: ids carry their pipeline in the top-level dir
+            # (art_generated -> gpt, art_source -> pixellab).
+            manifest[a.pipeline].append(entry)
         else:
             entry["error"] = a.error or "unparseable id"
             manifest.setdefault("unknown", []).append(entry)
@@ -866,7 +1063,9 @@ def build_parser():
         "  gen:<category>:<base_id>:<variant>  -> art_generated/<category>/v1/"
         "<base_id>_<variant>_<size>.png\n"
         "  px:<relpath>                        -> art_source/<relpath> (file, "
-        "rotation dir, or extensionless PNG path)\n\n"
+        "rotation dir, or extensionless PNG path)\n"
+        "  file:<relpath-from-art-root>        -> single file, extension "
+        "included (the full gallery's additive scheme)\n\n"
         "exit codes: nonzero from report/promote when any KEEP asset is blocked\n"
         "(unmapped category / unresolvable source / nothing under the 1MB cap).\n"
         "Explicit Hold (not-for-promotion) entries are reported but do not fail.\n\n"

--- a/tools/art_review/build_full_gallery.py
+++ b/tools/art_review/build_full_gallery.py
@@ -29,9 +29,10 @@ asset_id compatibility with apply_review.py / review_state.json:
       verbatim (no duplicate keys). New px assets get the relpath WITH
       extension, which apply_review.py can actually resolve.
   file:<relpath-from-repo-root>       ADDITIVE extension, only for files no
-      existing scheme can express (e.g. audiodump frames, loose files outside
-      a v1/ dir). apply_review.py will list these as UNRESOLVED; they are
-      review-notes-only until someone teaches it the prefix.
+      existing scheme can express (e.g. webp scene art, off-grid size stems,
+      loose files outside a v1/ dir). apply_review.py resolves these since
+      2026-08-04: single file, category derived from the path, destination
+      filename kept verbatim.
 
 Usage:
     python tools/art_review/build_full_gallery.py [--open]
@@ -43,9 +44,15 @@ import argparse
 import html
 import json
 import re
+import sys
 import time
 import webbrowser
 from pathlib import Path
+
+# Sibling module (this script runs from tools/art_review/, which is
+# sys.path[0] when invoked as a script). Supplies dest_rule_for_id -- the ONE
+# mapping-coverage predicate shared with the report gate and the tests.
+import apply_review
 
 REPO = Path(__file__).resolve().parents[2]
 ART_GEN = REPO / "art_generated"
@@ -273,14 +280,58 @@ def href_of(p):
         return html.escape("../art_source/" + rel.as_posix(), quote=True)
 
 
+def preflight_mapping(batches):
+    """Batches whose asset ids cannot map to a destination or explicit Hold.
+
+    Returns {batch_title: [unmappable asset ids]}. This is the pre-review
+    gate for the #1093/#1107 recurrence (2026-08-04): a batch indexed without
+    a mapping lets a whole review pass strand its own keeps -- the verdicts
+    land, then apply_review's promotion gate fails AFTER the reviewing was
+    spent. Failing HERE means the one-line map entry (destination or
+    Hold(reason)) exists BEFORE any verdict is cast."""
+    unmapped = {}
+    for b in batches:
+        bad = [g.id for g in b["assets"] if apply_review.dest_rule_for_id(g.id) is None]
+        if bad:
+            unmapped[b["title"]] = bad
+    return unmapped
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--open", action="store_true")
+    ap.add_argument(
+        "--allow-unmapped",
+        action="store_true",
+        help="index batches that have no destination mapping anyway (their "
+        "keep verdicts WILL be stranded until the map rules on them; the "
+        "default is to refuse so the map gets its one-line entry first).",
+    )
     args = ap.parse_args()
 
     t0 = time.time()
     state = load_state()
     batches = scan(state)
+
+    unmapped = preflight_mapping(batches)
+    if unmapped:
+        print(
+            "[!] {} batch(es) have assets with NO destination mapping -- a "
+            "review pass over them would strand its own keeps:".format(len(unmapped))
+        )
+        for title, ids in sorted(unmapped.items()):
+            print(f"    {title}  ({len(ids)} unmappable; e.g. {ids[0]})")
+        print(
+            "    Fix: add a godot/assets/... destination or an explicit "
+            "Hold(reason) per batch in tools/art_review/apply_review.py "
+            "(GEN_DEST / PX_DEST / PX_PREFIX_CATEGORY). A Hold is a "
+            "first-class outcome for concept/reference/master material."
+        )
+        if not args.allow_unmapped:
+            print("    Refusing to build (override: --allow-unmapped).")
+            sys.exit(2)
+        print("    --allow-unmapped given: building anyway.")
+
     page, n_assets, n_files, n_matched = build_page(batches, state)
     OUT.write_text(page, encoding="utf-8", newline="\n")
     dt = time.time() - t0


### PR DESCRIPTION
Second recurrence of the #1093 class, three days after #1107 fixed the first:
Pip's 2026-08-04 review pass judged 1,687 new assets, and 327 of the
resulting keeps could not move (297 unmapped-category, 30 unresolved-source).
The recurrence is the finding -- a hand-maintained category map goes stale
every time a review pass touches a batch the map has never seen. This PR
clears the 327 AND makes the next review pass unable to strand its own
results.

## Before / after (report run with --art-root at the main checkout, where the
untracked art lives)

| | before | after |
|---|---|---|
| promotable | 962 of 1958 keeps (194.2 MB) | 1206 of 1958 keeps (200.4 MB) |
| held (explicit) | 669 | 752 |
| contested | 0 | 0 |
| blocked | 327 (297 unmapped, 30 unresolved) | 0 |

Report exits 0. Nothing was promoted (dry-run only, all 1206 routings
checked); no art file was moved, copied or deleted.

## The 297 unmapped -- ruling per batch/category

Promoted (new destinations):
- `pixellab_2026-07-26_doom_overlays` (199) -> `godot/assets/effects/doom_overlays`.
  64x64 RGBA idle+loop sprite sets, the in-engine sprite-overlay candidate of
  docs/art/DOOM_OVERLAY.md; whole kept set ~0.3 MB. If the renderer lane
  rules for the shader pass instead, flip to Hold -- one line.
- `pixellab_2026-07-27_worker_round2` (12) -> `office_floor/characters`
  (walk-animation frames; prefix override).
- `pixellab_2026-07-27_prop_rebase/native` (1) -> `office_floor/props`
  (batch default; the natives are the kept game art per its MANIFEST).
- `vignettes_2026-07-28` (3) -> `godot/assets/images/vignettes` (seed-vignette
  stand-in heroes, already downscaled under the git cap). This also FIXES a
  latent wrong destination: `01_cat-in-the-alley.png` was resolving via the
  loose "cat" substring fallback into `cats/generated`.

Held (first-class not-for-promotion -- concept/reference/master material is
held, not force-fitted):
- The eight endgame art-direction study categories (56 keeps):
  `endgame_concepts`, `endgame_concepts_gen2`, `crisp_sweep`,
  `treatment_sweep`, `new_subjects`, `wanasai_calls`, `doomfield_ladder`,
  `people_policy`. One lineage of 1536x1024 direction STUDIES (their
  manifests are sweeps/probes/ladder controls chained off endgame_concepts).
  Library reference per ADR-0019; the eventual production endgame batch
  promotes, the studies never do.
- `prop_rebase/large_source` (15): 2x provenance masters behind the LANCZOS
  natives -- a master crossing into godot/ unchanged is a defect (ADR-0019).
- `pixellab_2026-07-26_prop_grain_vanguard` (11): dial/manifest-scale/native
  probes whose verdict was EXECUTED by the 07-27 prop re-base regeneration.
- `dump_october_31_2025` (1): October 2025 website/prototype dump.
- Also mapped so the preflight never trips on them: `audiodump` -> Hold
  (session recordings), `pixellab_2026-07-26_size_probe` -> Hold,
  `worker_rebase`/`t6_worker_diagonals` -> characters (no keeps yet, but the
  full-disk sweep must cover every batch the gallery can index).
- `icon_hires` Hold untouched (Pip's 2026-08-03 ruling).

## The 30 unresolved -- a third id scheme, not missing files

All 30 exist on disk. They are `file:<relpath>` ids -- build_full_gallery.py's
documented ADDITIVE scheme for files the gen:/px: grammars cannot express
("apply_review.py will list these as UNRESOLVED ... until someone teaches it
the prefix"). Concretely: 19 scene_art_wave2 `.webp` files and 11
iconset_round2 PNGs whose 48/32px size stems are outside the gallery's
KNOWN_SIZES. apply_review now parses `file:` ids: single file, category from
the path, destination filename kept VERBATIM (v1/v2/v4 of one base are
distinct kept assets; no variant-stripping collision possible). The
`scene_art_wave2` mapping became a prefix list so `event_*` webps land in
`images/events` BESIDE the already-shipped copies (routing them to
`images/scenes` would duplicate those bytes in the pack).

## Structural fix: an unmapped category can no longer be introduced silently

Root cause of the recurrence: #1107's live-tree test only sees TRACKED dirs,
and most of art_generated/ is machine-local -- so CI passed vacuously while
the gallery indexed 8 unmapped sweep dirs on Pip's machine. Three layers, all
sharing ONE new disk-free predicate (`dest_rule_for_id`):

1. **Gallery preflight (the pre-review gate, where the art actually is).**
   `build_full_gallery.py` now REFUSES to build when any batch contains
   unmappable ids, naming each batch dir and the one-line fix (destination or
   `Hold(reason)`); `--allow-unmapped` is the escape hatch. The mapping
   ruling now happens BEFORE verdicts are cast, so a review pass cannot
   strand its own keeps. Verified: exit 2 on a probe batch, exit 0 clean.
2. **CI-visible invariant on the tracked artifact.**
   `test_every_review_state_id_is_mappable` sweeps every id in
   `review_state.json` (in git, unlike the art) -- the commit that lands a
   review pass fails until the map rules on every category it touched.
3. **Report names the batch dir.** blocked-unmapped detail is now e.g.
   `art_generated/<cat> -- add GEN_DEST['<cat>'] (a godot/assets/...
   destination or Hold(reason))` instead of `no destination for category
   None`.

Plus the strengthened disk sweeps (art_source full-file coverage; image-less
dirs exempt). Per ADR-0019 this whole map remains interim -- "the
category->destination map dies" when the demand manifest lands; nothing here
entrenches it, `dest_rule_for_id` is one function to delete.

## Verification

- `python -m pytest tests/test_art_promotion_pipeline.py -q` -- 48 passed
  (was 24; every new mapping, the `file:` resolver, and the preflight
  predicate have tests).
- `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` --
  [PASS] 1089 tests, 0 failures, 104/104 files collected (nothing under
  godot/ was touched).
- `report` against the main checkout: exit 0, counts above.
- `promote --dry-run`: 1206 files / 200.4 MB, 0 skipped, 0 contested; spot
  checks of every new destination family included above.

Refs #1093, #1107, #1109.

Note for Pip: the promotable set is now 200.4 MB (was 194.2 in #1109's
figure; the delta is the scene webps + vignettes + 0.3 MB of overlays, and 7
of the event webps are byte-identical re-copies of files already shipped).
The #1109 refinement-pass debt stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
