### PR TITLE
fix(leaderboard): make a failed global fetch VISIBLE, and warn players about SmartScreen (#1126)

### DIFF
--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -337,6 +337,13 @@ jobs:
             echo "See CHANGELOG.md for details." >> release_notes.txt
           fi
 
+          # Unsigned-build / SmartScreen notice. Kept as a checked-in file rather than
+          # echo lines so the wording is reviewable, diffable, and reusable verbatim by
+          # the website. A downloading player meets SmartScreen BEFORE they ever open
+          # HOW-TO-RUN.txt inside the zip, so the release body has to carry it too.
+          echo "" >> release_notes.txt
+          cat tools/release_notes/RELEASE-BODY-security-notice.md >> release_notes.txt
+
           # Append manifest info
           echo "" >> release_notes.txt
           echo "## Build Information" >> release_notes.txt

--- a/docs/RELEASE_PLATFORMS.md
+++ b/docs/RELEASE_PLATFORMS.md
@@ -266,6 +266,54 @@ there is no render proof at all.
 here": *"Player-side download and launch on machines that are not the
 Commissioner's."* This sheet just names the platforms.
 
+### Windows: unsigned, so SmartScreen warns about an untrusted publisher
+
+Read from `godot/export_presets.cfg` preset 0: `codesign/enable=false`,
+`codesign/description=""`. Nothing signs the Windows executable, and no
+code-signing certificate has been bought.
+
+The consequence, reported by Pip on 2026-08-05 after a friend downloaded the
+build: **"The game came up with an untrusted publisher warning."** Windows
+Defender SmartScreen shows a blue "Windows protected your PC" panel naming an
+unrecognised app / unknown publisher, and the Run button is hidden behind a
+**More info** link. A player who does not know the link is there simply cannot
+start the game -- the dialog offers only "Don't run".
+
+The click path, which every player-facing surface must state in these words:
+**"More info" -> "Run anyway"**.
+
+Two things make this worse than macOS Gatekeeper rather than better. First, the
+button is HIDDEN, not merely scary. Second, SmartScreen is partly reputation-
+based, so it can warn on some machines and not others for the same file, which
+makes second-hand troubleshooting ("it works for me") useless.
+
+Because Windows cannot vouch for the publisher, the honest substitute is
+provenance: the GitHub release page is the only trusted download, and
+`release_manifest.json` (PR #1110) carries a per-asset **sha256** so a player
+can verify their copy with `Get-FileHash -Algorithm SHA256 .\PDoom-Windows.zip`.
+Say that alongside the warning -- the warning is the moment a cautious player
+wants a way to check, and this is the only one we can give them.
+
+Where the text lives (keep these three in step; the wording is deliberately
+close to identical):
+
+| Surface | File | Seen when |
+|---|---|---|
+| Zip contents | `tools/release_notes/HOW-TO-RUN-windows.txt` -> ships as `HOW-TO-RUN.txt` (`_zip_native_build` in `scripts/build_all_platforms.py`, which FAILS the package if the template is missing) | after extracting, if they look |
+| GitHub release body | `tools/release_notes/RELEASE-BODY-security-notice.md`, appended by `.github/workflows/enhanced-release.yml` | before downloading |
+| Website download page | pdoom1.com (separate repo -- must be copied there by hand) | before downloading |
+
+Note the ordering problem: the zip note is the LAST of the three a player
+reaches, because SmartScreen fires at the moment they run the exe, which is
+after extraction but likely before they open a text file. The release body and
+the website are the surfaces that actually prevent the alarm; the zip note is
+the one that rescues someone already staring at the dialog.
+
+The real fix is a code-signing certificate (an OV certificate is roughly
+100-400 USD/year and still accrues SmartScreen reputation slowly; an EV
+certificate is more expensive and gets reputation immediately). Not a tonight
+problem, and deliberately not attempted here.
+
 ### macOS: unsigned and un-notarized, so Gatekeeper will block it
 
 Read from `godot/export_presets.cfg` preset 2: `codesign/apple_team_id=""`,

--- a/godot/autoload/leaderboard_sync.gd
+++ b/godot/autoload/leaderboard_sync.gd
@@ -322,7 +322,10 @@ func _flush_outbox() -> void:
 		)
 
 ## Async board fetch. Invokes callback(ok: bool, entries: Array[ScoreEntry]).
-## On any failure -> callback(false, []) so callers fall back to local silently.
+## On any failure -> callback(false, []). The TRANSPORT is quiet (it never throws and
+## never blocks), but the CALLER must not be: ok=false is a reportable event and the UI
+## is required to show it. Falling back "silently" here is what made the global toggle
+## look like a dead button to the first external player (#1126).
 func fetch_board(seed: String, version: String, limit: int, callback: Callable) -> void:
 	if not can_fetch():
 		if callback.is_valid():

--- a/godot/scripts/ui/leaderboard_screen.gd
+++ b/godot/scripts/ui/leaderboard_screen.gd
@@ -32,9 +32,29 @@ var _default_key: String = ""       # newest / current board, shown on open
 var _aggregate_loaded: bool = false # true once the full all-seeds scan has run this instance
 
 # Remote/global board (LeaderboardSync). Pure view: fetched async, never on a
-# deterministic path. Falls back to local silently on any failure.
+# deterministic path.
+#
+# FAILURE IS VISIBLE, NEVER SILENT (#1126). This used to fall back to local *silently*:
+# on any fetch failure the toggle reset its own pressed state and its own label, so
+# pressing "View: Global" produced NO observable change and the first external player
+# concluded -- correctly, from the evidence available to them -- that the button was
+# dead. A failed request and a broken button must never look the same. On failure the
+# toggle now STAYS PRESSED, an amber status line says the global board could not be
+# reached, and a Retry button appears. Amber (1.0, 0.75, 0.25) is the established
+# "off the record" register (GameConfig NOT RANKED notices, #1060) -- not a new colour.
 var showing_global: bool = false
 var global_toggle_button: Button = null
+var global_status_row: HBoxContainer = null
+# True while the global view is up but the rows on screen are the LOCAL fallback
+# (the fetch failed). Keeps the empty-state text honest -- see _display_current_page.
+var _global_fetch_failed: bool = false
+var global_status_label: Label = null
+var global_retry_button: Button = null
+
+# The one "off the record / not on the board" colour this project uses. Kept in sync
+# with the NOT RANKED notices in GameConfig by convention, not by import (this screen
+# must not depend on run state).
+const GLOBAL_STATUS_AMBER := Color(1.0, 0.75, 0.25)
 
 # UI References
 @onready var seed_dropdown = $MarginContainer/VBoxContainer/Filters/SeedDropdown
@@ -99,6 +119,65 @@ func _setup_global_toggle():
 	global_toggle_button.tooltip_text = "Toggle between your local scores and the global (online) board for this seed"
 	global_toggle_button.toggled.connect(_on_global_toggle)
 	container.add_child(global_toggle_button)
+	_setup_global_status_row()
+
+func _setup_global_status_row():
+	"""Build the (hidden) amber status line + Retry button that make a failed global
+	fetch VISIBLE (#1126).
+
+	Built in code rather than in the .tscn for the same reason the toggle is: it only
+	exists when remote sync is configured. It sits on its own row directly under the
+	Filters row -- the Filters HBox is already crowded (label, dropdown, Refresh, Clear,
+	toggle) and a wrapping message wedged in there would squeeze the dropdown."""
+	var main_vbox = $MarginContainer/VBoxContainer
+	var filters = $MarginContainer/VBoxContainer/Filters
+	if main_vbox == null or filters == null:
+		return
+	global_status_row = HBoxContainer.new()
+	global_status_row.alignment = BoxContainer.ALIGNMENT_CENTER
+	global_status_row.add_theme_constant_override("separation", 12)
+
+	global_status_label = Label.new()
+	global_status_label.add_theme_font_size_override("font_size", 15)
+	global_status_label.add_theme_color_override("font_color", GLOBAL_STATUS_AMBER)
+	global_status_row.add_child(global_status_label)
+
+	global_retry_button = Button.new()
+	global_retry_button.text = "Retry"
+	global_retry_button.tooltip_text = "Try fetching the global board again"
+	global_retry_button.add_theme_font_size_override("font_size", 14)
+	global_retry_button.pressed.connect(_on_global_retry_pressed)
+	global_status_row.add_child(global_retry_button)
+
+	global_status_row.visible = false
+	main_vbox.add_child(global_status_row)
+	main_vbox.move_child(global_status_row, filters.get_index() + 1)
+
+func _show_global_status(message: String, show_retry: bool) -> void:
+	"""Put a player-visible amber line on screen. The ONLY way the global view reports
+	trouble -- there is deliberately no silent path (#1126)."""
+	if not is_instance_valid(global_status_label):
+		return
+	global_status_label.text = message
+	if is_instance_valid(global_retry_button):
+		global_retry_button.visible = show_retry
+	if is_instance_valid(global_status_row):
+		global_status_row.visible = true
+
+func _clear_global_status() -> void:
+	if is_instance_valid(global_status_label):
+		global_status_label.text = ""
+	if is_instance_valid(global_status_row):
+		global_status_row.visible = false
+
+func _on_global_retry_pressed():
+	"""Retry affordance: re-run the fetch without making the player toggle twice."""
+	ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Retrying global board fetch", {})
+	showing_global = true
+	if is_instance_valid(global_toggle_button):
+		global_toggle_button.set_pressed_no_signal(true)
+		global_toggle_button.text = "View: Global"
+	_fetch_and_show_global()
 
 func _on_global_toggle(pressed: bool):
 	showing_global = pressed
@@ -116,22 +195,44 @@ func _fetch_and_show_global():
 	players on different cosmetic builds share one board. BACKEND TASK (flagged, not
 	attempted here): api.pdoom1.com must key by ladder_version and alias the live
 	v0.12.0 board to L1 -- see GameConfig.get_board_version() docs."""
+	_global_fetch_failed = false  # a new attempt is not (yet) a failure
 	var board_seed = GameConfig.get_display_seed()
 	var version = GameConfig.get_board_version()
 	subtitle.text = "Global board: fetching %s ..." % board_seed
+	# In-flight is its own visible state: without this the screen looks identical for
+	# "asking the server" and "server never answered" for up to REQUEST_TIMEOUT_SEC (8s).
+	_show_global_status("Contacting the global board ...", false)
 	LeaderboardSync.fetch_board(board_seed, version, 100, _on_global_board_fetched)
 
 func _on_global_board_fetched(ok: bool, entries: Array):
-	"""Render the global board, or fall back to local silently on failure."""
+	"""Render the global board, or report a VISIBLE failure and show local underneath.
+
+	#1126: the failure branch must leave evidence. It keeps the toggle PRESSED (the
+	player's request stands; it is the network that did not deliver), states in amber
+	that the board could not be reached, and offers Retry. A player with no network can
+	now tell a failed request from a dead button -- which is the entire bar the issue
+	sets. The local board is still drawn underneath so the screen is never blank."""
 	if not showing_global:
 		return  # User toggled back to Local before the request resolved.
 	if not ok:
-		showing_global = false
+		_global_fetch_failed = true
+		# Deliberately do NOT clear showing_global and do NOT un-press the toggle: that
+		# self-undoing reset is the defect. Render local WITHOUT the local-view reset.
 		if is_instance_valid(global_toggle_button):
-			global_toggle_button.set_pressed_no_signal(false)
-			global_toggle_button.text = "View: Local"
-		_filter_and_display()  # Silent local fallback.
+			global_toggle_button.set_pressed_no_signal(true)
+			global_toggle_button.text = "View: Global"
+		_render_local_view()
+		_show_global_status(
+			"[!] Global board unavailable -- could not reach the server. Showing your LOCAL scores.",
+			true)
+		ErrorHandler.warning(
+			ErrorHandler.Category.VALIDATION,
+			"Global board fetch failed; showing local with a visible notice",
+			{"seed": GameConfig.get_display_seed(), "version": GameConfig.get_board_version()}
+		)
 		return
+	_global_fetch_failed = false
+	_clear_global_status()
 	filtered_entries = entries.duplicate()
 	current_page = 1
 	# Show BOTH: the epoch the board is scoped by, and the build the viewer runs --
@@ -337,13 +438,27 @@ func _select_default_view() -> void:
 	_filter_and_display()
 
 func _filter_and_display():
-	"""Filter entries based on current seed and display current page (LOCAL view)."""
+	"""Filter entries based on current seed and display current page (LOCAL view).
+
+	This is the path for DELIBERATE local actions (toggling to Local, changing the seed,
+	Refresh, Clear). It resets the global toggle because the player asked for local. The
+	failure path must NOT come through here -- see _render_local_view."""
 	# Any local filter action returns us to the local board.
 	showing_global = false
+	_global_fetch_failed = false
 	if is_instance_valid(global_toggle_button):
 		global_toggle_button.set_pressed_no_signal(false)
 		global_toggle_button.text = "View: Local"
+	_clear_global_status()
+	_render_local_view()
 
+func _render_local_view():
+	"""Draw the local board for the current seed WITHOUT touching the global toggle state.
+
+	Split out of _filter_and_display for #1126: the failed-fetch path needs to show local
+	entries while STAYING in the global view (pressed toggle + amber notice). Reusing
+	_filter_and_display there is exactly what made the failure invisible -- it silently
+	un-pressed the button the player had just pressed."""
 	# Filter by seed. The all-seeds view triggers the (cached) full parse; a single seed
 	# parses just that one file. Either way the population shown is complete and correctly
 	# sorted -- no data is dropped, only the parse is deferred until the view needs it.
@@ -404,7 +519,16 @@ func _display_current_page():
 
 	if filtered_entries.size() == 0:
 		var no_entries = Label.new()
-		no_entries.text = "No scores yet. Play a game to see your scores here!"
+		# Second silent conflation found while fixing #1126: an EMPTY GLOBAL board (a
+		# successful fetch that returned zero entries) used to render the LOCAL empty
+		# state, so "nobody has posted to this board yet" and "you have not played yet"
+		# read identically -- and both looked like the toggle had done nothing.
+		# _global_fetch_failed distinguishes "in the global view, showing a real global
+		# board" from "in the global view, but the rows underneath are the LOCAL fallback".
+		if showing_global and not _global_fetch_failed:
+			no_entries.text = "The global board for this seed is empty -- no scores posted yet."
+		else:
+			no_entries.text = "No scores yet. Play a game to see your scores here!"
 		no_entries.add_theme_font_size_override("font_size", 16)
 		no_entries.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 		entries_container.add_child(no_entries)

--- a/godot/tests/unit/test_leaderboard_global_failure_visible.gd
+++ b/godot/tests/unit/test_leaderboard_global_failure_visible.gd
@@ -1,0 +1,134 @@
+extends GutTest
+## #1126 regression: a FAILED global-board fetch must be visible to the player.
+##
+## The bug the first external player hit: on any fetch failure the Local/Global toggle
+## reset its own pressed state and its own label, then redrew the local board. Pressing
+## "View: Global" therefore produced no observable change whatsoever, and the player
+## concluded the button was broken. A failed request and a dead button looked identical.
+##
+## The bar these tests pin (straight from the issue): after the fix, a player who taps
+## Global with no network must be able to tell a failed request from a broken button.
+## Concretely, on failure the screen must (a) keep the toggle pressed, (b) say in words
+## that the global board could not be reached, and (c) offer a retry.
+##
+## NOTE ON WHAT THIS CANNOT PROVE: no test here shows the message READS well, is legible
+## against the records-room background, or lands in the right place on screen. That needs
+## Pip on a real build. These tests only prove the state is reported at all rather than
+## erased -- which is exactly what was missing.
+
+const SCREEN := preload("res://scenes/leaderboard_screen.tscn")
+
+var _saved_enabled: bool
+var _saved_base_url: String
+var _saved_token: String
+
+func before_each():
+	# The toggle (and therefore the status row) is only built when remote sync is
+	# configured. Force that on so the test does not depend on the shipped config, then
+	# restore -- LeaderboardSync is an autoload shared with every other suite.
+	_saved_enabled = LeaderboardSync.enabled
+	_saved_base_url = LeaderboardSync.base_url
+	_saved_token = LeaderboardSync.token
+	LeaderboardSync.enabled = true
+	LeaderboardSync.base_url = "https://example.invalid"
+	LeaderboardSync.token = "test-token-not-a-real-secret"
+
+func after_each():
+	LeaderboardSync.enabled = _saved_enabled
+	LeaderboardSync.base_url = _saved_base_url
+	LeaderboardSync.token = _saved_token
+
+func _make_screen():
+	var screen = SCREEN.instantiate()
+	add_child_autofree(screen)  # runs _ready -> _setup_global_toggle + status row
+	return screen
+
+## Drive the exact callback LeaderboardSync invokes on a timeout / 502 / DNS failure.
+## No HTTP is performed: fetch_board's contract is callback(false, []) on ANY failure,
+## so this is the real failure path, not a simulation of a different one.
+func _screen_in_failed_global_state():
+	var screen = _make_screen()
+	assert_not_null(screen.global_toggle_button,
+		"precondition: the Local/Global toggle must exist when sync is configured")
+	screen.showing_global = true
+	screen.global_toggle_button.set_pressed_no_signal(true)
+	screen.global_toggle_button.text = "View: Global"
+	screen._on_global_board_fetched(false, [])
+	return screen
+
+# --- The bar from the issue ---------------------------------------------------
+
+func test_failed_fetch_says_something_the_player_can_read():
+	var screen = _screen_in_failed_global_state()
+	assert_not_null(screen.global_status_label,
+		"a failed fetch must have somewhere to report itself")
+	assert_true(screen.global_status_row.visible,
+		"the status row must be VISIBLE after a failed fetch -- an invisible notice is the bug")
+	assert_ne(screen.global_status_label.text, "",
+		"a failed fetch must leave a non-empty message; silence is indistinguishable from a dead button")
+	assert_string_contains(screen.global_status_label.text, "Global board unavailable",
+		"the message must name what failed, not merely be non-empty")
+
+func test_failed_fetch_does_not_un_press_the_toggle():
+	# This is the precise regression. The old code called set_pressed_no_signal(false)
+	# and reset the label to "View: Local", erasing every trace of the player's input.
+	var screen = _screen_in_failed_global_state()
+	assert_true(screen.global_toggle_button.button_pressed,
+		"the toggle must STAY pressed on failure -- self-un-pressing is what made it look broken")
+	assert_eq(screen.global_toggle_button.text, "View: Global",
+		"the toggle label must not silently revert to 'View: Local' on a failed fetch")
+
+func test_failed_fetch_offers_a_retry():
+	var screen = _screen_in_failed_global_state()
+	assert_not_null(screen.global_retry_button, "a failed fetch must offer a retry affordance")
+	assert_true(screen.global_retry_button.visible, "the Retry button must be visible after a failure")
+
+func test_failed_fetch_still_shows_local_entries_underneath():
+	# The fallback itself was never the problem -- showing local is correct. It just has
+	# to be labelled. Assert the screen is not left blank.
+	var screen = _screen_in_failed_global_state()
+	assert_ne(screen.subtitle.text, "", "the board underneath must still be identified")
+
+# --- The notice must not become permanent chrome ------------------------------
+
+func test_successful_fetch_clears_the_notice():
+	var screen = _screen_in_failed_global_state()
+	assert_true(screen.global_status_row.visible, "precondition: notice is up after the failure")
+	screen.showing_global = true
+	screen._on_global_board_fetched(true, [])
+	assert_false(screen.global_status_row.visible,
+		"a later SUCCESSFUL fetch must clear the failure notice")
+
+func test_returning_to_local_clears_the_notice():
+	var screen = _screen_in_failed_global_state()
+	screen._filter_and_display()  # the deliberate 'go back to Local' path
+	assert_false(screen.global_status_row.visible,
+		"choosing Local deliberately must clear the global failure notice")
+	assert_false(screen.global_toggle_button.button_pressed,
+		"the DELIBERATE local path still un-presses the toggle (only the failure path must not)")
+
+# --- Second silent conflation found in the same file --------------------------
+
+func test_empty_global_board_does_not_read_as_an_empty_local_board():
+	# A successful fetch returning zero entries used to render the LOCAL empty state
+	# ("Play a game to see your scores here!"), so "nobody has posted yet" and "you have
+	# not played yet" looked the same -- and both looked like the toggle did nothing.
+	var screen = _make_screen()
+	screen.showing_global = true
+	screen._on_global_board_fetched(true, [])
+	var texts: Array = []
+	for child in screen.entries_container.get_children():
+		if child is Label:
+			texts.append(child.text)
+	assert_gt(texts.size(), 0, "an empty board must render an empty-state label")
+	assert_string_contains(texts[0], "global board",
+		"the empty GLOBAL board must name itself, not reuse the local empty state")
+
+func test_failed_fetch_empty_state_still_reads_as_local():
+	# Inverse guard: on a FAILED fetch the rows underneath are the LOCAL board, so if
+	# they are empty the empty-state must NOT claim the global board is empty.
+	var screen = _screen_in_failed_global_state()
+	for child in screen.entries_container.get_children():
+		if child is Label and child.text.contains("global board is empty"):
+			fail_test("a failed fetch must not claim the GLOBAL board is empty -- those rows are local")
+	pass_test("failed fetch does not mislabel the local fallback as an empty global board")

--- a/tools/release_notes/HOW-TO-RUN-windows.txt
+++ b/tools/release_notes/HOW-TO-RUN-windows.txt
@@ -1,13 +1,42 @@
 P(Doom) -- Windows
 
+READ THIS FIRST: WINDOWS WILL WARN YOU. THAT IS EXPECTED.
+
+  Windows SmartScreen shows a blue box saying "Windows protected your PC"
+  and "Windows Defender SmartScreen prevented an unrecognised app from
+  starting", and it may name an "Unknown publisher" / "untrusted publisher".
+
+  To run the game:
+      1. Click "More info" (small link under the message text).
+      2. Click "Run anyway" (the button that then appears).
+
+  Why it happens: this build is UNSIGNED. Signing an executable means buying
+  a code-signing certificate from a certificate authority; P(Doom) is an
+  alpha made by one person and has not bought one yet. SmartScreen warns
+  about every unsigned program it has not seen many times before, so the
+  warning says "we cannot check who made this", NOT "this is malware".
+  Nothing about the warning changes once you click through -- it may appear
+  again after each new download.
+
+  MAKING SURE YOU HAVE THE REAL FILE. Since Windows cannot vouch for the
+  publisher, you should check the source instead:
+    - The ONLY trusted download is the GitHub release page:
+      https://github.com/PipFoweraker/pdoom1/releases
+      Do not run a PDoom.exe that reached you any other way.
+    - Every release publishes release_manifest.json, which lists the exact
+      size and sha256 of each zip. To check your download, run this in
+      PowerShell and compare the hash to the one in the manifest:
+          Get-FileHash -Algorithm SHA256 .\PDoom-Windows.zip
+      Matching hash = byte-for-byte the file that was published.
+
 HOW TO RUN
 1. EXTRACT this whole zip to a folder first (right-click -> Extract All).
    Do NOT run PDoom.exe from inside the zip viewer -- the game needs the
    other files sitting next to it, and the zip viewer hides them. This is
    the #1 thing that trips people up.
 2. Open the extracted folder and double-click PDoom.exe.
-3. If Windows SmartScreen says "Windows protected your PC":
-   click "More info" -> "Run anyway". The build is unsigned (alpha).
+3. Click through the SmartScreen warning as described at the top of this
+   file ("More info" -> "Run anyway").
 
 WHATS IN HERE
    PDoom.exe    the game

--- a/tools/release_notes/RELEASE-BODY-security-notice.md
+++ b/tools/release_notes/RELEASE-BODY-security-notice.md
@@ -1,0 +1,44 @@
+## Before you download: your OS will warn you, and that is expected
+
+These builds are **unsigned**. Signing means buying a code-signing certificate
+(Windows) or an Apple Developer identity plus notarization (macOS). P(Doom) is
+an alpha made by one person and has not bought either yet, so every operating
+system reports that it cannot verify who made the program. The warnings mean
+"we cannot check the publisher", not "this is malware".
+
+### Windows -- SmartScreen
+
+You will see a blue **"Windows protected your PC"** box, often naming an
+**unknown / untrusted publisher**. To run the game:
+
+1. Click **More info** (the small link under the message).
+2. Click **Run anyway**.
+
+Also: extract the whole zip to a folder before running `PDoom.exe`. Running it
+from inside the zip viewer hides `PDoom.pck` from it, and the game will not
+start. That is the single most common problem people hit.
+
+### macOS -- Gatekeeper
+
+First launch is blocked. On macOS 15 (Sequoia) and later, double-click the app
+once, dismiss the warning, then go to **System Settings -> Privacy & Security**
+and click **Open Anyway**. On macOS 14 and earlier you can right-click (or
+Control-click) the app and choose **Open**. Full steps are in `HOW-TO-RUN.txt`
+inside the zip.
+
+### Linux
+
+You may need to set the executable bit: `chmod +x PDoom.x86_64`.
+
+### Checking you have the real file
+
+Because the OS cannot vouch for the publisher, verify the source instead:
+
+- **This release page is the only trusted download.** Do not run a P(Doom)
+  binary that reached you any other way.
+- `release_manifest.json`, attached to this release, lists the exact size and
+  **sha256** of every zip. Compare it against your download:
+  - Windows (PowerShell): `Get-FileHash -Algorithm SHA256 .\PDoom-Windows.zip`
+  - macOS / Linux: `shasum -a 256 PDoom-Linux.zip`
+
+A matching hash means the file is byte-for-byte what was published here.


### PR DESCRIPTION
Fixes the first bug reported by an external player (#1126), plus the first thing that player hit before the game even opened (the SmartScreen "untrusted publisher" warning, Pip 2026-08-05).

## Part 1 -- #1126: the toggle undid itself

`_on_global_board_fetched()` reset the button's own pressed state AND its own label to `"View: Local"` on any fetch failure, then redrew the local board. Press "View: Global", nothing changes, label unchanged. A failed request and a dead button were **observationally identical**, and the player drew the only conclusion the evidence supported.

### What a player now sees when the fetch fails

- The toggle **stays pressed**, still reading `View: Global`. The player's input is not erased.
- An amber line appears on its own row under the filters:
  `[!] Global board unavailable -- could not reach the server. Showing your LOCAL scores.`
- A **Retry** button beside it re-runs the fetch (no double-toggle needed).
- The local board renders underneath, so the screen is never blank.
- While the request is in flight (up to the 8s `REQUEST_TIMEOUT_SEC`): `Contacting the global board ...` -- otherwise "asking the server" and "server never answered" look the same for eight seconds.
- `ErrorHandler.warning` records the failure with seed + epoch, for log-side diagnosis.

Amber is `Color(1.0, 0.75, 0.25)` -- the existing "off the record" register from the NOT RANKED notices (#1060). No new colour invented. (The pre-commit style-guide check warns because a `Color` const appears in the diff; it is a restatement of an existing register, not a new one, so `UI_STYLE_GUIDE.md` is unchanged.)

### Structural change

`_render_local_view()` is split out of `_filter_and_display()`. `_filter_and_display()` remains the **deliberate** local path (toggling to Local, changing seed, Refresh, Clear) and still resets the toggle -- correctly, because the player asked for local. The failure path calls `_render_local_view()` instead. Reusing `_filter_and_display()` there is exactly what erased the player's input.

### Other silent degradation found in the same file

An **empty global board** (a *successful* fetch returning zero entries) rendered the LOCAL empty state -- "No scores yet. Play a game to see your scores here!" So "nobody has posted to this board yet" and "you have not played yet" read identically, and both looked like the toggle had done nothing. Now: `"The global board for this seed is empty -- no scores posted yet."` A `_global_fetch_failed` flag keeps this honest on the failure path, where the rows underneath are the local fallback and the local wording is the correct one.

Also retired two docstrings that presented silence as a feature (`leaderboard_screen.gd` header, `LeaderboardSync.fetch_board`). The transport staying quiet is fine; the caller staying quiet is the bug.

Not changed, deliberately: **the consent gate**. `should_submit()` withholding an unconsented upload is the privacy ruling of 2026-07-26 working as designed. Its legibility is a separate issue.

## Part 2 -- SmartScreen

`godot/export_presets.cfg` preset 0 is `codesign/enable=false`. SmartScreen therefore shows "Windows protected your PC" and **hides the Run button behind a "More info" link** -- a player who does not know the link is there sees only "Don't run" and cannot start the game.

Three surfaces, near-identical wording:

| Surface | File | Ships? |
|---|---|---|
| Inside the zip | `tools/release_notes/HOW-TO-RUN-windows.txt` | **Yes** -- `_zip_native_build()` in `scripts/build_all_platforms.py` writes it into every Windows zip as `HOW-TO-RUN.txt`, and **fails the package** if the template is missing. Verified, not assumed. |
| GitHub release body | `tools/release_notes/RELEASE-BODY-security-notice.md`, `cat`-appended by `.github/workflows/enhanced-release.yml` | New |
| Docs | `docs/RELEASE_PLATFORMS.md` -- a Windows section mirroring the existing macOS Gatekeeper one | n/a |

Note `builds/windows_desktop/HOW-TO-RUN.txt` from the brief **does not exist**; the template lives at `tools/release_notes/HOW-TO-RUN-windows.txt` and is copied in at packaging time.

Each surface states: the build is unsigned and why, the exact click path **"More info" -> "Run anyway"**, that the release page is the only trusted download, and that per-asset `sha256` in `release_manifest.json` (PR #1110) lets you verify the file (`Get-FileHash -Algorithm SHA256 .\PDoom-Windows.zip`).

There is an **ordering problem worth knowing**: the zip note is the LAST of the three a player reaches, because SmartScreen fires when they run the exe. The release body and the website are what prevent the alarm; the zip note only rescues someone already staring at the dialog.

### For the website repo (NOT touched, as instructed)

pdoom1.com's download page should carry this. Suggested text, ready to paste:

> **Windows will warn you, and that is expected.** This build is unsigned -- code-signing certificates cost money and P(Doom) is an alpha made by one person. Windows SmartScreen will show a blue "Windows protected your PC" box naming an unknown or untrusted publisher. To play: click **More info**, then **Run anyway**. The warning means Windows cannot check who made the program, not that the program is harmful.
>
> **Make sure you have the real file.** The GitHub release page is the only trusted download. Every release publishes `release_manifest.json` listing the sha256 of each zip; check yours with `Get-FileHash -Algorithm SHA256 .\PDoom-Windows.zip` in PowerShell. A matching hash means the file is byte-for-byte what was published.
>
> **Extract the zip before running `PDoom.exe`.** Running it from inside the zip viewer hides `PDoom.pck` and the game will not start -- the single most common problem people hit.

## Verification

Fast gate in this worktree: **1103 -> 1111 tests, 0 failures** (+8).

**The guard was proven to fail.** `git stash push godot/scripts/ui/leaderboard_screen.gd`, re-ran the gate: **6 of the 8 new tests went red**, then `git stash pop` and green again. The two that survive the revert are written as inverse/non-regression guards (the local fallback still identifies its board; the failed path does not mislabel local rows as an empty global board) -- both happen to hold under the old code, and both would catch a future over-correction.

The tests drive the real failure callback `_on_global_board_fetched(false, [])` -- the exact contract `LeaderboardSync.fetch_board` honours on a timeout, a 502, or a DNS failure. No HTTP is performed. `LeaderboardSync.enabled/base_url/token` are forced on in `before_each` and restored in `after_each`, so the tests do not depend on the shipped config and do not leak into other suites.

**No test proves the message reads well**, is legible against the records-room background, or sits in the right place on screen. That needs Pip on a real build.

Refs #1126

Generated with [Claude Code](https://claude.com/claude-code)
