### PR TITLE
fix(tools): split the dev gates -- backslash comes back in release builds, plus a music player

### DIFF
--- a/godot/autoload/music_manager.gd
+++ b/godot/autoload/music_manager.gd
@@ -71,6 +71,23 @@ var _adaptive_build_attempted: bool = false
 var _adaptive_active: bool = false
 var _current_music_tier: int = 0
 
+## ---- Audition override (ALPHA TOOLS music player, 2026-08-05) ----
+## -1 == automatic (doom drives the tier). >= 0 == a human is holding the tier open so a
+## track can be heard against the actual game state it plays under -- Pip's ask now that a
+## musician is interested in the game.
+##
+## NOT an Alpha Tool, deliberately: this writes NOTHING toward game state, RNG or scoring
+## (music is already a pure view-layer side-effect, ADR-0006), so it does not set the
+## sticky unranked flag. Playing a different track is not "add $50k".
+## RUN BOUNDARY: cleared by play_context(), which fires on every start-run /
+## return-to-menu / game-over transition -- so an override can never silently ride into a
+## scored run.
+var _tier_override: int = -1
+## The tier automatic selection WOULD be on right now. Kept up to date even while
+## overridden, so the overlay can say "you are hearing 4, the game is at 1" and so
+## releasing the override snaps back to the truth instead of to a stale value.
+var _auto_music_tier: int = 0
+
 # Music tracks organized by context
 var music_library = {
 	MusicContext.MENU: [
@@ -184,6 +201,12 @@ func play_context(context: MusicContext, shuffle: bool = true):
 	print("[MusicManager] Switching to context: ", MusicContext.keys()[context])
 
 	current_context = context
+
+	# Run boundary for the audition override: every caller of play_context() is a
+	# start-run / return-to-menu / game-over transition, so this is exactly where a
+	# hand-held tier must be let go of. Cleared silently (no re-switch) because the
+	# context change is about to choose a stream anyway.
+	_tier_override = -1
 
 	# GAMEPLAY prefers the doom-adaptive stream; anything else (or a failed
 	# adaptive build) falls back to the legacy per-context playlist.
@@ -389,6 +412,9 @@ func music_tier_for_doom(doom_percent: float) -> int:
 ## Never writes anything back toward game state.
 func set_doom_level(doom_percent: float):
 	var tier: int = music_tier_for_doom(doom_percent)
+	_auto_music_tier = tier
+	if _tier_override >= 0:
+		return  # a human is holding the tier; remember where automatic would be
 	if tier == _current_music_tier:
 		return
 	print("[MusicManager] Doom %.1f%% -> music tier %d (%s)" % [
@@ -396,11 +422,95 @@ func set_doom_level(doom_percent: float):
 	_current_music_tier = tier
 	_switch_adaptive_tier(tier)
 
-## Debug hook: force a music tier directly (dev overlay / manual testing).
+
+## ---- Audition API (ALPHA TOOLS music player) ----
+
+## Hold `tier` open regardless of doom, so it can be heard against the live game state.
+func set_tier_override(tier: int) -> void:
+	_tier_override = clampi(tier, 0, MUSIC_TIER_NAMES.size() - 1)
+	_current_music_tier = _tier_override
+	print("[MusicManager] Tier OVERRIDE -> %d (%s); automatic would be %d (%s)" % [
+		_tier_override, MUSIC_TIER_NAMES[_tier_override],
+		_auto_music_tier, MUSIC_TIER_NAMES[_auto_music_tier]])
+	_switch_adaptive_tier(_tier_override)
+
+
+## Give the tier back to doom. Snaps straight to wherever automatic is NOW, so releasing
+## never leaves the player hearing a tier the game left behind ten turns ago.
+func clear_tier_override() -> void:
+	if _tier_override < 0:
+		return
+	_tier_override = -1
+	print("[MusicManager] Tier override released -> automatic tier %d (%s)" % [
+		_auto_music_tier, MUSIC_TIER_NAMES[_auto_music_tier]])
+	if _auto_music_tier != _current_music_tier:
+		_current_music_tier = _auto_music_tier
+		_switch_adaptive_tier(_auto_music_tier)
+
+
+func is_tier_overridden() -> bool:
+	return _tier_override >= 0
+
+
+## True while the doom-adaptive interactive stream is the thing being heard (as opposed
+## to a standalone bed, e.g. after auditioning the victory track).
+func is_adaptive_active() -> bool:
+	return _adaptive_active
+
+
+func get_current_music_tier() -> int:
+	return _current_music_tier
+
+
+func get_auto_music_tier() -> int:
+	return _auto_music_tier
+
+
+## Legacy debug hook, kept for callers/tests: same thing as set_tier_override().
 func debug_force_tier(tier: int):
-	tier = clampi(tier, 0, MUSIC_TIER_NAMES.size() - 1)
-	_current_music_tier = tier
-	_switch_adaptive_tier(tier)
+	set_tier_override(tier)
+
+
+## Flat catalogue of every bed the game can play, for the overlay's one dropdown.
+## Entries: {"label": String, "kind": "tier"|"track", "tier": int, "path": String}.
+## Tiers come first (they are the adaptive score); the standalone context beds follow,
+## deduplicated against the tier stems -- checkpoint_saved.ogg is BOTH the MENU bed and
+## tier 0, and listing it twice would read as two different tracks.
+func audition_catalogue() -> Array:
+	var out: Array = []
+	var seen: Dictionary = {}
+	for tier in range(MUSIC_TIER_NAMES.size()):
+		var path := ""
+		if tier < MUSIC_TIER_STEMS.size() and not MUSIC_TIER_STEMS[tier].is_empty():
+			path = String(MUSIC_TIER_STEMS[tier][0]["path"])
+			seen[path] = true
+		out.append({
+			"label": "M%d %s  (%s)" % [tier, MUSIC_TIER_NAMES[tier], path.get_file().get_basename()],
+			"kind": "tier", "tier": tier, "path": path,
+		})
+	for context in [MusicContext.MENU, MusicContext.VICTORY, MusicContext.DEFEAT]:
+		for track in music_library[context]:
+			var p := String(track)
+			if seen.has(p):
+				continue
+			seen[p] = true
+			out.append({
+				"label": "%s  (%s)" % [MusicContext.keys()[context], p.get_file().get_basename()],
+				"kind": "track", "tier": -1, "path": p,
+			})
+	return out
+
+
+## One line for the overlay: what is playing, and WHY. Pure string build, unit-tested.
+func audition_status_line() -> String:
+	if not _adaptive_active:
+		return "Playing: %s  [standalone bed -- adaptive score is not running]" % get_current_track_name()
+	var tier := clampi(_current_music_tier, 0, MUSIC_TIER_NAMES.size() - 1)
+	var auto := clampi(_auto_music_tier, 0, MUSIC_TIER_NAMES.size() - 1)
+	if _tier_override >= 0:
+		return "Playing: M%d %s  [OVERRIDE -- doom says M%d %s]" % [
+			tier, MUSIC_TIER_NAMES[tier], auto, MUSIC_TIER_NAMES[auto]]
+	return "Playing: M%d %s  [AUTO -- following doom]" % [tier, MUSIC_TIER_NAMES[tier]]
 
 ## Start the adaptive gameplay stream. Returns false if it cannot be built
 ## (missing module or missing audio) so the caller can fall back.

--- a/godot/scripts/core/build_info.gd
+++ b/godot/scripts/core/build_info.gd
@@ -19,6 +19,13 @@ class_name BuildInfo
 ## to force the indicators off even in a dev checkout.
 const DEV_BUILD := true
 
+## Alpha-tools era switch (#1079 fallout, ruled 2026-08-05). While this is true the ALPHA
+## TOOLS overlay (backslash) is reachable in an EXPORTED RELEASE build too -- see
+## are_alpha_tools_available() below for the full reasoning. Flip false at 1.0, when the
+## tools stop being a promise the name already makes ("alpha" says they do not survive to
+## the finished game).
+const ALPHA_TOOLS_ERA := true
+
 ## res:// text file written by tools/write_build_stamp.py. Not a Godot resource, so
 ## it produces no .import churn; read via FileAccess.
 const STAMP_PATH := "res://build_stamp.txt"
@@ -49,8 +56,22 @@ static func get_commit() -> String:
 static func get_build_date() -> String:
 	return String(_read_stamp().get("date", ""))
 
-## True while this run should show the DEV BUILD indicators (badge, dev overlay,
-## flight recorder, perf log -- everything that gates on this function).
+## Test hook: null => follow OS.is_debug_build(); true/false => forced. Exists so the
+## GATE SPLIT below can be asserted under simulated RELEASE conditions -- a headless GUT
+## run is always a debug run, so without this hook the release branch of every gate is
+## untestable and can only be discovered at a friend's house (2026-08-05).
+static var _debug_run_override = null
+
+
+## True when this process is a debug run (editor or debug-template export).
+static func is_debug_run() -> bool:
+	if _debug_run_override != null:
+		return bool(_debug_run_override)
+	return OS.is_debug_build()
+
+
+## True while this run should show the BUILD-GATED dev features: the DEV BUILD badge,
+## the flight recorder (F6), the UI evolution recorder (F7) and the perf log.
 ##
 ## Discriminator: OS.is_debug_build() (same signal as OS.has_feature("debug")) is
 ## true in the editor AND in a debug-template export, and false ONLY in a
@@ -59,8 +80,42 @@ static func get_build_date() -> String:
 ## debug build, which would misclassify tester debug exports as public releases.
 ## Before this gate existed the const above shipped as-is, so the public v0.13.2
 ## release showed the amber DEV BUILD banner on every screen (issue #1067).
+##
+## NOTE (2026-08-05): this is NO LONGER the gate for the ALPHA TOOLS overlay. See
+## are_alpha_tools_available().
 static func is_dev_build() -> bool:
-	return DEV_BUILD and OS.is_debug_build()
+	return DEV_BUILD and is_debug_run()
+
+
+## THE GATE SPLIT (2026-08-05). PR #1079 correctly stopped a public release wearing the
+## amber DEV BUILD banner -- but the overlay, both recorders and the perf log all hung off
+## the SAME is_dev_build(), so they silently switched off in release exports as a side
+## effect. Pip lost backslash mid-playtest on a shipped build ("I wasn't able to bump
+## doom"). That consequence was flagged when #1079 merged and never ruled on; this is the
+## ruling.
+##
+## Which side each feature landed on, and why:
+##   BADGE            -> is_dev_build().             A release must not look like a dev cut.
+##   ALPHA TOOLS      -> are_alpha_tools_available(). Reachable in release.
+##   FLIGHT RECORDER  -> is_dev_build().             Writes a SCREENSHOT + the full
+##                       GameState JSON to the player's disk. Explicit F6, yes, but the
+##                       artefact is a picture of someone's screen; nobody asked for it in
+##                       a shipped build. Privacy posture, not convenience.
+##   UI EVOLUTION REC -> is_dev_build().             Same, and it is a SILENT screenshot
+##                       (no popup, no confirmation). Strictly worse than F6 to ship.
+##   PERF LOG         -> is_dev_build().             Writes user://logs/perf.log
+##                       continuously, unprompted, rotating at 5MB. The textbook
+##                       "invisible recorder on a player's disk". Stays off.
+##
+## Why the overlay is safe to un-gate and the recorders are not: PR #1104's Alpha Tools
+## made every state-MUTATING dev power set a STICKY, ONE-WAY unranked flag on the run,
+## carried through the save envelope, warned at first use and again at game over
+## (docs/decision-cards/2026-08-01_dev-powers-nomenclature.html). That system exists
+## PRECISELY so dev powers can ship without polluting the board -- so build-gating the
+## overlay is now both redundant and in tension with that ruling. The recorders have no
+## such protection because their risk is not the leaderboard, it is the disk.
+static func are_alpha_tools_available() -> bool:
+	return DEV_BUILD and ALPHA_TOOLS_ERA
 
 # --- Live git identity (L1 follow-up: the stamp went stale and cost a playtest) --------
 #
@@ -149,3 +204,10 @@ static func get_dev_badge_text() -> String:
 ## build are you running?") without the scary label or the git plumbing.
 static func get_release_badge_text() -> String:
 	return "v%s" % GameConfig.CURRENT_VERSION
+
+## Build identity for the ALPHA TOOLS overlay header. Unlike get_badge_text() this does
+## NOT change shape by build type: the overlay now opens in release builds too, and
+## "which build is this?" is the single most useful thing on it when Pip is standing in
+## someone else's lounge room. Always version + stamp.
+static func get_tools_stamp_text() -> String:
+	return "v%s  -  %s" % [GameConfig.CURRENT_VERSION, get_stamp()]

--- a/godot/scripts/debug/dev_mode_overlay.gd
+++ b/godot/scripts/debug/dev_mode_overlay.gd
@@ -4,8 +4,15 @@ class_name DevModeOverlay
 ##
 ## Press backslash (the `dev_mode` keybind) to toggle. Left column mirrors the verbose
 ## PowerShell logs on-screen (full live game state, refreshed each turn / state change);
-## right column gives dev "pokes" to set up test situations. Gated on BuildInfo.DEV_BUILD
-## so it never ships in a clean release cut.
+## right column gives dev "pokes" to set up test situations.
+##
+## GATE (2026-08-05): BuildInfo.are_alpha_tools_available(), NOT is_dev_build(). PR #1079
+## made the DEV BUILD badge conditional on OS.is_debug_build() -- correct for the badge,
+## but this overlay hung off the same call and so vanished from release exports, which is
+## how Pip lost backslash mid-playtest on a shipped build. The badge stays gated; the
+## tools come back, protected instead by Alpha Tools (PR #1104): every mutating control
+## below sets a sticky one-way UNRANKED flag on the run. See build_info.gd for the full
+## per-feature ruling (the two recorders and the perf log deliberately stayed build-gated).
 ##
 ## Built entirely in code (no .tscn) following dev_build_badge.gd, and added at runtime via
 ## `main_ui.gd`. The readout content comes from the pure, unit-tested DevModeReadout builder;
@@ -27,6 +34,8 @@ var main_ui: Node = null
 var _root: Control = null
 var _info_vbox: VBoxContainer = null
 var _event_dropdown: OptionButton = null
+var _music_dropdown: OptionButton = null
+var _music_status: Label = null
 var _built := false
 
 
@@ -44,8 +53,9 @@ func _live_gm() -> Node:
 
 func _ready() -> void:
 	layer = OVERLAY_LAYER
-	# Gate on dev build: in a release cut this overlay builds nothing and stays inert.
-	if not BuildInfo.is_dev_build():
+	# Gate on the ALPHA TOOLS era, not on the build type (see the header note). With
+	# ALPHA_TOOLS_ERA false this overlay builds nothing and stays inert.
+	if not BuildInfo.are_alpha_tools_available():
 		visible = false
 		return
 	_build_ui()
@@ -111,7 +121,9 @@ func _build_ui() -> void:
 	title.add_theme_color_override("font_color", Color(1.0, 0.75, 0.2))
 	header.add_child(title)
 	var stamp := Label.new()
-	stamp.text = "   " + BuildInfo.get_badge_text()
+	# Always version + stamp, both build types: this overlay now opens in release builds,
+	# and "which build is this?" is the most useful thing on it in someone else's lounge.
+	stamp.text = "   " + BuildInfo.get_tools_stamp_text()
 	stamp.add_theme_font_size_override("font_size", 11)
 	stamp.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
 	stamp.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -124,7 +136,9 @@ func _build_ui() -> void:
 	header.add_child(close_btn)
 
 	var hint := Label.new()
-	hint.text = "Backslash toggles - dev build only - not shipped in release"
+	# Was "dev build only - not shipped in release". That is no longer true and must not
+	# keep saying so: the overlay ships, and the leaderboard flag is what protects the board.
+	hint.text = "Backslash toggles - alpha build tool - will not exist in the finished game"
 	hint.add_theme_font_size_override("font_size", 10)
 	hint.add_theme_color_override("font_color", Color(0.55, 0.55, 0.6))
 	outer.add_child(hint)
@@ -203,7 +217,100 @@ func _build_controls() -> Control:
 	ev_note.add_theme_color_override("font_color", Color(0.55, 0.55, 0.6))
 	col.add_child(ev_note)
 
+	col.add_child(HSeparator.new())
+	col.add_child(_build_music_section())
+
 	return col
+
+
+## MUSIC -- Pip 2026-08-05, now that a musician is interested in the game: the point is
+## not "listen to the soundtrack" (tools/music/jukebox.html already does that) but
+## AUDITION a track against the live game state it plays under -- the one thing a
+## collaborator cannot currently do.
+##
+## NOT an Alpha Tool: nothing here calls _mark_alpha_tool_use(). Playing a different
+## track writes nothing to GameState, the seeded RNG or scoring (music is a pure
+## view-layer side-effect, ADR-0006), so unranking a run for it would be a lie about
+## what happened. Contrast "+$10k Money", two sections up, which does mark.
+func _build_music_section() -> Control:
+	var box := VBoxContainer.new()
+	box.add_child(_section_label("MUSIC (audition -- stays ranked)"))
+
+	_music_status = Label.new()
+	_music_status.text = "-"
+	_music_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_music_status.custom_minimum_size = Vector2(240, 0)
+	_music_status.add_theme_font_size_override("font_size", 10)
+	_music_status.add_theme_color_override("font_color", Color(0.55, 0.85, 1.0))
+	box.add_child(_music_status)
+
+	_music_dropdown = OptionButton.new()
+	_music_dropdown.focus_mode = Control.FOCUS_NONE
+	_music_dropdown.custom_minimum_size = Vector2(240, 0)
+	_populate_music_dropdown()
+	box.add_child(_music_dropdown)
+
+	box.add_child(_action_button("Play selected", _play_selected_music))
+	box.add_child(_action_button("Release -> AUTO (follow doom)", _release_music_override))
+
+	var note := Label.new()
+	note.text = "Tiers hold against live doom. Override releases itself at every run boundary."
+	note.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	note.custom_minimum_size = Vector2(240, 0)
+	note.add_theme_font_size_override("font_size", 9)
+	note.add_theme_color_override("font_color", Color(0.55, 0.55, 0.6))
+	box.add_child(note)
+	return box
+
+
+func _populate_music_dropdown() -> void:
+	if _music_dropdown == null or not is_instance_valid(MusicManager):
+		return
+	_music_dropdown.clear()
+	for entry in MusicManager.audition_catalogue():
+		_music_dropdown.add_item(str(entry["label"]))
+		_music_dropdown.set_item_metadata(_music_dropdown.item_count - 1, entry)
+
+
+func _selected_music_entry() -> Dictionary:
+	if _music_dropdown == null or _music_dropdown.item_count == 0:
+		return {}
+	var idx := _music_dropdown.selected
+	if idx < 0:
+		idx = 0
+	var meta = _music_dropdown.get_item_metadata(idx)
+	return meta if meta is Dictionary else {}
+
+
+## A tier entry HOLDS that tier open against live doom (the audition case). A standalone
+## bed (menu/victory/defeat) is played directly, which drops out of the adaptive stream --
+## "Release -> AUTO" restarts it.
+func _play_selected_music() -> void:
+	var entry := _selected_music_entry()
+	if entry.is_empty() or not is_instance_valid(MusicManager):
+		return
+	if str(entry.get("kind", "")) == "tier":
+		MusicManager.set_tier_override(int(entry.get("tier", 0)))
+	else:
+		MusicManager.play_track(str(entry.get("path", "")))
+	_refresh_music_status()
+
+
+func _release_music_override() -> void:
+	if not is_instance_valid(MusicManager):
+		return
+	MusicManager.clear_tier_override()
+	# A standalone bed replaced the adaptive stream entirely; re-entering the current
+	# context is what brings the doom-driven score back.
+	if not MusicManager.is_adaptive_active():
+		MusicManager.play_context(MusicManager.current_context)
+	_refresh_music_status()
+
+
+func _refresh_music_status() -> void:
+	if _music_status == null or not is_instance_valid(MusicManager):
+		return
+	_music_status.text = MusicManager.audition_status_line()
 
 
 func _section_label(text: String) -> Label:
@@ -253,6 +360,9 @@ func _populate_event_dropdown() -> void:
 # --- Rendering -------------------------------------------------------------
 
 func _render() -> void:
+	# Music status tracks doom, so refresh it on every state update -- and BEFORE the
+	# info-vbox guard, so it still updates in the unit tests that stub only the vbox.
+	_refresh_music_status()
 	if _info_vbox == null:
 		return
 	for c in _info_vbox.get_children():

--- a/godot/tests/unit/test_adaptive_music.gd
+++ b/godot/tests/unit/test_adaptive_music.gd
@@ -8,9 +8,11 @@ var _saved_tier: int = 0
 
 func before_each():
 	_saved_tier = MusicManager._current_music_tier
+	MusicManager._tier_override = -1  # never let an audition override leak between tests
 
 func after_each():
 	MusicManager._current_music_tier = _saved_tier
+	MusicManager._tier_override = -1
 
 func test_tier_mapping_tracks_canonical_bands():
 	# One probe per canonical ThemeManager band (below: 15/37/52/67/80/92/101),
@@ -109,3 +111,80 @@ func test_doom_signal_wiring_is_listen_only():
 	# And the handler tolerates a minimal/malformed state dict.
 	MusicManager._on_game_state_for_music({})
 	assert_eq(MusicManager._current_music_tier, 0, "Missing doom key reads as 0")
+
+
+# === Audition override -- the ALPHA TOOLS music player (Pip 2026-08-05) ==============
+#
+# The point of the feature is that a track can be HELD against live game state, so the
+# thing to pin is exactly that: doom keeps moving and does NOT take the tier back.
+
+func test_override_holds_the_tier_against_live_doom():
+	MusicManager.set_doom_level(0.0)
+	MusicManager.set_tier_override(4)
+	assert_true(MusicManager.is_tier_overridden(), "override is engaged")
+	assert_eq(MusicManager.get_current_music_tier(), 4, "the held tier is what plays")
+	MusicManager.set_doom_level(10.0)   # automatic would be 0
+	MusicManager.set_doom_level(60.0)   # automatic would be 2
+	assert_eq(MusicManager.get_current_music_tier(), 4,
+		"doom must NOT reclaim the tier while a human is auditioning")
+	assert_eq(MusicManager.get_auto_music_tier(), 2,
+		"automatic tier is still tracked underneath, for the readout and the release")
+
+func test_release_snaps_to_where_doom_is_now_not_where_it_was():
+	MusicManager.set_doom_level(0.0)
+	MusicManager.set_tier_override(4)
+	MusicManager.set_doom_level(95.0)
+	MusicManager.clear_tier_override()
+	assert_false(MusicManager.is_tier_overridden(), "override released")
+	assert_eq(MusicManager.get_current_music_tier(), 4,
+		"release follows doom NOW (95 -> tier 4), not the tier doom had at override time")
+	MusicManager.set_doom_level(0.0)
+	assert_eq(MusicManager.get_current_music_tier(), 0, "and doom drives again afterwards")
+
+func test_override_releases_itself_at_the_run_boundary():
+	# The stated safety property: an override cannot silently ride into a scored run.
+	# Every start-run / return-to-menu / game-over transition calls play_context().
+	MusicManager.set_tier_override(3)
+	MusicManager.play_context(MusicManager.MusicContext.GAMEPLAY)
+	assert_false(MusicManager.is_tier_overridden(),
+		"entering a run must hand the tier back to doom")
+	_silence_music()
+
+func test_audition_is_not_an_alpha_tool():
+	# Auditioning writes nothing toward game state or scoring, so it must NOT set the
+	# sticky unranked flag the mutating pokes set (decision card 2026-08-01).
+	GameConfig.reset_alpha_tools_flag()
+	MusicManager.set_tier_override(4)
+	MusicManager.clear_tier_override()
+	assert_false(GameConfig.alpha_tools_used,
+		"playing a different track is not a state mutation and must not unrank the run")
+	assert_true(GameConfig.is_ranked_run(), "run stays ranked after an audition")
+
+func test_catalogue_lists_every_tier_once_and_dedupes_shared_beds():
+	var cat := MusicManager.audition_catalogue()
+	var tiers: Array = []
+	var paths: Array = []
+	for entry in cat:
+		assert_true(entry.has("label") and entry.has("kind") and entry.has("path"),
+			"catalogue entries carry label/kind/path")
+		if str(entry["kind"]) == "tier":
+			tiers.append(int(entry["tier"]))
+		assert_false(paths.has(str(entry["path"])),
+			"no bed listed twice (checkpoint_saved.ogg is both MENU and tier 0)")
+		paths.append(str(entry["path"]))
+	assert_eq(tiers.size(), MusicManager.MUSIC_TIER_NAMES.size(),
+		"every music tier is auditionable")
+	assert_gt(cat.size(), MusicManager.MUSIC_TIER_NAMES.size(),
+		"the standalone victory/defeat beds are auditionable too")
+
+func test_status_line_says_what_is_playing_and_why():
+	MusicManager._adaptive_active = true
+	MusicManager.set_doom_level(0.0)
+	assert_string_contains(MusicManager.audition_status_line(), "AUTO",
+		"unoverridden playback reports as automatic")
+	MusicManager.set_tier_override(4)
+	var line := MusicManager.audition_status_line()
+	assert_string_contains(line, "OVERRIDE", "an override says so")
+	assert_string_contains(line, "terminal", "and names the tier being heard")
+	assert_string_contains(line, "cosy", "and names the tier doom would have chosen")
+	_silence_music()

--- a/godot/tests/unit/test_alpha_tools_gating.gd
+++ b/godot/tests/unit/test_alpha_tools_gating.gd
@@ -1,0 +1,119 @@
+extends GutTest
+## THE GATE SPLIT (2026-08-05) -- the regression that cost a playtest, pinned.
+##
+## PR #1079 made the DEV BUILD badge conditional on OS.is_debug_build(). Correct for the
+## badge. But the ALPHA TOOLS overlay, the flight recorder, the UI evolution recorder and
+## the perf log all hung off the SAME BuildInfo.is_dev_build(), so they silently switched
+## off in release exports too -- and Pip discovered it at a friend's house when backslash
+## stopped working ("I wasn't able to bump doom").
+##
+## These tests assert the SPLIT, both directions, under SIMULATED release conditions
+## (BuildInfo._debug_run_override -- a headless GUT run is always a debug run, so without
+## that hook the release branch of every gate is untestable and can only be found in the
+## field). Limit, stated plainly: this simulates the DISCRIMINATOR, not an actual exported
+## release build. A real release-template export still needs a human press of backslash.
+
+var _saved_debug_override
+var _saved_perf_override
+
+func before_each():
+	_saved_debug_override = BuildInfo._debug_run_override
+	_saved_perf_override = PerfLog._enabled_override
+	PerfLog._enabled_override = null  # follow the build gate, not a leftover test forcing
+
+func after_each():
+	BuildInfo._debug_run_override = _saved_debug_override
+	PerfLog._enabled_override = _saved_perf_override
+
+
+# --- The split itself -------------------------------------------------------------
+
+func test_release_build_hides_the_badge_but_keeps_alpha_tools():
+	BuildInfo._debug_run_override = false
+	assert_false(BuildInfo.is_dev_build(),
+		"a release-template export is not a dev build")
+	assert_eq(BuildInfo.get_badge_text(), BuildInfo.get_release_badge_text(),
+		"#1067: a public release must NOT wear the amber DEV BUILD banner")
+	assert_true(BuildInfo.are_alpha_tools_available(),
+		"but the ALPHA TOOLS overlay must still be reachable -- #1104's sticky unranked "
+		+ "flag, not the build type, is what protects the board")
+
+func test_dev_build_gets_both():
+	BuildInfo._debug_run_override = true
+	assert_true(BuildInfo.is_dev_build(), "a debug run is a dev build")
+	assert_true(BuildInfo.are_alpha_tools_available(), "and has the tools")
+
+func test_alpha_tools_gate_is_independent_of_the_build_type():
+	# The whole point: the two gates must not be the same expression again.
+	BuildInfo._debug_run_override = false
+	var release_tools := BuildInfo.are_alpha_tools_available()
+	BuildInfo._debug_run_override = true
+	assert_eq(release_tools, BuildInfo.are_alpha_tools_available(),
+		"are_alpha_tools_available() must not depend on OS.is_debug_build()")
+
+
+# --- The overlay actually builds under release conditions ---------------------------
+
+func test_overlay_builds_under_release_conditions():
+	# The direct proof of Pip's bug. Before the split this overlay early-returned with
+	# _built == false in a release build, so backslash did nothing.
+	BuildInfo._debug_run_override = false
+	var overlay := DevModeOverlay.new()
+	add_child_autofree(overlay)
+	assert_true(overlay._built,
+		"backslash overlay must build in a release build (this is the #1079 regression)")
+	assert_not_null(overlay._root, "and have a togglable root control")
+
+func test_overlay_toggles_under_release_conditions():
+	BuildInfo._debug_run_override = false
+	var overlay := DevModeOverlay.new()
+	add_child_autofree(overlay)
+	overlay._on_toggle()
+	assert_true(overlay._root.visible, "first backslash opens it in a release build")
+	overlay._on_toggle()
+	assert_false(overlay._root.visible, "second backslash closes it")
+
+func test_overlay_header_shows_the_build_identity_in_release_too():
+	BuildInfo._debug_run_override = false
+	var stamp := BuildInfo.get_tools_stamp_text()
+	assert_string_contains(stamp, GameConfig.CURRENT_VERSION,
+		"'which build is this?' must be answerable from the overlay in someone else's lounge")
+	assert_ne(stamp.strip_edges(), "", "never blank")
+
+
+# --- The recorders and the perf log deliberately STAY build-gated --------------------
+#
+# Ruling (build_info.gd carries the full reasoning): these three write to a player's disk.
+# F6 dumps a screenshot plus the whole GameState; F7 is a SILENT screenshot with no
+# confirmation at all; the perf log writes continuously and unprompted, rotating at 5MB.
+# The overlay's risk was the leaderboard, and #1104 solved that. Their risk is the disk,
+# and nothing solves that except not running them. No one asked for them in a shipped build.
+
+func test_flight_recorder_stays_off_in_a_release_build():
+	BuildInfo._debug_run_override = false
+	var fr := FlightRecorder.new()
+	add_child_autofree(fr)
+	assert_false(fr._built,
+		"F6 writes a screenshot + full state dump to disk -- not in a shipped build")
+
+func test_ui_evolution_recorder_stays_off_in_a_release_build():
+	BuildInfo._debug_run_override = false
+	var rec := UIEvolutionRecorder.new()
+	add_child_autofree(rec)
+	assert_false(rec._built,
+		"F7 is a SILENT screenshot -- strictly worse than F6 to ship")
+
+func test_perf_log_stays_off_in_a_release_build():
+	BuildInfo._debug_run_override = false
+	assert_false(PerfLog.is_active(),
+		"perf.log writes unprompted and continuously -- the invisible-recorder case")
+
+func test_all_three_come_back_in_a_dev_build():
+	BuildInfo._debug_run_override = true
+	assert_true(PerfLog.is_active(), "perf log runs in dev")
+	var fr := FlightRecorder.new()
+	add_child_autofree(fr)
+	assert_true(fr._built, "F6 runs in dev")
+	var rec := UIEvolutionRecorder.new()
+	add_child_autofree(rec)
+	assert_true(rec._built, "F7 runs in dev")

--- a/godot/tests/unit/test_alpha_tools_gating.gd.uid
+++ b/godot/tests/unit/test_alpha_tools_gating.gd.uid
@@ -1,0 +1,1 @@
+uid://c7alcwxlakart


### PR DESCRIPTION
Both of Pip's asks from the 2026-08-05 playtest at a friend's house.

## Part 1 -- backslash comes back in shipped builds

Pip: *"backslash didn't work any more, which felt weird because I wasn't able to bump doom."*

PR #1079 correctly made the amber `DEV BUILD` badge conditional on `OS.is_debug_build()`, so a public release stops wearing it. But the **ALPHA TOOLS overlay, the flight recorder, the UI evolution recorder and the perf log all gated on the same `BuildInfo.is_dev_build()`**, so they silently switched off in release exports as a side effect. That consequence was flagged when #1079 merged and was never ruled on, and it landed on Pip in someone else's lounge room.

**This splits the gates. It does not revert #1079** -- the badge fix was right and stays.

| Feature | Gate | Ships in release? |
| --- | --- | --- |
| `DEV BUILD` badge | `is_dev_build()` | no (unchanged, #1067) |
| ALPHA TOOLS overlay (backslash) | `are_alpha_tools_available()` | **yes** |
| Flight recorder (F6) | `is_dev_build()` | no |
| UI evolution recorder (F7) | `is_dev_build()` | no |
| Perf log | `is_dev_build()` | no |

**Why the overlay is safe to un-gate:** PR #1104 shipped Alpha Tools -- using any state-mutating dev power sets a sticky, one-way UNRANKED flag on the run, carried in the save envelope, warned at first use and again at game over. That system was built precisely so dev powers could exist in a shipped build without polluting the board. Build-gating the overlay on top of that is now both redundant and in tension with the 2026-08-01 decision card.

**Why the other three are not.** Judged separately, as asked -- their risk is not the leaderboard, it is the player's disk, and Alpha Tools does nothing about that:

- **Flight recorder (F6)** -- writes a screenshot *plus the full `GameState` JSON* into `user://`. It is explicit and user-initiated, which is the strongest argument for shipping it, but the artefact is a picture of someone's screen and nobody asked for that capability in a downloaded build. Left off.
- **UI evolution recorder (F7)** -- same, and it is a **silent** screenshot: no popup, no confirmation, by design. Strictly worse than F6 to ship. Left off.
- **Perf log** -- writes `user://logs/perf.log` continuously, unprompted, rotating at 5MB. The textbook invisible-recorder case. Left off.

If Pip wants F6 in testers' hands later, that is a deliberate follow-up with its own consent surface, not a side effect of this patch.

Two copy fixes that were quietly lying: the overlay's hint line said *"dev build only - not shipped in release"*, and the header showed `get_badge_text()`, which collapses to a bare version string in a release build. The hint now reads *"alpha build tool - will not exist in the finished game"*, and the header always shows version + build stamp -- "which build is this?" is the most useful thing on that overlay when Pip is standing in someone else's lounge.

## Part 2 -- a music player in the dev tools

Pip: *"A little music player in the dev tools function would be good to be able to, like, override and switch tracks etc? particularly now I have a muso who likes the game and is interested in it."*

New **MUSIC** section in the backslash overlay:

- one dropdown listing every bed the game can play -- the five adaptive doom tiers (`M0 cosy` .. `M4 terminal`, each labelled with its actual filename) plus the standalone menu/victory/defeat beds, deduplicated (`checkpoint_saved.ogg` is both the MENU bed and tier 0, and listing it twice would read as two different tracks);
- **Play selected** -- a tier *holds* against live doom; a standalone bed plays directly;
- **Release -> AUTO** -- hands the tier back to doom, snapping to where doom is *now*, not where it was when the override was taken;
- a status line saying what is playing **and why**: `Playing: M4 terminal  [OVERRIDE -- doom says M1 uneasy]` or `Playing: M1 uneasy  [AUTO -- following doom]`.

The holding behaviour is the whole feature. `tools/music/jukebox.html` already lets you listen to the soundtrack; what a collaborator cannot currently do is **audition a track against the actual game state it plays under**. Now they can: set doom to 80 with the nudge buttons, hold M0 against it, hear whether the calm bed is wrong there.

**Is this an Alpha Tool? No** -- and the case against is worth stating because the answer is not obvious. The argument *for* is consistency: it lives in a panel whose header warns "using any of these takes this run off the leaderboard", so a player who reads that and then uses the music player has been told something false about their run. The argument *against*, which wins: the Alpha Tools flag exists to keep the board honest, and honesty runs both directions -- unranking a run because someone changed the music would misreport what happened in it. Music is already declared a pure view-layer side-effect (ADR-0006); this writes nothing to `GameState`, the seeded RNG or scoring. Same boundary the overlay already draws between the JUMP buttons (navigation, no mark) and `+$10k Money` (mutation, marks). The section is labelled `MUSIC (audition -- stays ranked)` so the panel's blanket warning does not silently over-claim.

**Run boundaries:** an override cannot ride into a scored run. `play_context()` releases it, and every start-run / return-to-menu / game-over transition calls `play_context()`. Pinned by a test.

## What a player sees

Nothing, unless they press backslash. Same key, same overlay, same amber NOT-RANKED warning on the toggle surface, same one-way flag on first mutation. The change is that in a **downloaded release build** the panel now opens instead of doing nothing. The `DEV BUILD` banner still does not appear on any screen.

## Testing

Fast gate: **1128 tests / 0 failures / 108 files** (baseline on main: 1112 / 107). Delta +16 tests, +1 file.

New `BuildInfo._debug_run_override` makes the release branch of every gate assertable headlessly -- without it, that branch could only be discovered in the field, which is exactly what happened. `test_alpha_tools_gating.gd` asserts the overlay builds *and toggles* under simulated release conditions while the badge does not, that `are_alpha_tools_available()` does not depend on `OS.is_debug_build()` at all, and that all three recorders stay off in release and come back in dev.

**Proved the guard fails without the fix:** reverting `dev_mode_overlay.gd` to `is_dev_build()` turns exactly the two overlay tests red (1128 tests, 2 failures); restoring it turns them green. Done and undone.

**Not verifiable headlessly, stated plainly:** a real release-template export cannot be simulated in a headless GUT run -- `OS.is_debug_build()` is always true there, so these tests exercise the *discriminator*, not a packaged build. A human still has to press backslash on an actual exported release once. That is the one thing left.

## Overlap

Deliberately stays out of `main.tscn` and `main_ui.gd` (another lane is on those for a layout fix) and out of `debug_overlay.tscn`. No scene files touched at all. The music panel went into `dev_mode_overlay.gd`, which is built entirely in code -- note the brief pointed at `debug_overlay.gd` (F3), but backslash is `dev_mode_overlay.gd`, and backslash is the surface Pip lost and the one carrying the ALPHA TOOLS contract.

Safe to ship today. `main_ui.gd` still carries a stale comment saying the overlay is "gated on BuildInfo.DEV_BUILD" -- left alone on purpose to avoid the conflict; worth a one-line follow-up once that lane lands.

Generated with [Claude Code](https://claude.com/claude-code)
