### PR TITLE
feat(events): retime historical deck to one-turn-one-month, timing dial, ruled promotions (#1125, #1111)

### DIFF
--- a/docs/design/EVENT_PROMOTION_PASS.md
+++ b/docs/design/EVENT_PROMOTION_PASS.md
@@ -1,10 +1,25 @@
 # EVENT PROMOTION PASS -- ranked shortlist, ready to execute
 
 - **Date:** 2026-08-04
+- **EXECUTED 2026-08-06, with a retime correction -- read this first.** Pip's
+  rulings (#1111, GO order #1125) approved the pass but corrected the premise:
+  **one turn = one month**, so the recommended 26 turns/year in section 1/6a is
+  SUPERSEDED by **12 turns/year** (calendar-true under the month ruling; the
+  2017-2025 arc lands at turns 7-103, inside the observed run band). Timing is
+  now a DIAL: `rarity_curves.json` carries `timescales` variants
+  (`month_per_turn` active, `week_per_turn` = the old 52/yr as the "punished"
+  variant) resolved by `EventService._resolve_timescale`. Promotions applied:
+  A1-A5, B1-B8, all C promoted to B, PLUS sandbagging / Apollo / METR
+  (ruled in #1111 against section 5's advice). Shipped as
+  `godot/data/events/overrides/promotion_pass_2026_08.json`; firing turns
+  guarded by `godot/tests/unit/test_event_retime.gd`. Sections below are kept
+  as the mechanical reference (F1-F8 findings remain accurate); their turn
+  numbers assume 26/yr and are stale.
 - **Ask (Pip):** "a little half hour of promoting some events from different
   timelines will let us work on mechanics a bit and give players a touch more
   variety."
-- **Status:** PROPOSAL. No data or code changed. Every mechanical claim below
+- **Status:** PROPOSAL (executed with changes -- see above). No data or code changed
+  by this document itself. Every mechanical claim below
   was verified against the tree on 2026-08-04; file:line refs are to that tree.
   Assumes the 2026-08-02 audit
   (`docs/decision-cards/2026-08-02_pdoom-data-contract.md`) -- its measured

--- a/godot/autoload/event_service.gd
+++ b/godot/autoload/event_service.gd
@@ -308,10 +308,12 @@ func _transform_event(raw: Dictionary) -> Dictionary:
 	var rarity_settings = _get_rarity_settings(rarity)
 	var trigger_mode = rarity_settings.get("trigger_mode", "random_after_eligible")
 
-	# Calculate trigger turn based on year (52 turns per year)
+	# Calculate trigger turn based on year. turns_per_year is the timing DIAL
+	# (#1125: one turn = one month, so the shipped default is 12) -- resolved from
+	# the active timescale variant by _resolve_timescale at config load.
 	var year_config = _rarity_curves.get("year_trigger", {})
 	var base_year = year_config.get("base_year", 2017)
-	var turns_per_year = year_config.get("turns_per_year", 52)
+	var turns_per_year = year_config.get("turns_per_year", 12)
 
 	# Years before game start get clamped to turn 1
 	var years_from_start = year - base_year
@@ -839,7 +841,40 @@ func _load_rarity_curves() -> void:
 		return
 
 	_rarity_curves = data
-	print("[EventService] Loaded rarity curves")
+	_resolve_timescale()
+	print("[EventService] Loaded rarity curves (timescale: %s)" % str(_rarity_curves.get("timescale", "flat")))
+
+
+func _resolve_timescale() -> void:
+	"""Apply the active timescale variant (the timing DIAL, #1125 / #1111) onto
+	year_trigger and the rare eligibility window.
+
+	rarity_curves.json ships its flat year_trigger values equal to the active
+	variant, so this is a no-op until someone flips the `timescale` key -- at
+	which point every turns-denominated timing value (turns_per_year, legendary
+	offset, rare spread, rare eligibility window) rescales together. That is
+	what makes the pacing a dial instead of four constants that must be edited
+	in lockstep.
+
+	Runs only at config load / reload_config -- never on the seeded RNG path
+	(ADR-0006). Changing the dial changes which turns roll probabilities, so it
+	forks replay compatibility exactly like any balance-data change: ship dial
+	flips on a release boundary with a version bump (board key forks by design)."""
+	var scales = _rarity_curves.get("timescales", {})
+	var active := str(_rarity_curves.get("timescale", ""))
+	if active.is_empty() or not scales is Dictionary or not scales.has(active):
+		return
+	var scale = scales[active]
+	if not scale is Dictionary:
+		push_warning("[EventService] Timescale '%s' is not a dictionary; keeping flat year_trigger values" % active)
+		return
+	var year_trigger = _rarity_curves.get("year_trigger", {})
+	for key in ["turns_per_year", "legendary_month_offset", "rare_spread_turns"]:
+		if scale.has(key):
+			year_trigger[key] = scale[key]
+	_rarity_curves["year_trigger"] = year_trigger
+	if scale.has("rare_eligibility_window_turns") and _rarity_curves.get("rare") is Dictionary:
+		_rarity_curves["rare"]["eligibility_window_turns"] = scale["rare_eligibility_window_turns"]
 
 
 func _set_default_rarity_curves() -> void:

--- a/godot/data/events/balancing/rarity_curves.json
+++ b/godot/data/events/balancing/rarity_curves.json
@@ -1,6 +1,7 @@
 {
   "_description": "Probability and timing curves for event rarity tiers",
   "_note": "Historical events use year-based triggering; rarity affects behavior",
+  "_retime_2026_08": "Retimed for the #1125 ruling (one turn = one month). The historical arc 2017-2025 now spans turns 1-108: legendaries land at (year-2017)*12+7, inside the observed run band (deaths turn 14-229, best board 153). The old 52 turns/year values parked everything dated 2022+ past turn 287, where no run ever went. See docs/design/EVENT_PROMOTION_PASS.md section 1 and issues #1125 / #1111.",
   "common": {
     "base_probability": 0.12,
     "min_turn": 10,
@@ -12,7 +13,7 @@
     "base_probability": 0.06,
     "min_turn": 20,
     "cooldown_turns": 15,
-    "eligibility_window_turns": 26,
+    "eligibility_window_turns": 6,
     "trigger_mode": "probabilistic_window",
     "description": "Notable events - become eligible around historical date, then roll probability each turn within window."
   },
@@ -24,12 +25,29 @@
     "description": "Major narrative moments - always fire at their historical date. Key story beats."
   },
   "default_rarity": "common",
+  "timescale": "month_per_turn",
+  "timescales": {
+    "_description": "The timing DIAL (#1111: 'change the timing of things so that we can give people week-by-week versions of the game if they want to be punished'). EventService._resolve_timescale applies the active variant named by 'timescale' onto year_trigger and the rare eligibility window at config load. Flip the one string to rescale every turns-denominated timing value together.",
+    "_warning_week_per_turn": "week_per_turn restores the old 52 turns/year fiction pacing. Under CURRENT survival pacing (deaths turn 14-229) that makes everything dated 2022+ unreachable again (turn 287+). Do not ship it as a playable mode until the F4/F5 timing-dial pass (deferred in #1125) also rescales survival pacing.",
+    "month_per_turn": {
+      "turns_per_year": 12,
+      "legendary_month_offset": 6,
+      "rare_spread_turns": 3,
+      "rare_eligibility_window_turns": 6
+    },
+    "week_per_turn": {
+      "turns_per_year": 52,
+      "legendary_month_offset": 26,
+      "rare_spread_turns": 13,
+      "rare_eligibility_window_turns": 26
+    }
+  },
   "year_trigger": {
-    "_description": "Settings for year-based event triggering",
-    "turns_per_year": 52,
+    "_description": "Settings for year-based event triggering. These flat values equal the ACTIVE timescale variant (month_per_turn) so behavior is identical with or without the dial resolver; change the 'timescale' key, not these, to switch pacing.",
+    "turns_per_year": 12,
     "base_year": 2017,
     "base_month": 7,
-    "legendary_month_offset": 26,
-    "rare_spread_turns": 13
+    "legendary_month_offset": 6,
+    "rare_spread_turns": 3
   }
 }

--- a/godot/data/events/overrides/README.md
+++ b/godot/data/events/overrides/README.md
@@ -12,6 +12,14 @@
 > dead keys (`openai_founded`, `chatgpt_released`) until 2026-08-04 -- the file
 > teaching the format was wrong in 2 of its 3 examples and nothing said so.
 > **Grep `historical_events.json` for your id before trusting an override.**
+> Since 2026-08-06 `tests/unit/test_event_retime.gd` asserts every key in every
+> file here exists in the corpus -- a dead key is now a red test, not a silence.
+>
+> **Same key in two files = whole-entry replacement, in directory-listing order**
+> (`_load_override_file` assigns, it does not merge across files). If you must
+> repeat a key (see `ftx_future_fund_collapse_2022` in both `example.json` and
+> `promotion_pass_2026_08.json`), make the entries semantically identical so load
+> order cannot matter.
 
 This directory contains game-balance overrides for pdoom-data events.
 
@@ -54,7 +62,16 @@ Each override file is a JSON object mapping event IDs to override values:
   verified 2026-08-04). It also contradicts ADR-0015, which makes DoomSystem the
   single authority on the doom level. Write a world-state intermediary via
   `impacts` instead.
-- `category` - Override event category
+- `category` - Override event category. This picks the generated decision
+  template (incident, policy_event, organization, alignment_research,
+  funding_catastrophe...) -- and it is how a record escapes the
+  `technical_research_breakthrough` flavour demotion.
+- `id` - Rename the event (keyed by the ORIGINAL id; the new id applies before
+  the flavour gate runs). Required to promote `arxiv_*` records, whose id prefix
+  alone demotes them to the feed. See `promotion_pass_2026_08.json`.
+- `year` - Override the historical year (drives the firing turn; see
+  `balancing/rarity_curves.json` `timescales` for the turns-per-year dial).
+- `significance` - 1-10, scales generated option magnitudes.
 - `title` - Override display title
 - `description` - Override description text
 

--- a/godot/data/events/overrides/promotion_pass_2026_08.json
+++ b/godot/data/events/overrides/promotion_pass_2026_08.json
@@ -1,0 +1,214 @@
+{
+  "_description": "Event promotion pass 2026-08: promote historical records to window-tier decisions, retimed for one-turn-one-month (#1125). Rulings in #1111; mechanics in docs/design/EVENT_PROMOTION_PASS.md.",
+  "_note": "Keyed by ORIGINAL record id. An 'id' key inside an entry renames the event (required to promote arxiv_* records past the flavour gate). category picks the option template; rarity picks the trigger mode (legendary = deterministic turn, rare = 6 pct/turn after eligibility, common = 12 pct/turn); significance (1-10) scales option magnitudes. NEVER add doom/pdoom_impact keys (ADR-0015).",
+  "_firing_turns": "Under the month_per_turn dial (12 turns/year): base_turn(year) = (year-2017)*12+1; legendary fires base+6. 2017:t7 2018:t19 2019:t31 2020:t43 2021:t55 2022:t67 2023:t79 2024:t91 2025:t103. Rare/common become eligible at ~base_turn and roll from there. Guarded by tests/unit/test_event_retime.gd.",
+  "_dead_key_guard": "Every key here is asserted to exist in historical_events.json by test_event_retime.gd (example.json shipped 2 dead keys for months; that failure mode is now a red test).",
+
+  "ftx_future_fund_collapse_2022": {
+    "_reason": "A1. Escalate the best-authored funding shock to a deterministic story beat at t67. Keeps funding_catastrophe template; impacts stated here in full (same values as example.json) so whichever override file loads last, the entry is identical.",
+    "rarity": "legendary",
+    "impacts": [
+      {"variable": "money", "change": -80}
+    ]
+  },
+
+  "microsoft_tay_2016": {
+    "_reason": "A2. Re-year + re-categorize. 2016 records cannot fire (start-year filter); year 2017 is a documented timeline echo. Fires t7: the teaching window's first low-stakes incident (respond/review/note).",
+    "year": 2017,
+    "category": "incident",
+    "rarity": "legendary",
+    "significance": 4
+  },
+
+  "arxiv_f48be4c3fb9d9ad0": {
+    "_reason": "A3. Full arxiv promotion: new id escapes the arxiv flavour gate, policy_event picks the support/critique/neutral template. Fires t31 -- the empty middle's publication-norms fight.",
+    "id": "gpt2_staged_release_2019",
+    "category": "policy_event",
+    "rarity": "legendary",
+    "significance": 6,
+    "title": "GPT-2 and the Staged Release Debate",
+    "description": "OpenAI withholds its full language model, citing misuse potential, and releases it in stages. The field splits: responsible precedent, or reputational theater that broke publication norms? Everyone wants to know where your lab stands.",
+    "safety_researcher_reaction": "Finally someone treats release itself as a safety decision",
+    "media_reaction": "AI lab says its text generator is too dangerous to release"
+  },
+
+  "openai_board_crisis_2023": {
+    "_reason": "A4. Strongest governance story in the corpus, previously blank-template AND unreachable (t339 under 52/yr). Fires t79.",
+    "category": "incident",
+    "rarity": "legendary",
+    "significance": 8
+  },
+
+  "anthropic_exodus_2021": {
+    "_reason": "A5. The only viable record for the organization template (collaborate/compete/observe). Fires t55, mid-run where the reputation-for-velocity trade is live.",
+    "category": "organization",
+    "rarity": "legendary",
+    "significance": 6
+  },
+
+  "google_project_maven_2018": {
+    "_reason": "B1. Employee-revolt ethics story; incident template. Eligible ~t13, 6 pct/turn.",
+    "category": "incident",
+    "rarity": "rare",
+    "significance": 5
+  },
+
+  "arxiv_eaef206260f37f45": {
+    "_reason": "B2. The mid-run security incident. Eligible ~t37.",
+    "id": "training_data_extraction_2020",
+    "category": "incident",
+    "rarity": "rare",
+    "significance": 5,
+    "title": "Extracting Training Data from Language Models",
+    "description": "Researchers demonstrate that verbatim training examples -- names, contact details, private text -- can be pulled back out of a deployed language model by querying it. Every lab training on scraped data now has a security problem with a paper attached.",
+    "safety_researcher_reaction": "Memorization is not hypothetical anymore -- audit your training pipeline",
+    "media_reaction": "AI models can leak the private data they were trained on"
+  },
+
+  "arxiv_ac6144846c25f722": {
+    "_reason": "B3 (strong yes, #1111). The first real invest-in-a-result decision; research template costs money+hours. Eligible from the opening turns.",
+    "id": "rlhf_origin_2017",
+    "category": "alignment_research",
+    "rarity": "rare",
+    "significance": 5,
+    "title": "Deep RL from Human Preferences",
+    "description": "A joint OpenAI-DeepMind team trains agents from human comparisons of behavior instead of hand-coded reward functions. Learning what people want by asking them becomes a practical alignment technique -- and every lab must decide how much to invest in it.",
+    "safety_researcher_reaction": "Reward learning turns alignment from philosophy into an engineering agenda",
+    "media_reaction": "AI learns backflips from human thumbs-ups"
+  },
+
+  "arxiv_19f1abcbac7010a1": {
+    "_reason": "B4 (strong yes, #1111). Research-agenda beat for the early game. Eligible ~t13, 12 pct/turn.",
+    "id": "reward_modeling_agenda_2018",
+    "category": "alignment_research",
+    "rarity": "common",
+    "significance": 4,
+    "title": "Scalable Agent Alignment via Reward Modeling",
+    "description": "DeepMind publishes a research agenda for aligning agents by learning reward models from human feedback, recursively amplified. It is a roadmap rather than a result -- and a public bet on where alignment work should go next.",
+    "safety_researcher_reaction": "Finally an agenda you can put engineers on"
+  },
+
+  "arxiv_eb20cd0d24a7d685": {
+    "_reason": "B5. Capability-shock texture for the empty middle. Eligible ~t25.",
+    "id": "emergent_tool_use_2019",
+    "category": "capability_advance",
+    "rarity": "rare",
+    "significance": 5,
+    "title": "Emergent Tool Use From Multi-Agent Play",
+    "description": "OpenAI's hide-and-seek agents invent tool use, barricades, and physics exploits nobody programmed. Simple objectives at scale are producing strategies their designers did not anticipate -- delightful, and a little alarming.",
+    "media_reaction": "AI agents invent tools and break the game physics to win at hide-and-seek"
+  },
+
+  "distill_ed5ab808068ad61f": {
+    "_reason": "B6 (Pip: yes, #1111). The interpretability milestone; safety-analysis option shines. Distill id passes the arxiv gate, so category override suffices. Fires t43.",
+    "category": "alignment_research",
+    "rarity": "legendary",
+    "significance": 5,
+    "description": "Distill publishes Zoom In: a research agenda arguing neural networks can be understood neuron by neuron, circuit by circuit. Interpretability moves from wishful thinking toward a discipline with methods and results.",
+    "safety_researcher_reaction": "For the first time it feels like we might actually read what a network is doing"
+  },
+
+  "cais_ftx_clawback_2023": {
+    "_reason": "B7. The delayed second bill from the FTX collapse -- arrives after you thought the crisis was over. Keeps funding_catastrophe template and its impacts. Eligible ~t73.",
+    "rarity": "rare",
+    "significance": 6
+  },
+
+  "anthropic_alignment_faking_2024": {
+    "_reason": "B8. THE scheming story beat -- the deterministic one; its three siblings below are rare variety so a run sees a different subset. Fires t91.",
+    "category": "incident",
+    "rarity": "legendary",
+    "significance": 8
+  },
+
+  "tesla_autopilot_incidents_2016_2024": {
+    "_reason": "C-tier promoted to B (#1111: promote all C up). Early-game incident texture. Eligible ~t13.",
+    "category": "incident",
+    "rarity": "common",
+    "significance": 5
+  },
+
+  "arxiv_7c7c5101e999d894": {
+    "_reason": "C2 promoted (#1111). Models start acting in environments. Eligible ~t49.",
+    "id": "webgpt_browsing_2021",
+    "category": "capability_advance",
+    "rarity": "common",
+    "significance": 4,
+    "title": "WebGPT: Language Models That Browse",
+    "description": "OpenAI wires a language model to a web browser and trains it to research answers with citations. Models are beginning to take actions in environments instead of just predicting text.",
+    "media_reaction": "The chatbot can Google things now"
+  },
+
+  "arxiv_c356f4bb1fc1101d": {
+    "_reason": "C3 promoted (#1111). Scaling is not buying truthfulness, with a number attached. Eligible ~t49.",
+    "id": "truthfulqa_benchmark_2021",
+    "category": "alignment_research",
+    "rarity": "common",
+    "significance": 4,
+    "title": "TruthfulQA: Do Models Imitate Our Falsehoods?",
+    "description": "A new benchmark shows larger models are often MORE likely to repeat common human misconceptions. Scaling alone is not buying truthfulness, and now there is a score to cite.",
+    "safety_researcher_reaction": "Bigger is not truer -- we finally measured it"
+  },
+
+  "arxiv_5b9b42f6b9b6a092": {
+    "_reason": "C4 promoted (#1111). Adversarial evaluation starts to scale. Eligible ~t61.",
+    "id": "red_teaming_lms_2022",
+    "category": "alignment_research",
+    "rarity": "common",
+    "significance": 4,
+    "title": "Red Teaming Language Models with Language Models",
+    "description": "DeepMind uses one language model to automatically generate test cases that make another misbehave. Adversarial evaluation stops being a manual craft and starts to scale.",
+    "safety_researcher_reaction": "Automated red teaming means the attack surface finally gets mapped faster than it grows"
+  },
+
+  "international_coordination_breakdown_2025": {
+    "_reason": "C5 promoted (#1111). The one institutional_decay record worth a window; policy template. Endgame sighting, eligible ~t97.",
+    "category": "policy_event",
+    "rarity": "rare",
+    "significance": 7
+  },
+
+  "claude_4_opus_blackmail_2025": {
+    "_reason": "C6 promoted (#1111). Final-act jolt for long runs. Fires t103.",
+    "category": "incident",
+    "rarity": "legendary",
+    "significance": 9
+  },
+
+  "distill_eb5c12bc89464f38": {
+    "_reason": "C7 promoted (#1111). Alignment needs social science; light research beat. Base rarity was legendary -- demoted to common so it is variety, not a mandatory beat. Eligible ~t25.",
+    "category": "alignment_research",
+    "rarity": "common",
+    "significance": 3,
+    "description": "Distill argues that aligning AI to human values needs experimental social science, not just mathematics -- because knowing what humans actually want is itself a research problem.",
+    "safety_researcher_reaction": "The hard part of alignment might be the humans"
+  },
+
+  "openai_safety_team_departures_2024": {
+    "_reason": "C8 promoted (#1111). Staffing THEME only -- the template cannot remove a researcher (event_service F3); copy stays honest. Eligible ~t85.",
+    "category": "incident",
+    "rarity": "rare",
+    "significance": 6
+  },
+
+  "ai_sandbagging_research_2024": {
+    "_reason": "Promoted against the pack's advice by explicit ruling (#1111): in-game hooks for decomposing situational awareness. Rare (not legendary) so the four scheming siblings scatter across seeds instead of firing as the same window four times; alignment faking stays the one deterministic beat. Eligible ~t85.",
+    "category": "incident",
+    "rarity": "rare",
+    "significance": 6
+  },
+
+  "apollo_scheming_evals_2024": {
+    "_reason": "Promoted by explicit ruling (#1111), same situational-awareness rationale as sandbagging. Eligible ~t85.",
+    "category": "incident",
+    "rarity": "rare",
+    "significance": 7
+  },
+
+  "metr_deceptive_ai_evaluation_2024": {
+    "_reason": "Promoted by explicit ruling (#1111, 'METER' in the transcript = METR), same situational-awareness rationale. Eligible ~t85.",
+    "category": "incident",
+    "rarity": "rare",
+    "significance": 6
+  }
+}

--- a/godot/tests/unit/test_event_retime.gd
+++ b/godot/tests/unit/test_event_retime.gd
@@ -1,0 +1,224 @@
+extends GutTest
+## Retime + promotion pass (#1125 / #1111): historical events must land in the
+## ruled ERA under the month-per-turn dial, the week dial must rescale them, and
+## every override key must target a record that actually exists (example.json
+## shipped 2 dead keys for months -- that failure mode is a red test now).
+##
+## Uses a FRESH EventService instance (not the autoload) so nothing here mutates
+## the live deck other tests isolate against (#534).
+
+const EventServiceScript = preload("res://autoload/event_service.gd")
+const CORPUS_PATH := "res://data/historical_events.json"
+const OVERRIDES_DIR := "res://data/events/overrides/"
+
+# Expected firing turns under month_per_turn (12/yr):
+# base_turn(year) = (year-2017)*12 + 1; legendary fires base+6.
+const LEGENDARY_TURNS := {
+	"hist_microsoft_tay_2016": 7,             # year overridden to 2017
+	"hist_gpt2_staged_release_2019": 31,
+	"hist_distill_ed5ab808068ad61f": 43,      # Circuits, 2020
+	"hist_anthropic_exodus_2021": 55,
+	"hist_ftx_future_fund_collapse_2022": 67,
+	"hist_openai_board_crisis_2023": 79,
+	"hist_anthropic_alignment_faking_2024": 91,
+	"hist_claude_4_opus_blackmail_2025": 103,
+}
+
+# Rare promotions: eligibility_start == base_turn (spread 3, window 6).
+const RARE_ELIGIBILITY := {
+	"hist_rlhf_origin_2017": 1,
+	"hist_google_project_maven_2018": 13,
+	"hist_emergent_tool_use_2019": 25,
+	"hist_training_data_extraction_2020": 37,
+	"hist_cais_ftx_clawback_2023": 73,
+	"hist_openai_safety_team_departures_2024": 85,
+	"hist_ai_sandbagging_research_2024": 85,
+	"hist_apollo_scheming_evals_2024": 85,
+	"hist_metr_deceptive_ai_evaluation_2024": 85,
+	"hist_international_coordination_breakdown_2025": 97,
+}
+
+# Common promotions: trigger_turn == max(10, base_turn).
+const COMMON_TURNS := {
+	"hist_reward_modeling_agenda_2018": 13,
+	"hist_tesla_autopilot_incidents_2016_2024": 13,
+	"hist_distill_eb5c12bc89464f38": 25,      # social scientists, 2019
+	"hist_webgpt_browsing_2021": 49,
+	"hist_truthfulqa_benchmark_2021": 49,
+	"hist_red_teaming_lms_2022": 61,
+}
+
+var svc
+
+
+func before_each():
+	svc = EventServiceScript.new()
+	autofree(svc)
+	svc._load_variable_mapping()
+	svc._load_rarity_curves()
+	svc._load_overrides()
+
+
+func _load_corpus_into(service) -> void:
+	assert_true(service._load_bundled_data(), "bundled historical corpus should load")
+
+
+func _find(service, event_id: String) -> Dictionary:
+	for ev in service.transformed_events:
+		if ev.get("id", "") == event_id:
+			return ev
+	return {}
+
+
+func _parse_json_file(path: String) -> Dictionary:
+	var file = FileAccess.open(path, FileAccess.READ)
+	assert_not_null(file, "should open %s" % path)
+	var json = JSON.new()
+	assert_eq(json.parse(file.get_as_text()), OK, "should parse %s" % path)
+	file.close()
+	var data = json.get_data()
+	assert_true(data is Dictionary, "%s should be a dictionary" % path)
+	return data
+
+
+func test_month_dial_is_active_and_calendar_true():
+	# THE GUARD: one turn = one month (#1125) means 12 turns per historical year.
+	# If someone restores the old 52/yr numbers, everything dated 2022+ fires
+	# past turn 287 -- beyond every observed run -- and the promotion pass
+	# regresses to events nobody sees (the #1027 signature failure).
+	assert_eq(str(svc._rarity_curves.get("timescale", "")), "month_per_turn",
+		"month_per_turn is the shipped timescale")
+	var yt = svc._rarity_curves.get("year_trigger", {})
+	assert_eq(int(yt.get("turns_per_year", 0)), 12, "one turn = one month -> 12 turns/year")
+	assert_eq(int(yt.get("legendary_month_offset", 0)), 6, "legendary beats land mid-year")
+	assert_eq(int(yt.get("rare_spread_turns", 0)), 3, "rare spread scaled to month grain")
+	assert_eq(int(svc._rarity_curves.get("rare", {}).get("eligibility_window_turns", 0)), 6,
+		"rare eligibility window scaled to month grain")
+
+
+func test_override_keys_all_exist_in_corpus():
+	# Kills the example.json failure mode: an override keyed to a missing record
+	# is a silent no-op that looks exactly like a working override.
+	var corpus = _parse_json_file(CORPUS_PATH)
+	var dir = DirAccess.open(OVERRIDES_DIR)
+	assert_not_null(dir, "overrides dir should open")
+	dir.list_dir_begin()
+	var filename = dir.get_next()
+	var checked := 0
+	while filename != "":
+		if not dir.current_is_dir() and filename.ends_with(".json"):
+			var data = _parse_json_file(OVERRIDES_DIR + filename)
+			for key in data.keys():
+				if str(key).begins_with("_"):
+					continue
+				checked += 1
+				assert_true(corpus.has(key),
+					"%s: override key '%s' must exist in historical_events.json" % [filename, key])
+		filename = dir.get_next()
+	dir.list_dir_end()
+	assert_gt(checked, 20, "the promotion pass overrides should be present and counted")
+
+
+func test_promoted_events_land_in_their_era():
+	_load_corpus_into(svc)
+	assert_gt(svc.transformed_events.size(), 1100, "full corpus transformed")
+
+	for event_id in LEGENDARY_TURNS.keys():
+		var ev = _find(svc, event_id)
+		assert_false(ev.is_empty(), "%s should exist after overrides" % event_id)
+		if ev.is_empty():
+			continue
+		assert_eq(ev.get("trigger_type", ""), "turn_exact", "%s is a deterministic beat" % event_id)
+		assert_eq(int(ev.get("trigger_turn", -1)), int(LEGENDARY_TURNS[event_id]),
+			"%s fires in its era" % event_id)
+		assert_lte(int(ev.get("trigger_turn", 999)), 110,
+			"%s stays inside the realistic run band (deaths observed t14-229, best board 153)" % event_id)
+
+	for event_id in RARE_ELIGIBILITY.keys():
+		var ev = _find(svc, event_id)
+		assert_false(ev.is_empty(), "%s should exist after overrides" % event_id)
+		if ev.is_empty():
+			continue
+		assert_eq(int(ev.get("eligibility_start", -1)), int(RARE_ELIGIBILITY[event_id]),
+			"%s becomes eligible at its historical date" % event_id)
+
+	for event_id in COMMON_TURNS.keys():
+		var ev = _find(svc, event_id)
+		assert_false(ev.is_empty(), "%s should exist after overrides" % event_id)
+		if ev.is_empty():
+			continue
+		assert_eq(int(ev.get("trigger_turn", -1)), int(COMMON_TURNS[event_id]),
+			"%s becomes eligible at its historical date" % event_id)
+
+
+func test_promoted_events_are_windows_not_flavour():
+	_load_corpus_into(svc)
+	var all_promoted := LEGENDARY_TURNS.keys() + RARE_ELIGIBILITY.keys() + COMMON_TURNS.keys()
+	for event_id in all_promoted:
+		var ev = _find(svc, event_id)
+		assert_false(ev.is_empty(), "%s should exist" % event_id)
+		if ev.is_empty():
+			continue
+		assert_ne(str(ev.get("delivery_tier", "")), "feed",
+			"%s must not be flavour-demoted" % event_id)
+		var options = ev.get("options", [])
+		assert_gt(options.size(), 0, "%s has options" % event_id)
+		if options.size() > 0:
+			assert_ne(str(options[0].get("id", "")), "engage",
+				"%s uses a real template, not the bland default" % event_id)
+
+	# Spot-check template routing: category override picks the decision.
+	var tay = _find(svc, "hist_microsoft_tay_2016")
+	if not tay.is_empty():
+		assert_eq(str(tay["options"][0].get("id", "")), "respond_publicly", "incident template")
+	var exodus = _find(svc, "hist_anthropic_exodus_2021")
+	if not exodus.is_empty():
+		assert_eq(str(exodus["options"][0].get("id", "")), "collaborate", "organization template")
+	var gpt2 = _find(svc, "hist_gpt2_staged_release_2019")
+	if not gpt2.is_empty():
+		assert_eq(str(gpt2["options"][0].get("id", "")), "support", "policy template")
+	var ftx = _find(svc, "hist_ftx_future_fund_collapse_2022")
+	if not ftx.is_empty():
+		assert_eq(str(ftx["options"][0].get("id", "")), "emergency_fundraise", "funding template")
+
+	# The flavour gate itself must survive the pass: an unpromoted arxiv record
+	# stays on the feed tier.
+	var still_flavour := 0
+	for ev in svc.transformed_events:
+		if str(ev.get("id", "")).begins_with("hist_arxiv_") and str(ev.get("delivery_tier", "")) == "feed":
+			still_flavour += 1
+	assert_gt(still_flavour, 1000, "the arxiv bulk stays flavour-demoted")
+
+
+func test_ten_turn_grace_2018_content_stays_out_of_the_opening():
+	# Pip's pacing frame (#1125): a player should be unlikely to die in the first
+	# ten turns (= ten months), so a 2017 start reliably reaches 2018. Nothing
+	# promoted and dated 2018+ may enter play inside that grace window.
+	_load_corpus_into(svc)
+	var all_promoted := LEGENDARY_TURNS.keys() + RARE_ELIGIBILITY.keys() + COMMON_TURNS.keys()
+	for event_id in all_promoted:
+		var ev = _find(svc, event_id)
+		if ev.is_empty():
+			continue
+		if int(ev.get("year", 0)) >= 2018:
+			assert_gte(int(ev.get("min_turn", 0)), 11,
+				"%s (year %d) must not enter the 10-turn grace window" % [event_id, int(ev.get("year", 0))])
+
+
+func test_week_dial_rescales_firing_turns():
+	# The dial is the deliverable (#1111): flipping one string re-times the whole
+	# corpus to week-per-turn pacing (52/yr -- the 'punished' variant).
+	_load_corpus_into(svc)
+	svc._rarity_curves["timescale"] = "week_per_turn"
+	svc._resolve_timescale()
+	svc._transform_all_events()
+
+	var yt = svc._rarity_curves.get("year_trigger", {})
+	assert_eq(int(yt.get("turns_per_year", 0)), 52, "week dial -> 52 turns/year")
+	assert_eq(int(svc._rarity_curves.get("rare", {}).get("eligibility_window_turns", 0)), 26,
+		"rare window rescales with the dial")
+
+	var tay = _find(svc, "hist_microsoft_tay_2016")
+	assert_eq(int(tay.get("trigger_turn", -1)), 27, "Tay under week pacing: (2017-2017)*52+1+26")
+	var ftx = _find(svc, "hist_ftx_future_fund_collapse_2022")
+	assert_eq(int(ftx.get("trigger_turn", -1)), 287, "FTX under week pacing: (2022-2017)*52+1+26")

--- a/godot/tests/unit/test_event_retime.gd.uid
+++ b/godot/tests/unit/test_event_retime.gd.uid
@@ -1,0 +1,1 @@
+uid://clh0meuh4tk8n


### PR DESCRIPTION
Implements the retime + promotion pass ruled in #1111, per GO order #1125. Adapts `docs/design/EVENT_PROMOTION_PASS.md` to the corrected premise (one turn = one month) rather than applying its 26/yr numbers blindly.

## The retime: 12 turns/year, and why

The pack reasoned in 26 or 52 turns/year; #1125 ruled **one turn = one month**, which makes 12 turns/year the calendar-true curve -- and under month-per-turn pacing, calendar-true is also REACHABLE. The 2017-2025 arc (Pip's alpha-through-first-release window) lands at turns 7-103, comfortably inside the observed run band (deaths t14-229, best board 153), and leaves everything past turn ~108 free for the AI-2027 mid-game. The old 52/yr numbers parked everything dated 2022+ at turn 287+, where no run ever went (the #1027 signature failure: content nobody sees).

`base_turn(year) = (year-2017)*12 + 1`; legendary fires `base+6`; rare rolls 6%/turn from `base`; common 12%/turn from `max(10, base)`.

## The dial (the actual deliverable)

`rarity_curves.json` now carries a `timescales` block with two variants and a `timescale` selector string:

- **`month_per_turn`** (active): 12/yr, offset 6, spread 3, rare window 6
- **`week_per_turn`** (the "punished" variant, #1111): 52/yr, offset 26, spread 13, rare window 26

`EventService._resolve_timescale()` (new, ~20 lines) applies the named variant onto `year_trigger` + the rare eligibility window at config load. Flip the one string and every turns-denominated timing value rescales together. The flat `year_trigger` values ship equal to the active variant, so the resolver is a no-op until the dial is turned.

**Design finding, stated plainly:** flipping to `week_per_turn` today restores the old fiction pacing but NOT longer runs -- survival pacing is per-turn and unchanged, so 2022+ content goes back out of reach (turn 287+ vs deaths <=229). A playable week-scale mode needs the deferred F4/F5 pass to rescale survival pacing too. The variant is shipped as a dial position with a `_warning` key saying exactly this, not as a playable mode.

## Promotions applied (24), with firing turns under the active dial

Legendary (deterministic, every run):

| turn | event |
|---|---|
| 7 | Tay (year echoed 2016->2017; teaching incident) |
| 31 | GPT-2 staged release debate (policy) |
| 43 | Circuits / Zoom In (alignment research) |
| 55 | Anthropic exodus (organization template) |
| 67 | FTX Future Fund collapse (funding, impacts kept) |
| 79 | OpenAI board crisis (incident) |
| 91 | Alignment faking (THE scheming beat) |
| 103 | Claude 4 Opus blackmail (final-act jolt) |

Rare (eligible at listed turn, 6%/turn, expected ~+17): Maven t13, RLHF origin t1, emergent tool use t25, training-data extraction t37, FTX clawback t73, safety-team departures t85, **sandbagging t85, Apollo t85, METR t85** (ruled in over the pack's advice -- situational-awareness hooks; rare rather than legendary so the four scheming siblings scatter across seeds instead of firing as the same window four times, alignment faking staying the one deterministic beat), coordination breakdown t97.

Common (eligible at listed turn, 12%/turn, expected ~+8): reward modeling t13, Tesla autopilot t13, social scientists t25, WebGPT t49, TruthfulQA t49, red teaming t61.

Every arxiv/distill promotion carries a rewritten title/description (base text is PDF-extraction garbage); arxiv records get `id` renames past the flavour gate (pack F4). No `doom`/`pdoom_impact` keys anywhere (ADR-0015). The 10-turn grace holds: nothing dated 2018+ enters play before turn 11, so a 2017 start reliably reaches 2018.

## Tests

`godot/tests/unit/test_event_retime.gd` (6 tests, 237 asserts):
- pins the firing turn / eligibility for every promoted event and bounds legendaries to the run band
- asserts promoted events are windows on real templates, and the arxiv bulk stays flavour-demoted
- asserts the week dial rescales (Tay 7->27, FTX 67->287)
- enforces the 10-turn grace for 2018+ content
- asserts **every override key in every override file exists in the corpus** -- the `example.json` dead-key failure mode is now a red test

**Guard proven to fail:** restored the old 52/yr numbers, ran the suite, got 30+ named failures (FTX at 287, board crisis at 339, blackmail at 443, each flagged outside the run band), reverted, re-ran green.

Fast gate in this worktree: **1148 tests / 0 fail**; baseline (main state, same worktree): **1142 / 0**. Delta +6 = the new test file.

## Ship constraints -- do not merge mid-league-week

The retime changes which turns roll probabilities, so RNG consumption forks old replays and board comparability (accepted in the pack section 7, approved in #1111). **Land on a release boundary with a version bump** so the board key forks by design. The `_resolve_timescale` resolver itself runs only at config load, never on the seeded RNG path (ADR-0006).

## Deferred / not touched

- F4/F5 timing dials and F6 effect magnitudes (explicitly deferred in #1125): the rarity percentages, cooldowns, and template scalars are untouched. Per-event `significance` values are applied as part of the approved shortlist, not as an F6 repair.
- The `events.gd:290-310` literal-doom-vs-panic-stream doc/code disagreement: not touched, not relied on.
- `historical_events.json`: zero edits (contains a pre-existing non-ASCII arrow that would trip the gate).
- The badge/calendar seam (clock.gd still ticks workdays while the fiction says months): out of scope here; the retime targets the ruled fiction per "right ERA, not right calendar date".

Refs #1125, #1111. Overlap note: two design-doc lanes are in flight; this PR's only doc edits are the EXECUTED addendum on `EVENT_PROMOTION_PASS.md` and the overrides README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
