### PR TITLE
fix(ux): turn-1 hand above the fold, Fundraising is tile 1 -- 2 of 2 playtesters could not find it

### DIFF
--- a/godot/data/actions/core.json
+++ b/godot/data/actions/core.json
@@ -56,7 +56,7 @@
 			"name": "Fundraising",
 			"description": "Choose funding strategy - different risk/reward options",
 			"costs": {},
-			"category": "management",
+			"category": "funding",
 			"is_submenu": true
 		},
 		{

--- a/godot/scenes/ui/plan_screen.tscn
+++ b/godot/scenes/ui/plan_screen.tscn
@@ -18,6 +18,7 @@ theme_override_colors/font_color = Color(0.5, 0.8, 0.5, 0.9)
 [node name="ActionsScroll" type="ScrollContainer" parent="."]
 layout_mode = 2
 size_flags_vertical = 3
+size_flags_stretch_ratio = 0.8
 
 [node name="ActionsList" type="VBoxContainer" parent="ActionsScroll"]
 layout_mode = 2
@@ -32,7 +33,7 @@ theme_override_colors/font_color = Color(0.8, 0.9, 1.0, 1)
 [node name="UpgradesScroll" type="ScrollContainer" parent="."]
 layout_mode = 2
 size_flags_vertical = 3
-size_flags_stretch_ratio = 0.45
+size_flags_stretch_ratio = 0.65
 
 [node name="UpgradesList" type="VBoxContainer" parent="UpgradesScroll"]
 layout_mode = 2

--- a/godot/scripts/ui/action_bar_renderer.gd
+++ b/godot/scripts/ui/action_bar_renderer.gd
@@ -143,8 +143,11 @@ func render(actions: Array) -> void:
 		_seen_unlocked_actions[id] = true
 	_actions_primed = true
 
-	# Define category order
-	var category_order = ["hiring", "resources", "research", "funding", "management", "influence", "strategic", "other"]
+	# Define category order. FUNDING LEADS (playtest 2026-08-05: 2 of 2 external players could
+	# not find Fundraising): money is the enabling resource -- it buys hires, compute and
+	# upgrades -- so the economic opener renders as tile 1 with keyboard badge [1]. The
+	# cold-open first-lever nudge is unaffected (it pulses its target by action id, not index).
+	var category_order = ["funding", "hiring", "resources", "research", "management", "influence", "strategic", "other"]
 
 	# Define category colors
 	var category_colors = {
@@ -179,10 +182,16 @@ func render(actions: Array) -> void:
 # --- LAYOUT: classic single-column icon grid (was inline in _on_actions_available) ---------
 
 func _render_flat(categories: Dictionary, category_order: Array, category_colors: Dictionary, current_state: Dictionary) -> void:
-	# Create a single-column vertical stack for icons on left edge
-	var icon_stack = VBoxContainer.new()
-	icon_stack.add_theme_constant_override("separation", 1)  # #594: tighter vertical packing for 11+ icons
-	icon_stack.alignment = BoxContainer.ALIGNMENT_BEGIN  # P2/#768: pack to the top, no vertical float
+	# WRAPPING icon grid (playtest 2026-08-05 / #1043 item 1). The old single VBox column put
+	# ~15 70px tiles (~1,065px) inside a ~550px scroll viewport, with the scrollbar at the FAR
+	# RIGHT of the panel, ~470px away from the 70px-wide tile column it scrolls -- an invisible
+	# affordance, so 2 of 2 external players never found Fundraising (tile 10, below the fold).
+	# An HFlowContainer wraps tiles across the panel's full width (~8 per row at 1080p): the
+	# whole turn-1 hand sits above the fold and the dead width beside the column is reclaimed.
+	# Keyboard badges keep index order (reading order: left-to-right, top-to-bottom).
+	var icon_stack = HFlowContainer.new()
+	icon_stack.add_theme_constant_override("h_separation", 2)
+	icon_stack.add_theme_constant_override("v_separation", 2)
 	host.actions_list.add_child(icon_stack)
 
 	# Create icon buttons - single column layout

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -680,17 +680,17 @@ static func dialog_key_advances(dialog: Control, keycode: int) -> bool:
 
 func _trigger_action_by_index(index: int):
 	"""Trigger action button by its index (for keyboard shortcuts)"""
-	# Find the VBoxContainer (icon_stack) first
-	var icon_stack: VBoxContainer = null
+	# Find the icon_stack first (HFlowContainer since the wrap fix; was a VBox column)
+	var icon_stack: Container = null
 	for child in actions_list.get_children():
-		if child is VBoxContainer:
+		if child is Container:
 			icon_stack = child
 			break
 
 	if not icon_stack:
 		return
 
-	# Get buttons directly from stack (single column layout)
+	# Get buttons directly from stack (index = reading order in the wrapped grid)
 	var buttons = icon_stack.get_children()
 	if index < buttons.size():
 		var button = buttons[index] as Button
@@ -1524,11 +1524,13 @@ func _populate_upgrades():
 
 		# Create button
 		var button = ThemeManager.create_button(upgrade_name)
-		# Blockier tiles (#594): hug content instead of stretching across the wide right
-		# panel, and ~20% taller (32 -> 38) so they read as tighter, blockier tiles.
-		# Playtest-3: right-align the column to free up central screen space (was
-		# SIZE_SHRINK_BEGIN, hugging the left edge instead).
-		button.size_flags_horizontal = Control.SIZE_SHRINK_END
+		# Uniform full-width LIST rows (playtest 2026-08-05: "fix the upgrade button layout").
+		# The previous SIZE_SHRINK_END sized each button to its own text (200..283px measured)
+		# and right-aligned the stack, so the column floated mid-screen with ragged left edges.
+		# Full-width rows give one aligned column, bigger hit targets, and put the scrollbar
+		# directly beside the content it scrolls. Left-aligned text reads as a list.
+		button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		button.alignment = HORIZONTAL_ALIGNMENT_LEFT
 		button.custom_minimum_size = Vector2(200, 38)
 
 		# If purchased, show differently

--- a/godot/scripts/ui/submenu_chrome.gd
+++ b/godot/scripts/ui/submenu_chrome.gd
@@ -13,7 +13,7 @@ static func find_action_button(actions_list: Control, action_id: String) -> Butt
 	if actions_list == null:
 		return null
 	for child in actions_list.get_children():
-		if child is VBoxContainer:
+		if child is Container:  # HFlowContainer since the wrap fix (was a VBox column)
 			for b in child.get_children():
 				if b is Button and b.get_meta("action_id", "") == action_id:
 					return b

--- a/godot/tests/unit/test_action_visibility.gd
+++ b/godot/tests/unit/test_action_visibility.gd
@@ -1,0 +1,192 @@
+extends GutTest
+## Guard for the 2026-08-05 playtest failure: 2 of 2 external players could not find
+## Fundraising. Root cause was geometry, not comprehension -- the turn-1 hand rendered as a
+## single 70px-wide VBox column of 15 tiles (~1,065px tall) inside an ActionsScroll viewport
+## of ~550px at 1080p, and the scrollbar sat at the FAR RIGHT edge of the ~573px panel,
+## ~470px away from the 70px tile column it scrolls -- an invisible affordance. Fundraising
+## was tile 10 (y ~639px), below the fold. (#1043 item 1: "no scrolling at the opening
+## view"; #798: action grouping.)
+##
+## Guards:
+##   1. the REAL turn-1 hand (GameActions defs, fresh-run state) rendered into a plan panel
+##      sized like the 1080p layout fits entirely above the fold, with a floor on the count.
+##      The fixed panel size matters: GUT's headless window is larger than 1080p, so only a
+##      pinned panel reproduces the geometry playtesters actually saw.
+##   2. the Fundraising tile is the FIRST tile (money is the enabling resource);
+##   3. in the real booted scene: every tile inside the live ActionsScroll viewport, and
+##      upgrade rows are uniform full-width list rows (replacing the ragged, content-sized
+##      right-aligned float -- 200..283px buttons, measured -- that read as clutter).
+##
+## HONESTY NOTE: these prove geometry -- tiles inside the fold, fundraise first, uniform
+## rows. No test proves the screen READS well; that stays a human playtest call.
+
+# The plan panel at the default 1920x1080 canvas: ContentArea gives the Plan column
+# 0.3/(0.3+0.3+0.4) of ~1910px = ~573px wide; the column's vertical budget after the
+# reserve gauge / hint / upgrades label / command zone rows is ~808px, split 0.8:0.65
+# with UpgradesScroll = ~445px for the action hand. Conservative vs the GUT window.
+const PLAN_PANEL_1080P := Vector2(573, 445)
+const MIN_VISIBLE_ACTIONS := 12  # floor: the whole turn-1 hand (15 tiles today) stays visible
+
+# Fresh-run state (mirrors the #1043 F6 capture: turn 1, $245k, nobody hired yet).
+const FRESH_STATE := {
+	"money": 245000, "turn": 1, "total_staff": 0, "reputation": 0.0,
+	"papers": 0, "research": 0.0, "purchased_upgrades": [],
+}
+
+
+# --- Fixed-size harness (same FakeHost pattern as test_action_bar_renderer) ----------------
+
+class FakeGameManager:
+	extends RefCounted
+	var _state: Dictionary
+	func _init(state: Dictionary) -> void:
+		_state = state
+	func get_game_state() -> Dictionary:
+		return _state
+
+class FakeHost:
+	extends Node
+	var actions_list: Control
+	var game_manager
+	var _ui_layout: String = "classic"
+	func _populate_upgrades() -> void: pass
+	func _apply_first_lever_nudge() -> void: pass
+	func _show_strategic_unlock_fanfare() -> void: pass
+	func _on_dynamic_action_pressed(_id: String, _name: String) -> void: pass
+	func _on_action_hover(_a: Dictionary, _c: bool, _m: Array) -> void: pass
+	func _on_action_unhover() -> void: pass
+
+
+var _harness_scroll: ScrollContainer = null
+
+
+func _render_real_hand_in_1080p_panel() -> Array:
+	"""Render the REAL action defs with a fresh-run state into a plan panel pinned to the
+	1080p geometry. Returns the tile buttons in visual order."""
+	var host := FakeHost.new()
+	host.game_manager = FakeGameManager.new(FRESH_STATE)
+	add_child_autofree(host)
+
+	var panel := Control.new()
+	panel.custom_minimum_size = PLAN_PANEL_1080P
+	panel.size = PLAN_PANEL_1080P
+	host.add_child(panel)
+
+	_harness_scroll = ScrollContainer.new()
+	_harness_scroll.set_anchors_preset(Control.PRESET_FULL_RECT)
+	panel.add_child(_harness_scroll)
+
+	var list := VBoxContainer.new()
+	list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_harness_scroll.add_child(list)
+	host.actions_list = list
+
+	var renderer = ActionBarRenderer.new(host)
+	renderer.render(GameActions.get_all_actions())
+	await get_tree().process_frame
+	await get_tree().process_frame
+	return _tiles_in(list)
+
+
+func _tiles_in(actions_list: Control) -> Array:
+	"""All action tiles in the hand, in visual order (buttons tagged with action_id meta,
+	inside whatever container the active layout mounted under actions_list)."""
+	var out: Array = []
+	if actions_list == null:
+		return out
+	for stack in actions_list.get_children():
+		if stack is Container:
+			for b in stack.get_children():
+				if b is Button and String(b.get_meta("action_id", "")) != "":
+					out.append(b)
+	return out
+
+
+func _clipped_tiles(tiles: Array, fold: Rect2) -> Array:
+	var clipped: Array = []
+	for t in tiles:
+		var r: Rect2 = t.get_global_rect()
+		if not fold.encloses(r):
+			clipped.append("%s at y=%.0f..%.0f (fold bottom %.0f)" % [
+				String(t.get_meta("action_id")), r.position.y, r.end.y, fold.end.y])
+	return clipped
+
+
+func test_turn1_hand_fits_above_the_fold_at_1080p() -> void:
+	var tiles: Array = await _render_real_hand_in_1080p_panel()
+	assert_true(tiles.size() >= MIN_VISIBLE_ACTIONS,
+		"turn-1 hand should render at least %d tiles (got %d)" % [MIN_VISIBLE_ACTIONS, tiles.size()])
+	var fold: Rect2 = _harness_scroll.get_global_rect()
+	var clipped: Array = _clipped_tiles(tiles, fold)
+	assert_eq(clipped.size(), 0,
+		"every turn-1 action must be visible without scrolling in the %s plan panel; %d of %d tiles are outside the fold: %s" % [
+			str(PLAN_PANEL_1080P), clipped.size(), tiles.size(), ", ".join(clipped)])
+
+
+func test_fundraise_is_the_first_tile() -> void:
+	var tiles: Array = await _render_real_hand_in_1080p_panel()
+	var ids: Array = []
+	for t in tiles:
+		ids.append(String(t.get_meta("action_id")))
+	assert_true(ids.has("fundraise"),
+		"the fundraise action must be in the turn-1 hand (got: %s)" % [ids])
+	if ids.is_empty():
+		return
+	assert_eq(ids[0], "fundraise",
+		"money is the enabling resource -- Fundraising must be tile 1 (keyboard [1]); hand order: %s" % [ids])
+
+
+# --- Real booted scene: live fold containment + upgrade-row uniformity ---------------------
+
+func test_real_scene_hand_fits_and_upgrade_rows_are_uniform() -> void:
+	# Boot main.tscn exactly as the game does (same pattern as test_game_start_actionable).
+	var scene: PackedScene = load("res://scenes/main.tscn")
+	assert_not_null(scene, "main.tscn must load")
+	if scene == null:
+		return
+	var root: Node = scene.instantiate()
+	add_child_autofree(root)
+	var main_ui: Node = root.find_child("MainUI", true, false)
+	assert_not_null(main_ui, "MainUI node must exist under the scene root")
+	if main_ui == null:
+		return
+	var plan = main_ui.get("plan_screen")
+
+	# _ready awaits one frame then auto-boots; poll until the hand has rendered tiles.
+	for _i in range(60):
+		await get_tree().process_frame
+		if plan != null and not _tiles_in(plan.actions_list).is_empty():
+			break
+	# Deterministic register: measure the CLASSIC flat hand even if a local pref persisted
+	# the proposed layout on this machine.
+	if main_ui.get("_ui_layout") != "classic":
+		main_ui._apply_ui_layout("classic")
+		for _i in range(3):
+			await get_tree().process_frame
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var tiles: Array = _tiles_in(plan.actions_list)
+	assert_false(tiles.is_empty(), "turn-1 action hand must render tiles in the booted scene")
+
+	# 1. Live fold containment at whatever size the headless window gives (weaker than the
+	# pinned-panel guard above, but it exercises the REAL scene tree and ratios).
+	var fold: Rect2 = plan.actions_scroll.get_global_rect()
+	assert_gt(fold.size.y, 200.0, "ActionsScroll viewport should be a real panel (got %s)" % fold.size)
+	var clipped: Array = _clipped_tiles(tiles, fold)
+	assert_eq(clipped.size(), 0,
+		"booted scene: %d of %d tiles are outside the live %s fold: %s" % [
+			clipped.size(), tiles.size(), str(fold.size), ", ".join(clipped)])
+
+	# 2. Upgrade rows: one uniform full-width column, not a ragged right-aligned float.
+	var rows: Array = []
+	for c in plan.upgrades_list.get_children():
+		if c is Button:
+			rows.append(c)
+	assert_gt(rows.size(), 0, "upgrades list must render rows")
+	var list_width: float = plan.upgrades_list.size.x
+	for r in rows:
+		assert_eq(r.size_flags_horizontal, Control.SIZE_EXPAND_FILL,
+			"upgrade row '%s' must fill the column (uniform list rows, not a ragged float)" % r.text)
+		assert_almost_eq(r.size.x, list_width, 1.0,
+			"upgrade row '%s' width %.0f should span the %.0f column" % [r.text, r.size.x, list_width])

--- a/godot/tests/unit/test_action_visibility.gd.uid
+++ b/godot/tests/unit/test_action_visibility.gd.uid
@@ -1,0 +1,1 @@
+uid://cc3na8jc5e1e1


### PR DESCRIPTION
## The defect

2026-08-05 playtest: **2 of 2 external players could not find Fundraising** -- the primary economic action ("75% of the total feedback received"). This PR fixes exactly that, measured rather than eyeballed.

## Why Fundraising was unreachable (measured)

- The classic hand rendered as **one 70px-wide VBox column of 15 tiles (~1,065px tall)** inside an ActionsScroll viewport of **~445px** at 1080p.
- The scroll's vertical bar sits at the far RIGHT edge of the ~573px plan panel -- **~470px away from the 70px tile column it scrolls**. An affordance nobody can see next to content that looks complete.
- `fundraise` carried category `management` (a data bug -- its own submenu items are category `funding`), so it rendered **10th**, at y=639..709 against a fold bottom of 445. Guard-test output pre-fix: `9 of 15 tiles are outside the fold ... fundraise at y=639..709 (fold bottom 445)`.
- **Not caused by #1116** (top-bar prefixes): that bar grows horizontally only; the column overflow predates it and is structural (15 unlocked core actions x 70px tiles). #1116/#1100 are untouched.

This is #1043 item 1 ("no scrolling at the opening view") and lands in the spirit of #798's grouping/ordering ask without forking the layout design work #1043 reserves for a workshop.

## The fix

1. **Wrapping grid instead of a hidden scroll** (`action_bar_renderer.gd::_render_flat`): `HFlowContainer`, ~8 tiles per row at 1080p. The whole turn-1 hand (15 tiles -> 2 rows, ~145px) sits above the fold; the dead width beside the old column is reclaimed. Keyboard badges keep reading order (left-to-right, top-to-bottom). Late-game worst case (~18 tiles = 3 rows) still fits.
2. **Fundraising is tile 1** with keyboard badge `[1]`: `core.json` category `management` -> `funding` (data fix; the funding icon/color/header already existed), and `funding` moved to the front of `category_order` -- money is the enabling resource. The cold-open first-lever nudge is unaffected (it pulses its target by action id, not index). Alternative considered: keep hiring first, funding second -- happy to flip one line if preferred.
3. **Upgrade rows are a uniform full-width left-aligned list** (`main_ui.gd::_populate_upgrades`). The previous `SIZE_SHRINK_END` sized each button to its own text (**200..283px, measured**) and right-aligned the stack -- a ragged float in mid-screen. **Deliberate revert of the "playtest-3 right-align" treatment**, per Pip naming the upgrade layout a must-fix on 2026-08-05; flagged here rather than done silently.
4. **Freed height goes to upgrades**: `plan_screen.tscn` ActionsScroll:UpgradesScroll stretch ratios `1.0:0.45 -> 0.8:0.65` (sum preserved, so the rest of the column is untouched). All 7 current upgrade rows are now visible without scrolling at 1080p.
5. Consumers hard-typed to the old VBox column (`_trigger_action_by_index`, `SubmenuChrome.find_action_button`) accept the flow container.

## Guard test (proven red first)

`godot/tests/unit/test_action_visibility.gd`:
- renders the REAL action defs with a fresh-run state into a panel **pinned to the 1080p geometry (573x445)** -- pinned because GUT's headless window is larger than 1080p and would make the check vacuous -- and asserts every turn-1 tile is inside the fold, with a floor of 12 visible;
- asserts Fundraising is the first tile;
- boots the real `main.tscn` and asserts live fold containment + uniform full-width upgrade rows.

Red/green protocol followed: with the fix stashed, all three tests fail (`9 of 15 tiles outside the fold`, `fundraise` 10th, upgrade rows 200..283px); with it restored, all pass. **Honesty note:** these pin geometry -- no test proves the screen READS well; that stays a human playtest call.

## Verification

- Fast gate: **1115 tests / 0 failures / 108 files** (baseline on main: 1112 / 0 / 107 -- the delta is exactly this new test file).
- No simulation/economy/replay code touched (view + one data category field); ladder unaffected.

## Ship call

Safe to ship in today's patch: view-layer + one JSON category field, no gameplay/RNG/scoring change, full gate green. The known visual risk is taste (tile grid vs column, upgrade row width) -- worth Pip's 2-minute eyeball in a preview build before cutting.

Refs #1043 (item 1), #798. Leaves #1043's larger workshop questions (persistent-across-screens columns, middle-of-screen use) open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
