### PR TITLE
fix(copy): stop teaching a different game -- the Player Guide, the win condition, the cold open

### DIFF
--- a/godot/scenes/main.tscn
+++ b/godot/scenes/main.tscn
@@ -93,7 +93,7 @@ modulate = Color(0.4, 0.4, 0.5, 1)
 
 [node name="TurnLabel" type="Label" parent="TabManager/MainUI/TopBar"]
 layout_mode = 2
-text = "Week 1 | Mon Jul 3, 2017 | Day 1/5"
+text = "Turn 1 - Wed 5 Jul 2017"
 theme_override_font_sizes/font_size = 18
 theme_override_colors/font_color = Color(1, 0.72, 0.2, 1)
 theme_override_styles/normal = SubResource("StyleBoxFlat_TurnCounter")
@@ -266,13 +266,13 @@ layout_mode = 2
 
 [node name="ExplanationLabel" type="Label" parent="TabManager/MainUI/ContentArea/InstrumentColumn/CoreZone/RightZones/DoomExplanation"]
 layout_mode = 2
-text = "Buy time · survival is the score | Lose: P(Doom) = 100%"
+text = "Buy time -- survival is the score | Lose: P(Doom) = 100%"
 horizontal_alignment = 1
 theme_override_font_sizes/font_size = 10
 theme_override_colors/font_color = Color(0.6, 0.7, 0.6, 0.8)
 tooltip_text = "P(Doom) = Probability of catastrophic AI outcome.
-Win by solving alignment (0%) or finishing below the league baseline.
-Lose if doom reaches 100% or you finish above baseline."
+There is no victory condition. Your score is the number of months you survive.
+The run ends when doom reaches 100%, or when your reputation collapses to zero."
 
 [node name="EmployeeRosterZone" type="VBoxContainer" parent="TabManager/MainUI/ContentArea/InstrumentColumn"]
 layout_mode = 2
@@ -371,7 +371,7 @@ theme_override_font_sizes/font_size = 12
 [node name="EndTurnButton" type="Button" parent="TabManager/MainUI/BottomBar/ControlButtons"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "END TURN (Space)"
+text = "COMMIT THE MONTH >"
 tooltip_text = "Commit the queued plan and advance the month. Warns if you have unspent Attention."
 disabled = true
 theme_override_font_sizes/font_size = 16
@@ -381,7 +381,7 @@ theme_override_colors/font_disabled_color = Color(0.4, 0.4, 0.4, 1)
 [node name="CommitPlanButton" type="Button" parent="TabManager/MainUI/BottomBar/ControlButtons"]
 layout_mode = 2
 text = "Plan (Enter)"
-tooltip_text = "Execute queued actions immediately without warnings. Use when you've planned your turn."
+tooltip_text = "Commit the month immediately, with no warnings, and RESERVE all your remaining Attention. Use only when the plan is finished."
 disabled = true
 theme_override_font_sizes/font_size = 12
 

--- a/godot/scenes/player_guide.tscn
+++ b/godot/scenes/player_guide.tscn
@@ -30,9 +30,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -550.0
-offset_top = -330.0
+offset_top = -430.0
 offset_right = 550.0
-offset_bottom = 330.0
+offset_bottom = 430.0
 grow_horizontal = 2
 grow_vertical = 2
 
@@ -47,7 +47,7 @@ offset_right = -30.0
 offset_bottom = -30.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 20
+theme_override_constants/separation = 14
 
 [node name="Title" type="Label" parent="Panel/VBox"]
 layout_mode = 2
@@ -60,7 +60,7 @@ horizontal_alignment = 1
 layout_mode = 2
 theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
 theme_override_font_sizes/font_size = 16
-text = "How to Navigate P(Doom): Bureaucracy Strategy"
+text = "One turn is one month. Plan it, watch it, survive the next one."
 horizontal_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="Panel/VBox"]
@@ -74,40 +74,42 @@ size_flags_vertical = 3
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-theme_override_constants/separation = 20
+theme_override_constants/separation = 14
 
 [node name="ObjectiveSection" type="VBoxContainer" parent="Panel/VBox/ContentScroll/ContentVBox"]
 layout_mode = 2
