### PR TITLE
feat(audio): let players pick the track from the pause menu (#802)

### DIFF
--- a/godot/autoload/music_manager.gd
+++ b/godot/autoload/music_manager.gd
@@ -65,6 +65,27 @@ const MUSIC_TIER_STEMS := [
 const ADAPTIVE_BPM := 120.0
 const ADAPTIVE_FADE_BEATS := 8.0
 
+## Human titles for the beds, keyed by resource path. The dev overlay is happy with
+## "M3 eldritch (mesa_optimizer)"; a player is not. These are the names the tracks were
+## COMPOSED under (tools/music/jukebox.html track list), so the credits, the jukebox and
+## the in-game picker all say the same words. Anything missing falls back to a
+## prettified filename rather than going blank.
+const TRACK_TITLES := {
+	"res://assets/audio/music/checkpoint_saved.ogg": "Checkpoint saved",
+	"res://assets/audio/music/distribution_shift.ogg": "Distribution shift",
+	"res://assets/audio/music/proxy_gaming.ogg": "Proxy gaming",
+	"res://assets/audio/music/mesa_optimizer.ogg": "Mesa optimizer",
+	"res://assets/audio/music/treacherous_turn.ogg": "Treacherous turn",
+	"res://assets/audio/music/the_off_switch_worked.ogg": "The off switch worked",
+	"res://assets/audio/music/out_of_distribution_trudge.ogg": "Out of distribution",
+	"res://assets/audio/music/unit_tests_passing.ogg": "Unit tests passing",
+}
+
+## Plain-language name for each music tier, for the player-facing picker and status line.
+## MUSIC_TIER_NAMES are the internal spec words (cosy..terminal); these say what the tier
+## MEANS to someone who has never read docs/audio/MUSIC_DESIGN.md.
+const MUSIC_TIER_MOODS := ["Calm", "Uneasy", "Tense", "Dire", "Terminal"]
+
 var adaptive_enabled: bool = true
 var _adaptive_stream: AudioStreamInteractive = null
 var _adaptive_build_attempted: bool = false
@@ -87,6 +108,10 @@ var _tier_override: int = -1
 ## overridden, so the overlay can say "you are hearing 4, the game is at 1" and so
 ## releasing the override snaps back to the truth instead of to a stale value.
 var _auto_music_tier: int = 0
+## Path of a standalone bed a HUMAN chose (as opposed to one the game chose for a
+## context, or the legacy playlist running because the adaptive build failed). Only
+## used to word the status line honestly; nothing reads it for behaviour.
+var _manual_pick_path: String = ""
 
 # Music tracks organized by context
 var music_library = {
@@ -134,6 +159,15 @@ var _crossfade_tween: Tween = null
 
 func _ready():
 	print("[MusicManager] Initializing music system...")
+
+	# Keep processing while the tree is paused. The pause menu sets
+	# get_tree().paused = true, and a Tween created by create_tween() is bound to the
+	# node that made it -- so with the default (inherited, PAUSABLE) process mode a
+	# crossfade started from the pause menu's music picker would freeze half-done:
+	# both players audible, `is_crossfading` stuck true, and every later switch
+	# ignored ("Already crossfading"). Music is a view-layer side-effect (ADR-0006)
+	# with no game state to freeze, so ALWAYS is also the honest process mode for it.
+	process_mode = Node.PROCESS_MODE_ALWAYS
 
 	# Create two audio stream players for crossfading
 	player_a = AudioStreamPlayer.new()
@@ -207,6 +241,7 @@ func play_context(context: MusicContext, shuffle: bool = true):
 	# hand-held tier must be let go of. Cleared silently (no re-switch) because the
 	# context change is about to choose a stream anyway.
 	_tier_override = -1
+	_manual_pick_path = ""
 
 	# GAMEPLAY prefers the doom-adaptive stream; anything else (or a failed
 	# adaptive build) falls back to the legacy per-context playlist.
@@ -486,6 +521,7 @@ func audition_catalogue() -> Array:
 			seen[path] = true
 		out.append({
 			"label": "M%d %s  (%s)" % [tier, MUSIC_TIER_NAMES[tier], path.get_file().get_basename()],
+			"title": track_title(path),
 			"kind": "tier", "tier": tier, "path": path,
 		})
 	for context in [MusicContext.MENU, MusicContext.VICTORY, MusicContext.DEFEAT]:
@@ -496,9 +532,134 @@ func audition_catalogue() -> Array:
 			seen[p] = true
 			out.append({
 				"label": "%s  (%s)" % [MusicContext.keys()[context], p.get_file().get_basename()],
+				"title": track_title(p),
 				"kind": "track", "tier": -1, "path": p,
 			})
 	return out
+
+
+## Human title for a bed. Unknown paths degrade to a prettified filename rather than an
+## empty string, so a newly added track is ugly in the picker but never invisible.
+func track_title(path: String) -> String:
+	if path == "":
+		return "Unknown track"
+	if TRACK_TITLES.has(path):
+		return String(TRACK_TITLES[path])
+	return path.get_file().get_basename().replace("_", " ").capitalize()
+
+
+## ---- PLAYER-FACING music picker (pause menu, 2026-08-06) ----------------------------
+##
+## Same machinery as the dev audition tool, different words. Pip's ruling that promoted
+## it: "if people want to listen to their favourite tracks, they can do so and if they
+## miss out on doom indicators etc, so be it, that's their choice." That is only safe
+## because a pick writes NOTHING toward GameState, the seeded RNG or scoring -- see the
+## _tier_override comment above and test_music_player_controls.gd, which snapshots the
+## whole state dict across a full picker session and asserts it is byte-identical.
+
+## The picker's list: "Automatic" first (the default and the designed experience),
+## then every bed by human title. Entries carry the same kind/tier/path contract as
+## audition_catalogue(), plus kind "auto".
+func player_catalogue() -> Array:
+	var out: Array = [{
+		"label": "Automatic -- follows the situation",
+		"title": "Automatic", "kind": "auto", "tier": -1, "path": "",
+	}]
+	for entry in audition_catalogue():
+		var e: Dictionary = entry.duplicate()
+		if String(e.get("kind", "")) == "tier":
+			var tier: int = int(e.get("tier", 0))
+			e["label"] = "%s -- %s" % [
+				String(e.get("title", "")), MUSIC_TIER_MOODS[clampi(tier, 0, MUSIC_TIER_MOODS.size() - 1)]]
+		else:
+			e["label"] = String(e.get("title", ""))
+		out.append(e)
+	return out
+
+
+## Apply a catalogue entry. ONE code path for the pause menu and the dev overlay, so
+## "what a pick does" cannot drift between the two surfaces. Returns nothing and
+## touches nothing outside this node.
+func apply_catalogue_entry(entry: Dictionary) -> void:
+	if entry.is_empty():
+		return
+	match String(entry.get("kind", "")):
+		"auto":
+			return_to_automatic()
+		"tier":
+			_manual_pick_path = ""
+			set_tier_override(int(entry.get("tier", 0)))
+		_:
+			_manual_pick_path = String(entry.get("path", ""))
+			play_track(_manual_pick_path)
+
+
+## Hand the music back to the game. Releases a held tier AND, if a standalone bed
+## replaced the adaptive stream entirely, restarts the current context so the
+## doom-following score comes back rather than the player being left on a dead bed.
+func return_to_automatic() -> void:
+	clear_tier_override()
+	if not is_adaptive_active():
+		play_context(current_context)
+
+
+## Index into player_catalogue() of the entry currently being heard, so the picker can
+## open showing the truth instead of resetting to item 0. -1 means "not in the list".
+func player_catalogue_index() -> int:
+	var cat := player_catalogue()
+	if not is_tier_overridden() and _adaptive_active:
+		return 0  # Automatic
+	if is_tier_overridden():
+		for i in range(cat.size()):
+			if String(cat[i].get("kind", "")) == "tier" and int(cat[i].get("tier", -1)) == _current_music_tier:
+				return i
+		return 0
+	# A standalone bed is playing (or nothing is): match on what the player is hearing.
+	var playing_path := ""
+	if active_player != null and active_player.stream != null:
+		playing_path = active_player.stream.resource_path
+	for i in range(cat.size()):
+		if String(cat[i].get("path", "")) == playing_path and playing_path != "":
+			return i
+	return 0
+
+
+## The player-facing counterpart of audition_status_line(). Plainer words, and it answers
+## the question the dev line answers in jargon: what am I hearing, and what does the game
+## want to play instead? Pure string build, unit-tested.
+func player_status_line() -> String:
+	if not _adaptive_active:
+		# Two very different situations look the same from here: the player picked a
+		# standalone bed, or the adaptive stream could not be built (missing audio, and
+		# the legacy playlist took over). Only the first is "your pick" -- blaming the
+		# player for the second would be the silent-wrongness failure mode in words.
+		if _manual_pick_path != "":
+			return ("Now playing: %s -- your pick. The music that follows the situation "
+				+ "is paused until you choose Automatic.") % get_current_track_name_pretty()
+		return "Now playing: %s." % get_current_track_name_pretty()
+	var tier := clampi(_current_music_tier, 0, MUSIC_TIER_MOODS.size() - 1)
+	var auto := clampi(_auto_music_tier, 0, MUSIC_TIER_MOODS.size() - 1)
+	var heard := "%s (%s)" % [track_title(_tier_path(tier)), MUSIC_TIER_MOODS[tier]]
+	if _tier_override < 0:
+		return "Now playing: %s -- following the situation." % heard
+	if tier == auto:
+		return "Now playing: %s -- your pick. It is what the game would play anyway." % heard
+	return ("Now playing: %s -- your pick. The game would switch to %s (%s); it will not "
+		+ "while your pick is held.") % [heard, track_title(_tier_path(auto)), MUSIC_TIER_MOODS[auto]]
+
+
+func _tier_path(tier: int) -> String:
+	if tier < 0 or tier >= MUSIC_TIER_STEMS.size() or MUSIC_TIER_STEMS[tier].is_empty():
+		return ""
+	return String(MUSIC_TIER_STEMS[tier][0]["path"])
+
+
+## Title-cased current track, for player-facing text (get_current_track_name() returns
+## the raw basename, which is fine for the dev line and wrong in front of a player).
+func get_current_track_name_pretty() -> String:
+	if active_player != null and active_player.stream != null:
+		return track_title(active_player.stream.resource_path)
+	return "Nothing"
 
 
 ## One line for the overlay: what is playing, and WHY. Pure string build, unit-tested.

--- a/godot/scenes/pause_menu.tscn
+++ b/godot/scenes/pause_menu.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://cnj8yk4x5oopm"]
+[gd_scene load_steps=5 format=3 uid="uid://cnj8yk4x5oopm"]
 
 [ext_resource type="Script" path="res://scripts/ui/pause_menu.gd" id="1_pause"]
 [ext_resource type="Theme" uid="uid://dmenuthemepd001" path="res://theme/menu_theme.tres" id="2_theme"]
+[ext_resource type="Script" path="res://scripts/ui/music_controls.gd" id="3_musicctl"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
 bg_color = Color(0.09, 0.04, 0.11, 0.96)
@@ -42,10 +43,10 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -300.0
-offset_top = -250.0
-offset_right = 300.0
-offset_bottom = 250.0
+offset_left = -320.0
+offset_top = -300.0
+offset_right = 320.0
+offset_bottom = 300.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_bg")
@@ -146,6 +147,10 @@ custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 text = "80%"
+
+[node name="MusicControls" type="VBoxContainer" parent="Panel/VBox/SettingsContainer"]
+layout_mode = 2
+script = ExtResource("3_musicctl")
 
 [node name="HSeparator2" type="HSeparator" parent="Panel/VBox"]
 layout_mode = 2

--- a/godot/scripts/debug/dev_mode_overlay.gd
+++ b/godot/scripts/debug/dev_mode_overlay.gd
@@ -289,21 +289,18 @@ func _play_selected_music() -> void:
 	var entry := _selected_music_entry()
 	if entry.is_empty() or not is_instance_valid(MusicManager):
 		return
-	if str(entry.get("kind", "")) == "tier":
-		MusicManager.set_tier_override(int(entry.get("tier", 0)))
-	else:
-		MusicManager.play_track(str(entry.get("path", "")))
+	# One code path with the player-facing pause-menu picker (MusicControls, 2026-08-06),
+	# so "what a pick does" cannot drift between the dev surface and the shipped one.
+	MusicManager.apply_catalogue_entry(entry)
 	_refresh_music_status()
 
 
 func _release_music_override() -> void:
 	if not is_instance_valid(MusicManager):
 		return
-	MusicManager.clear_tier_override()
-	# A standalone bed replaced the adaptive stream entirely; re-entering the current
-	# context is what brings the doom-driven score back.
-	if not MusicManager.is_adaptive_active():
-		MusicManager.play_context(MusicManager.current_context)
+	# Releases a held tier and, if a standalone bed replaced the adaptive stream
+	# entirely, restarts the current context to bring the doom-driven score back.
+	MusicManager.return_to_automatic()
 	_refresh_music_status()
 
 

--- a/godot/scripts/ui/music_controls.gd
+++ b/godot/scripts/ui/music_controls.gd
@@ -1,0 +1,107 @@
+class_name MusicControls
+extends VBoxContainer
+## Player-facing music picker. Lives in the pause menu (ESC), next to the music volume
+## slider that is already there.
+##
+## Pip 2026-08-06: "I think giving players access to the music control options including
+## track swapping from the escape screen while in game would be cool." The machinery is
+## PR #1129's dev audition tool; this is the same machinery with plain words and one
+## control instead of four.
+##
+## WHY THIS IS SAFE TO SHIP TO PLAYERS (the property the whole feature rests on):
+## picking a track calls MusicManager and nothing else. MusicManager is a pure view-layer
+## side-effect (ADR-0006) -- it LISTENS to game_state_updated and never writes GameState,
+## the seeded RNG, the turn loop or scoring. So this is not an Alpha Tool and does not
+## unrank a run (Pip's ruling: "if people want to listen to their favourite tracks, they
+## can do so and if they miss out on doom indicators etc, so be it, that's their choice").
+## test_music_player_controls.gd snapshots the entire game state dict across a full picker
+## session and asserts it comes back identical; that test is the guard on this paragraph.
+##
+## SELF-CONTAINED BY DESIGN: builds its own children in _ready(), reads nothing from its
+## parent, and is a plain VBoxContainer. It drops into the settings menu or a future
+## audio panel unchanged -- the UI architecture pass (docs/design/UI_ARCHITECTURE_2026-08-06.md)
+## wants components, not more lines in main_ui.gd.
+
+const SECTION_TITLE := "Music track"
+const HINT_TEXT := ("The score normally follows how the run is going. Pick a track to keep "
+	+ "it playing instead -- you may miss what the music was telling you. Your pick lasts "
+	+ "this run; a new run starts on Automatic.")
+
+var _picker: OptionButton = null
+var _status: Label = null
+var _hint: Label = null
+## Guards the programmatic reselect in refresh() from firing item_selected and
+## re-applying the entry that is already playing (which would restart a crossfade
+## every time the pause menu opens).
+var _applying: bool = false
+
+
+func _ready() -> void:
+	add_theme_constant_override("separation", 6)
+	_build()
+	refresh()
+
+
+func _build() -> void:
+	var title := Label.new()
+	title.text = SECTION_TITLE
+	title.add_theme_font_size_override("font_size", 14)
+	title.add_theme_color_override("font_color", Color(0.91, 0.64, 0.24))
+	add_child(title)
+
+	_picker = OptionButton.new()
+	_picker.name = "Picker"
+	_picker.custom_minimum_size = Vector2(440, 0)
+	_picker.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_picker.item_selected.connect(_on_item_selected)
+	add_child(_picker)
+
+	_status = Label.new()
+	_status.name = "Status"
+	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_status.custom_minimum_size = Vector2(440, 0)
+	_status.add_theme_font_size_override("font_size", 12)
+	_status.add_theme_color_override("font_color", Color(0.55, 0.85, 1.0))
+	add_child(_status)
+
+	_hint = Label.new()
+	_hint.text = HINT_TEXT
+	_hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_hint.custom_minimum_size = Vector2(440, 0)
+	_hint.add_theme_font_size_override("font_size", 11)
+	_hint.add_theme_color_override("font_color", Color(0.6, 0.6, 0.65))
+	add_child(_hint)
+
+
+## Repopulate and re-sync to what is actually playing. Called on every pause-menu open,
+## because doom moves while the menu is closed and a stale readout here would be a lie
+## about the one thing this panel exists to report.
+func refresh() -> void:
+	if _picker == null or not is_instance_valid(MusicManager):
+		return
+	_applying = true
+	_picker.clear()
+	for entry in MusicManager.player_catalogue():
+		_picker.add_item(String(entry.get("label", "?")))
+		_picker.set_item_metadata(_picker.item_count - 1, entry)
+	var idx: int = MusicManager.player_catalogue_index()
+	if idx >= 0 and idx < _picker.item_count:
+		_picker.select(idx)
+	_applying = false
+	_refresh_status()
+
+
+func _on_item_selected(index: int) -> void:
+	if _applying or not is_instance_valid(MusicManager):
+		return
+	var meta = _picker.get_item_metadata(index)
+	if not (meta is Dictionary):
+		return
+	MusicManager.apply_catalogue_entry(meta)
+	_refresh_status()
+
+
+func _refresh_status() -> void:
+	if _status == null or not is_instance_valid(MusicManager):
+		return
+	_status.text = MusicManager.player_status_line()

--- a/godot/scripts/ui/music_controls.gd.uid
+++ b/godot/scripts/ui/music_controls.gd.uid
@@ -1,0 +1,1 @@
+uid://ue1amdkl5sg1

--- a/godot/scripts/ui/pause_menu.gd
+++ b/godot/scripts/ui/pause_menu.gd
@@ -8,6 +8,10 @@ extends Control
 @onready var sfx_volume_label = $Panel/VBox/SettingsContainer/AudioSettings/SFXVolumeRow/ValueLabel
 @onready var music_volume_slider = $Panel/VBox/SettingsContainer/AudioSettings/MusicVolumeRow/Slider
 @onready var music_volume_label = $Panel/VBox/SettingsContainer/AudioSettings/MusicVolumeRow/ValueLabel
+## Player-facing track picker (Pip 2026-08-06). Self-contained component -- the pause
+## menu only has to tell it when to re-read reality. Volume already lives one row up,
+## so nothing is duplicated here.
+@onready var music_controls: MusicControls = $Panel/VBox/SettingsContainer/MusicControls
 
 func _ready():
 	print("[PauseMenu] Initializing...")
@@ -96,6 +100,10 @@ func show_pause_menu():
 	"""Show the pause menu and pause the game"""
 	print("[PauseMenu] Pausing game...")
 	update_ui_from_game_config()
+	# Doom moved while the menu was shut, so the track readout must be re-derived on
+	# every open rather than trusted from last time.
+	if music_controls != null:
+		music_controls.refresh()
 	$Panel/VBox/ButtonContainer/SaveButton.text = "Save Game"  # reset any "Saved!" feedback
 	show()
 	get_tree().paused = true

--- a/godot/tests/unit/test_music_player_controls.gd
+++ b/godot/tests/unit/test_music_player_controls.gd
@@ -1,0 +1,371 @@
+extends GutTest
+## The player-facing music picker in the pause menu (Pip 2026-08-06).
+##
+## THE PROPERTY THE WHOLE FEATURE RESTS ON, and the reason this file exists:
+## a music pick is COSMETIC. It writes nothing to GameState, nothing to the seeded RNG,
+## nothing to scoring, and it does not set the sticky unranked flag. PR #1129 asserted
+## that for the DEV audition tool by construction ("nothing here calls
+## _mark_alpha_tool_use()"). Promoting the same machinery to a shipped, player-reachable
+## surface makes construction-by-inspection too weak a guarantee: the next person to
+## touch music_controls.gd or apply_catalogue_entry() has no red light telling them they
+## just made the soundtrack part of the run.
+##
+## So the guard here is DIFFERENTIAL, not structural: snapshot the entire serialized
+## game state plus the RNG cursor, drive a full picker session through the real
+## component (every catalogue entry, in order, then back to Automatic), snapshot again,
+## and assert the two snapshots are identical strings. It cannot be satisfied by a
+## careful reading; it can only be satisfied by the code actually not writing anything.
+##
+## PROVED TO FAIL BEFORE BEING TRUSTED (2026-08-06), both halves separately, by
+## inserting one line into MusicControls._on_item_selected and running the file:
+##   * `GameManager.state.money += 1` -> 15/16, snapshot diff money 245000 -> 245009
+##     (nine picks). The STATE half is live.
+##   * `GameManager.state.rng.randf()` -> 15/16, snapshot diff
+##     rng.state 2051973181613222691 -> 7931504141110957565, with every visible field
+##     unchanged. The RNG half is live, and it catches the invisible case -- a hidden
+##     draw that desyncs a replay while the run still looks identical.
+## In BOTH runs test_a_music_pick_cannot_unrank_the_run stayed green: neither mutation
+## touches the alpha-tools flag. That is precisely the hole the differential snapshot
+## exists to cover, and why "we did not call _mark_alpha_tool_use()" is not a guarantee.
+## Removing the line restores 16/16. Transcripts in the PR body.
+##
+## SCOPE LIMIT, stated plainly: this proves a pick does not change the run. It does NOT
+## prove the reverse direction is harmless -- a player who pins Calm through a doom spike
+## really does lose the music's warning. That is Pip's explicit ruling ("if they miss out
+## on doom indicators etc, so be it, that's their choice"), not an oversight, and the
+## picker's hint text says so in words.
+
+const PAUSE_MENU_SCENE := "res://scenes/pause_menu.tscn"
+
+var _saved_tier: int = 0
+var _saved_override: int = -1
+var _saved_pick: String = ""
+var _saved_context: int = 0
+
+
+func before_each() -> void:
+	_saved_tier = MusicManager._current_music_tier
+	_saved_override = MusicManager._tier_override
+	_saved_pick = MusicManager._manual_pick_path
+	_saved_context = MusicManager.current_context
+	MusicManager._tier_override = -1
+	MusicManager._manual_pick_path = ""
+
+
+func after_each() -> void:
+	MusicManager._current_music_tier = _saved_tier
+	MusicManager._tier_override = _saved_override
+	MusicManager._manual_pick_path = _saved_pick
+	MusicManager.current_context = _saved_context
+	MusicManager._adaptive_active = false
+	for player in [MusicManager.player_a, MusicManager.player_b]:
+		if player != null:
+			player.stop()
+			player.stream = null
+	# Insurance: no test in this file may leave the tree frozen for the rest of the suite.
+	get_tree().paused = false
+
+
+# === THE GUARD ======================================================================
+
+func test_a_music_pick_cannot_change_the_run() -> void:
+	GameManager.start_new_game("music-guard-seed", true)
+	var controls := _make_controls()
+
+	# Precondition: the snapshot function must be stable on its own, or a green result
+	# below would mean nothing and a red one would be noise. Two reads, no music in
+	# between -- if THIS fails, to_dict() carries a clock and the guard needs stripping.
+	assert_eq(_snapshot(), _snapshot(),
+		"the state snapshot must be deterministic before it can be used as a guard")
+
+	var before := _snapshot()
+	_drive_every_pick(controls)
+	assert_eq(_snapshot(), before,
+		"a full music picker session must leave the serialized run and the RNG cursor "
+		+ "byte-identical -- music is a view-layer side-effect (ADR-0006)")
+
+
+func test_a_music_pick_cannot_unrank_the_run() -> void:
+	GameManager.start_new_game("music-guard-seed-2", true)
+	GameConfig.reset_alpha_tools_flag()
+	var controls := _make_controls()
+	_drive_every_pick(controls)
+	assert_false(GameConfig.alpha_tools_used,
+		"picking a track is not a state mutation and must never set the sticky "
+		+ "unranked flag -- Pip's 2026-08-06 ruling depends on this staying true")
+	assert_true(GameConfig.is_ranked_run(),
+		"the run stays on the leaderboard after a player listens to what they like")
+
+
+## Every catalogue entry, in order, ending back on Automatic -- through the REAL signal
+## handler, so the guard covers the shipped code path and not a test-only shortcut.
+func _drive_every_pick(controls: MusicControls) -> void:
+	var picker: OptionButton = controls._picker
+	assert_gt(picker.item_count, 1, "the picker has Automatic plus at least one track")
+	for i in range(picker.item_count):
+		controls._on_item_selected(i)
+	controls._on_item_selected(0)  # back to Automatic
+
+
+## Everything the run IS, as one comparable string: the serialized state (money, doom,
+## turn, staff, rivals, risk, events...) plus the seeded RNG's cursor, which is the thing
+## a hidden extra draw would move without changing any visible field.
+func _snapshot() -> String:
+	if GameManager.state == null:
+		return "<no run>"
+	var parts := [
+		var_to_str(GameManager.state.to_dict()),
+		"rng.seed=%d" % GameManager.state.rng.seed,
+		"rng.state=%d" % GameManager.state.rng.state,
+	]
+	return "\n".join(parts)
+
+
+func _make_controls() -> MusicControls:
+	var controls := MusicControls.new()
+	add_child_autofree(controls)
+	controls.refresh()
+	return controls
+
+
+# === THE PICKER SPEAKS PLAYER ========================================================
+
+func test_catalogue_offers_automatic_first_then_every_track_by_human_name() -> void:
+	var cat := MusicManager.player_catalogue()
+	assert_eq(String(cat[0]["kind"]), "auto", "Automatic is the first and default choice")
+	assert_string_contains(String(cat[0]["label"]), "Automatic", "and says so")
+	var tiers: Array = []
+	for entry in cat:
+		if String(entry["kind"]) == "tier":
+			tiers.append(int(entry["tier"]))
+	assert_eq(tiers.size(), MusicManager.MUSIC_TIER_NAMES.size(),
+		"every adaptive tier is pickable")
+	assert_gt(cat.size(), MusicManager.MUSIC_TIER_NAMES.size() + 1,
+		"and the standalone menu/victory/defeat beds too")
+
+
+func test_no_label_leaks_a_filename_or_dev_jargon() -> void:
+	# The dev overlay's labels are deliberately "M3 eldritch (mesa_optimizer)". A player
+	# must never see a snake_case basename or an internal tier code.
+	for entry in MusicManager.player_catalogue():
+		var label := String(entry["label"])
+		assert_false(label.contains("_"), "no snake_case filename in '%s'" % label)
+		assert_false(label.contains(".ogg"), "no file extension in '%s'" % label)
+		assert_false(label.begins_with("M0") or label.begins_with("M1")
+			or label.begins_with("M2") or label.begins_with("M3") or label.begins_with("M4"),
+			"no internal tier code in '%s'" % label)
+		assert_ne(label.strip_edges(), "", "no blank entry")
+
+
+func test_every_player_facing_string_is_plain_ascii() -> void:
+	# The no-emoji gate (scripts/check_no_emoji.py) covers source files; this covers the
+	# strings that are BUILT at runtime, which that scanner cannot see.
+	var strings: Array = [MusicControls.SECTION_TITLE, MusicControls.HINT_TEXT]
+	for entry in MusicManager.player_catalogue():
+		strings.append(String(entry["label"]))
+	MusicManager._adaptive_active = true
+	strings.append(MusicManager.player_status_line())
+	MusicManager.set_tier_override(4)
+	strings.append(MusicManager.player_status_line())
+	MusicManager._adaptive_active = false
+	MusicManager._manual_pick_path = "res://assets/audio/music/checkpoint_saved.ogg"
+	strings.append(MusicManager.player_status_line())
+	for s in strings:
+		for i in range(String(s).length()):
+			assert_lt(String(s).unicode_at(i), 128,
+				"non-ASCII codepoint in player-facing string: '%s'" % s)
+
+
+func test_unknown_tracks_get_a_readable_name_instead_of_going_blank() -> void:
+	assert_eq(MusicManager.track_title("res://assets/audio/music/checkpoint_saved.ogg"),
+		"Checkpoint saved", "known beds use their composed title")
+	var fallback := MusicManager.track_title("res://assets/audio/music/a_new_bed.ogg")
+	assert_ne(fallback.strip_edges(), "", "an unlisted bed is ugly, never invisible")
+	assert_false(fallback.contains("_"), "and still not snake_case")
+
+
+# === "WHAT IS PLAYING AND WHY", IN PLAIN WORDS =======================================
+
+func test_status_says_the_game_is_choosing_when_nobody_has_picked() -> void:
+	MusicManager._adaptive_active = true
+	MusicManager.set_doom_level(0.0)
+	var line := MusicManager.player_status_line()
+	assert_string_contains(line, "following the situation",
+		"Automatic mode explains itself without jargon")
+	assert_false(line.contains("your pick"), "and does not claim the player chose")
+
+
+func test_status_names_the_track_the_game_wanted_when_a_pick_is_held() -> void:
+	# The interesting case Pip asked about: the adaptive system wants to move and cannot.
+	MusicManager._adaptive_active = true
+	MusicManager.set_doom_level(0.0)
+	MusicManager.set_tier_override(4)
+	MusicManager.set_doom_level(30.0)  # automatic would be tier 1
+	var line := MusicManager.player_status_line()
+	assert_string_contains(line, "your pick", "it is honest about who chose")
+	assert_string_contains(line, "Treacherous turn", "names what is being heard")
+	assert_string_contains(line, "Distribution shift", "names what the game would play")
+	assert_string_contains(line, "it will not", "and says the pick is what is stopping it")
+
+
+func test_status_does_not_pretend_a_pick_was_made_when_audio_simply_failed() -> void:
+	# Adaptive off with NO pick means the stream could not be built (missing audio) and
+	# the legacy playlist took over. Blaming the player for that is silent wrongness in
+	# words -- the exact failure mode this repo keeps meeting.
+	MusicManager._adaptive_active = false
+	MusicManager._manual_pick_path = ""
+	assert_false(MusicManager.player_status_line().contains("your pick"),
+		"a degraded fallback must not be reported as a player choice")
+
+
+func test_status_owns_the_consequence_when_a_standalone_bed_is_picked() -> void:
+	MusicManager._adaptive_active = false
+	MusicManager._manual_pick_path = "res://assets/audio/music/out_of_distribution_trudge.ogg"
+	var line := MusicManager.player_status_line()
+	assert_string_contains(line, "your pick", "the player did this")
+	assert_string_contains(line, "Automatic",
+		"and is told exactly how to get the adaptive score back")
+
+
+# === MODE ROUND-TRIP =================================================================
+
+func test_picker_reopens_showing_what_is_actually_playing() -> void:
+	# A picker that resets to item 0 every open would report Automatic while a pick is
+	# held -- the readout lying about the one thing the panel exists to report.
+	MusicManager._adaptive_active = true
+	MusicManager.set_doom_level(0.0)
+	assert_eq(MusicManager.player_catalogue_index(), 0, "no pick -> Automatic")
+	MusicManager.set_tier_override(3)
+	var idx: int = MusicManager.player_catalogue_index()
+	var cat := MusicManager.player_catalogue()
+	assert_eq(String(cat[idx]["kind"]), "tier", "a held pick resolves to its tier entry")
+	assert_eq(int(cat[idx]["tier"]), 3, "and to the RIGHT tier")
+
+
+func test_choosing_automatic_hands_the_music_back_to_the_game() -> void:
+	MusicManager.play_context(MusicManager.MusicContext.GAMEPLAY)
+	MusicManager.set_doom_level(0.0)
+	MusicManager.set_tier_override(4)
+	assert_true(MusicManager.is_tier_overridden(), "pick is held")
+	MusicManager.apply_catalogue_entry({"kind": "auto"})
+	assert_false(MusicManager.is_tier_overridden(), "Automatic releases it")
+	assert_eq(MusicManager.get_current_music_tier(), MusicManager.get_auto_music_tier(),
+		"and snaps to where the run actually is now")
+
+
+func test_a_pick_survives_turns_but_not_a_new_run() -> void:
+	# The persistence call, executable. WITHIN a run nothing clears a pick -- turn ends
+	# only push doom in, and set_doom_level respects the override. ACROSS runs it is
+	# released, because every start-run / return-to-menu / game-over path goes through
+	# play_context(), and a cosmetic choice must not be the one piece of session state
+	# that quietly outlives the run it was made in.
+	MusicManager.play_context(MusicManager.MusicContext.GAMEPLAY)
+	MusicManager.set_tier_override(4)
+	for doom in [5.0, 25.0, 55.0, 88.0]:
+		MusicManager.set_doom_level(doom)
+	assert_true(MusicManager.is_tier_overridden(), "a pick holds across turns of doom")
+	assert_eq(MusicManager.get_current_music_tier(), 4, "and keeps playing what was picked")
+	MusicManager.play_context(MusicManager.MusicContext.MENU)
+	assert_false(MusicManager.is_tier_overridden(), "a run boundary hands it back")
+	assert_eq(MusicManager._manual_pick_path, "", "including a standalone-bed pick")
+
+
+func test_the_music_keeps_working_while_the_tree_is_paused() -> void:
+	# The pause menu freezes the tree. create_tween() binds its tween to the node that
+	# made it, so with the default (inherited/PAUSABLE) process mode a crossfade started
+	# from the picker would freeze half-done -- both players audible and is_crossfading
+	# stuck true, refusing every later switch. This is why MusicManager is ALWAYS.
+	assert_eq(MusicManager.process_mode, Node.PROCESS_MODE_ALWAYS,
+		"MusicManager must process while paused or the pause-menu picker jams mid-crossfade")
+
+
+# === THE PAUSE MENU ACTUALLY CARRIES IT ==============================================
+
+func test_pause_menu_wires_up_the_picker() -> void:
+	# Node-path wiring is exactly what a rename in the .tscn breaks silently.
+	var menu = load(PAUSE_MENU_SCENE).instantiate()
+	add_child_autofree(menu)
+	assert_not_null(menu.music_controls, "the pause menu finds its MusicControls node")
+	assert_true(menu.music_controls is MusicControls, "and it is the component, not a stub")
+	assert_gt(menu.music_controls._picker.item_count, 1, "populated on open")
+
+
+func test_pause_menu_still_fits_on_screen_with_the_picker_in_it() -> void:
+	# The picker adds ~4 rows to a panel whose height is hand-set in the .tscn, so the
+	# obvious way to ship this broken is a menu whose Quit button is off the bottom.
+	# Precedent for owning geometry in a test: test_action_visibility.gd (#1130).
+	var menu = load(PAUSE_MENU_SCENE).instantiate()
+	add_child_autofree(menu)
+	menu.show_pause_menu()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var panel: Control = menu.get_node("Panel")
+	var needed: Vector2 = panel.get_combined_minimum_size()
+	menu._on_resume_pressed()
+
+	# TWO ASSERTIONS I TRIED FIRST AND THREW AWAY, recorded so nobody re-adds them:
+	#   child.size.y <= panel.size.y  -- PanelContainer CLAMPS its child to its own
+	#     rect, so this is true by construction.
+	#   needed.y <= panel.size.y      -- a Control never renders smaller than its
+	#     combined minimum, so the panel silently GROWS past its authored offsets and
+	#     this is true by construction too.
+	# Both passed when I shrank the panel back to its pre-change 500px height, which is
+	# how I found out they were tautologies rather than guards. The real (and only)
+	# failure mode is the grown panel outgrowing the screen, so that is what is asserted.
+	# Measured 2026-08-06: the menu needs 551px with the picker in it; the .tscn asks
+	# for 600 so the authored box is not a lie about what the panel actually occupies.
+	assert_lte(needed.y, 1080.0,
+		"the pause menu needs %dpx of height -- more than the 1080p design viewport, so "
+		% int(needed.y) + "it will run off the top and bottom of the screen")
+	assert_lte(needed.x, 1920.0, "and it must fit horizontally too")
+	# The one sensitive check: the AUTHORED height, which has to be read out of the
+	# .tscn text because Godot rewrites a grown control's offsets in memory. Not a
+	# rendering bug when it drifts -- but the numbers in the scene file stop describing
+	# the thing on screen, and the next person sizing this menu is then reading fiction.
+	# Verified red: at the pre-change 500px this fails with 551 > 500.
+	var authored: float = _authored_panel_height()
+	assert_lte(needed.y, authored,
+		"pause_menu.tscn asks for a %dpx panel and the contents need %dpx -- Godot will "
+		% [int(authored), int(needed.y)]
+		+ "grow it silently. Update the Panel offset_top/offset_bottom to match.")
+
+
+## Panel height as WRITTEN in the scene file. Godot adjusts a centred control's offsets
+## to whatever it grew to, so the authored intent is unreachable from the live node.
+func _authored_panel_height() -> float:
+	var text := FileAccess.get_file_as_string(PAUSE_MENU_SCENE)
+	var in_panel := false
+	var top := 0.0
+	var bottom := 0.0
+	for raw in text.split("\n"):
+		var line := String(raw).strip_edges()
+		if line.begins_with("[node "):
+			in_panel = line.contains("name=\"Panel\"") and line.contains("parent=\".\"")
+			continue
+		if not in_panel:
+			continue
+		if line.begins_with("offset_top ="):
+			top = float(line.split("=")[1])
+		elif line.begins_with("offset_bottom ="):
+			bottom = float(line.split("=")[1])
+	assert_ne(bottom - top, 0.0, "could not read the Panel offsets out of pause_menu.tscn")
+	return bottom - top
+
+
+func test_pause_menu_refreshes_the_readout_on_every_open() -> void:
+	var menu = load(PAUSE_MENU_SCENE).instantiate()
+	add_child_autofree(menu)
+	MusicManager._adaptive_active = true
+	MusicManager.set_doom_level(0.0)
+	menu.show_pause_menu()
+	var opened_line: String = menu.music_controls._status.text
+	menu._on_resume_pressed()
+	assert_false(get_tree().paused, "resume unfreezes the tree")
+	# Doom moves while the menu is shut; reopening must re-derive, not replay.
+	MusicManager.set_doom_level(95.0)
+	menu.show_pause_menu()
+	menu._on_resume_pressed()
+	assert_ne(menu.music_controls._status.text, opened_line,
+		"reopening after a doom swing must show the NEW track, not the cached line")
+	assert_string_contains(menu.music_controls._status.text, "Treacherous turn",
+		"and name the track the run has actually escalated to")

--- a/godot/tests/unit/test_music_player_controls.gd.uid
+++ b/godot/tests/unit/test_music_player_controls.gd.uid
@@ -1,0 +1,1 @@
+uid://ba6jug1x2ew1r


### PR DESCRIPTION
Pip 2026-08-06: "I think giving players access to the music control options including
track swapping from the escape screen while in game would be cool."

PR #1129 built the machinery yesterday as a dev audition tool behind the backslash
overlay. This does not rebuild it -- it promotes it. Same override, same run-boundary
release, same catalogue; a new player-facing surface with plain words, and one shared
code path so the two surfaces cannot drift.

Substantially addresses **#802** ("In-game music controller + expose the doom-triggered
rotation"). Not auto-closing it -- #802 also asks for "more track variety", which is a
content job, not this.

## What a player sees

ESC -> the pause menu, directly under the Music Volume slider that was already there:

```
Music track
[ Automatic -- follows the situation            v ]
Now playing: Distribution shift (Uneasy) -- following the situation.
The score normally follows how the run is going. Pick a track to keep it playing
instead -- you may miss what the music was telling you. Your pick lasts this run;
a new run starts on Automatic.
```

Pick a track and the readout becomes:

```
Now playing: Treacherous turn (Terminal) -- your pick. The game would switch to
Distribution shift (Uneasy); it will not while your pick is held.
```

## The design calls, and the arguments

**1. Compact, not the full dev set -- and no link to full settings.**
The dev panel is four controls (status, dropdown, Play, Release). The pause menu gets
two: the dropdown and the readout. Two reasons. (a) "Play selected" only exists in the
dev tool because auditioning means re-triggering the same track deliberately; a player
picking from a dropdown has already expressed the intent, so a second click is a step
that does nothing they wanted. (b) "Release -> AUTO" becomes the FIRST ITEM of the
dropdown, because Automatic is not an escape hatch from the picker -- it is one of the
choices, mutually exclusive with the others. A dropdown is a radio group; the mode
belongs in the group. That kills a control and makes the default visible instead of
hidden behind a button labelled with an arrow.

No link to full settings, because there is nothing to link to: music VOLUME already
lives in this same panel one row up (and again in settings_menu.tscn). Nothing is
duplicated and nothing is moved.

**2. What it says when the adaptive system wants to move and the player has pinned.**
The dev line is `Playing: M4 terminal [OVERRIDE -- doom says M1 uneasy]`. The
player-facing line names both tracks by their COMPOSED titles, says who chose, and says
what is being prevented: "Now playing: Treacherous turn (Terminal) -- your pick. The
game would switch to Distribution shift (Uneasy); it will not while your pick is held."
Three deliberate choices inside that:

- Human titles, never filenames or tier codes. `TRACK_TITLES` maps path -> the name each
  bed was composed under in `tools/music/jukebox.html`, so the jukebox, the credits and
  the in-game picker all say the same words. A test forbids `_`, `.ogg` and `M0..M4` in
  any player-facing label.
- Mood words (Calm / Uneasy / Tense / Dire / Terminal) alongside, because "cosy" and
  "eldritch" are spec vocabulary from MUSIC_DESIGN.md, not player vocabulary.
- The degraded case is worded differently on purpose. Adaptive-off with no pick means
  the stream could not be BUILT (missing audio, legacy playlist took over), and the
  naive wording would have told the player they had chosen that. Blaming the player for
  an asset failure is this repo's silent-wrongness pattern expressed in a string, so
  `_manual_pick_path` distinguishes the two and a test pins it.

**3. Persistence: across turns yes, across runs no, in the save file never.**

- ACROSS TURNS: a pick holds. Nothing in the turn loop clears it; `set_doom_level()`
  already respects the override. Test drives doom 5 -> 88 with a pick held.
- ACROSS RUNS: released. Every start-run / return-to-menu / game-over path goes through
  `play_context()`, which clears it. This is #1129's existing property and I did not
  weaken it.
- SAVE/LOAD: the state lives in the MusicManager autoload and nowhere else. Putting it
  in the save envelope would make a cosmetic choice part of run state -- exactly the
  property this PR claims does not exist -- and the envelope is hashed by the
  determinism/replay tier.

The honest cost, and the one call I expect Pip may overturn: a player whose favourite
track is Treacherous turn re-picks it at the start of every run. The alternative is a
GameConfig key re-applied after `play_context()`; it is about six lines and cheap to add
LATER, but it changes what the default listening experience is for a returning player --
the designed doom arc stops being what most sessions actually play -- and that is a
design decision, not an implementation detail. Shipping the conservative version and
letting playtest ask for the other one.

**4. Where the code lives.** `MusicControls` is a self-contained `VBoxContainer` that
builds its own children, reads nothing from its parent, and drops into the settings menu
or a future audio panel unchanged. Zero lines added to `main_ui.gd`; the pause menu
gained four lines (an `@onready` and a `refresh()` on open).
`docs/design/UI_ARCHITECTURE_2026-08-06.md` wants components, and the pause menu is not
in that document's scope (it governs the ACTION hand), so nothing here fights the
planned structure.

## The cosmetic-only property: still holds, now with a guard

It holds. There is no path from a pick to run state: the handler calls
`MusicManager.apply_catalogue_entry()` and nothing else; MusicManager LISTENS to
`game_state_updated` and has no reference to GameState, the RNG or scoring (ADR-0006).
Nothing calls `_mark_alpha_tool_use()`. So a pick does not unrank a run, which is what
Pip's ruling depends on.

But "we inspected it and it does not write anything" is not a guard -- it is a claim that
decays the moment someone edits either file. `test_music_player_controls.gd` makes it
DIFFERENTIAL instead: start a seeded run, snapshot `var_to_str(state.to_dict())` plus
`rng.seed` and `rng.state`, drive the REAL signal handler across every catalogue entry
and back to Automatic, snapshot again, assert the strings are identical. It also asserts
the snapshot function is stable against itself first, so a green result is not vacuous.

### Red/green proof (I did not trust the guard until it failed)

One line inserted into `MusicControls._on_item_selected`, file run, line removed:

```
+ GameManager.state.money += 1
[Failed]: "money": 245009.0  expected to equal  "money": 245000.0
15/16 passed.
```

```
+ GameManager.state.rng.randf()
[Failed]: "rng_state": "7931504141110957565" expected to equal "2051973181613222691"
15/16 passed.
```

The second is the one that matters: every visible field was unchanged and the run still
looked identical -- only the RNG cursor moved, which is how a music feature would desync
a replay without anyone noticing. And in BOTH runs
`test_a_music_pick_cannot_unrank_the_run` stayed GREEN, because neither mutation touches
the alpha-tools flag. That is precisely the hole the differential snapshot covers, and
why the structural argument above is not sufficient on its own. Removing the line
restores 17/17.

A second guard got the same treatment and FAILED the treatment twice. The pause-menu
geometry check was written first as `child.size.y <= panel.size.y` (tautology:
PanelContainer clamps its child) and then as `needed.y <= panel.size.y` (tautology: a
Control never renders below its combined minimum, so the panel grows silently). Both
passed when I shrank the panel back to its old 500px to test them. The version that
ships reads the AUTHORED height out of the .tscn text and fails red at 500 with
"asks for a 500px panel and the contents need 551px". All three attempts are recorded
in the test file so nobody re-adds the tautologies.

## One real bug fixed on the way

`MusicManager.process_mode` is now `PROCESS_MODE_ALWAYS`. `create_tween()` binds its
tween to the node that made it, and the pause menu sets `get_tree().paused = true` --
so with the default inherited/PAUSABLE mode, a crossfade started from this picker would
have frozen half-done: both players audible, `is_crossfading` stuck true, every later
switch refused with "Already crossfading". This is only reachable now that a music
control exists on a surface that pauses the tree. Asserted.

## The owed player-facing note, and why this raises its priority

Ruled 2026-08-06 and recorded in `docs/HANDOVER_2026-08-06_EVENING.md` s7: **owed, a
player-facing note that the music is presently loosely tied to the game and will become
more so -- destination the website's static pages.**

This PR makes that debt more visible, and it should be treated as more urgent now. Until
today the adaptive score was something a player experienced without ever being told it
existed; a loose coupling nobody has been promised is not yet a broken promise. This
panel names the mechanism in the UI -- "follows the situation", "the game would switch
to X" -- so from here the player has been TOLD the music tracks the run, and every gap
between that sentence and what the score actually does is now a discrepancy they can
notice. The in-game hint hedges as far as a hint can ("The score normally follows how
the run is going"), but the honest version of the statement does not fit in a pause
menu. It needs the static page.

## Test gate (measured, same worktree, same machine)

`python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`

| | tests | failures | files |
|---|---|---|---|
| baseline (`origin/main` @ 78be0370) | 1146 | 0 | 112 |
| this branch | 1163 | 0 | 113 |

+17, all in the new file.

Simulation tier not run: nothing here touches simulation, economy or replay code -- and
the RNG half of the guard above is the evidence for that claim rather than an assurance
about it.

## What a human still has to check

The panel LAYOUT at 1080p on a real display. The geometry test proves the menu fits the
design viewport and that the .tscn numbers are honest; it says nothing about whether the
dropdown and two wrapped labels look right under the volume sliders.

Preview worktree, already imported:
`G:\Documents\Organising_Life\Code\pdoom1\.claude\worktrees\music-pause-menu`

Launch:
`& "C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe" --path "G:/Documents/Organising_Life/Code/pdoom1/.claude/worktrees/music-pause-menu/godot"`

Then start a run and press ESC.

Generated with [Claude Code](https://claude.com/claude-code)
