### PR TITLE
feat(identity): one-time default-name prompt at upload + a lab-name generator worth keeping

### DIFF
--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -3,8 +3,14 @@ extends Node
 ## Manages persistent settings and game state across scenes
 
 # Player/Game Configuration
-var player_name: String = "Researcher"
-var lab_name: String = "AI Safety Lab"
+# Install-default identity as NAMED consts: the game-over default-identity
+# prompt (Pip 2026-08-06, after two friends' scores landed as identical
+# "AI Safety Lab" rows) compares against these, so the field initialisers,
+# reset_game_config() and has_default_identity() must all read the same pair.
+const DEFAULT_PLAYER_NAME := "Researcher"
+const DEFAULT_LAB_NAME := "AI Safety Lab"
+var player_name: String = DEFAULT_PLAYER_NAME
+var lab_name: String = DEFAULT_LAB_NAME
 var game_seed: String = ""  # Empty = weekly challenge seed
 var difficulty: int = 1  # 0=Easy, 1=Standard, 2=Hard -- the player's stored PREFERENCE. What a run actually PLAYS at is effective_difficulty() below (league lock, #1058/#1084).
 var org_type: String = "nonprofit"  # Early-game org form: "nonprofit" | "for_profit" (DQ-19). Set at pregame; default flow forces nonprofit.
@@ -106,6 +112,17 @@ var leaderboard_consent_asked: bool = false
 # reminder that the global board exists; this flag persists so later
 # playthroughs stay silent. See LeaderboardSync.consent_flow_state.
 var leaderboard_reminder_shown: bool = false
+# One-time default-identity prompt (Pip 2026-08-06): a player about to UPLOAD a
+# score while still carrying the unedited install defaults gets exactly ONE
+# chance to claim a name first -- a public board of identical "Researcher --
+# AI Safety Lab" rows is one nobody can find themselves on. Keeping the default
+# is a legitimate answer; this flag persists either way (set at SHOW time, the
+# leaderboard_reminder_shown shape above), so the question is never asked twice.
+# See LeaderboardSync.default_identity_prompt_state -- deliberately LAYERED ON
+# TOP of the consent flow, never a change to it: consent still decides WHETHER
+# an upload can happen; this only decides whether the name is worth a one-time
+# ask first.
+var default_identity_prompt_shown: bool = false
 
 # Privacy: anonymous launch ping opt-out (#799). The ping is a single Plausible
 # event on boot carrying ONLY a random install UUID + version + OS + first_launch
@@ -263,6 +280,7 @@ func save_config() -> void:
 	config.set_value("leaderboard", "submit_scores_global", submit_scores_global)
 	config.set_value("leaderboard", "consent_asked", leaderboard_consent_asked)
 	config.set_value("leaderboard", "reminder_shown", leaderboard_reminder_shown)
+	config.set_value("leaderboard", "identity_prompt_shown", default_identity_prompt_shown)
 
 	# Privacy + updates section (#799)
 	config.set_value("privacy", "send_launch_ping", send_launch_ping)
@@ -327,6 +345,7 @@ func load_config() -> void:
 	submit_scores_global = config.get_value("leaderboard", "submit_scores_global", submit_scores_global)
 	leaderboard_consent_asked = config.get_value("leaderboard", "consent_asked", leaderboard_consent_asked)
 	leaderboard_reminder_shown = config.get_value("leaderboard", "reminder_shown", leaderboard_reminder_shown)
+	default_identity_prompt_shown = config.get_value("leaderboard", "identity_prompt_shown", default_identity_prompt_shown)
 
 	# Load privacy + updates settings (#799)
 	send_launch_ping = config.get_value("privacy", "send_launch_ping", send_launch_ping)
@@ -494,10 +513,18 @@ func get_game_config() -> Dictionary:
 		"scenario_id": scenario_id
 	}
 
+## True while EITHER identity field still holds the unedited install default.
+## Either alone keeps the board entry generic (the board renders the lab name;
+## consent shares both names), so either alone keeps the one-time prompt armed.
+## Exact match on purpose: "unedited default" means literally these strings --
+## a player who deliberately typed something else, however close, has chosen it.
+func has_default_identity() -> bool:
+	return player_name.strip_edges() == DEFAULT_PLAYER_NAME or lab_name.strip_edges() == DEFAULT_LAB_NAME
+
 ## Reset game configuration to defaults (keep settings)
 func reset_game_config() -> void:
-	player_name = "Researcher"
-	lab_name = "AI Safety Lab"
+	player_name = DEFAULT_PLAYER_NAME
+	lab_name = DEFAULT_LAB_NAME
 	game_seed = ""
 	difficulty = 1
 	scenario_id = ""