-theme_override_constants/separation = 10
+theme_override_constants/separation = 6
 
 [node name="Title" type="Label" parent="Panel/VBox/ContentScroll/ContentVBox/ObjectiveSection"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 24
-text = "GAME OBJECTIVE"
+text = "THE OBJECTIVE"
 
 [node name="Text" type="RichTextLabel" parent="Panel/VBox/ContentScroll/ContentVBox/ObjectiveSection"]
-custom_minimum_size = Vector2(0, 100)
+custom_minimum_size = Vector2(0, 96)
 layout_mode = 2
 theme_override_colors/default_color = Color(0.9, 0.9, 0.9, 1)
 theme_override_font_sizes/normal_font_size = 16
 bbcode_enabled = true
-text = "Your goal is to [color=#3f8a5c][b]reduce P(Doom) to 0%[/b][/color] before running out of money or turns.
+text = "[b]You cannot win. You can only buy time.[/b] There is no victory screen and no finish line.
 
-P(Doom) represents the probability of AI causing human extinction. Balance [color=#e24a3b]AI capabilities[/color] research with [color=#3f8a5c]safety research[/color] to prevent catastrophe while advancing the field."
+Your score is [color=#f6a800][b]turns survived[/b][/color] -- the number of months your lab kept going. The run ends when P(Doom) reaches 100%, or when your reputation collapses to zero. Runs that survive the same number of months are separated by how much doom they held off along the way.
+
+P(Doom) is the probability of AI catastrophe. Nothing you can do drives it to zero. A good month is one where the curve bends, not one where the number gets small."
 
 [node name="HSeparator1" type="HSeparator" parent="Panel/VBox/ContentScroll/ContentVBox"]
 layout_mode = 2
 
 [node name="ControlsSection" type="VBoxContainer" parent="Panel/VBox/ContentScroll/ContentVBox"]
 layout_mode = 2
-theme_override_constants/separation = 10
+theme_override_constants/separation = 6
 
 [node name="Title" type="Label" parent="Panel/VBox/ContentScroll/ContentVBox/ControlsSection"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 24
-text = "CONTROLS"
+text = "THE MONTH: PLAN, THEN WATCH"
 
 [node name="Text" type="RichTextLabel" parent="Panel/VBox/ContentScroll/ContentVBox/ControlsSection"]
 custom_minimum_size = Vector2(0, 150)
@@ -115,54 +117,54 @@ layout_mode = 2
 theme_override_colors/default_color = Color(0.9, 0.9, 0.9, 1)
 theme_override_font_sizes/normal_font_size = 16
 bbcode_enabled = true
-text = "[b]Mouse:[/b] Click buttons and UI elements
-[b]Keyboard Numbers (1-9):[/b] Quick-select actions
-[b]Space/Enter:[/b] End turn and execute queued actions
-[b]Escape:[/b] Cancel/Back
+text = "Every turn is one calendar month, played in two halves. The banner at the top of the screen always says which half you are in and what the next verb is.
 
-[b]In-Game:[/b]
-• Select actions from the left panel
-• Actions cost Attention -- the founder's month -- plus money and resources
-• End your turn to execute all queued actions
-• Watch resource changes in the top panel"
+[color=#ffb833][b]## PLAN[/b][/color] -- lay out the month. Click action tiles to queue them. Hover a tile for its name, its cost, and why it is greyed out.
+[color=#5cec78][b]## WATCH[/b][/color] -- the month plays out in the feed. Respond to windows as they arrive. Then a month review, and you plan the next month.
+
+[b]Mouse:[/b] click tiles and buttons; hover anything you do not recognise
+[b]1-9:[/b] queue the numbered action    [b]Z:[/b] undo last    [b]C:[/b] clear the queue
+[b]SPACE / COMMIT THE MONTH >:[/b] end planning, with warnings if the plan looks dangerous
+[b]ENTER:[/b] commit straight away with no warnings -- this also reserves all your leftover Attention
+[b]ESC:[/b] pause menu    [b]N:[/b] report a bug"
 
 [node name="HSeparator2" type="HSeparator" parent="Panel/VBox/ContentScroll/ContentVBox"]
 layout_mode = 2
 
 [node name="ResourcesSection" type="VBoxContainer" parent="Panel/VBox/ContentScroll/ContentVBox"]
 layout_mode = 2
-theme_override_constants/separation = 10
+theme_override_constants/separation = 6
 
 [node name="Title" type="Label" parent="Panel/VBox/ContentScroll/ContentVBox/ResourcesSection"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
 theme_override_font_sizes/font_size = 24
-text = "KEY RESOURCES"
+text = "ATTENTION AND RESOURCES"
 
 [node name="Text" type="RichTextLabel" parent="Panel/VBox/ContentScroll/ContentVBox/ResourcesSection"]
-custom_minimum_size = Vector2(0, 200)
+custom_minimum_size = Vector2(0, 190)
 layout_mode = 2
 theme_override_colors/default_color = Color(0.9, 0.9, 0.9, 1)
 theme_override_font_sizes/normal_font_size = 16
 bbcode_enabled = true
-text = "[color=#f6a800][b]Money ($):[/b][/color] Hire staff, buy compute, fund research
-[color=#1ec3b3][b]Compute:[/b][/color] Required for running AI experiments
-[color=#b380e6][b]Research:[/b][/color] Accumulated knowledge points
-[color=#e9752e][b]Papers:[/b][/color] Published research (increases reputation)
-[color=#5c7ac3][b]Reputation:[/b][/color] Affects fundraising and hiring
+text = "[color=#f6a800][b]Attention[/b][/color] is the founder's month. You get a fresh grant every month and whatever you do not spend evaporates -- there is no banking.
 
-[color=#3f8a5c][b]Safety Researchers:[/b][/color] Green dots (●) - Reduce P(Doom)
-[color=#e24a3b][b]Capability Researchers:[/b][/color] Red dots (●) - Increase capabilities
-[color=#5c7ac3][b]Compute Engineers:[/b][/color] Blue dots (●) - Boost compute efficiency
+Attention splits two ways. [b]Planning hours[/b] queue strategic work; [b]operating hours[/b] pay for response windows, hiring and travel. A crisis can eat your planning hours, and planning can never buy back presence. That is why a tile can be dead while the top bar still shows Attention left: hover the tile, and hover the Attention readout, to see which hours are gone.
 
-[color=#e24a3b][b]P(Doom):[/b][/color] The probability of AI catastrophe - REDUCE TO ZERO TO WIN!"
+[color=#f6a800][b]Money ($):[/b][/color] hire staff, buy compute, fund research
+[color=#1ec3b3][b]Compute:[/b][/color] required to run experiments
+[color=#b380e6][b]Research:[/b][/color] accumulated knowledge; enough of it publishes a paper on its own
+[color=#e9752e][b]Papers:[/b][/color] published work -- raises reputation
+[color=#5c7ac3][b]Reputation:[/b][/color] drives fundraising and hiring; at zero, the run ends
+
+Staff glyphs beside Attention: [color=#3f8a5c][b]green *[/b][/color] safety researchers, [color=#e24a3b][b]red *[/b][/color] capability researchers, [color=#5c7ac3][b]blue *[/b][/color] compute engineers."
 
 [node name="HSeparator3" type="HSeparator" parent="Panel/VBox/ContentScroll/ContentVBox"]
 layout_mode = 2
 
 [node name="StrategySection" type="VBoxContainer" parent="Panel/VBox/ContentScroll/ContentVBox"]
 layout_mode = 2
-theme_override_constants/separation = 10
+theme_override_constants/separation = 6
 
 [node name="Title" type="Label" parent="Panel/VBox/ContentScroll/ContentVBox/StrategySection"]
 layout_mode = 2
@@ -171,22 +173,20 @@ theme_override_font_sizes/font_size = 24
 text = "STRATEGY TIPS"
 
 [node name="Text" type="RichTextLabel" parent="Panel/VBox/ContentScroll/ContentVBox/StrategySection"]
-custom_minimum_size = Vector2(0, 180)
+custom_minimum_size = Vector2(0, 140)
 layout_mode = 2
 theme_override_colors/default_color = Color(0.9, 0.9, 0.9, 1)
 theme_override_font_sizes/normal_font_size = 16
 bbcode_enabled = true
-text = "1. [b]Early Game:[/b] Hire safety researchers and fundraise for sustainability
-2. [b]Balance:[/b] Don't ignore capabilities - you need research progress
-3. [b]Reputation:[/b] Publish papers to boost reputation for better fundraising
-4. [b]Compute:[/b] Buy compute upgrades to accelerate research
-5. [b]Watch P(Doom):[/b] If it rises too fast, pivot to safety research
-6. [b]Attention:[/b] Unspent Attention evaporates at month end - there is no banking
-7. [b]Events:[/b] Random events can help or harm - read them carefully!"
+text = "1. [b]Runway first.[/b] Fundraising is the first tile for a reason. Most early runs die of bookkeeping, not of doom.
+2. [b]Spend the month.[/b] Unspent Attention evaporates at month end, so an under-planned month is a wasted one.
+3. [b]Both kinds of research cost you something.[/b] Capability work buys leverage and adds doom; safety work buys the reverse.
+4. [b]Reputation is life support,[/b] not a vanity stat -- it ends runs.
+5. [b]Read the feed during WATCH.[/b] Rival labs, the literature and your own results all land there.
+6. [b]Read events carefully.[/b] Response windows cost operating hours, and a rejected choice tells you why."
 
 [node name="Spacer" type="Control" parent="Panel/VBox"]
 layout_mode = 2
-size_flags_vertical = 3
 
 [node name="ButtonRow" type="HBoxContainer" parent="Panel/VBox"]
 layout_mode = 2

--- a/godot/scenes/ui/game_over_screen.tscn
+++ b/godot/scenes/ui/game_over_screen.tscn
@@ -55,7 +55,7 @@ horizontal_alignment = 1
 [node name="SubtitleLabel" type="Label" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 24
-text = "Victory Message"
+text = "Cause of death"
 horizontal_alignment = 1
 
 [node name="HSeparator" type="HSeparator" parent="CenterContainer/PanelContainer/MarginContainer/VBox"]

--- a/godot/scripts/ui/cold_open_sequence.gd
+++ b/godot/scripts/ui/cold_open_sequence.gd
@@ -22,7 +22,8 @@ extends Control
 
 # ============================================================================
 # TUNABLE COPY + TIMING -- Pip edits EVERYTHING player-facing here, in ONE place.
-# Copy is placeholder / Pip's to finalize (see COLD_OPEN_SEQUENCE.md beats).
+# Ship copy (see COLD_OPEN_SEQUENCE.md beats). Nothing here may describe itself as
+# placeholder: every new player reads these strings exactly once, at first impression.
 # ============================================================================
 
 # The narrative beats, played top-to-bottom. kind "text" = a fade-up line; the single
@@ -52,8 +53,8 @@ const BANK_SUBTITLE: String = "Operating account -- balance"
 const MESSAGES_TITLE: String = "MESSAGES"
 const STRANGER_NAME: String = "Mysterious Helpful Stranger"
 # HANDOFF (#811 item 1): the last thing the cold-open says hands the player an ACTIVE
-# SCOUTING CHOICE, not a closing narrative line. Copy still Pip's to finalize.
-const STRANGER_MESSAGE: String = "Hello past me! I am expository filler (for now). You know nothing yet -- go and find out. Read, show up somewhere, or be loud online. Scouting. -- MHS"
+# SCOUTING CHOICE, not a closing narrative line.
+const STRANGER_MESSAGE: String = "Hello past me! No, I can't tell you how it ends. You know nothing yet -- go and find out. Read something, show up somewhere, or be loud online. Scouting. -- MHS"
 # What the nudge points at when the cold-open ends. Content, not machinery: re-pointing
 # the handoff is this one string plus its hint line.
 const HANDOFF_ACTION_ID: String = "scouting"

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -133,10 +133,17 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 	print("[GameOverScreen] Game ended - Verification hash: %s..." % final_hash.substr(0, 16))
 
 	# Set title and colors based on outcome
+	# ADR-0002: THERE IS NO VICTORY CONDITION. `GameState.victory` is initialised false and
+	# is never assigned true anywhere in the engine (check_win_lose sets it false on both
+	# death routes; test_game_state.test_check_win_lose_doom_zero_no_victory pins doom<=0 as
+	# a non-ending). This branch is therefore unreachable, but it used to headline "VICTORY!
+	# / Humanity Survived the AI Revolution" -- the third surface disagreeing with the menu's
+	# "You can't win. You can only buy time." Copy is now consistent whichever way it goes;
+	# deleting the branch outright is a code change for issue #809 to make, not a copy fix.
 	if is_victory:
-		title_label.text = "VICTORY!"
+		title_label.text = "RUN ENDED"
 		title_label.add_theme_color_override("font_color", Color(0.2, 1.0, 0.2))  # Green
-		subtitle_label.text = "Humanity Survived the AI Revolution"
+		subtitle_label.text = "You bought humanity more time"
 		subtitle_label.add_theme_color_override("font_color", Color(0.6, 1.0, 0.6))
 	else:
 		title_label.text = "DEFEAT"
@@ -225,7 +232,7 @@ func show_game_over(is_victory: bool, final_state: Dictionary):
 	# Victory/defeat flavor text
 	stats_text += "\n[center][color=gray]-------------------[/color][/center]\n"
 	if is_victory:
-		stats_text += "\n[center][color=lime]Your leadership guided humanity safely through\nthe development of transformative AI.[/color][/center]"
+		stats_text += "\n[center][color=lime]Your lab held the line for %d months.\nThat is the whole game: time bought, not a war won.[/color][/center]" % final_turns
 	else:
 		var reason = _get_defeat_reason(final_state)
 		stats_text += "\n[center][color=red]%s[/color][/center]" % reason

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -1221,7 +1221,7 @@ func _on_game_state_updated(state: Dictionary):
 	if state.get("game_over", false):
 		var victory = state.get("victory", false)
 		if victory:
-			log_message("[color=gold]VICTORY! You survived![/color]")
+			log_message("[color=gold]RUN ENDED. You bought time.[/color]")
 		else:
 			log_message("[color=red]GAME OVER! The AI destroyed humanity.[/color]")
 

--- a/godot/tests/unit/test_no_win_condition_copy.gd
+++ b/godot/tests/unit/test_no_win_condition_copy.gd
@@ -1,0 +1,274 @@
+extends GutTest
+## ASSERTION GUARD, not an enumeration (fresh-eyes teardown 2026-08-06, finding 2).
+##
+## ADR-0002 (design series, docs/game-design/decisions/) deleted the victory bonus and
+## ruled: "There is no victory condition." The score is turns survived with a
+## doom-integral tiebreak. The engine agrees -- `GameState.victory` is initialised false
+## and is never assigned true anywhere (check_win_lose sets it false on BOTH death
+## routes; test_game_state.test_check_win_lose_doom_zero_no_victory pins doom<=0 as a
+## non-ending).
+##
+## The COPY did not agree. On 2026-08-06 four player-facing surfaces still promised a
+## win the game cannot award: the doom instrument tooltip ("Win by solving alignment
+## (0%) or finishing below the league baseline"), the Player Guide ("REDUCE TO ZERO TO
+## WIN!"), the game-over headline ("VICTORY!"), and the feed line ("VICTORY! You
+## survived!") -- while the main menu subtitle said "You can't win. You can only buy
+## time." Enumeration is the failure mode (#1050 enumerated nine AP strings and missed
+## six). This test asserts the ABSENCE of the win claim across every player-facing
+## surface, so the next one fails the fast gate instead of waiting for a playtest.
+##
+## Structure deliberately mirrors test_no_stale_ap_vocabulary.gd (#1073/#1116).
+##
+## NOT in scope: code comments and docstrings (this file's own tombstone comments SHOULD
+## say "there is no victory condition"), internal identifiers such as the `victory`
+## field and `is_victory` parameter, dev-only overlays, and the historical release
+## record in data/patch_notes.json.
+##
+## The colliding docs/adr/0002 ("rare apex victory") is issue #809 and is NOT settled
+## here; this guard encodes what the game currently IMPLEMENTS and what the menu tells
+## the player first. If #809 rules the other way, this test is the thing to change.
+
+const SCAN_DIRS := {
+	"res://scenes": "tscn",
+	"res://data": "json",
+	"res://scripts/ui": "gd",
+	"res://autoload": "gd",
+}
+
+## Dev-only / historical-record surfaces. Substring match on the res:// path.
+const EXCLUDED_PATHS := [
+	"debug_overlay",
+	"dev_mode",
+	"scripts/debug/",
+	"data/patch_notes.json",
+	"data/historical_events.json",  # verbatim arXiv abstract dumps, not authored copy
+	"office_floor/",                # sandbox/dev tooling, not the played screen
+]
+
+const PLAYER_FACING_JSON_KEYS := [
+	"name", "description", "text", "title", "message", "label", "summary",
+	"detailed_description", "tooltip", "hint", "body", "subtitle", "flavor",
+]
+
+## A string that DENIES the win condition is the copy we want, not an offence. The menu
+## subtitle and the resign tooltip both use the word "win" to say there isn't one.
+## Checked case-insensitively against the whole string, before any offence matching.
+const DENIALS := [
+	"cannot win",
+	"can not win",
+	"can't win",
+	"cant win",
+	"no way to win",
+	"never win",
+	"no win condition",
+	"no victory",
+	"not a victory",
+	"unwinnable",
+]
+
+
+func _is_excluded(path: String) -> bool:
+	for frag in EXCLUDED_PATHS:
+		if path.contains(frag):
+			return true
+	return false
+
+
+func _walk(dir_path: String, ext: String, out: Array) -> void:
+	var d := DirAccess.open(dir_path)
+	if d == null:
+		return
+	d.list_dir_begin()
+	var name := d.get_next()
+	while name != "":
+		if name.begins_with("."):
+			name = d.get_next()
+			continue
+		var full := dir_path.path_join(name)
+		if d.current_is_dir():
+			_walk(full, ext, out)
+		elif name.get_extension() == ext and not _is_excluded(full):
+			out.append(full)
+		name = d.get_next()
+	d.list_dir_end()
+
+
+func _read(path: String) -> String:
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return ""
+	var t := f.get_as_text()
+	f.close()
+	return t
+
+
+## The offence patterns.
+##   - `victory` / `victorious` in a player-facing string always announces the thing
+##     ADR-0002 deleted.
+##   - `win` / `wins` / `winnable` as a standalone word, UNLESS the same string denies
+##     it. Deliberately NOT matching `won`: "won't show again" is a real, innocent
+##     string and \bwon\b matches it, so the false-positive cost outweighs catching a
+##     hypothetical "you have won".
+## Plumbing, not prose: a bare lowercase token with no spaces is a dict key, a res://
+## path, a signal name or a node name -- `state.get("victory", false)` is the engine
+## FIELD, which ADR-0002 kept (initialised false, never assigned true). Same carve-out
+## the AP guard makes for internal keys such as `ap_cost`. A player-facing sentence
+## always has a space or a capital in it.
+func _is_internal_identifier(text: String) -> bool:
+	return RegEx.create_from_string("^[a-z0-9_./:%-]+$").search(text) != null
+
+
+func _offences(text: String) -> Array:
+	var found: Array = []
+	if _is_internal_identifier(text):
+		return found
+	var lower := text.to_lower()
+	for denial in DENIALS:
+		if lower.contains(denial):
+			return found
+	if RegEx.create_from_string("(?i)\\b(victory|victorious|victories)\\b").search(text) != null:
+		found.append("victory")
+	if RegEx.create_from_string("(?i)\\b(win|wins|winnable)\\b").search(text) != null:
+		found.append("win")
+	return found
+
+
+# --- .tscn: only the properties that render as words on screen -----------------------
+
+func _tscn_player_strings(src: String) -> Array:
+	var out: Array = []
+	var re := RegEx.create_from_string(
+		"(?m)^(text|tooltip_text|placeholder_text|hint_tooltip)\\s*=\\s*\"((?:[^\"\\\\]|\\\\.)*)\"")
+	for m in re.search_all(src):
+		out.append(m.get_string(2))
+	return out
+
+
+# --- .gd: string literals only, with comments and docstrings removed -----------------
+
+func _gd_string_literals(src: String) -> Array:
+	var stripped := RegEx.create_from_string("(?s)\"\"\".*?\"\"\"").sub(src, "", true)
+	stripped = RegEx.create_from_string("(?m)#.*$").sub(stripped, "", true)
+	var out: Array = []
+	for m in RegEx.create_from_string("\"((?:[^\"\\\\\\n]|\\\\.)*)\"").search_all(stripped):
+		out.append(m.get_string(1))
+	return out
+
+
+# --- .json: values of player-facing keys, at any nesting depth ------------------------
+
+func _json_player_strings(value, out: Array) -> void:
+	if value is Dictionary:
+		for k in value.keys():
+			var v = value[k]
+			if v is String and String(k) in PLAYER_FACING_JSON_KEYS:
+				out.append(v)
+			else:
+				_json_player_strings(v, out)
+	elif value is Array:
+		for item in value:
+			_json_player_strings(item, out)
+
+
+func _player_strings_for(path: String, ext: String) -> Array:
+	var src := _read(path)
+	if src.is_empty():
+		return []
+	match ext:
+		"tscn":
+			return _tscn_player_strings(src)
+		"gd":
+			return _gd_string_literals(src)
+		"json":
+			var json := JSON.new()
+			if json.parse(src) != OK:
+				return []
+			var out: Array = []
+			_json_player_strings(json.data, out)
+			return out
+	return []
+
+
+func collect_offences() -> Array:
+	var offences: Array = []
+	for dir_path in SCAN_DIRS.keys():
+		var ext: String = SCAN_DIRS[dir_path]
+		var files: Array = []
+		_walk(dir_path, ext, files)
+		for path in files:
+			for s in _player_strings_for(path, ext):
+				for hit in _offences(s):
+					offences.append("%s -- '%s' in: %s" % [path, hit, s.substr(0, 120)])
+	return offences
+
+
+func test_no_player_facing_surface_claims_a_win_condition():
+	var offences := collect_offences()
+	assert_eq(offences.size(), 0,
+		"ADR-0002: there is no victory condition and the engine never sets victory=true. "
+		+ "These player-facing strings still promise one:\n  - %s" % "\n  - ".join(offences))
+
+
+func test_the_engine_never_awards_a_victory():
+	# The copy guard is only honest if the mechanic really is absent. Both death routes
+	# in check_win_lose set victory=false; doom<=0 is not an ending at all.
+	var state = GameState.new("test_seed")
+	state.doom = 100.0
+	if state.doom_system:
+		state.doom_system.current_doom = 100.0
+	state.check_win_lose()
+	assert_true(state.game_over, "doom 100 must end the run")
+	assert_false(state.victory, "a doom death is not a victory (ADR-0002)")
+
+	var state2 = GameState.new("test_seed")
+	state2.reputation = 0.0
+	state2.check_win_lose()
+	assert_true(state2.game_over, "reputation collapse must end the run")
+	assert_false(state2.victory, "a reputation death is not a victory (ADR-0002)")
+
+
+func test_the_scan_actually_reaches_the_files_it_claims_to():
+	# A guard that scans nothing passes forever.
+	for dir_path in SCAN_DIRS.keys():
+		var files: Array = []
+		_walk(dir_path, SCAN_DIRS[dir_path], files)
+		assert_gt(files.size(), 0, "scan found no .%s files under %s" % [SCAN_DIRS[dir_path], dir_path])
+
+
+func test_the_offence_detector_is_not_vacuous():
+	# Proves the matcher goes red on the exact strings that shipped on 2026-08-06 --
+	# the cheap standing half of "reintroduce a string and watch it fail".
+	assert_gt(_offences("Win by solving alignment (0%) or finishing below the league baseline.").size(), 0,
+		"the main.tscn doom tooltip that shipped must be detected")
+	assert_gt(_offences("The probability of AI catastrophe - REDUCE TO ZERO TO WIN!").size(), 0,
+		"the player-guide line that shipped must be detected")
+	assert_gt(_offences("VICTORY!").size(), 0,
+		"the game-over headline that shipped must be detected")
+	assert_gt(_offences("VICTORY! You survived!").size(), 0,
+		"the main_ui feed line that shipped must be detected")
+	# Known limit, stated rather than hidden: "Humanity Survived the AI Revolution" is a
+	# victory claim with no win-word in it. Word matching cannot catch that class; it was
+	# removed by hand, and it only ever appeared attached to the "VICTORY!" title which
+	# this guard DOES catch.
+
+	# The denials must NOT trip: the design's own voice uses "win" to negate it.
+	assert_eq(_offences("You can't win. You can only buy time.").size(), 0,
+		"the menu subtitle is the SOURCE of truth, not an offence")
+	assert_eq(_offences("There is no way to win P(Doom); you are only ever buying time.").size(), 0,
+		"the resign tooltip states the ruling and must not false-positive")
+	assert_eq(_offences("There is no victory screen and no finish line.").size(), 0,
+		"the rewritten guide denies the win condition and must not false-positive")
+	assert_eq(_offences("Dismiss (won't show again for this version)").size(), 0,
+		"'won't' must not trip -- this is why \\bwon\\b is deliberately not a pattern")
+	assert_eq(_offences("Open the settings window").size(), 0,
+		"'window' must not trip the word boundary")
+
+	# The identifier carve-out must be narrow: it may swallow dict keys, never sentences.
+	assert_eq(_offences("victory").size(), 0,
+		"the bare `victory` dict key in state.get(\"victory\", false) is plumbing")
+	assert_eq(_offences("res://scenes/ui/victory_screen.tscn").size(), 0,
+		"a res:// path is plumbing")
+	assert_gt(_offences("Victory").size(), 0,
+		"a capitalised word is authored copy, not a dict key")
+	assert_gt(_offences("you win").size(), 0,
+		"a lowercase SENTENCE (it has a space) is still copy")

--- a/godot/tests/unit/test_no_win_condition_copy.gd.uid
+++ b/godot/tests/unit/test_no_win_condition_copy.gd.uid
@@ -1,0 +1,1 @@
+uid://ddbxl4f7mpp64


### PR DESCRIPTION
Fixes the copy that teaches new players a different game from the one they downloaded.
Source: `docs/design/FRESH_EYES_TEARDOWN_2026-08-06.md`, findings 1, 2 and 4.

## The judgement call: REWRITE the guide, not hide it

Hiding is genuinely the safer default -- an absent guide leaves a player uninformed,
whereas the shipped one left them confidently wrong, which takes longer to unlearn.
Rewriting won for two reasons:

1. The guide is the **only help surface that exists after turn 3** (teardown finding 9:
   the getting-started hint self-hides at turn 3, the first-lever pulse retires at turn 3,
   the welcome overlay and cold open are show-once, and the pause menu has no guide entry).
   Hiding it would have closed the last door.
2. The first-launch welcome overlay's **primary button** routes to it and its copy
   promises "walks you through the goal, the turn loop, and how your actions move doom,
   money, and reputation". Hiding the guide makes that promise a dead end too.

The guide is static scene text, so the rewrite is the same class of work as hiding it.

## Defect 1 -- Player Guide

Now describes the game that shipped: one turn is one calendar month (#1125), PLAN then
WATCH, founder Attention with its planning/operating hour split (including *why* a tile
can be dead while the top bar shows Attention left), turns-survived as the score
(ADR-0002), and keybinds verified against `main_ui.gd` / `keybind_manager.gd` rather than
copied forward (1-9, Z, C, SPACE, ENTER, ESC, N).

Removed: "reduce P(Doom) to 0% before running out of money or turns", "REDUCE TO ZERO TO
WIN!", "Space/Enter: End turn and execute queued actions", the pygame-era subtitle
"How to Navigate P(Doom): Bureaucracy Strategy", and the non-ASCII bullets/dots (#1035).

Node structure is unchanged. The panel grew 660 -> 860px tall and the flex spacer stopped
competing with the scroll container for vertical space, which roughly halves the scroll.
It does **not** fully fit above the fold -- four sections at 16pt cannot, without the
two-column pass that `docs/design/UI_ARCHITECTURE_2026-08-06.md` Phase 1 owns. Flagged,
not smuggled.

## Defect 2 -- the win condition, three surfaces disagreeing

Made consistent with the DESIGN-SERIES ADR-0002 and the menu tagline:

| surface | was | now |
| --- | --- | --- |
| `main.tscn` doom tooltip | "Win by solving alignment (0%) or finishing below the league baseline" | no victory condition; score is months survived; run ends at doom 100 or reputation 0 |
| `game_over_screen.gd` title | "VICTORY! / Humanity Survived the AI Revolution" | "RUN ENDED / You bought humanity more time" |
| `game_over_screen.gd` flavor | "Your leadership guided humanity safely through the development of transformative AI." | "Your lab held the line for N months. That is the whole game: time bought, not a war won." |
| `main_ui.gd` feed line | "VICTORY! You survived!" | "RUN ENDED. You bought time." |
| `game_over_screen.tscn` | authored placeholder "Victory Message" | "Cause of death" |

**No mechanic was relabelled.** `GameState.victory` is initialised false and is never
assigned true anywhere in the engine: `check_win_lose` sets it false on both death
routes, and `doom <= 0` is explicitly not an ending (pinned by the existing
`test_check_win_lose_doom_zero_no_victory`). Those branches are dead code. Deleting them
is #809's call -- the colliding `docs/adr/0002` series still says "rare apex victory" --
and this PR deliberately does not resolve that. It only stops a dead branch lying.

The undefined term "league baseline" is gone from the tooltip with it.

## Defect 3 -- the cold open

`cold_open_sequence.gd` no longer tells every new player, once, at maximum
first-impression leverage, that its writing is unfinished. Keeps the function (points at
scouting, opens a decision -- ADR-0001), the MHS voice, and the dry register:

> "Hello past me! No, I can't tell you how it ends. You know nothing yet -- go and find
> out. Read something, show up somewhere, or be loud online. Scouting. -- MHS"

The `# Copy is placeholder / Pip's to finalize` header comment is replaced with a note
saying nothing in that block may describe itself as placeholder.

## Also found, same class, not in the brief

- `main.tscn` TurnLabel authored text `"Week 1 | Mon Jul 3, 2017 | Day 1/5"` -- the
  Week/Day time model the game retired, painted for a frame before first state paint
  (#1031). Now `"Turn 1 - Wed 5 Jul 2017"`, matching the runtime format.
- `main.tscn` EndTurnButton authored text `"END TURN (Space)"` -- same class; the runtime
  relabels it to `"COMMIT THE MONTH >"`, so the scene now matches what a player ever sees.
- `main.tscn` CommitPlanButton tooltip never mentioned that it silently reserves ALL
  remaining Attention (teardown finding 3's real hazard). It says so now. The button is
  NOT renamed -- finding 3's verb collision belongs to the UI architecture pass.
- `main.tscn` non-ASCII middle dot in the doom line (#1035 family).

Deliberately left alone and reported instead: `main_ui.gd:849` "reputation and the
contact are placeholders until the adoption pipeline lands" is an honest disclosure of a
stub reward, not a retired mechanic. `action_bar_renderer.gd`'s COMING SOON suffix is
out of scope by the brief and is likewise honest.

## The guard

`godot/tests/unit/test_no_win_condition_copy.gd`, same shape as
`test_no_stale_ap_vocabulary.gd` (#1073/#1116). Asserts the ABSENCE of a win claim across
`scenes/`, `data/`, `scripts/ui/` and `autoload/`, because enumeration is the failure mode
(#1050 enumerated nine AP strings and missed six).

Strings that DENY the win condition are exempt by design -- "You can't win. You can only
buy time." is the source of truth, not an offence. Bare lowercase identifiers are exempt
as plumbing (`state.get("victory", false)` is the engine field ADR-0002 kept); the guard
caught that on its first run, which is independent evidence the scan really reaches
`main_ui.gd`.

**Proved it fails.** Reintroduced the shipped doom tooltip; the fast gate went red naming
the exact string and file; removed it; green again. Four in-test assertions also pin the
matcher against the specific strings that shipped, and five pin it against false
positives ("won't show again", "window", the menu subtitle, the resign tooltip).

Known limit, stated rather than hidden: "Humanity Survived the AI Revolution" is a
victory claim containing no win-word. Word matching cannot catch that class. It was
removed by hand, and it only ever appeared attached to the "VICTORY!" title the guard
does catch.

## Verification

Fast gate in this worktree: **1146 tests / 0 failures / 112 files**.
Baseline measured in the same worktree by stashing this branch: **1142 / 0 / 111**.
Delta: **+4 tests, +1 file, 0 new failures.**

All touched files are ASCII-clean. `main_ui.gd`'s action rendering and
`action_bar_renderer.gd` are untouched.

## Safe to ship today

Yes. Every change is a string or a comment except two `.tscn` geometry properties on the
Player Guide panel, which is a leaf screen reachable only from the main menu. Nothing
touches game logic, scoring, save format, the board key, or scene navigation. The two
dead victory branches are still structurally intact, so #809 can still rule either way.

Refs: `docs/design/FRESH_EYES_TEARDOWN_2026-08-06.md`, #1073, #809, #1031, #1035, #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
