### PR TITLE
fix(debug): retire the debug event-trigger -- delete the feature, not guard it (#1134)

### DIFF
--- a/godot/ERROR_HANDLING_QUICK_REFERENCE.md
+++ b/godot/ERROR_HANDLING_QUICK_REFERENCE.md
@@ -100,7 +100,8 @@ func apply_doom_change(change: float):
 
 - **Add $50k Money**: Instant cash injection for testing
 - **Add 5 Action Points**: Extra AP to test action queuing
-- **Trigger Random Event**: Force event spawn
+- ~~Trigger Random Event~~: RETIRED 2026-08-06 (#1134) -- injected into
+  `state.pending_events` with no phase guard and permalocked runs.
 - **Advance Turn**: Fast-forward gameplay
 - **Reset Game**: Quick restart
 

--- a/godot/OPTION_E_ERROR_HANDLING_COMPLETE.md
+++ b/godot/OPTION_E_ERROR_HANDLING_COMPLETE.md
@@ -179,7 +179,7 @@ Vertices: 3,456
 **Controls Tab**:
 - [Add $50k Money] - Instant cash injection
 - [Add 5 Action Points] - Extra AP for testing
-- [Trigger Random Event] - Force event spawn
+- [Trigger Random Event] - RETIRED 2026-08-06 (#1134), see the quick reference
 - [Advance Turn] - Fast-forward gameplay
 - [Reset Game] - Quick restart
 

--- a/godot/scenes/debug_overlay.tscn
+++ b/godot/scenes/debug_overlay.tscn
@@ -97,10 +97,6 @@ text = "Add $50k Money"
 layout_mode = 2
 text = "Add 5 Action Points"
 
-[node name="TriggerEventButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/TabContainer/Controls/ControlsVBox"]
-layout_mode = 2
-text = "Trigger Random Event"
-
 [node name="CommitPlanButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/TabContainer/Controls/ControlsVBox"]
 layout_mode = 2
 text = "Commit Plan"
@@ -134,7 +130,6 @@ text = "1.0s"
 [connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/Header/CloseButton" to="." method="_on_close_button_pressed"]
 [connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/TabContainer/Controls/ControlsVBox/AddMoneyButton" to="." method="_on_add_money_button_pressed"]
 [connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/TabContainer/Controls/ControlsVBox/AddAPButton" to="." method="_on_add_ap_button_pressed"]
-[connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/TabContainer/Controls/ControlsVBox/TriggerEventButton" to="." method="_on_trigger_event_button_pressed"]
 [connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/TabContainer/Controls/ControlsVBox/CommitPlanButton" to="." method="_on_commit_plan_button_pressed"]
 [connection signal="pressed" from="Panel/MarginContainer/VBoxContainer/TabContainer/Controls/ControlsVBox/ResetGameButton" to="." method="_on_reset_game_button_pressed"]
 [connection signal="value_changed" from="Panel/MarginContainer/VBoxContainer/RefreshRate/RateSlider" to="." method="_on_rate_slider_value_changed"]

--- a/godot/scripts/debug/debug_overlay.gd
+++ b/godot/scripts/debug/debug_overlay.gd
@@ -8,9 +8,15 @@ extends CanvasLayer
 @onready var rate_slider = $Panel/MarginContainer/VBoxContainer/RefreshRate/RateSlider
 @onready var rate_label = $Panel/MarginContainer/VBoxContainer/RefreshRate/RateLabel
 
-# Event trigger UI (dynamically created)
-var event_dropdown: OptionButton
-var event_trigger_container: VBoxContainer
+## RETIRED 2026-08-06 (#1134): the "Trigger Random Event" button and its popup lived
+## here. Its handler appended an event dict straight onto state.pending_events with no
+## phase guard, so injecting from a phase that never drains the queue permalocked the
+## run (TurnManager gates can_select_actions on pending_events being empty). Pip
+## reproduced it repeatably in a release build and ruled the feature out rather than
+## made phase-safe: "triggering random events doesn't seem so useful for debugging at
+## this point, just creating bugs lol." The read-only tabs below are the useful part.
+## Re-adding any write into pending_events from here fails
+## tests/unit/test_no_debug_event_injection.gd.
 
 var is_visible: bool = false
 var update_timer: float = 0.0
@@ -378,81 +384,6 @@ func _on_add_ap_button_pressed():
 			gm.state.month_plan.grant_hours(5, MonthPlan.HOUR_OPERATING)
 		gm.game_state_updated.emit(gm.state.to_dict())
 		ErrorHandler.info(ErrorHandler.Category.VALIDATION, "Debug: Added 5 AP", {})
-
-func _on_trigger_event_button_pressed():
-	var gm = _live_gm()
-	if gm and gm.state:
-		# Show event selection popup
-		_show_event_selection_popup()
-
-func _show_event_selection_popup():
-	"""Show a popup with all available events to trigger"""
-	# Create popup dialog if it doesn't exist
-	var popup = AcceptDialog.new()
-	popup.title = "Trigger Event"
-	popup.size = Vector2(400, 500)
-
-	var vbox = VBoxContainer.new()
-	vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-
-	# Label
-	var label = Label.new()
-	label.text = "Select an event to trigger:"
-	vbox.add_child(label)
-
-	# Scrollable list of events
-	var scroll = ScrollContainer.new()
-	scroll.custom_minimum_size = Vector2(380, 400)
-	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
-
-	var event_list = VBoxContainer.new()
-	event_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-
-	# Get all events
-	var all_events = GameEvents.get_all_events()
-	for event in all_events:
-		var btn = Button.new()
-		btn.text = "%s (%s)" % [event.get("name", "Unknown"), event.get("id", "")]
-		btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		btn.pressed.connect(_trigger_specific_event.bind(event, popup))
-		event_list.add_child(btn)
-
-	scroll.add_child(event_list)
-	vbox.add_child(scroll)
-	popup.add_child(vbox)
-
-	# Add to scene and show
-	add_child(popup)
-	popup.popup_centered()
-
-	# Clean up when closed
-	popup.confirmed.connect(func(): popup.queue_free())
-	popup.canceled.connect(func(): popup.queue_free())
-
-func _trigger_specific_event(event: Dictionary, popup: AcceptDialog):
-	"""Trigger a specific event"""
-	var gm = _live_gm()
-	if not gm or not gm.state:
-		return
-
-	var event_name = event.get("name", "Unknown Event")
-	var event_id = event.get("id", "")
-
-	_mark_alpha_tool_use()  # event injection mutates the run -- alpha tool
-	ErrorHandler.info(ErrorHandler.Category.EVENTS, "Debug: Triggering event '%s'" % event_name, {"event_id": event_id})
-
-	# Add to pending events so it will be shown to player
-	gm.state.pending_events.append(event)
-
-	# Emit signal if main UI is listening
-	if gm.has_signal("event_triggered"):
-		gm.emit_signal("event_triggered", event)
-
-	# Close popup
-	popup.queue_free()
-
-	# Log to debug overlay
-	ErrorHandler.info(ErrorHandler.Category.EVENTS, "Event '%s' added to pending events" % event_name, {})
 
 func _on_commit_plan_button_pressed():
 	var gm = _live_gm()

--- a/godot/scripts/debug/dev_mode_overlay.gd
+++ b/godot/scripts/debug/dev_mode_overlay.gd
@@ -33,7 +33,6 @@ var main_ui: Node = null
 
 var _root: Control = null
 var _info_vbox: VBoxContainer = null
-var _event_dropdown: OptionButton = null
 var _music_dropdown: OptionButton = null
 var _music_status: Label = null
 var _built := false
@@ -203,19 +202,10 @@ func _build_controls() -> Control:
 	# L1: the single day-step is DEV-ONLY now -- the game's End Turn plays a whole month
 	# (game_manager.end_month). This button remains the debugging escape hatch.
 	col.add_child(_action_button(">> Day step (dev -- old path)", _advance_turn))
-	_event_dropdown = OptionButton.new()
-	_event_dropdown.focus_mode = Control.FOCUS_NONE
-	_populate_event_dropdown()
-	col.add_child(_event_dropdown)
-	col.add_child(_action_button("Queue selected event", _queue_selected_event))
-	col.add_child(_action_button("Trigger random event", _trigger_random_event))
-	var ev_note := Label.new()
-	ev_note.text = "Queued events surface on turn processing."
-	ev_note.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	ev_note.custom_minimum_size = Vector2(240, 0)
-	ev_note.add_theme_font_size_override("font_size", 9)
-	ev_note.add_theme_color_override("font_color", Color(0.55, 0.55, 0.6))
-	col.add_child(ev_note)
+	# RETIRED 2026-08-06 (#1134): the event dropdown, "Queue selected event" and "Trigger
+	# random event" stood here. Same unguarded shape as the F3 button that permalocked
+	# Pip's release-build run -- an append onto state.pending_events with no phase guard.
+	# Retired together, per his ruling that random event injection is not worth its bugs.
 
 	col.add_child(HSeparator.new())
 	col.add_child(_build_music_section())
@@ -349,14 +339,6 @@ func _nudge_row(label: String, field: String, step: float) -> HBoxContainer:
 	return row
 
 
-func _populate_event_dropdown() -> void:
-	_event_dropdown.clear()
-	for e in GameEvents.get_all_events():
-		var label := str(e.get("name", e.get("id", "?")))
-		_event_dropdown.add_item(label)
-		_event_dropdown.set_item_metadata(_event_dropdown.item_count - 1, str(e.get("id", "")))
-
-
 # --- Rendering -------------------------------------------------------------
 
 func _render() -> void:
@@ -387,7 +369,7 @@ func _render() -> void:
 # --- Control handlers ------------------------------------------------------
 
 ## ALPHA TOOL boundary (decision card 2026-08-01): every state-MUTATING control below
-## (nudges, day-step, event injection) calls this at the moment of actual mutation.
+## (nudges, day-step) calls this at the moment of actual mutation.
 ## First use flips the run's sticky one-way UNRANKED flag and warns mid-run. The JUMP
 ## buttons and the readout are navigation/observation, NOT alpha tools.
 func _mark_alpha_tool_use() -> void:
@@ -474,37 +456,3 @@ func _advance_turn() -> void:
 	if not gm.state.game_over:
 		gm.start_next_turn()
 	_render()
-
-
-func _queue_event(event_id: String) -> void:
-	var gm := _live_gm()
-	if not is_instance_valid(gm) or gm.state == null or event_id == "":
-		return
-	_mark_alpha_tool_use()  # event injection mutates the run -- alpha tool
-	# Inject into the pending queue exactly like SeedSchedule's inject_event cause does.
-	gm.state.pending_events.append({"id": event_id, "scheduled": true})
-	if is_instance_valid(NotificationManager) and NotificationManager.has_method("info"):
-		NotificationManager.info("Dev: queued event '%s' (fires on turn processing)" % event_id)
-	_render()
-
-
-func _queue_selected_event() -> void:
-	if _event_dropdown == null or _event_dropdown.item_count == 0:
-		return
-	var idx := _event_dropdown.selected
-	if idx < 0:
-		idx = 0
-	_queue_event(str(_event_dropdown.get_item_metadata(idx)))
-
-
-func _trigger_random_event() -> void:
-	var all := GameEvents.get_all_events()
-	if all.is_empty():
-		return
-	var gm := _live_gm()
-	var idx := 0
-	if is_instance_valid(gm) and gm.state != null and gm.state.rng != null:
-		idx = gm.state.rng.randi() % all.size()
-	else:
-		idx = randi() % all.size()
-	_queue_event(str(all[idx].get("id", "")))

--- a/godot/tests/unit/test_no_debug_event_injection.gd
+++ b/godot/tests/unit/test_no_debug_event_injection.gd
@@ -1,0 +1,136 @@
+extends GutTest
+## ASSERTION GUARD (#1134): no debug/dev surface may WRITE into state.pending_events.
+##
+## The defect: debug_overlay's "Trigger Random Event" button appended a raw event dict
+## straight onto `gm.state.pending_events` behind nothing but `if gm and gm.state`. No
+## phase guard. Injected while the run sat in a phase that never drains the queue, the
+## queue never emptied -- and TurnManager gates `can_select_actions` on
+## `pending_events.size() == 0`, so the run was permanently unplayable. Pip reproduced
+## the hard lock repeatably in a release build (2026-08-06) and ruled the feature out:
+## "triggering random events doesn't seem so useful for debugging at this point, just
+## creating bugs lol."
+##
+## The fix was DELETION, not a phase guard -- so the guard that keeps it deleted is a
+## ban on the whole write path, not a check on one caller. Reading pending_events from
+## a debug surface stays legal (the F3 readout prints the queue); touching it does not.
+##
+## The overlay is instanced unconditionally in main.tscn and its keybind is bound with
+## no build check, so this surface is reachable by any player in a shipped build. That
+## is why the ban is asserted in the fast gate rather than left to review.
+
+const DEBUG_SCRIPT_DIR := "res://scripts/debug"
+const DEBUG_OVERLAY_SCENE := "res://scenes/debug_overlay.tscn"
+
+## Retired entry points. If any of these names comes back in scripts/debug, the feature
+## has been resurrected under its old shape.
+const RETIRED_SYMBOLS := [
+	"_on_trigger_event_button_pressed",
+	"_show_event_selection_popup",
+	"_trigger_specific_event",
+	"_queue_event",
+	"_queue_selected_event",
+	"_trigger_random_event",
+	"_populate_event_dropdown",
+]
+
+## Mutating uses of pending_events. Plain reads (.size(), .is_empty(), indexing, `for`)
+## are deliberately absent -- looking is free, touching is not.
+const MUTATION_PATTERN := "pending_events\\s*(=[^=]|\\+=|\\.\\s*(append|append_array|push_back|push_front|insert|assign|clear|remove_at|erase|resize|pop_front|pop_back|pop_at|fill|reverse|sort|sort_custom|shuffle))"
+
+
+func _gd_files(dir_path: String, out: Array) -> void:
+	var d := DirAccess.open(dir_path)
+	if d == null:
+		return
+	d.list_dir_begin()
+	var entry := d.get_next()
+	while entry != "":
+		if not entry.begins_with("."):
+			var full := dir_path.path_join(entry)
+			if d.current_is_dir():
+				_gd_files(full, out)
+			elif entry.get_extension() == "gd":
+				out.append(full)
+		entry = d.get_next()
+	d.list_dir_end()
+
+
+func _read(path: String) -> String:
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return ""
+	var text := f.get_as_text()
+	f.close()
+	return text
+
+
+## Drop comments so a tombstone comment naming the banned call does not fail the guard.
+## Heuristic: a `#` with an even number of double quotes before it on the line starts a
+## comment. Good enough for GDScript that does not embed `#` inside a string literal.
+func _strip_comments(source: String) -> String:
+	var kept: Array[String] = []
+	for line in source.split("\n"):
+		var quotes := 0
+		var cut := -1
+		for i in line.length():
+			var ch := line[i]
+			if ch == "\"":
+				quotes += 1
+			elif ch == "#" and quotes % 2 == 0:
+				cut = i
+				break
+		kept.append(line if cut < 0 else line.substr(0, cut))
+	return "\n".join(kept)
+
+
+func test_debug_dir_is_scanned_at_all():
+	# Backstop against a silently-empty scan (the #640 lesson: a guard that inspects
+	# nothing passes forever).
+	var files: Array = []
+	_gd_files(DEBUG_SCRIPT_DIR, files)
+	assert_gt(files.size(), 2,
+		"expected several .gd files under %s -- an empty scan makes this guard hollow" % DEBUG_SCRIPT_DIR)
+
+
+func test_no_debug_surface_writes_into_pending_events():
+	var re := RegEx.new()
+	assert_eq(re.compile(MUTATION_PATTERN), OK, "mutation regex must compile")
+
+	var files: Array = []
+	_gd_files(DEBUG_SCRIPT_DIR, files)
+	var offenders: Array[String] = []
+	for path in files:
+		var code := _strip_comments(_read(path))
+		var line_no := 0
+		for line in code.split("\n"):
+			line_no += 1
+			if re.search(line) != null:
+				offenders.append("%s:%d: %s" % [path, line_no, line.strip_edges()])
+
+	assert_eq(offenders.size(), 0,
+		"no debug/dev surface may enqueue or edit state.pending_events (#1134 -- the F3 " +
+		"event-trigger permalock). Offenders:\n" + "\n".join(offenders))
+
+
+func test_retired_event_trigger_symbols_are_gone():
+	var files: Array = []
+	_gd_files(DEBUG_SCRIPT_DIR, files)
+	var offenders: Array[String] = []
+	for path in files:
+		var code := _strip_comments(_read(path))
+		for symbol in RETIRED_SYMBOLS:
+			if code.contains(symbol):
+				offenders.append("%s defines/calls retired symbol %s" % [path, symbol])
+
+	assert_eq(offenders.size(), 0,
+		"the debug event-trigger feature was RETIRED by #1134 -- do not reintroduce it. " +
+		"Offenders:\n" + "\n".join(offenders))
+
+
+func test_debug_overlay_scene_has_no_event_trigger_control():
+	var scene_text := _read(DEBUG_OVERLAY_SCENE)
+	assert_gt(scene_text.length(), 0, "debug_overlay.tscn must be readable")
+	assert_false(scene_text.contains("TriggerEventButton"),
+		"debug_overlay.tscn still carries the retired Trigger Event button (#1134)")
+	assert_false(scene_text.contains("_on_trigger_event_button_pressed"),
+		"debug_overlay.tscn still connects a signal to the retired trigger-event handler (#1134)")

--- a/godot/tests/unit/test_no_debug_event_injection.gd.uid
+++ b/godot/tests/unit/test_no_debug_event_injection.gd.uid
@@ -1,0 +1,1 @@
+uid://cvwpl5ycu8hs0


### PR DESCRIPTION
Closes #1134 -- **by removing the feature, not by fixing it.**

## Pip's ruling (2026-08-06, after a release-build playtest)

> "the hard lock from popping an event in the wrong screen was repeatable so that might just be something we disable or put on the back burner for now, triggering random events doesn't seem so useful for debugging at this point, just creating bugs lol."

He reproduced the permalock repeatably and judged the feature's debugging value lower than its bug-creation cost. So this PR deletes the debug event-trigger rather than making it phase-safe. #1134 closes as "feature retired", not "bug fixed" -- there is nothing left to be phase-unsafe.

## The defect, verified against the code

`debug_overlay._trigger_specific_event()` appended a raw event dict onto `gm.state.pending_events` behind nothing but `if not gm or not gm.state: return`. **No phase guard.** `TurnManager` gates `can_select_actions` on `pending_events.size() == 0`, so an injection made in a phase that never drains the queue left the run permanently unplayable.

The overlay is instanced unconditionally in `main.tscn` (~line 415) and its keybind is bound in `_ready` with no build check, so this was reachable by any player in a shipped build, not only in dev.

## Sibling unguarded writer -- found and retired too

`dev_mode_overlay.gd` (ALPHA TOOLS, backslash) carried the identical shape: an event dropdown, "Queue selected event" and "Trigger random event", all routing through `_queue_event()` -> `gm.state.pending_events.append(...)` with no phase guard. That overlay is *also* reachable in release builds (gated on `BuildInfo.are_alpha_tools_available()` since PR #1079/#1104, deliberately). Same trivially-removable shape, and Pip's words name random event injection specifically, so it went with the F3 button.

No other dev/debug surface writes to `pending_events`. `SeedSchedule.inject_event` does, but that is core sim, not a dev surface -- left alone.

## Removed

- `debug_overlay.gd`: `_on_trigger_event_button_pressed`, `_show_event_selection_popup`, `_trigger_specific_event`, plus the already-dead `event_dropdown` / `event_trigger_container` fields
- `debug_overlay.tscn`: the `TriggerEventButton` node and its `pressed` connection
- `dev_mode_overlay.gd`: the dropdown / two buttons / note in the TRIGGERS section, `_populate_event_dropdown`, `_queue_event`, `_queue_selected_event`, `_trigger_random_event`, the `_event_dropdown` field
- Two stale doc lines in `godot/ERROR_HANDLING_QUICK_REFERENCE.md` and `godot/OPTION_E_ERROR_HANDLING_COMPLETE.md`

Left intact: the read-only inspection (the F3 readout still prints the pending-events queue -- looking is free, touching is not), the resource nudges, the day-step, the jumps. Tombstone comments at both sites say what was removed and why.

## Regression guard, proved red then green

New `godot/tests/unit/test_no_debug_event_injection.gd` (4 tests):

1. the scan actually finds files (backstop against a hollow guard -- the #640 lesson)
2. no `.gd` under `scripts/debug` **mutates** `pending_events` (comment-stripped source scan; reads such as `.size()` stay legal)
3. none of the retired symbol names reappears
4. `debug_overlay.tscn` carries no trigger-event control or connection

**Red run** (guard added, feature still present) -- 3 failures, naming both offenders unprompted:

```
res://scripts/debug/debug_overlay.gd:445: gm.state.pending_events.append(event)
res://scripts/debug/dev_mode_overlay.gd:485: gm.state.pending_events.append({"id": event_id, "scheduled": true})
...
debug_overlay.gd defines/calls retired symbol _on_trigger_event_button_pressed  (+6 more)
...
debug_overlay.tscn still carries the retired Trigger Event button (#1134)
```

```
[FAIL] 'quick': 1150 tests, 3 failures, 113/113 files collected.
```

**Green run** (after removal):

```
[PASS] 'quick': 1150 tests, 0 failures, 113/113 files collected.
[SUCCESS] All requested suites passed the gate!
```

Test count: 1146 before this PR, 1150 after (the new file adds 4). Measured both times with `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`.

## Note for Pip (out of scope, not touched)

`docs/CONTROLS.md:53` documents the debug overlay on `~`; the actual keybind is **F3** (`keybind_manager.gd:22`). Stale, but unrelated to this change -- say the word and it gets its own one-liner.

Generated with [Claude Code](https://claude.com/claude-code)