--- a/godot/autoload/leaderboard_sync.gd
+++ b/godot/autoload/leaderboard_sync.gd
@@ -114,6 +114,28 @@ static func consent_flow_state(asked: bool, opted_in: bool, has_identity: bool, 
 		return "remind" if not reminded else "silent"
 	return "ask"
 
+## Should the game-over screen offer the ONE-TIME "still the default name"
+## prompt before an upload? (Pip 2026-08-06: two friends' first scores landed
+## as identical "AI Safety Lab" rows nobody could recognise.) PURE; unit-tested
+## directly. Deliberately LAYERED ON TOP of consent_flow_state above and never
+## a change to it: consent decides WHETHER an upload may happen (privacy ruling
+## 2026-07-26, untouched); this decides only whether the imminent upload is
+## worth one "want to claim a name first?" ask.
+##   flow          -- the consent_flow_state result for this submission
+##   is_default    -- GameConfig.has_default_identity()
+##   prompt_shown  -- GameConfig.default_identity_prompt_shown (persisted at
+##                    SHOW time, so the prompt can never fire twice)
+## Returns "prompt" or "pass". Only "submit" and "ask" can prompt -- the only
+## states where an upload is imminent. "remind"/"silent" never prompt: an
+## anonymous or declined player is exercising a legitimate choice and is never
+## nagged about names (same remind-once ruling as the flow above).
+static func default_identity_prompt_state(flow: String, is_default: bool, prompt_shown: bool) -> String:
+	if prompt_shown or not is_default:
+		return "pass"
+	if flow == "submit" or flow == "ask":
+		return "prompt"
+	return "pass"
+
 # --------------------------------------------------------------------------
 # Pure helpers (no HTTP, no state) -- this is where the contract bugs hide,
 # so these are unit-tested directly.

--- a/godot/scripts/core/lab_name_generator.gd
+++ b/godot/scripts/core/lab_name_generator.gd
@@ -1,0 +1,167 @@
+class_name LabNameGenerator
+extends RefCounted
+## Random lab-name generator (the [random] button on pre-game setup, plus the
+## one-time default-identity prompt's reroll at game over).
+##
+## REGISTER (docs/game-design/DESIGN_PHILOSOPHY.md): dry gallows humour. "You
+## can't win. You can only buy time." A rolled name should be keepable -- earnest,
+## corporate, faintly ominous, or (rarely) openly absurd. The old generator was
+## one shape (prefix + topic + suffix) over beige word lists, so every result
+## sounded like the same institute; the benchmark for "good" is that Pip's own
+## hand-typed "Notkilleveryone Inc" beat every generated name.
+##
+## FIVE SHAPES, WEIGHTED (why these): real AI-org names cluster into a few
+## recognisable species -- the university institute, the startup, the law-firm-
+## like consultancy, the backronymed NGO -- and shape variety reads as a
+## different ORG each roll, where longer word lists inside one shape still read
+## as the same org with the serial number filed off. The openly-absurd shape is
+## weighted rare (10%) so it stays a punchline instead of the house style.
+## Freeform portmanteau-mashing was considered and rejected: at these pool sizes
+## curation beats combinatorics (syllable-mash produces embarrassments; every
+## curated entry below was chosen on purpose).
+##
+## RNG / DETERMINISM (ADR-0006, replay is sacred): draws come ONLY from the
+## RandomNumberGenerator the caller hands in. Callers are UI-side (pregame
+## setup's randomize()d local RNG; the game-over identity prompt) -- the seeded
+## run RNG (GameState.rng) never routes through here, so draw counts here can
+## never shift a seeded run. Tests pass a seeded RNG to pin THIS generator's
+## own determinism.
+##
+## ASCII ONLY (issue #744): every pool entry below must stay plain ASCII.
+
+# ---- shape weights (out of 100) --------------------------------------------
+const _W_INSTITUTE := 30  # "Bureau of Recursive Alignment Triage"
+const _W_CORPORATE := 25  # "Paperclip Holdings"
+const _W_FIRM := 20       # "Voss & Okafor Containment"
+const _W_ACRONYM := 15    # "SAFE (Society Against Foom Events)"
+const _W_GALLOWS := 10    # "Five More Minutes Foundation"
+
+# ---- institute shape --------------------------------------------------------
+const _PREFIXES := [
+	"Center for", "Institute for", "Bureau of", "Department of",
+	"Coalition for", "Office of", "Commission on", "Society for",
+	"Initiative for", "Foundation for",
+]
+const _TOPICS := [
+	"AI Safety", "Aligned Intelligence", "Machine Cognition",
+	"Frontier Oversight", "Existential Risk", "Recursive Alignment",
+	"Model Interpretability", "Beneficial Computation", "Artificial Prudence",
+	"Catastrophe Deferral", "Applied Foresight", "Machine Ethics",
+]
+const _SUFFIXES := [
+	"Research", "Studies", "Assurance", "Preparedness",
+	"Stewardship", "Triage", "Mitigation", "Containment",
+]
+
+# ---- corporate shape --------------------------------------------------------
+const _CORP_WORDS := [
+	"Failsafe", "Sentinel", "Guardrail", "Foresight", "Redline",
+	"Tripwire", "Bastion", "Lighthouse", "Deadline", "Provenance",
+	"Halcyon", "Meridian", "Paperclip", "Anodyne",
+]
+const _ORG_SUFFIXES := [
+	"Labs", "Systems", "Dynamics", "Analytics", "Holdings",
+	"Collective", "Group", "Trust", "Inc", "Ventures",
+]
+
+# ---- surname-firm shape -----------------------------------------------------
+const _SURNAMES := [
+	"Voss", "Okafor", "Marlowe", "Chen", "Ishikawa", "Reyes",
+	"Lindqvist", "Adeyemi", "Novak", "Whitmore", "Kaur", "Petrov",
+]
+const _FIRM_DOMAINS := [
+	"Alignment", "Oversight", "Containment", "Associates", "Consulting",
+]
+
+# ---- acronym shape (curated pairs: the letters must actually expand) --------
+const _ACRONYMS := [
+	"HALT (Halting Autonomous Lethal Takeoff)",
+	"CALM (Center for Aligned Language Models)",
+	"SAFE (Society Against Foom Events)",
+	"GRIM (Global Risk Intervention Mechanism)",
+	"LATE (League Against Terminal Events)",
+	"WELP (Worldwide Emergency Longtermist Partnership)",
+	"OMEN (Oversight of Machine-Emergent Networks)",
+	"DOOM (Department of Ominous Machines)",
+]
+
+# ---- gallows shape (curated, rare on purpose) -------------------------------
+const _GALLOWS := [
+	"Probably Fine Labs",
+	"Time Buyers Collective",
+	"The Off Switch Company",
+	"Mostly Aligned Ventures",
+	"Deadline Extension Bureau",
+	"Five More Minutes Foundation",
+	"Second Thoughts Institute",
+	"It Gets Worse Analytics",
+	"Room for Error Holdings",
+	"Fine Print Futures",
+]
+
+## Roll one lab name. Same seeded rng in -> same name out (unit-pinned).
+static func generate(rng: RandomNumberGenerator) -> String:
+	# Belt-and-braces: the pools are curated so adjacent-duplicate words cannot
+	# occur today, but a future pool edit could introduce one ("AI Safety" +
+	# "Safety Research"); redraw rather than ship "Safety Safety".
+	for _attempt in range(5):
+		var name := _compose(rng)
+		if not _has_adjacent_duplicate(name):
+			return name
+	return _GALLOWS[0]  # unreachable with the current pools; total fallback
+
+static func _compose(rng: RandomNumberGenerator) -> String:
+	var roll := rng.randi_range(0, 99)
+	if roll < _W_INSTITUTE:
+		return _institute(rng)
+	roll -= _W_INSTITUTE
+	if roll < _W_CORPORATE:
+		return "%s %s" % [_pick(rng, _CORP_WORDS), _pick(rng, _ORG_SUFFIXES)]
+	roll -= _W_CORPORATE
+	if roll < _W_FIRM:
+		return _firm(rng)
+	roll -= _W_FIRM
+	if roll < _W_ACRONYM:
+		return _pick(rng, _ACRONYMS)
+	return _pick(rng, _GALLOWS)
+
+static func _institute(rng: RandomNumberGenerator) -> String:
+	var topic: String = _pick(rng, _TOPICS)
+	var form := rng.randi_range(0, 3)
+	if form <= 1:  # 50%: the full three-parter
+		return "%s %s %s" % [_pick(rng, _PREFIXES), topic, _pick(rng, _SUFFIXES)]
+	if form == 2:  # 25%: "Bureau of Existential Risk"
+		return "%s %s" % [_pick(rng, _PREFIXES), topic]
+	return "%s %s" % [topic, _pick(rng, _SUFFIXES)]  # 25%: "Machine Ethics Triage"
+
+static func _firm(rng: RandomNumberGenerator) -> String:
+	# Distinct surnames: walk from a random start so no redraw loop is needed
+	# (keeps the draw count per shape fixed and the output well-formed).
+	var n := _SURNAMES.size()
+	var first := rng.randi_range(0, n - 1)
+	var second: int = (first + rng.randi_range(1, n - 1)) % n
+	var form := rng.randi_range(0, 3)
+	if form <= 1:  # 50%: "Voss & Chen Containment"
+		return "%s & %s %s" % [_SURNAMES[first], _SURNAMES[second], _pick(rng, _FIRM_DOMAINS)]
+	if form == 2:  # 25%: the bare two-name partnership
+		return "%s & %s" % [_SURNAMES[first], _SURNAMES[second]]
+	# 25%: the three-name letterhead
+	var third: int = (second + rng.randi_range(1, n - 1)) % n
+	if third == first:
+		third = (third + 1) % n
+		if third == second:  # squeezed between the other two: step once more
+			third = (third + 1) % n
+	return "%s, %s & %s" % [_SURNAMES[first], _SURNAMES[second], _SURNAMES[third]]
+
+static func _pick(rng: RandomNumberGenerator, pool: Array) -> String:
+	return pool[rng.randi_range(0, pool.size() - 1)]
+
+## True if two consecutive words match case-insensitively ("Safety Safety").
+## Punctuation-bearing tokens ("&", "(Society") never match a plain word, which
+## is fine: the failure this guards against is doubled plain words.
+static func _has_adjacent_duplicate(name: String) -> bool:
+	var words := name.split(" ", false)
+	for i in range(1, words.size()):
+		if words[i].nocasecmp_to(words[i - 1]) == 0:
+			return true
+	return false

--- a/godot/scripts/core/lab_name_generator.gd.uid
+++ b/godot/scripts/core/lab_name_generator.gd.uid
@@ -1,0 +1,1 @@
+uid://dlfshy7jfxk8u

--- a/godot/scripts/leaderboard.gd
+++ b/godot/scripts/leaderboard.gd
@@ -138,6 +138,25 @@ func add_score(entry: ScoreEntry) -> Dictionary:
 
 	return {"added": was_added, "rank": rank}
 
+func rename_entry(uuid: String, new_name: String) -> bool:
+	"""Rename one entry's displayed lab name in place (found by entry_uuid).
+
+	Exists for the game-over default-identity prompt (Pip 2026-08-06): the local
+	save runs FIRST (isolation contract rule 2 -- durable before any dialog), so
+	a player who claims a name at the prompt has already saved the score under
+	the old default. This retrofits the just-saved LOCAL row so the player can
+	recognise their run on their own board too. Name-only: score, rank order,
+	uuid and every other field are untouched, so this can never move a row."""
+	var name := new_name.strip_edges()
+	if uuid == "" or name == "":
+		return false
+	for entry in entries:
+		if entry.entry_uuid == uuid:
+			entry.player_name = name
+			_save_leaderboard()
+			return true
+	return false
+
 func get_top_scores(count: int = 10) -> Array[ScoreEntry]:
 	"""Get top N scores from leaderboard"""
 	var top_count = min(count, entries.size())

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -307,6 +307,24 @@ func _maybe_submit_remote(entry, game_seed: String) -> void:
 		_has_submittable_identity(),
 		GameConfig.leaderboard_reminder_shown
 	)
