### PR TITLE
tools(taxonomy): action-taxonomy checker + generated index -- red on the live take_loan duplicate (#798)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,6 +106,20 @@ repos:
         files: '^(scripts/.*\.py|tools/.*\.py|tests/test_.*\.py|docs/TOOLS\.md|\.pre-commit-config\.yaml|Makefile|\.github/workflows/.*\.ya?ml)$'
         pass_filenames: false
 
+      # Action taxonomy index is GENERATED (same anti-rot pattern again). NOTE THE
+      # FLAG: --check-stale gates the INDEX only. The full --check also fails on
+      # taxonomy VIOLATIONS, and is deliberately NOT wired while `take_loan` is
+      # defined in two files -- a gate that is red on arrival gets disabled inside a
+      # week (#1117: a Python lane here already ran as `|| echo` over zero
+      # assertions). Flip this entry to `--check` when the error list is empty; a
+      # test in tests/test_generate_action_taxonomy.py fails when that day comes.
+      - id: action-taxonomy-index-check
+        name: action taxonomy index up to date
+        entry: python scripts/generate_action_taxonomy.py --check-stale
+        language: system
+        files: '^(godot/data/actions/.*\.json|godot/scripts/ui/(action_bar_renderer|submenu_controller)\.gd|docs/ACTION_TAXONOMY\.md|scripts/generate_action_taxonomy\.py)$'
+        pass_filenames: false
+
       - id: scene-nav-check
         name: Scene navigation routes through SceneTransition
         entry: python tools/check_scene_nav.py

--- a/docs/ACTION_TAXONOMY.md
+++ b/docs/ACTION_TAXONOMY.md
@@ -1,0 +1,136 @@
+# Action taxonomy (GENERATED -- do not hand-edit)
+
+> Derived from `godot/data/actions/*.json`, `action_bar_renderer.gd`
+> (`category_order`, `HIDDEN_FROM_ACTION_BAR_IDS`) and
+> `submenu_controller.gd` (`GRID_CONFIG`) by
+> `scripts/generate_action_taxonomy.py`. Regenerate with:
+> `python scripts/generate_action_taxonomy.py`.
+>
+> Implements Part D of `docs/design/UI_ARCHITECTURE_2026-08-06.md`.
+> The rule it serves: **an action is top-level iff it is the single door to a
+> system the player steers when composing an ordinary month's plan.**
+>
+> **The violation gate is REPORT-ONLY.** Pre-commit runs `--check-stale`, which
+> fails only if THIS FILE is out of date. `--check` additionally exits nonzero on
+> the errors below and is deliberately NOT wired while a known violation is live:
+> a gate that is red on arrival gets disabled within a week (#1117). Flip the hook
+> to `--check` when the error list is empty.
+
+## Counts
+
+| Measure | Value |
+|---|---|
+| Action entries | 62 |
+| Distinct action ids | 61 |
+| Files scanned | 12 |
+| Files carrying actions | 11 |
+| Doors (`is_submenu`) | 9 (cap 10) |
+| Loose top-level tiles | 9 |
+| Hidden from the bar | 3 |
+| Errors | 1 |
+| Warnings | 6 |
+
+- `risk_contributions.json` carries ZERO actions and is excluded from the count (it is a lookup table, not an action list). The commission's earlier inventory credited it with 2.
+
+## Findings
+
+### Errors (`--check` exits 1)
+
+- DUPLICATE ID 'take_loan' defined in 2 files: financing.json (category financing), fundraising.json (category funding). The domain caches are separate, so BOTH are live at once and neither shadows the other loudly; which one a lookup returns depends on accessor order in GameActions.get_action_by_id. They DISAGREE on: category (financing.json="financing" vs fundraising.json="funding"); description (financing.json="+$50k now; a balloon repayment (~$60k) bills in 4 turns and compounds until paid." vs fundraising.json="Immediate funds via debt - creates future repayment obligation"); gains (financing.json=null vs fundraising.json={"debt": 90000, "money": 75000}); name (financing.json="Take Loan" vs fundraising.json="Business Loan"). Deduping is therefore not a merge -- pick the record that matches what execute_action actually does, and say so.
+
+### Warnings (reported, never fatal)
+
+- NAMESPACE CATEGORY -- door 'operations' is category 'management'; its operations.json members are operations, which the action bar has no group for. The door has to borrow a render category, so `category` means two different things at the two levels. Phase 2 workitem.
+- NAMESPACE CATEGORY -- door 'travel' is category 'research'; its travel.json members are travel, which the action bar has no group for. The door has to borrow a render category, so `category` means two different things at the two levels. Phase 2 workitem.
+- NAMESPACE CATEGORY -- door 'financing' is category 'influence'; its financing.json members are financing, which the action bar has no group for. The door has to borrow a render category, so `category` means two different things at the two levels. Phase 2 workitem.
+- NAMESPACE CATEGORY -- door 'office' is category 'management'; its office.json members are office, which the action bar has no group for. The door has to borrow a render category, so `category` means two different things at the two levels. Phase 2 workitem.
+- NAMESPACE CATEGORY -- door 'scouting' is category 'influence'; its scouting.json members are scouting, which the action bar has no group for. The door has to borrow a render category, so `category` means two different things at the two levels. Phase 2 workitem.
+- LOOSE TOP-LEVEL ACTIONS -- 9 actions render as bare tiles alongside the 9 doors (advertise, audit_safety, buy_compute, capability_research, onboard_next, publish_paper, safety_research, team_building, use_connections). Under the Part A rule each competes only with its door's siblings; phase 1/2 of docs/design/UI_ARCHITECTURE_2026-08-06.md folds them.
+
+## Every action
+
+`Door (today)` is measured from the data: which submenu file the action lives
+in, and which `is_submenu` action opens that file. `Door (proposed)` is
+transcribed from Part B of the architecture doc and is **reference only** --
+nothing here checks it, and the Research door is gated on a workshop.
+
+| # | id | Name | File | Category | Placement | Door (today) | Door (proposed) |
+|---|---|---|---|---|---|---|---|
+| 1 | `pass` | Do Nothing | `command.json` | `command` | top-level | (top level) | (command) |
+| 2 | `hire_staff` | Hire Staff | `core.json` | `hiring` | door | (is a door) | People |
+| 3 | `buy_compute` | Purchase Compute | `core.json` | `resources` | top-level | (top level) | Compute |
+| 4 | `safety_research` | Safety Research | `core.json` | `research` | top-level | (top level) | Research |
+| 5 | `capability_research` | Capability Research | `core.json` | `research` | top-level | (top level) | Research |
+| 6 | `publish_paper` | Publish Safety Paper | `core.json` | `research` | top-level | (top level) | Research |
+| 7 | `fundraise` | Fundraising | `core.json` | `funding` | door | (is a door) | Funding |
+| 8 | `publicity` | Publicity | `core.json` | `influence` | door | (is a door) | Publicity |
+| 9 | `team_building` | Team Building | `core.json` | `management` | top-level | (top level) | People |
+| 10 | `audit_safety` | Safety Audit | `core.json` | `research` | top-level | (top level) | Research |
+| 11 | `operations` | Operations | `core.json` | `management` | door | (is a door) | Operations |
+| 12 | `strategic` | Strategic | `core.json` | `strategic` | door | (is a door) | Strategic |
+| 13 | `travel` | Travel & Conferences | `core.json` | `research` | door | (is a door) | Travel |
+| 14 | `financing` | Financing | `core.json` | `influence` | door | (is a door) | Funding (merged) |
+| 15 | `office` | Office | `core.json` | `management` | door | (is a door) | Operations (merged) |
+| 16 | `scouting` | Scouting | `core.json` | `influence` | door | (is a door) | Scouting |
+| 17 | `advertise` | Advertise a Role | `core.json` | `hiring` | top-level | (top level) | People |
+| 18 | `use_connections` | Work Your Connections | `core.json` | `hiring` | top-level | (top level) | People |
+| 19 | `interview_next` | Interview a Candidate | `core.json` | `hiring` | top-level (hidden) | (top level) | People |
+| 20 | `hire_best` | Make an Offer | `core.json` | `hiring` | top-level (hidden) | (top level) | People |
+| 21 | `onboard_next` | Onboard New Hires | `core.json` | `hiring` | top-level | (top level) | People |
+| 22 | `take_loan` | Take Loan | `financing.json` | `financing` | member | financing | Funding |
+| 23 | `funding_strings` | Funding (Strings) | `financing.json` | `financing` | member | financing | Funding |
+| 24 | `desperation_lever` | Desperation Lever | `financing.json` | `financing` | member | financing | Funding |
+| 25 | `staff_rider` | Contractor | `financing.json` | `financing` | member | financing | Funding |
+| 26 | `seek_financing` | Seek Financing | `financing.json` | `financing` | member | financing | Funding |
+| 27 | `accept_financing_offer` | Accept Offer | `financing.json` | `financing` | member | financing | Funding |
+| 28 | `pay_bills` | Pay the Bill | `financing.json` | `financing` | member | financing | Funding |
+| 29 | `fundraise_small` | Modest Funding Round | `fundraising.json` | `funding` | member | fundraise | Funding |
+| 30 | `fundraise_big` | Major Funding Round | `fundraising.json` | `funding` | member | fundraise | Funding |
+| 31 | `take_loan` | Business Loan | `fundraising.json` | `funding` | member | fundraise | Funding |
+| 32 | `apply_grant` | Research Grant | `fundraising.json` | `funding` | member | fundraise | Funding |
+| 33 | `hire_safety_researcher` | Safety Researcher | `hiring.json` | `hiring` | member | hire_staff | People |
+| 34 | `hire_capability_researcher` | Capability Researcher | `hiring.json` | `hiring` | member | hire_staff | People |
+| 35 | `hire_compute_engineer` | Compute Engineer | `hiring.json` | `hiring` | member | hire_staff | People |
+| 36 | `hire_manager` | Manager | `hiring.json` | `hiring` | member | hire_staff | People |
+| 37 | `hire_ethicist` | AI Ethicist | `hiring.json` | `hiring` | member | hire_staff | People |
+| 38 | `hire_interpretability_researcher` | Interpretability Researcher | `hiring.json` | `hiring` | member | hire_staff | People |
+| 39 | `hire_alignment_researcher` | Alignment Researcher | `hiring.json` | `hiring` | member | hire_staff | People |
+| 40 | `tour_offices` | Tour Offices | `office.json` | `office` | member | office | Operations |
+| 41 | `sign_lease_coworking_corner` | Sign: Co-working corner | `office.json` | `office` | member | office | Operations |
+| 42 | `sign_lease_walkup_office` | Sign: Walk-up office | `office.json` | `office` | member | office | Operations |
+| 43 | `sign_lease_university_annex` | Sign: University annex | `office.json` | `office` | member | office | Operations |
+| 44 | `order_supplies` | Order Office Supplies | `operations.json` | `operations` | member | operations | Operations |
+| 45 | `office_maintenance` | Office Maintenance | `operations.json` | `operations` | member (hidden) | operations | Operations |
+| 46 | `audit_self_directed` | Audit Self-Directed Work | `operations.json` | `operations` | member | operations | Operations |
+| 47 | `network` | Networking | `publicity.json` | `influence` | member | publicity | Publicity |
+| 48 | `media_campaign` | Media Campaign | `publicity.json` | `influence` | member | publicity | Publicity |
+| 49 | `lobby_government` | Lobby Government | `publicity.json` | `influence` | member | publicity | Publicity |
+| 50 | `release_warning` | Public Warning | `publicity.json` | `influence` | member | publicity | Publicity |
+| 51 | `open_source_release` | Open Source Tools | `publicity.json` | `influence` | member | publicity | Publicity |
+| 52 | `scout_read` | Read the Literature | `scouting.json` | `scouting` | member | scouting | Scouting |
+| 53 | `scout_meetups` | Go to Meetups | `scouting.json` | `scouting` | member | scouting | Scouting |
+| 54 | `scout_shitpost` | Post Online | `scouting.json` | `scouting` | member | scouting | Scouting |
+| 55 | `acquire_startup` | Acquire Startup | `strategic.json` | `strategic` | member | strategic | Strategic |
+| 56 | `sabotage_competitor` | Corporate Espionage | `strategic.json` | `strategic` | member | strategic | Strategic |
+| 57 | `emergency_pivot` | Emergency Pivot | `strategic.json` | `strategic` | member | strategic | Strategic |
+| 58 | `grant_proposal` | Grant Proposal | `strategic.json` | `strategic` | member | strategic | Strategic |
+| 59 | `submit_paper` | Submit Paper | `travel.json` | `travel` | member | travel | Travel |
+| 60 | `attend_conference` | Attend Conference | `travel.json` | `travel` | member | travel | Travel |
+| 61 | `attend_conference_trip` | Attend Conference (trip) | `travel.json` | `travel` | member | travel | Travel |
+| 62 | `send_delegation` | Send Delegation | `travel.json` | `travel` | member | travel | Travel |
+
+## Doors today
+
+| Door id | Door category | Members file | Members | Member categories | Builder |
+|---|---|---|---|---|---|
+| `hire_staff` | `hiring` | `hiring.json` | 7 | `hiring` | bespoke |
+| `fundraise` | `funding` | `fundraising.json` | 4 | `funding` | GRID_CONFIG |
+| `publicity` | `influence` | `publicity.json` | 5 | `influence` | GRID_CONFIG |
+| `operations` | `management` | `operations.json` | 3 | `operations` | GRID_CONFIG |
+| `strategic` | `strategic` | `strategic.json` | 4 | `strategic` | GRID_CONFIG |
+| `travel` | `research` | `travel.json` | 4 | `travel` | bespoke |
+| `financing` | `influence` | `financing.json` | 7 | `financing` | bespoke |
+| `office` | `management` | `office.json` | 4 | `office` | GRID_CONFIG |
+| `scouting` | `influence` | `scouting.json` | 3 | `scouting` | GRID_CONFIG |
+
+Action bar `category_order` (the render groups): `funding`, `hiring`, `resources`, `research`, `management`, `influence`, `strategic`, `other`.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -39,7 +39,8 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | devblog_automation.py | -- | Dev Blog Automation System with Metadata | tool:content_publisher.py |
 | enforce_standards.py | -- | P(Doom) Development Standards Enforcement Script | pre-commit; ci:enhanced-cicd-pipeline.yml; ci:quality-checks.yml; tool:intelligent_ascii_converter.py; tool:pre_version_bump.py |
 | find_duplicates.py | -- | Duplicate File Detector | human (docstring usage) |
-| generate_adr_index.py | GENERATE | Generate docs/game-design/decisions/README.md from the ADR files themselves. | pre-commit; tool:generate_tools_index.py |
+| generate_action_taxonomy.py | GENERATE | Generate docs/ACTION_TAXONOMY.md and check the action taxonomy for rot. | pre-commit; test:test_generate_action_taxonomy.py |
+| generate_adr_index.py | GENERATE | Generate docs/game-design/decisions/README.md from the ADR files themselves. | pre-commit; tool:generate_action_taxonomy.py; tool:generate_tools_index.py |
 | generate_dq_index.py | GENERATE | Generate docs/game-design/DQ_INDEX.md from WORKSHOP_2_BACKLOG.md. | pre-commit; tool:enforce_standards.py; tool:generate_release_metadata.py; tool:intelligent_ascii_converter.py |
 | generate_mechanics_docs.py | GENERATE | Generate mechanics documentation from game code. | ci:docs-sync.yml |
 | generate_release_manifest.py | GENERATE | Generate release_manifest.json -- the machine-readable release descriptor. | ci:enhanced-release.yml; test:test_generate_release_manifest.py |
@@ -200,4 +201,4 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 
 23 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
 
-Total: 104 active tools (6 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 86 undeclared); 11 in UNKNOWN; 6 archived.
+Total: 105 active tools (7 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 86 undeclared); 11 in UNKNOWN; 6 archived.

--- a/scripts/generate_action_taxonomy.py
+++ b/scripts/generate_action_taxonomy.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+"""Generate docs/ACTION_TAXONOMY.md and check the action taxonomy for rot.
+
+Layer: GENERATE
+
+WHY THIS EXISTS. `category` on an action definition is a SORT KEY with no checker,
+and an unchecked data field rots. Two measured consequences, not hypotheticals:
+
+  * The `fundraise` door was tagged `category: management` while every item in its
+    own submenu was `funding`. Nothing failed. The tile just rendered tenth and fell
+    below the fold, and two external playtesters (2026-08-05) could not find
+    fundraising at all. Fixed in #1130 by hand -- the DEFECT was invisible because
+    the only symptom was a rendering position.
+  * `take_loan` is defined TWICE, in `fundraising.json` (category `funding`,
+    advertising +$75k / $90k debt) and in `financing.json` (category `financing`,
+    advertising +$50k / ~$60k balloon). They live in different domain caches, so
+    both are live at once and neither shadows the other loudly.
+
+Same anti-rot pattern as generate_dq_index.py / generate_adr_index.py /
+generate_tools_index.py: the index is DERIVED from the JSON, `--check` reports
+staleness AND violations, and hand edits are therefore impossible to sustain.
+
+WHAT IT IS NOT. This implements Part D of docs/design/UI_ARCHITECTURE_2026-08-06.md
+(keeping the taxonomy honest) and nothing else. Part B (the nine-door sort) and
+Part C (the digit grammar) are NOT enforced here -- Part B's Research door is
+explicitly gated on a workshop with Pip. The proposed door column in the emitted
+table is transcribed from that document and clearly marked PROPOSED; it is
+reference material for the phase 1/2 lanes, never a gate.
+
+SEVERITY IS TWO-TIERED, deliberately:
+  ERROR   -- a defect: duplicate id, unknown/missing category, a door disagreeing
+             with its members over a category that the action bar actually renders,
+             an unbuildable submenu, a door nested inside a door.
+  WARNING -- a structural observation that is true of the tree TODAY and is a
+             phase-1/2 workitem, not a bug: loose top-level actions, and doors whose
+             members carry a NAMESPACE category (`travel`, `office`, `scouting`,
+             `operations`, `financing`) that the action bar has no group for.
+Reporting those as errors would make the check red on arrival, and a check that is
+red on arrival gets disabled inside a week (#1117: this repo already ran a Python
+lane as `|| echo` and reported green over zero assertions).
+
+WHAT IS AND IS NOT WIRED INTO PRE-COMMIT. `--check-stale` IS (a stale index is a
+condition anyone can fix in one command, so gating it costs nothing and is the only
+thing keeping the index from rotting the way decisions/README.md did). `--check`,
+which additionally fails on the violations, is NOT -- it is red on arrival while
+take_loan is duplicated. Flip the hook to `--check` the moment the error list is
+empty; that is the phase-2 ratchet in Part E, and there is a test in
+tests/test_generate_action_taxonomy.py that fails when the moment arrives.
+
+Usage:
+    python scripts/generate_action_taxonomy.py                # (re)write the index
+    python scripts/generate_action_taxonomy.py --check        # exit 1 if stale OR violated
+    python scripts/generate_action_taxonomy.py --check-stale  # exit 1 only if stale
+    python scripts/generate_action_taxonomy.py --report       # print findings, exit 0
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTIONS_DIR = ROOT / "godot" / "data" / "actions"
+OUT = ROOT / "docs" / "ACTION_TAXONOMY.md"
+RENDERER = ROOT / "godot" / "scripts" / "ui" / "action_bar_renderer.gd"
+SUBMENU_CONTROLLER = ROOT / "godot" / "scripts" / "ui" / "submenu_controller.gd"
+DESIGN_DOC_REL = "docs/design/UI_ARCHITECTURE_2026-08-06.md"
+
+# The emitted file must be ASCII (enforce-standards + no-emoji hooks). Keys are
+# built with chr() DELIBERATELY -- literal characters would make this file
+# non-ASCII, and backslash-u escapes get un-escaped back to literals by black on
+# the next commit (observed 2026-08-03 on generate_adr_index.py).
+ASCII_MAP = {
+    chr(0x00B7): "-",  # middle dot
+    chr(0x2013): "--",  # en dash
+    chr(0x2014): "--",  # em dash
+    chr(0x2018): "'",  # left single quote
+    chr(0x2019): "'",  # right single quote
+    chr(0x201C): '"',  # left double quote
+    chr(0x201D): '"',  # right double quote
+    chr(0x2026): "...",  # ellipsis
+    chr(0x2192): "->",  # right arrow
+    chr(0x00A0): " ",  # nbsp
+}
+
+# Files under godot/data/actions/ that hold no actions. risk_contributions.json is
+# a per-action risk-pool table (top-level keys `_description` + `contributions`).
+# Verified by measurement: the commission's "64 actions" count wrongly credited it
+# with 2. Listed explicitly so a NEW non-action file has to be declared here rather
+# than silently dropping out of the count.
+NON_ACTION_FILES = {"risk_contributions.json"}
+
+# door action id -> the domain file holding its members. Mirrors the dispatch in
+# GameActions.get_action_by_id / the get_*_options accessors (scripts/core/actions.gd).
+DOOR_DOMAIN = {
+    "hire_staff": "hiring",
+    "fundraise": "fundraising",
+    "publicity": "publicity",
+    "strategic": "strategic",
+    "travel": "travel",
+    "operations": "operations",
+    "financing": "financing",
+    "office": "office",
+    "scouting": "scouting",
+}
+
+# Domains that are not reached through a door tile. `command` holds `pass`, a
+# Plan-screen control rather than a bar tile; `core` is the top level itself.
+NON_DOOR_DOMAINS = {"core", "command"}
+
+# Categories the ACTION BAR actually groups by. Read from action_bar_renderer.gd
+# at runtime; this is the fallback if the parse fails, kept so a renderer refactor
+# degrades to a stale-but-loud check rather than a silent no-op.
+FALLBACK_RENDER_CATEGORIES = [
+    "funding",
+    "hiring",
+    "resources",
+    "research",
+    "management",
+    "influence",
+    "strategic",
+    "other",
+]
+
+# Categories that exist ONLY as a submenu namespace: no group in the action bar's
+# category_order, so a top-level tile carrying one would fall into "other".
+NAMESPACE_CATEGORIES = {
+    "travel",
+    "office",
+    "scouting",
+    "operations",
+    "financing",
+    "command",
+}
+
+# Submenu ids SubmenuController.open() handles outside GRID_CONFIG. Documented
+# bespoke builders, not a hole -- the hole this pins shut is the `else` branch's
+# push_warning("unknown submenu id"), which is a runtime warning nobody sees.
+BESPOKE_SUBMENU_IDS = {"financing", "hire_staff", "travel"}
+
+# PROPOSED placement, transcribed from Part B of the architecture doc. REFERENCE
+# ONLY -- never checked, never enforced. Part B's Research door is gated on a
+# workshop with Pip (Part E phase 3), so encoding it as truth would be a lie.
+PROPOSED_DOOR = {
+    "Funding": [
+        "fundraise_small",
+        "fundraise_big",
+        "apply_grant",
+        "take_loan",
+        "funding_strings",
+        "desperation_lever",
+        "staff_rider",
+        "seek_financing",
+        "accept_financing_offer",
+        "pay_bills",
+    ],
+    "People": [
+        "hire_safety_researcher",
+        "hire_capability_researcher",
+        "hire_compute_engineer",
+        "hire_manager",
+        "hire_ethicist",
+        "hire_interpretability_researcher",
+        "hire_alignment_researcher",
+        "advertise",
+        "use_connections",
+        "interview_next",
+        "hire_best",
+        "onboard_next",
+        "team_building",
+    ],
+    "Research": [
+        "safety_research",
+        "capability_research",
+        "publish_paper",
+        "audit_safety",
+    ],
+    "Compute": ["buy_compute"],
+    "Publicity": [
+        "network",
+        "media_campaign",
+        "lobby_government",
+        "release_warning",
+        "open_source_release",
+    ],
+    "Scouting": ["scout_read", "scout_meetups", "scout_shitpost"],
+    "Travel": [
+        "submit_paper",
+        "attend_conference",
+        "attend_conference_trip",
+        "send_delegation",
+    ],
+    "Operations": [
+        "order_supplies",
+        "audit_self_directed",
+        "tour_offices",
+        "sign_lease_coworking_corner",
+        "sign_lease_walkup_office",
+        "sign_lease_university_annex",
+        "office_maintenance",
+    ],
+    "Strategic": [
+        "acquire_startup",
+        "sabotage_competitor",
+        "emergency_pivot",
+        "grant_proposal",
+    ],
+    "(command)": ["pass"],
+}
+
+# Where each of today's DOORS lands under the same proposed sort. `financing` folds
+# into Funding and `office` into Operations (Part E phase 2), which is why two of
+# today's nine doors map onto a door that is not their own name.
+PROPOSED_DOOR_FOR_DOOR = {
+    "hire_staff": "People",
+    "fundraise": "Funding",
+    "financing": "Funding (merged)",
+    "publicity": "Publicity",
+    "strategic": "Strategic",
+    "travel": "Travel",
+    "operations": "Operations",
+    "office": "Operations (merged)",
+    "scouting": "Scouting",
+}
+
+# Pip's cap (#1132): "no more than 10 buttons along the top ... including how many
+# buttons we want to have unlocked in total". Enforced against DOORS, which is the
+# quantity the architecture rule produces. Ratchets down per Part E; asserted at the
+# value the tree actually meets, never at an aspiration.
+MAX_DOORS = 10
+
+
+def to_ascii(text: str) -> str:
+    for src, dst in ASCII_MAP.items():
+        text = text.replace(src, dst)
+    return "".join(c if ord(c) < 128 else "?" for c in text)
+
+
+# --- source-of-truth readers --------------------------------------------------
+
+
+def read_render_categories(text: str) -> list:
+    """Pull category_order out of action_bar_renderer.gd.
+
+    A DERIVED read, not a copy: the whole point of this checker is that placement
+    currently lives in four places that can drift (the category field, this
+    category_order, GRID_CONFIG's keys, and which file an action sits in). Copying
+    one of them into this script would add a fifth.
+    """
+    m = re.search(r"var\s+category_order\s*=\s*\[(.*?)\]", text, re.S)
+    if not m:
+        return list(FALLBACK_RENDER_CATEGORIES)
+    return re.findall(r'"([^"]+)"', m.group(1))
+
+
+def read_hidden_ids(text: str) -> list:
+    m = re.search(r"HIDDEN_FROM_ACTION_BAR_IDS\s*:?=\s*\[(.*?)\]", text, re.S)
+    if not m:
+        return []
+    return re.findall(r'"([^"]+)"', m.group(1))
+
+
+def read_grid_config_ids(text: str) -> list:
+    """Top-level keys of SubmenuController.GRID_CONFIG.
+
+    Matched at exactly one level of indentation (one tab) so nested dict keys
+    inside an entry ("panel_size", "summary", ...) cannot be mistaken for panels.
+    """
+    m = re.search(r"const\s+GRID_CONFIG\s*:?=\s*\{(.*?)\n\}", text, re.S)
+    if not m:
+        return []
+    return re.findall(r'^\t"([^"]+)"\s*:\s*\{', m.group(1), re.M)
+
+
+def load_actions() -> tuple:
+    """Return (records, notes). One record per action ENTRY, duplicates included.
+
+    Duplicates are deliberately NOT collapsed here: the whole take_loan finding is
+    that two entries share an id, and a dict keyed by id would eat the evidence --
+    which is precisely how the defect survived this long.
+    """
+    if not ACTIONS_DIR.is_dir():
+        raise SystemExit("ERROR: %s does not exist" % ACTIONS_DIR)
+
+    records = []
+    notes = []
+    for path in sorted(ACTIONS_DIR.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if path.name in NON_ACTION_FILES:
+            if data.get("actions"):
+                raise SystemExit(
+                    "ERROR: %s is declared a non-action file (NON_ACTION_FILES) but "
+                    "now carries an 'actions' array. Remove it from that set." % path.name
+                )
+            notes.append(
+                "`%s` carries ZERO actions and is excluded from the count "
+                "(it is a lookup table, not an action list). The commission's "
+                "earlier inventory credited it with 2." % path.name
+            )
+            continue
+        actions = data.get("actions")
+        if not isinstance(actions, list):
+            raise SystemExit(
+                "ERROR: %s has no 'actions' array. Every file in godot/data/actions/ "
+                "is either an action list or declared in NON_ACTION_FILES." % path.name
+            )
+        for index, action in enumerate(actions):
+            if not isinstance(action, dict):
+                raise SystemExit("ERROR: %s entry %d is not an object" % (path.name, index))
+            action_id = action.get("id")
+            if not action_id:
+                raise SystemExit(
+                    "ERROR: %s entry %d has no 'id'. A blank id is worse than a wrong "
+                    "one -- it cannot be queued, iconed, or replayed." % (path.name, index)
+                )
+            records.append(
+                {
+                    "id": action_id,
+                    "name": to_ascii(action.get("name", "")),
+                    "domain": path.stem,
+                    "file": path.name,
+                    "category": action.get("category"),
+                    "is_submenu": bool(action.get("is_submenu", False)),
+                    "index": index,
+                    "raw": action,
+                }
+            )
+    if not records:
+        raise SystemExit("ERROR: no actions found in %s" % ACTIONS_DIR)
+    return records, notes
+
+
+# --- the checks ---------------------------------------------------------------
+
+
+def describe_divergence(group) -> str:
+    """Name the fields on which duplicate definitions of one id disagree.
+
+    Reported because "duplicate" understates it. The two `take_loan` records do not
+    merely coexist -- they promise the player different money. Whoever dedups needs
+    to see that before choosing, or the dedup silently ships one of two prices.
+    """
+    keys = sorted({k for g in group for k in g["raw"] if not k.startswith("_")})
+    parts = []
+    for key in keys:
+        values = [json.dumps(g["raw"].get(key), sort_keys=True) for g in group]
+        if len(set(values)) == 1:
+            continue
+        rendered = " vs ".join(
+            "%s=%s" % (g["file"], (v if len(v) <= 90 else v[:87] + "..."))
+            for g, v in zip(group, values)
+        )
+        parts.append("%s (%s)" % (key, rendered))
+    return "; ".join(parts) if parts else "nothing (the records are identical)"
+
+
+def analyse(records, render_categories, hidden_ids, grid_ids) -> dict:
+    errors = []
+    warnings = []
+
+    known_categories = set(render_categories) | NAMESPACE_CATEGORIES
+    doors = [r for r in records if r["is_submenu"]]
+    by_domain = {}
+    for r in records:
+        by_domain.setdefault(r["domain"], []).append(r)
+
+    # 1. duplicate ids across files -- the take_loan case.
+    seen = {}
+    for r in records:
+        seen.setdefault(r["id"], []).append(r)
+    for action_id, group in sorted(seen.items()):
+        if len(group) > 1:
+            where = ", ".join("%s (category %s)" % (g["file"], g["category"]) for g in group)
+            errors.append(
+                "DUPLICATE ID '%s' defined in %d files: %s. The domain caches are "
+                "separate, so BOTH are live at once and neither shadows the other "
+                "loudly; which one a lookup returns depends on accessor order in "
+                "GameActions.get_action_by_id. They DISAGREE on: %s. Deduping is "
+                "therefore not a merge -- pick the record that matches what "
+                "execute_action actually does, and say so."
+                % (action_id, len(group), where, describe_divergence(group))
+            )
+
+    # 2. missing or unknown category.
+    for r in records:
+        if not r["category"]:
+            errors.append("MISSING CATEGORY on '%s' (%s)" % (r["id"], r["file"]))
+        elif r["category"] not in known_categories:
+            errors.append(
+                "UNKNOWN CATEGORY '%s' on '%s' (%s). Known: %s."
+                % (
+                    r["category"],
+                    r["id"],
+                    r["file"],
+                    ", ".join(sorted(known_categories)),
+                )
+            )
+
+    # 3. category disagreement between a door and its own members.
+    #    ERROR when the members' category is one the action bar RENDERS -- that is
+    #    exactly the fundraise defect (door said `management`, members said
+    #    `funding`, tile sorted tenth and fell below the fold).
+    #    WARNING when the members' category is a namespace with no render group:
+    #    the door CANNOT carry it without falling into "other". That is the
+    #    two-meanings-of-`category` rot, a phase-2 workitem, not a live defect.
+    for door in doors:
+        domain = DOOR_DOMAIN.get(door["id"])
+        if domain is None:
+            errors.append(
+                "UNMAPPED DOOR '%s' (%s) is is_submenu but no domain file is mapped "
+                "to it in DOOR_DOMAIN." % (door["id"], door["file"])
+            )
+            continue
+        member_cats = sorted({m["category"] for m in by_domain.get(domain, []) if m["category"]})
+        if not member_cats:
+            errors.append("EMPTY DOOR '%s' -> %s.json has no members" % (door["id"], domain))
+            continue
+        if door["category"] in member_cats:
+            continue
+        detail = "door '%s' is category '%s'; its %s.json members are %s" % (
+            door["id"],
+            door["category"],
+            domain,
+            "/".join(member_cats),
+        )
+        if any(c in render_categories for c in member_cats):
+            errors.append(
+                "CATEGORY DISAGREEMENT -- %s. The members' category is one the action "
+                "bar groups by, so the door sorts into a group unrelated to what it "
+                "opens (the #1130 fundraise defect)." % detail
+            )
+        else:
+            warnings.append(
+                "NAMESPACE CATEGORY -- %s, which the action bar has no group for. The "
+                "door has to borrow a render category, so `category` means two "
+                "different things at the two levels. Phase 2 workitem." % detail
+            )
+
+    # 4. placement: door, member of exactly one door, hidden, command, or loose.
+    placement = {}
+    for r in records:
+        if r["is_submenu"]:
+            placement[r["id"]] = "door"
+        elif r["domain"] in NON_DOOR_DOMAINS:
+            placement.setdefault(r["id"], "top-level")
+        else:
+            placement[r["id"]] = "member"
+    door_domains = set(DOOR_DOMAIN.values())
+    for domain in sorted(by_domain):
+        if domain in NON_DOOR_DOMAINS or domain in door_domains:
+            continue
+        errors.append(
+            "ORPHAN DOMAIN '%s.json' -- %d actions with no door mapped to it; nothing "
+            "in the UI can reach them." % (domain, len(by_domain[domain]))
+        )
+    for door_id, domain in sorted(DOOR_DOMAIN.items()):
+        if domain not in by_domain:
+            errors.append("DOOR '%s' maps to missing domain file %s.json" % (door_id, domain))
+
+    # 5. depth invariant: no door inside a door.
+    for door in doors:
+        domain = DOOR_DOMAIN.get(door["id"])
+        for member in by_domain.get(domain, []):
+            if member["is_submenu"]:
+                errors.append(
+                    "DEPTH VIOLATION -- '%s' is a door nested inside door '%s'. Two "
+                    "menus then at most one picker; a third menu of verbs is out."
+                    % (member["id"], door["id"])
+                )
+
+    # 6. every door has a builder (GRID_CONFIG entry or documented bespoke). This
+    #    pins shut SubmenuController.open()'s push_warning("unknown submenu id"),
+    #    which is a runtime warning in a headless-quiet log -- i.e. invisible.
+    buildable = set(grid_ids) | BESPOKE_SUBMENU_IDS
+    for door in doors:
+        if door["id"] not in buildable:
+            errors.append(
+                "NO BUILDER for door '%s' -- not in SubmenuController.GRID_CONFIG %s "
+                "and not a documented bespoke builder %s. Opening it would only "
+                "push_warning." % (door["id"], sorted(grid_ids), sorted(BESPOKE_SUBMENU_IDS))
+            )
+    for grid_id in sorted(grid_ids):
+        if grid_id not in {d["id"] for d in doors}:
+            warnings.append(
+                "ORPHAN BUILDER -- GRID_CONFIG has a panel '%s' with no is_submenu "
+                "action of that id." % grid_id
+            )
+
+    # 7. the cap, executable (#1132).
+    if len(doors) > MAX_DOORS:
+        errors.append(
+            "DOOR CAP -- %d doors exceeds the cap of %d. An 11th door means the game "
+            "grew an 11th steerable system; interrogate that, not the pixel width."
+            % (len(doors), MAX_DOORS)
+        )
+
+    # 8. loose top-level actions -- true today, folded by phase 1/2. WARNING.
+    loose = [
+        r
+        for r in records
+        if r["domain"] == "core" and not r["is_submenu"] and r["id"] not in hidden_ids
+    ]
+    if loose:
+        warnings.append(
+            "LOOSE TOP-LEVEL ACTIONS -- %d actions render as bare tiles alongside the "
+            "%d doors (%s). Under the Part A rule each competes only with its door's "
+            "siblings; phase 1/2 of %s folds them."
+            % (
+                len(loose),
+                len(doors),
+                ", ".join(sorted(r["id"] for r in loose)),
+                DESIGN_DOC_REL,
+            )
+        )
+
+    # 9. hidden ids must actually exist.
+    all_ids = {r["id"] for r in records}
+    for hidden in hidden_ids:
+        if hidden not in all_ids:
+            errors.append(
+                "STALE HIDE -- HIDDEN_FROM_ACTION_BAR_IDS names '%s', which no action "
+                "defines." % hidden
+            )
+
+    return {
+        "errors": errors,
+        "warnings": warnings,
+        "doors": doors,
+        "placement": placement,
+        "loose": loose,
+        "unique_ids": len(all_ids),
+    }
+
+
+def proposed_door_for(action_id: str) -> str:
+    if action_id in PROPOSED_DOOR_FOR_DOOR:
+        return PROPOSED_DOOR_FOR_DOOR[action_id]
+    for door, members in PROPOSED_DOOR.items():
+        if action_id in members:
+            return door
+    return "--"
+
+
+def today_door_for(record: dict, doors) -> str:
+    if record["is_submenu"]:
+        return "(is a door)"
+    if record["domain"] in NON_DOOR_DOMAINS:
+        return "(top level)"
+    for door in doors:
+        if DOOR_DOMAIN.get(door["id"]) == record["domain"]:
+            return door["id"]
+    return "(unreachable)"
+
+
+# --- rendering ----------------------------------------------------------------
+
+
+def render() -> str:
+    records, notes = load_actions()
+    renderer_text = RENDERER.read_text(encoding="utf-8")
+    render_categories = read_render_categories(renderer_text)
+    hidden_ids = read_hidden_ids(renderer_text)
+    grid_ids = read_grid_config_ids(SUBMENU_CONTROLLER.read_text(encoding="utf-8"))
+    result = analyse(records, render_categories, hidden_ids, grid_ids)
+    doors = result["doors"]
+
+    lines = [
+        "# Action taxonomy (GENERATED -- do not hand-edit)",
+        "",
+        "> Derived from `godot/data/actions/*.json`, `action_bar_renderer.gd`",
+        "> (`category_order`, `HIDDEN_FROM_ACTION_BAR_IDS`) and",
+        "> `submenu_controller.gd` (`GRID_CONFIG`) by",
+        "> `scripts/generate_action_taxonomy.py`. Regenerate with:",
+        "> `python scripts/generate_action_taxonomy.py`.",
+        ">",
+        "> Implements Part D of `%s`." % DESIGN_DOC_REL,
+        "> The rule it serves: **an action is top-level iff it is the single door to a",
+        "> system the player steers when composing an ordinary month's plan.**",
+        ">",
+        "> **The violation gate is REPORT-ONLY.** Pre-commit runs `--check-stale`, which",
+        "> fails only if THIS FILE is out of date. `--check` additionally exits nonzero on",
+        "> the errors below and is deliberately NOT wired while a known violation is live:",
+        "> a gate that is red on arrival gets disabled within a week (#1117). Flip the hook",
+        "> to `--check` when the error list is empty.",
+        "",
+        "## Counts",
+        "",
+        "| Measure | Value |",
+        "|---|---|",
+        "| Action entries | %d |" % len(records),
+        "| Distinct action ids | %d |" % result["unique_ids"],
+        "| Files scanned | %d |" % len(list(ACTIONS_DIR.glob("*.json"))),
+        "| Files carrying actions | %d |"
+        % len([p for p in ACTIONS_DIR.glob("*.json") if p.name not in NON_ACTION_FILES]),
+        "| Doors (`is_submenu`) | %d (cap %d) |" % (len(doors), MAX_DOORS),
+        "| Loose top-level tiles | %d |" % len(result["loose"]),
+        "| Hidden from the bar | %d |" % len(hidden_ids),
+        "| Errors | %d |" % len(result["errors"]),
+        "| Warnings | %d |" % len(result["warnings"]),
+        "",
+    ]
+    for note in notes:
+        lines.append("- %s" % note)
+    if notes:
+        lines.append("")
+
+    lines += [
+        "## Findings",
+        "",
+    ]
+    if result["errors"]:
+        lines.append("### Errors (`--check` exits 1)")
+        lines.append("")
+        for e in result["errors"]:
+            lines.append("- %s" % to_ascii(e))
+        lines.append("")
+    else:
+        lines += ["### Errors (`--check` exits 1)", "", "None.", ""]
+    if result["warnings"]:
+        lines.append("### Warnings (reported, never fatal)")
+        lines.append("")
+        for w in result["warnings"]:
+            lines.append("- %s" % to_ascii(w))
+        lines.append("")
+
+    lines += [
+        "## Every action",
+        "",
+        "`Door (today)` is measured from the data: which submenu file the action lives",
+        "in, and which `is_submenu` action opens that file. `Door (proposed)` is",
+        "transcribed from Part B of the architecture doc and is **reference only** --",
+        "nothing here checks it, and the Research door is gated on a workshop.",
+        "",
+        "| # | id | Name | File | Category | Placement | Door (today) | Door (proposed) |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    ordered = sorted(records, key=lambda r: (r["file"], r["index"]))
+    for n, r in enumerate(ordered, 1):
+        placement = "door" if r["is_submenu"] else result["placement"].get(r["id"], "member")
+        if r["id"] in hidden_ids:
+            placement += " (hidden)"
+        lines.append(
+            "| %d | `%s` | %s | `%s` | `%s` | %s | %s | %s |"
+            % (
+                n,
+                r["id"],
+                r["name"],
+                r["file"],
+                r["category"],
+                placement,
+                today_door_for(r, doors),
+                proposed_door_for(r["id"]),
+            )
+        )
+    lines.append("")
+
+    lines += [
+        "## Doors today",
+        "",
+        "| Door id | Door category | Members file | Members | Member categories | Builder |",
+        "|---|---|---|---|---|---|",
+    ]
+    by_domain = {}
+    for r in records:
+        by_domain.setdefault(r["domain"], []).append(r)
+    for door in sorted(doors, key=lambda d: d["index"]):
+        domain = DOOR_DOMAIN.get(door["id"], "")
+        members = by_domain.get(domain, [])
+        member_cats = sorted({m["category"] for m in members if m["category"]})
+        builder = "GRID_CONFIG" if door["id"] in grid_ids else "bespoke"
+        lines.append(
+            "| `%s` | `%s` | `%s.json` | %d | %s | %s |"
+            % (
+                door["id"],
+                door["category"],
+                domain,
+                len(members),
+                ", ".join("`%s`" % c for c in member_cats),
+                builder,
+            )
+        )
+    lines.append("")
+    lines.append(
+        "Action bar `category_order` (the render groups): %s."
+        % ", ".join("`%s`" % c for c in render_categories)
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    content = render()
+
+    records, _ = load_actions()
+    renderer_text = RENDERER.read_text(encoding="utf-8")
+    result = analyse(
+        records,
+        read_render_categories(renderer_text),
+        read_hidden_ids(renderer_text),
+        read_grid_config_ids(SUBMENU_CONTROLLER.read_text(encoding="utf-8")),
+    )
+
+    check = "--check" in argv
+    check_stale = "--check-stale" in argv
+    stale = not OUT.exists() or OUT.read_text(encoding="utf-8") != content
+
+    if "--report" in argv or check:
+        for e in result["errors"]:
+            print("ERROR: %s" % e)
+        for w in result["warnings"]:
+            print("WARN:  %s" % w)
+        print(
+            "%d entries, %d distinct ids, %d errors, %d warnings."
+            % (len(records), result["unique_ids"], len(result["errors"]), len(result["warnings"]))
+        )
+
+    if check or check_stale:
+        if stale:
+            print("ACTION_TAXONOMY.md is stale. Run: python scripts/generate_action_taxonomy.py")
+        if check_stale and result["errors"]:
+            # Deliberately not fatal here: this mode gates the INDEX, not the tree.
+            print(
+                "(%d taxonomy error(s) reported in %s -- not gated. See the script "
+                "docstring for why.)" % (len(result["errors"]), OUT.relative_to(ROOT))
+            )
+        return 1 if (stale or (check and result["errors"])) else 0
+
+    if "--report" in argv:
+        return 0
+
+    OUT.write_text(content, encoding="utf-8", newline="\n")
+    print("Wrote %s" % OUT.relative_to(ROOT))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_action_taxonomy.py
+++ b/tests/test_generate_action_taxonomy.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/generate_action_taxonomy.py (the action-taxonomy checker).
+
+What these lock down:
+
+- Duplicate id detection across files -- the live `take_loan` defect, asserted
+  against a synthetic fixture AND against the real tree, so a future dedup makes
+  the real-tree assertion fail loudly rather than the tool going quietly green on
+  a bug nobody re-read.
+- Missing / unknown `category`.
+- The two-tier category-disagreement rule: ERROR when the members' category is one
+  the action bar renders (the #1130 `fundraise` defect, replayed as a fixture),
+  WARNING when it is a submenu-only namespace with no render group.
+- Depth (no door inside a door), unbuildable doors, orphan domains, stale hides,
+  the door cap.
+- The GDScript readers really parse the two real files (category_order,
+  HIDDEN_FROM_ACTION_BAR_IDS, GRID_CONFIG keys) rather than silently falling back.
+- The guard can actually fail: analyse() over a tree with an injected duplicate
+  goes red naming BOTH files, and green when the injection is removed. Two guards
+  shipped in this repo could not fail; this asserts ours can.
+
+Run: python -m unittest tests.test_generate_action_taxonomy -v
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import generate_action_taxonomy as gat  # noqa: E402
+
+RENDER_CATEGORIES = ["funding", "hiring", "research", "management", "other"]
+
+
+def rec(action_id, domain, category, is_submenu=False, index=0, name="X", **extra):
+    raw = {"id": action_id, "name": name, "category": category}
+    if is_submenu:
+        raw["is_submenu"] = True
+    raw.update(extra)
+    return {
+        "id": action_id,
+        "name": name,
+        "domain": domain,
+        "file": "%s.json" % domain,
+        "category": category,
+        "is_submenu": is_submenu,
+        "index": index,
+        "raw": raw,
+    }
+
+
+def run(records, hidden=None, grid=None, render=None):
+    return gat.analyse(
+        records,
+        render if render is not None else RENDER_CATEGORIES,
+        hidden or [],
+        grid if grid is not None else ["fundraise"],
+    )
+
+
+def joined(messages):
+    return "\n".join(messages)
+
+
+class DuplicateIds(unittest.TestCase):
+    def test_duplicate_across_files_is_an_error_naming_both(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("take_loan", "fundraising", "funding"),
+                rec("take_loan", "financing", "financing"),
+                rec("financing", "core", "financing", is_submenu=True, index=1),
+            ],
+            grid=["fundraise", "financing"],
+        )
+        errors = joined(result["errors"])
+        self.assertIn("DUPLICATE ID 'take_loan'", errors)
+        self.assertIn("fundraising.json", errors)
+        self.assertIn("financing.json", errors)
+        self.assertEqual(result["unique_ids"], 3)
+
+    def test_duplicate_error_names_the_fields_the_records_disagree_on(self):
+        """ "Duplicate" understates it: the real pair promise different money."""
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("take_loan", "fundraising", "funding", gains={"money": 75000}),
+                rec("take_loan", "financing", "financing"),
+                rec("financing", "core", "financing", is_submenu=True, index=1),
+            ],
+            grid=["fundraise", "financing"],
+        )
+        errors = joined(result["errors"])
+        self.assertIn("They DISAGREE on:", errors)
+        self.assertIn("gains", errors)
+        self.assertIn("category", errors)
+
+    def test_identical_duplicates_still_error_and_say_they_are_identical(self):
+        a = rec("clone", "fundraising", "funding")
+        b = rec("clone", "financing", "funding")
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("financing", "core", "funding", is_submenu=True, index=1),
+                a,
+                b,
+            ],
+            grid=["fundraise", "financing"],
+        )
+        errors = joined(result["errors"])
+        self.assertIn("DUPLICATE ID 'clone'", errors)
+        self.assertIn("the records are identical", errors)
+
+    def test_no_duplicate_when_ids_are_unique(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("take_loan", "fundraising", "funding"),
+            ]
+        )
+        self.assertNotIn("DUPLICATE", joined(result["errors"]))
+
+
+class Categories(unittest.TestCase):
+    def test_missing_category_is_an_error(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("take_loan", "fundraising", None),
+            ]
+        )
+        self.assertIn("MISSING CATEGORY on 'take_loan'", joined(result["errors"]))
+
+    def test_unknown_category_is_an_error(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("take_loan", "fundraising", "funding"),
+                rec("stray", "core", "wibble"),
+            ]
+        )
+        self.assertIn("UNKNOWN CATEGORY 'wibble'", joined(result["errors"]))
+
+    def test_namespace_categories_are_known(self):
+        """`travel`/`office`/... are absent from category_order but legitimate."""
+        result = run(
+            [
+                rec("travel", "core", "research", is_submenu=True),
+                rec("submit_paper", "travel", "travel"),
+            ],
+            grid=["travel"],
+        )
+        self.assertNotIn("UNKNOWN CATEGORY", joined(result["errors"]))
+
+
+class CategoryDisagreement(unittest.TestCase):
+    def test_the_fundraise_defect_is_an_error(self):
+        """#1130 replayed: door tagged `management`, members `funding`.
+
+        `funding` IS a render category, so the door sorted into a group unrelated
+        to what it opens -- the tile rendered tenth and fell below the fold.
+        """
+        result = run(
+            [
+                rec("fundraise", "core", "management", is_submenu=True),
+                rec("fundraise_small", "fundraising", "funding"),
+                rec("fundraise_big", "fundraising", "funding"),
+            ]
+        )
+        errors = joined(result["errors"])
+        self.assertIn("CATEGORY DISAGREEMENT", errors)
+        self.assertIn("door 'fundraise' is category 'management'", errors)
+        self.assertIn("funding", errors)
+
+    def test_agreement_is_silent(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("fundraise_small", "fundraising", "funding"),
+            ]
+        )
+        self.assertNotIn("CATEGORY DISAGREEMENT", joined(result["errors"]))
+
+    def test_namespace_mismatch_is_only_a_warning(self):
+        """A door CANNOT carry `travel`: the action bar has no group for it."""
+        result = run(
+            [
+                rec("travel", "core", "research", is_submenu=True),
+                rec("submit_paper", "travel", "travel"),
+            ],
+            grid=["travel"],
+        )
+        self.assertNotIn("CATEGORY DISAGREEMENT", joined(result["errors"]))
+        self.assertIn("NAMESPACE CATEGORY", joined(result["warnings"]))
+
+    def test_partial_agreement_counts_as_agreement(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("a", "fundraising", "funding"),
+                rec("b", "fundraising", "management"),
+            ]
+        )
+        self.assertNotIn("CATEGORY DISAGREEMENT", joined(result["errors"]))
+
+
+class Structure(unittest.TestCase):
+    def test_door_inside_a_door_is_a_depth_violation(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("financing", "fundraising", "funding", is_submenu=True),
+            ],
+            grid=["fundraise", "financing"],
+        )
+        self.assertIn("DEPTH VIOLATION", joined(result["errors"]))
+
+    def test_door_without_a_builder_is_an_error(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("fundraise_small", "fundraising", "funding"),
+            ],
+            grid=[],
+        )
+        self.assertIn("NO BUILDER for door 'fundraise'", joined(result["errors"]))
+
+    def test_bespoke_builders_satisfy_the_builder_check(self):
+        result = run(
+            [
+                rec("hire_staff", "core", "hiring", is_submenu=True),
+                rec("hire_manager", "hiring", "hiring"),
+            ],
+            grid=[],
+        )
+        self.assertNotIn("NO BUILDER", joined(result["errors"]))
+
+    def test_grid_panel_with_no_door_is_a_warning(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("fundraise_small", "fundraising", "funding"),
+            ],
+            grid=["fundraise", "ghost_panel"],
+        )
+        self.assertIn("ORPHAN BUILDER", joined(result["warnings"]))
+
+    def test_unmapped_door_is_an_error(self):
+        result = run([rec("mystery_door", "core", "funding", is_submenu=True)], grid=[])
+        self.assertIn("UNMAPPED DOOR 'mystery_door'", joined(result["errors"]))
+
+    def test_stale_hide_is_an_error(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("fundraise_small", "fundraising", "funding"),
+            ],
+            hidden=["ghost_action"],
+        )
+        self.assertIn("STALE HIDE", joined(result["errors"]))
+
+    def test_hidden_actions_are_not_counted_as_loose_tiles(self):
+        result = run(
+            [
+                rec("fundraise", "core", "funding", is_submenu=True),
+                rec("fundraise_small", "fundraising", "funding"),
+                rec("interview_next", "core", "hiring"),
+            ],
+            hidden=["interview_next"],
+        )
+        self.assertEqual(result["loose"], [])
+
+    def test_door_cap_fires_above_the_limit(self):
+        records = []
+        for n, (door, domain) in enumerate(gat.DOOR_DOMAIN.items()):
+            records.append(rec(door, "core", "funding", is_submenu=True, index=n))
+            records.append(rec("%s_member" % domain, domain, "funding", index=n))
+        result = run(records, grid=list(gat.DOOR_DOMAIN))
+        self.assertNotIn("DOOR CAP", joined(result["errors"]))
+        self.assertLessEqual(len(result["doors"]), gat.MAX_DOORS)
+
+
+class GdscriptReaders(unittest.TestCase):
+    """The readers must really parse the real files; a silent fallback is the bug."""
+
+    def test_category_order_is_read_from_the_renderer(self):
+        cats = gat.read_render_categories(gat.RENDERER.read_text(encoding="utf-8"))
+        self.assertIn("funding", cats)
+        self.assertIn("hiring", cats)
+        self.assertGreaterEqual(len(cats), 5)
+
+    def test_hidden_ids_are_read_from_the_renderer(self):
+        hidden = gat.read_hidden_ids(gat.RENDERER.read_text(encoding="utf-8"))
+        self.assertIn("interview_next", hidden)
+
+    def test_grid_config_keys_exclude_nested_entry_keys(self):
+        grid = gat.read_grid_config_ids(gat.SUBMENU_CONTROLLER.read_text(encoding="utf-8"))
+        self.assertIn("fundraise", grid)
+        self.assertIn("operations", grid)
+        # Nested per-entry keys must NOT leak in as if they were panels.
+        for leak in ("panel_size", "summary", "key_labels", "log_label"):
+            self.assertNotIn(leak, grid)
+
+
+class RealTree(unittest.TestCase):
+    """Assertions about the tree as it stands. These are meant to change with it."""
+
+    def setUp(self):
+        self.records, self.notes = gat.load_actions()
+        renderer = gat.RENDERER.read_text(encoding="utf-8")
+        self.result = gat.analyse(
+            self.records,
+            gat.read_render_categories(renderer),
+            gat.read_hidden_ids(renderer),
+            gat.read_grid_config_ids(gat.SUBMENU_CONTROLLER.read_text(encoding="utf-8")),
+        )
+
+    def test_inventory_is_62_entries_in_11_action_files(self):
+        """The commission said 64; risk_contributions.json holds ZERO actions."""
+        self.assertEqual(len(self.records), 62)
+        self.assertEqual(len({r["file"] for r in self.records}), 11)
+        self.assertEqual(len(list(gat.ACTIONS_DIR.glob("*.json"))), 12)
+        self.assertTrue(any("risk_contributions.json" in n for n in self.notes))
+
+    def test_take_loan_is_still_duplicated_and_the_checker_says_so(self):
+        """Delete this assertion WHEN take_loan is deduped -- and only then.
+
+        Failing here means the defect was fixed, which is the moment to flip the
+        checker from report-only to a blocking pre-commit gate.
+        """
+        self.assertEqual(len(self.records) - self.result["unique_ids"], 1)
+        self.assertIn("DUPLICATE ID 'take_loan'", joined(self.result["errors"]))
+
+    def test_take_loan_is_the_only_error_left(self):
+        self.assertEqual(len(self.result["errors"]), 1, joined(self.result["errors"]))
+
+    def test_nine_doors_under_the_cap(self):
+        self.assertEqual(len(self.result["doors"]), 9)
+        self.assertLessEqual(len(self.result["doors"]), gat.MAX_DOORS)
+
+
+class GuardCanFail(unittest.TestCase):
+    """Red-first: inject a duplicate, watch it name both files, remove it, green."""
+
+    def test_injecting_a_duplicate_into_the_real_records_goes_red(self):
+        records, _ = gat.load_actions()
+        renderer = gat.RENDERER.read_text(encoding="utf-8")
+        args = (
+            gat.read_render_categories(renderer),
+            gat.read_hidden_ids(renderer),
+            gat.read_grid_config_ids(gat.SUBMENU_CONTROLLER.read_text(encoding="utf-8")),
+        )
+
+        clone = dict(records[-1])
+        clone["domain"] = "publicity"
+        clone["file"] = "publicity.json"
+        injected = gat.analyse(records + [clone], *args)
+        message = joined(injected["errors"])
+        self.assertIn("DUPLICATE ID '%s'" % clone["id"], message)
+        self.assertIn("publicity.json", message)
+        self.assertIn(records[-1]["file"], message)
+
+        baseline = gat.analyse(records, *args)
+        self.assertNotIn("DUPLICATE ID '%s'" % clone["id"], joined(baseline["errors"]))
+        self.assertEqual(len(injected["errors"]), len(baseline["errors"]) + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase 0 of `docs/design/UI_ARCHITECTURE_2026-08-06.md` -- **Part D only** (keeping the taxonomy honest). Parts B (the nine-door sort) and C (the digit grammar) are NOT implemented; Part B's Research door is explicitly gated on a workshop with Pip.

Relates to #798 (compute deserves a grouped submenu -- absorbed by the architecture doc, and this is the measuring instrument that lands first). Follows #1130 (the `fundraise` mis-tag).

## Why

`category` on an action definition is a sort key with no checker. An unchecked data field rots, and the rot is invisible because the symptom is a rendering position, not a red test:

- The `fundraise` door shipped tagged `category: management` while every item in its own submenu was `funding`. It rendered tenth, fell below the fold, and two external playtesters (2026-08-05) could not find fundraising. Fixed by hand in #1130.
- `take_loan` is defined **twice** and still is.

## What it detects

`scripts/generate_action_taxonomy.py` derives `docs/ACTION_TAXONOMY.md` from `godot/data/actions/*.json` **plus the two GDScript files that actually decide placement** -- `action_bar_renderer.gd` (`category_order`, `HIDDEN_FROM_ACTION_BAR_IDS`) and `submenu_controller.gd` (`GRID_CONFIG`). It reads them rather than copying them: placement currently lives in four drift-prone places, and a fifth copy would not help. Same anti-rot shape as `generate_dq_index.py` / `generate_adr_index.py` / `generate_tools_index.py`.

Checks:

| # | Check | Severity |
|---|---|---|
| 1 | Duplicate action id across files -- names both files AND the fields the two records disagree on | ERROR |
| 2 | Missing or unknown `category` | ERROR |
| 3 | A door disagreeing with its own submenu members over a category the action bar renders (the #1130 defect) | ERROR |
| 3b | ...over a submenu-only NAMESPACE category the bar has no group for | WARNING |
| 4 | A door nested inside a door (Part C depth invariant) | ERROR |
| 5 | A door with no builder -- neither a `GRID_CONFIG` entry nor a documented bespoke one | ERROR |
| 6 | Orphan domain file (actions no door can reach) / unmapped door / empty door | ERROR |
| 7 | Stale entry in `HIDDEN_FROM_ACTION_BAR_IDS` | ERROR |
| 8 | Door cap (#1132's cap-of-10, executable) | ERROR |
| 9 | Loose top-level actions competing with doors | WARNING |
| 10 | `GRID_CONFIG` panel with no `is_submenu` action of that id | WARNING |

## Counts (measured, not asserted)

**62 action entries, 61 distinct ids, 11 files carrying actions, 12 files scanned, 9 doors, 9 loose tiles, 3 hidden.** `risk_contributions.json` holds **zero** actions -- it is a risk-pool lookup table. The earlier inventory of 64 credited it with 2; the architecture doc's correction to 62 is confirmed.

## What it found

**1 error.** `take_loan` in both `fundraising.json` and `financing.json`. The domain caches are separate, so both are live at once and neither shadows the other loudly. They do not merely duplicate -- **they promise different money**:

| field | `fundraising.json` | `financing.json` | `execute_action` |
|---|---|---|---|
| name | Business Loan | Take Loan | -- |
| category | `funding` | `financing` | -- |
| description | "Immediate funds via debt" | "+$50k now; balloon (~$60k) in 4 turns" | -- |
| gains | `{money: 75000, debt: 90000}` | (none) | `+$50k` and `Ledger.loan(50000)` |

The fundraising record is **false against the engine**, and its $75k/$90k figure has already propagated into `docs/game-design/SEED_FUNDING_MODES.md`. `docs/TECH_DEBT_REGISTER.md` item 2 recorded the *code* half of this (two `execute_action` arms) -- that half was fixed; the data half was never noticed.

**6 warnings.** Five doors (`operations`, `travel`, `financing`, `office`, `scouting`) carry a render category unrelated to their members' -- because member categories `operations`/`travel`/`financing`/`office`/`scouting` have **no group in `category_order` at all**, so the door has to borrow one. Same disease as the fundraise mis-tag, one degree milder: `category` means two different things at the two levels. Phase 2 workitem. Plus 9 loose top-level tiles rendering alongside the 9 doors.

## Report-only, and why

Pre-commit runs `--check-stale`, which fails **only if the generated index is out of date** -- a condition anyone fixes in one command, and the only thing stopping this index rotting the way `decisions/README.md` did.

The full `--check` also exits nonzero on the violations and is **deliberately not wired**: it is red on arrival while `take_loan` is duplicated, and a gate that is red on arrival gets disabled inside a week (#1117 records this repo already running a Python lane as `|| echo` over zero assertions).

**To flip it to blocking:** dedup `take_loan`, then change the hook entry from `--check-stale` to `--check`. A test in `tests/test_generate_action_taxonomy.py` fails the day the dedup lands, so nobody has to remember.

`take_loan` is **not fixed here**, on purpose. Deduping it is not a merge: the two records promise different money, so choosing means ruling on whether the engine's $50k or the advertised $75k is right (a balance call), and removing either entry changes what a turn-1 submenu panel contains (a player-visible change owned by the phase 1/2 lane). Recommendation for whoever takes it: keep the `financing.json` record (it matches the engine), delete the `fundraising.json` one, and correct `SEED_FUNDING_MODES.md`.

## Proof the guard can fail

Injected a duplicate `network` into `scouting.json`: `--check` went from 1 error to 2, naming `publicity.json` and `scouting.json` explicitly, and exited 1. Removed it: back to 1 error. The same red/green cycle is asserted in `GuardCanFail` in the test file so it stays proven.

## Verification

- 27 new Python unit tests (`python -m unittest tests.test_generate_action_taxonomy`), all passing. They cover every check above against synthetic fixtures -- including a **replay of the #1130 fundraise defect** -- plus assertions against the real tree, plus that the GDScript readers really parse the real files rather than silently falling back to a stale constant.
- Godot fast gate unchanged: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **1146 tests, 0 failures**, same as the branch point.
- Note: the repo's Python test lane in `enhanced-cicd-pipeline.yml` runs as `|| echo`, so these tests do not gate CI. That is #1117's problem, flagged not fixed.

## Coordination

Touches only `scripts/`, `tests/`, `docs/ACTION_TAXONOMY.md`, the regenerated `docs/TOOLS.md`, and one `.pre-commit-config.yaml` entry. `main_ui.gd`, `action_bar_renderer.gd`, `godot/data/events/**` and the action JSONs are untouched.

One naming note for the phase 1 lane: the architecture doc's Part D names the output `docs/design/ACTION_TAXONOMY.md`; the commission asked for `docs/ACTION_TAXONOMY.md` and that is what shipped. Trivially movable if the doc's path is preferred.

Do not merge without Pip's review.

Generated with [Claude Code](https://claude.com/claude-code)