+	# ONE-TIME default-identity gate (Pip 2026-08-06), LAYERED BEFORE the consent
+	# flow resolves: when an upload is imminent ("submit"/"ask") and the player
+	# still carries the unedited install defaults, offer one chance to claim a
+	# name -- so the name is worth uploading BEFORE it is baked into a public row.
+	# Never fires twice (persisted flag, set at show time); never fires for
+	# "remind"/"silent" (anonymity and decline are legitimate, never nagged).
+	# Consent itself (consent_flow_state above) is deliberately untouched.
+	var identity_gate: String = LeaderboardSync.default_identity_prompt_state(
+		flow, GameConfig.has_default_identity(), GameConfig.default_identity_prompt_shown
+	)
+	if identity_gate == "prompt":
+		_show_default_identity_prompt(entry, game_seed, flow)
+		return
+	_continue_consent_flow(flow, entry, game_seed)
+
+func _continue_consent_flow(flow: String, entry, game_seed: String) -> void:
+	"""Resolve a consent_flow_state result. Split out of _maybe_submit_remote so
+	the default-identity prompt can continue the SAME flow after it closes."""
 	match flow:
 		"submit":
 			_do_remote_submit(entry, game_seed)
@@ -337,6 +355,104 @@ func _do_remote_submit(entry, game_seed: String) -> void:
 	# not attempted here): api.pdoom1.com's score API must key by ladder_version and
 	# alias the live v0.12.0 board to L1 -- see GameConfig.get_board_version() docs.
 	LeaderboardSync.submit_score(entry, game_seed, GameConfig.get_board_version())
+
+func _show_default_identity_prompt(entry, game_seed: String, flow: String) -> void:
+	"""ONE-TIME (persisted flag, set at SHOW time -- the remind-once shape): the
+	player is about to upload while still carrying the unedited install defaults
+	("Researcher" / "AI Safety Lab"). One dialog, answerable in one click either
+	way; the score is already saved locally (isolation contract rule 2), so
+	nothing here can lose it. Keeping the default is a legitimate choice and is
+	never asked about again. Either answer continues the consent flow unchanged."""
+	GameConfig.default_identity_prompt_shown = true
+	GameConfig.save_config()
+
+	var dialog := ConfirmationDialog.new()
+	dialog.title = "STILL THE DEFAULT NAME -- ONE-TIME ASK"
+	# Custom content instead of dialog_text: the dialog needs editable fields, and
+	# AcceptDialog lays out Control children in its content area only when its own
+	# text label is unused.
+	var vbox := VBoxContainer.new()
+	vbox.custom_minimum_size = Vector2(460, 0)
+	vbox.add_theme_constant_override("separation", 8)
+	var info := Label.new()
+	info.text = (
+		"This score is headed for the global board under the install defaults.\n"
+		+ "Every unedited copy of the game posts as exactly this name, so nobody\n"
+		+ "can tell your run from anyone else's. Claim yours here, once:"
+	)
+	vbox.add_child(info)
+
+	var name_row := HBoxContainer.new()
+	var name_label := Label.new()
+	name_label.text = "Operator:"  # nomenclature ruling (#957): the player is the Operator
+	name_label.custom_minimum_size = Vector2(80, 0)
+	var name_edit := LineEdit.new()
+	name_edit.text = GameConfig.player_name
+	name_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	name_row.add_child(name_label)
+	name_row.add_child(name_edit)
+	vbox.add_child(name_row)
+
+	var lab_row := HBoxContainer.new()
+	var lab_label := Label.new()
+	lab_label.text = "Lab:"
+	lab_label.custom_minimum_size = Vector2(80, 0)
+	var lab_edit := LineEdit.new()
+	lab_edit.text = GameConfig.lab_name
+	lab_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	var reroll := Button.new()
+	reroll.text = "Reroll"
+	reroll.tooltip_text = "Roll a generated lab name until one fits"
+	# UI-side RNG only -- never the seeded run RNG (ADR-0006).
+	var reroll_rng := RandomNumberGenerator.new()
+	reroll_rng.randomize()
+	reroll.pressed.connect(func():
+		lab_edit.text = LabNameGenerator.generate(reroll_rng)
+	)
+	lab_row.add_child(lab_label)
+	lab_row.add_child(lab_edit)
+	lab_row.add_child(reroll)
+	vbox.add_child(lab_row)
+
+	dialog.add_child(vbox)
+	dialog.register_text_enter(name_edit)
+	dialog.register_text_enter(lab_edit)
+	dialog.ok_button_text = "[OK] Use this name"
+	dialog.cancel_button_text = "Keep the default"
+	dialog.confirmed.connect(func():
+		_apply_identity_from_prompt(name_edit.text, lab_edit.text, entry, game_seed)
+		_continue_consent_flow(flow, entry, game_seed)
+	)
+	# Cancel / ESC / close = keep the default, remembered; the flow continues so a
+	# consented player's upload still happens -- the prompt must never cost a score.
+	dialog.canceled.connect(func():
+		_continue_consent_flow(flow, entry, game_seed)
+	)
+	add_child(dialog)
+	dialog.popup_centered()
+
+func _apply_identity_from_prompt(name_text: String, lab_text: String, entry, game_seed: String) -> void:
+	"""Persist the claimed identity and retrofit it onto the CURRENT run's entry.
+	An emptied field keeps its previous value -- the prompt can never strip
+	identity below what the consent flow already deemed submittable."""
+	var new_name := name_text.strip_edges()
+	var new_lab := lab_text.strip_edges()
+	if new_name != "":
+		GameConfig.player_name = new_name
+	if new_lab != "":
+		GameConfig.lab_name = new_lab
+	GameConfig.save_config()
+	print("[GameOverScreen] Identity claimed at default-name prompt: %s -- %s"
+		% [GameConfig.player_name, GameConfig.lab_name])
+	if new_lab != "" and entry != null and "player_name" in entry:
+		# The ScoreEntry's display field carries the LAB name (leaderboard.gd).
+		entry.player_name = new_lab
+		# The LOCAL row was saved before the dialog (rule 2: durable first), under
+		# the old default -- rename it in place so the player can recognise their
+		# run on their own board too. Name-only; rank order untouched.
+		var board = Leaderboard.new(game_seed, GameConfig.get_board_version())
+		board.rename_entry(entry.entry_uuid, new_lab)
+		board.free()
 
 func _show_consent_prompt(entry, game_seed: String) -> void:
 	"""FIRST-TIME identity opt-in (privacy ruling 2026-07-26): the player must click

--- a/godot/scripts/ui/pregame_setup.gd
+++ b/godot/scripts/ui/pregame_setup.gd
@@ -25,26 +25,14 @@ var available_scenarios: Array[Dictionary] = []
 # Org-form choice control (built programmatically in _setup_org_type_choice)
 var org_type_option: OptionButton
 
-# Random lab name components (ported from pygame)
-var lab_prefixes = [
-	"Advanced", "Applied", "Center for", "Institute for",
-	"Laboratory of", "Division of", "Department of",
-	"Initiative for", "Research into", "Foundation for"
-]
-
-var lab_topics = [
-	"AI Safety", "Machine Learning", "Artificial Intelligence",
-	"Computational Intelligence", "Cognitive Systems",
-	"Neural Networks", "Autonomous Systems", "Intelligent Agents",
-	"Beneficial AI", "Aligned Intelligence"
-]
-
-var lab_suffixes = [
-	"Research", "Studies", "Analysis", "Exploration",
-	"Development", "Innovation", "Excellence"
-]
+# Lab-name generation lives in LabNameGenerator (scripts/core/lab_name_generator.gd)
+# -- unit-testable, shared with the game-over identity prompt's reroll. This screen
+# keeps its own randomize()d RNG: the [random] button is pre-game cosmetic flavour
+# and must never draw from the seeded run RNG (ADR-0006, replay is sacred).
+var _name_rng := RandomNumberGenerator.new()
 
 func _ready():
+	_name_rng.randomize()
 	print("[PreGameSetup] Initializing...")
 
 	# Load values from GameConfig
@@ -216,27 +204,12 @@ func _on_org_type_selected(index: int):
 
 func _on_random_lab_name_pressed():
 	"""Generate a random lab name"""
-	var random_name = _generate_random_lab_name()
+	var random_name = LabNameGenerator.generate(_name_rng)
 	lab_name_input.text = random_name
 	GameConfig.lab_name = random_name
 	_update_launch_button()
 
 	print("[PreGameSetup] Generated random lab name: ", random_name)
-
-func _generate_random_lab_name() -> String:
-	"""Generate a random lab name from components"""
-	var prefix = lab_prefixes[randi() % lab_prefixes.size()]
-	var topic = lab_topics[randi() % lab_topics.size()]
-	var suffix = lab_suffixes[randi() % lab_suffixes.size()]
-
-	# Randomly choose format
-	var formats = [
-		"%s %s %s" % [prefix, topic, suffix],
-		"%s %s" % [topic, suffix],
-		"%s %s" % [prefix, topic]
-	]
-
-	return formats[randi() % formats.size()]
 
 func _on_weekly_seed_pressed():
 	"""Clear seed to use weekly challenge seed"""

--- a/godot/tests/unit/test_default_identity_prompt.gd
+++ b/godot/tests/unit/test_default_identity_prompt.gd
@@ -1,0 +1,120 @@
+extends GutTest
+## Default-identity prompt tests (Pip 2026-08-06: two friends' first scores
+## landed on the global board as identical "AI Safety Lab" rows).
+##
+## The game-over screen layers LeaderboardSync.default_identity_prompt_state
+## ON TOP of the consent flow -- consent_flow_state itself (privacy ruling
+## 2026-07-26) is untouched and stays covered by test_leaderboard_consent.gd.
+## Tested here:
+##   - the prompt fires ONLY when an upload is imminent with a default identity
+##     and has never been offered before
+##   - anonymity ("remind"/"silent") and remembered decline are never nagged
+##   - GameConfig.has_default_identity() -- either unedited field arms it
+##   - the persisted shown-flag round-trips through save/load
+##   - Leaderboard.rename_entry retrofits the local row name-only
+
+var SyncScript = load("res://autoload/leaderboard_sync.gd")
+
+
+# ---- default_identity_prompt_state: the matrix ------------------------------
+# args: (flow, is_default, prompt_shown)
+
+func test_prompt_fires_when_upload_imminent_with_default_identity():
+	# The two states where an upload is imminent are exactly the two that prompt.
+	assert_eq(SyncScript.default_identity_prompt_state("submit", true, false), "prompt",
+		"consented player about to auto-upload the default name must get the one-time ask")
+	assert_eq(SyncScript.default_identity_prompt_state("ask", true, false), "prompt",
+		"first-time consent with a default name: claim the name BEFORE it is worth uploading")
+
+func test_prompt_never_fires_twice():
+	# The persisted flag (set at SHOW time) silences it forever -- a player who
+	# kept the default made a legitimate choice and is never nagged again.
+	assert_eq(SyncScript.default_identity_prompt_state("submit", true, true), "pass")
+	assert_eq(SyncScript.default_identity_prompt_state("ask", true, true), "pass")
+
+func test_prompt_never_fires_for_claimed_identity():
+	assert_eq(SyncScript.default_identity_prompt_state("submit", false, false), "pass")
+	assert_eq(SyncScript.default_identity_prompt_state("ask", false, false), "pass")
+
+func test_prompt_never_fires_when_no_upload_imminent():
+	# "remind" = anonymous nudge path, "silent" = remembered decline or already
+	# nudged. Neither uploads, so neither may nag about names -- anonymity and
+	# decline are legitimate choices (same ruling as the remind-once shape).
+	for flow in ["remind", "silent"]:
+		assert_eq(SyncScript.default_identity_prompt_state(flow, true, false), "pass",
+			"'%s' must never surface the identity prompt" % flow)
+		assert_eq(SyncScript.default_identity_prompt_state(flow, true, true), "pass")
+
+
+# ---- GameConfig.has_default_identity ----------------------------------------
+
+func test_has_default_identity_matrix():
+	var prev_player = GameConfig.player_name
+	var prev_lab = GameConfig.lab_name
+
+	GameConfig.player_name = GameConfig.DEFAULT_PLAYER_NAME
+	GameConfig.lab_name = GameConfig.DEFAULT_LAB_NAME
+	assert_true(GameConfig.has_default_identity(), "both fields default")
+
+	GameConfig.player_name = "Pip"
+	assert_true(GameConfig.has_default_identity(),
+		"lab still default: the board renders the LAB name, so the entry is still generic")
+
+	GameConfig.player_name = GameConfig.DEFAULT_PLAYER_NAME
+	GameConfig.lab_name = "Notkilleveryone Inc"
+	assert_true(GameConfig.has_default_identity(), "player name still default")
+
+	GameConfig.player_name = "Pip"
+	assert_false(GameConfig.has_default_identity(), "both fields claimed")
+
+	# Exact match on purpose: a deliberately-typed near-default is a choice.
+	GameConfig.player_name = "researcher"
+	GameConfig.lab_name = "My AI Safety Lab"
+	assert_false(GameConfig.has_default_identity(),
+		"only the literal unedited defaults count as 'default'")
+
+	GameConfig.player_name = prev_player
+	GameConfig.lab_name = prev_lab
+
+
+# ---- persistence: the shown-flag survives save/load -------------------------
+
+func test_prompt_shown_flag_round_trips():
+	var orig := {
+		"shown": GameConfig.default_identity_prompt_shown,
+	}
+
+	GameConfig.default_identity_prompt_shown = true
+	GameConfig.save_config()
+	GameConfig.default_identity_prompt_shown = false
+	GameConfig.load_config()
+	assert_true(GameConfig.default_identity_prompt_shown,
+		"identity_prompt_shown must persist -- otherwise the prompt fires every session")
+
+	# Restore the player's real value on disk and in memory.
+	GameConfig.default_identity_prompt_shown = orig["shown"]
+	GameConfig.save_config()
+
+
+# ---- Leaderboard.rename_entry: the local-row retrofit -----------------------
+
+func test_rename_entry_renames_in_place_name_only():
+	var board = Leaderboard.new("test_identity_rename_%d" % Time.get_ticks_usec(), "test")
+	var entry = Leaderboard.ScoreEntry.new(12, "AI Safety Lab", 12, "vtest", 60.0)
+	var other = Leaderboard.ScoreEntry.new(30, "Rival Lab", 30, "vtest", 90.0)
+	board.add_score(entry)
+	board.add_score(other)
+
+	assert_true(board.rename_entry(entry.entry_uuid, "Paperclip Holdings"))
+	assert_eq(entry.player_name, "Paperclip Holdings")
+	assert_eq(other.player_name, "Rival Lab", "only the targeted row is renamed")
+	assert_eq(board.get_top_scores(1)[0].entry_uuid, other.entry_uuid,
+		"rename is name-only: rank order untouched")
+
+	# Guards: unknown uuid and empty name are refused.
+	assert_false(board.rename_entry("no-such-uuid", "X"))
+	assert_false(board.rename_entry(entry.entry_uuid, "   "))
+	assert_eq(entry.player_name, "Paperclip Holdings")
+
+	board.clear()
+	board.free()

--- a/godot/tests/unit/test_default_identity_prompt.gd.uid
+++ b/godot/tests/unit/test_default_identity_prompt.gd.uid
@@ -1,0 +1,1 @@
+uid://b738j74afjj4m

--- a/godot/tests/unit/test_lab_name_generator.gd
+++ b/godot/tests/unit/test_lab_name_generator.gd
@@ -1,0 +1,84 @@
+extends GutTest
+## LabNameGenerator tests (Pip 2026-08-06: "fix improving the random lab name
+## generation mechanisms a bit" -- the old single-shape generator made every
+## roll sound like the same beige institute).
+##
+## Pinned properties:
+##   - deterministic under a seed (same seeded rng -> same sequence)
+##   - real variety across draws (shape + word variety, not one shape)
+##   - never malformed: non-empty, ASCII-only (house rule #744), no doubled
+##     spaces, no leading/trailing space, no duplicate-adjacent words,
+##     board-friendly length
+##   - RNG isolation is structural: the generator draws ONLY from the rng the
+##     caller passes, so the seeded run RNG (GameState.rng) cannot be touched
+##     unless a caller hands it in -- and no caller does (UI-only usage).
+
+const DRAWS := 500
+
+func _batch(seed_value: int, count: int) -> Array:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = seed_value
+	var out: Array = []
+	for _i in range(count):
+		out.append(LabNameGenerator.generate(rng))
+	return out
+
+
+func test_deterministic_under_a_seed():
+	# Same seed -> identical sequence; different seed -> (overwhelmingly) not.
+	var a := _batch(1234, 50)
+	var b := _batch(1234, 50)
+	assert_eq(a, b, "same seeded rng must reproduce the same name sequence")
+	var c := _batch(99999, 50)
+	assert_ne(a, c, "a different seed should produce a different sequence")
+
+
+func test_variety_not_one_beige_institute():
+	var names := _batch(42, DRAWS)
+	var distinct := {}
+	for n in names:
+		distinct[n] = true
+	assert_gt(distinct.size(), 100,
+		"%d draws produced only %d distinct names -- pools/shapes too small" % [DRAWS, distinct.size()])
+
+	# Every structural shape must actually be reachable: the acronym form
+	# (contains a parenthesised expansion), the surname firm (contains " & "),
+	# and the plain-word forms. 500 draws at the smallest weight (10%) miss a
+	# shape with probability ~(0.9)^500 -- effectively never.
+	var saw_acronym := false
+	var saw_firm := false
+	var saw_plain := false
+	for n in names:
+		if n.contains("("):
+			saw_acronym = true
+		elif n.contains(" & "):
+			saw_firm = true
+		else:
+			saw_plain = true
+	assert_true(saw_acronym, "acronym shape never rolled in %d draws" % DRAWS)
+	assert_true(saw_firm, "surname-firm shape never rolled in %d draws" % DRAWS)
+	assert_true(saw_plain, "institute/corporate/gallows shapes never rolled in %d draws" % DRAWS)
+
+
+func test_never_malformed():
+	var names := _batch(7, DRAWS)
+	for n in names:
+		var s: String = n
+		assert_ne(s.strip_edges(), "", "empty name rolled")
+		assert_eq(s, s.strip_edges(), "leading/trailing whitespace: '%s'" % s)
+		assert_false(s.contains("  "), "doubled space in '%s'" % s)
+		assert_lt(s.length(), 61, "board-unfriendly length (%d): '%s'" % [s.length(), s])
+		for i in range(s.length()):
+			assert_lt(s.unicode_at(i), 128, "non-ASCII char in '%s' (house rule #744)" % s)
+		assert_false(LabNameGenerator._has_adjacent_duplicate(s),
+			"duplicate adjacent words in '%s'" % s)
+
+
+func test_adjacent_duplicate_guard_detects():
+	# The guard itself must actually catch the failure it exists for --
+	# otherwise test_never_malformed's last assertion is vacuously green.
+	assert_true(LabNameGenerator._has_adjacent_duplicate("AI Safety Safety Research"))
+	assert_true(LabNameGenerator._has_adjacent_duplicate("AI Safety safety Research"),
+		"guard must be case-insensitive")
+	assert_false(LabNameGenerator._has_adjacent_duplicate("AI Safety Research"))
+	assert_false(LabNameGenerator._has_adjacent_duplicate("Voss & Okafor Containment"))

--- a/godot/tests/unit/test_lab_name_generator.gd.uid
+++ b/godot/tests/unit/test_lab_name_generator.gd.uid
@@ -1,0 +1,1 @@
+uid://dvbwxvomdg3nb


### PR DESCRIPTION
Make a player's identity theirs before their score reaches a public board, and make the generated lab names good. From Pip 2026-08-06, after two friends played: default-name entries fill the (now working, #1127) global board with identical rows nobody can recognise.

Relates to #1063 (name editing on the FIRST screen -- deliberately NOT duplicated here; this PR covers only the about-to-upload moment) and #957 (own-row highlight -- untouched; the "Operator" nomenclature from that issue is used in the new dialog's field label).

## Part 1 -- the one-time default-identity prompt

New pure state helper `LeaderboardSync.default_identity_prompt_state(flow, is_default, prompt_shown)`, LAYERED ON TOP of `consent_flow_state`. **`consent_flow_state` itself is byte-for-byte untouched** -- the 2026-07-26 privacy ruling still decides WHETHER an upload may happen; the new layer only decides whether the imminent upload is worth one "claim a name first?" ask.

**When it fires** (returns `"prompt"`): flow is `"submit"` (consented earlier, about to auto-upload) or `"ask"` (first-time consent moment) AND `GameConfig.has_default_identity()` (either field still literally `"Researcher"` / `"AI Safety Lab"`) AND the persisted `default_identity_prompt_shown` flag is unset. Firing before the consent "ask" is deliberate: the name gets claimed BEFORE it is baked into the first uploaded entry -- fixing it one game-over later is exactly the defect being reported.

**When it deliberately does not fire:**
- `"remind"` / `"silent"` flows -- an anonymous or declined player never uploads, so they are never nagged about names (anonymity is a legitimate choice; same ruling as the existing remind-once nudge)
- after it has fired once, ever -- the flag persists at SHOW time (the `leaderboard_reminder_shown` shape), so "keep the default" is one click and the question never returns
- once BOTH fields are player-claimed -- either field still holding the literal default keeps it armed, since either alone keeps the board entry generic (exact-match: a deliberately typed near-default counts as claimed)
- when sync is unconfigured/disabled (nothing to upload)

**The dialog** (game_over_screen): one ConfirmationDialog -- editable Operator + Lab fields prefilled, a Reroll button wired to the Part 2 generator, `[OK] Use this name` / `Keep the default`. Cancel/ESC = keep default AND the flow still continues, so the prompt can never cost a consented player their upload. The score is already saved locally before any of this (isolation contract rule 2 unchanged); on rename, the just-saved local row is retrofitted name-only via new `Leaderboard.rename_entry(uuid, name)` (rank order provably untouched -- tested).

## Part 2 -- LabNameGenerator (`godot/scripts/core/lab_name_generator.gd`)

**Why shapes, not longer word lists:** real AI-org names cluster into recognisable species; shape variety reads as a different ORG each roll, where a longer list inside one shape still reads as the same beige institute. Five weighted shapes:

- **institute 30%** -- `"Bureau of Recursive Alignment Triage"`, `"Coalition for Beneficial Computation Mitigation"` (the old shape, kept, with pools moved to the game's register)
- **corporate 25%** -- `"Paperclip Holdings"`, `"Deadline Ventures"` (the startup species; short, board-friendly)
- **surname firm 20%** -- `"Voss & Chen Containment"`, `"Marlowe, Kaur & Petrov"` (the consultancy/letterhead species)
- **curated acronym 15%** -- `"SAFE (Society Against Foom Events)"`, `"LATE (League Against Terminal Events)"` (curated pairs so the letters always actually expand)
- **gallows 10%** -- `"Five More Minutes Foundation"`, `"It Gets Worse Analytics"` (weighted rare so the punchline stays a punchline, not the house style)

Freeform portmanteau-mashing was considered and rejected: at these pool sizes curation beats combinatorics -- syllable-mash produces embarrassments, and every curated entry was chosen on purpose.

**20 samples (seed 20260806):** Fine Print Futures / Model Interpretability Triage / Halcyon Labs / It Gets Worse Analytics / Voss, Novak & Okafor / Guardrail Analytics / Halcyon Holdings / Foundation for Applied Foresight Stewardship / Institute for Catastrophe Deferral / DOOM (Department of Ominous Machines) / Coalition for Beneficial Computation Mitigation / Institute for Frontier Oversight / Voss & Lindqvist Oversight / Meridian Collective / The Off Switch Company / Foresight Labs / Paperclip Collective / Five More Minutes Foundation / Chen & Okafor Containment / Fine Print Futures

## Seeded RNG: not touched

The generator draws ONLY from the `RandomNumberGenerator` the caller passes. Callers are pregame setup (own `randomize()`d local RNG -- previously the global `randi()`, equally outside the sim) and the new game-over reroll (own local RNG). The seeded run RNG is `GameState.rng` and never routes through any of this; draw counts here cannot shift a seeded run (ADR-0006 respected; verified by grep -- every sim-side draw goes through `state.rng`/`rng` params, none through this path).

## Tests

- Fast gate in this worktree: **1123 tests / 0 failures / 109 files** (baseline 1112 / 0 / 107 -- delta is exactly the +11 new tests in +2 new files).
- `test_default_identity_prompt.gd`: full prompt-state matrix (fires on submit/ask + default + unshown; never twice; never for claimed identity; never on remind/silent), `has_default_identity` matrix, flag save/load round-trip, `rename_entry` name-only semantics + guards.
- `test_lab_name_generator.gd`: same-seed determinism, variety (>100 distinct in 500 draws, all shapes reachable), never-malformed (ASCII-only per #744, no doubled/adjacent-duplicate words, length <= 60), and the duplicate-guard's own detection.
- **Guards proven to fail:** (1) removed the `prompt_shown` short-circuit -> `test_prompt_never_fires_twice` went red; (2) disabled `_has_adjacent_duplicate`'s comparison -> `test_adjacent_duplicate_guard_detects` went red. Both restored; gate re-run green.

## Coordination

No overlap with the two live lanes (`main.tscn`/`main_ui.gd`/`action_bar_renderer.gd`; `build_info.gd`/`debug_overlay.gd`). Files touched: `game_config.gd`, `leaderboard_sync.gd`, `leaderboard.gd`, `game_over_screen.gd`, `pregame_setup.gd`, new `lab_name_generator.gd` + 2 test files.

## Ship risk (Pip intends a patch today)

Safe to ship today, with one caveat worth 60 seconds of eyeballing: the new dialog uses ConfirmationDialog with custom child controls (LineEdits) instead of `dialog_text` -- layout is the standard Godot 4 pattern but is the one part no unit test can see. Quick visual check: set `player_name`/`lab_name` to the defaults in `user://config.cfg` (or delete it), opt in to the global board, finish a run. Everything behavioural (state machine, persistence, generator output, rename) is unit-covered. No sim, scoring, board-key, or consent-semantics changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
