### PR TITLE
ui(pause): grow the ESC menu into its text, not into padding (#1146 follow-up)

### DIFF
--- a/godot/UI_STYLE_GUIDE.md
+++ b/godot/UI_STYLE_GUIDE.md
@@ -61,12 +61,12 @@ tier_4 = Color(0.702, 0.071, 0.090, 0.18)  # Deep red 18% (80-100%)
 
 #### Functional Colors
 ```gdscript
-# Doom tiers (from ThemeManager — the SINGLE source since L6/#617):
+# Doom tiers (from ThemeManager -- the SINGLE source since L6/#617):
 # DOOM_STOPS is the smooth colour ramp; DOOM_STATUS_BANDS the tier thresholds.
 # NOMINAL <15 | ELEVATED <37 | HIGH <52 | SEVERE <67 | EXTREME <80
 # | CATASTROPHIC <92 | TERMINAL <=100
 # Use ThemeManager.get_doom_color / get_doom_stroke_color for colours and
-# get_doom_band_index / get_doom_band / get_doom_status_label for tiers —
+# get_doom_band_index / get_doom_band / get_doom_status_label for tiers --
 # never hardcode doom thresholds in a screen.
 
 # UI feedback
@@ -102,6 +102,60 @@ caption = 12         # Tooltips, hints
 - **All-caps for labels**: +0.06em letter-spacing
 - **Title case for actions/buttons**
 - **Sentence case for descriptions**
+
+### The 16px floor, and why it is not 14
+
+Everything above is authored against a 1920x1080 base viewport, and
+`project.godot` stretches it with `stretch/mode="canvas_items"` /
+`aspect="expand"`. So on a 1280x720 laptop one authored pixel is **0.667
+physical pixels**: a 14px label is ~9 real pixels and an 11px hint is ~7.
+
+Consequence, and the rule: **no font a player reads while operating a control
+goes below 16** (which is also Godot's own `Label` default -- several screens
+were authoring BELOW the engine default). Secondary explanatory prose may sit
+at 14; nothing goes under 14.
+
+Corollary for panels with hand-authored sizes: growing the box does not fix
+cramping, growing the type does. If a panel ends up materially bigger than the
+size its contents need, the room belonged in the type scale.
+
+### Pause menu (ESC) type scale
+
+Enlarged 2026-08-06 after Pip in a preview build: *"Overall things feel a bit
+cramped. If we increase the size of the Escape screen by 30%, the text could be
+larger and friendlier."* Sizes live in `godot/scenes/pause_menu.tscn` and, for
+the music picker, as named constants at the top of
+`godot/scripts/ui/music_controls.gd`.
+
+| Element | Was | Now |
+|---|---|---|
+| Panel title ("GAME PAUSED") | 36 | 40 |
+| Section headers ("Audio Settings", "Music track") | 18 / 14 | 22 / 22 |
+| Control rows (volume labels, percentages) | 14 | 18 |
+| Buttons | 16 | 20 |
+| Music picker (OptionButton) | 16 (theme default) | 20 |
+| Music "now playing" readout | 12 | 16 |
+| Music hint prose | 11 | 14 |
+| Panel box | 640 x 600 | 800 x 792 |
+
+The two section headers were 18 and 14 before -- the same kind of thing at two
+sizes, one row apart. That reads as "cramped" and never as "a bug", which is
+why `test_music_player_controls.gd` now pins them equal.
+
+`test_music_player_controls.gd` also guards this table from BOTH sides: the
+authored panel must be big enough for its contents **and not more than 40px
+bigger**, so a future resize that adds padding instead of legibility fails.
+
+### Colours: local palettes are allowed, undocumented ones are not
+
+`MusicControls` uses the pause menu's own amber `Color(0.91, 0.64, 0.24)` --
+the panel border and the Audio Settings header, not `ThemeManager`'s generic
+`warning` amber `Color(0.9, 0.7, 0.2)`, which is close but not equal and would
+have split two adjacent headers. Sizes there are likewise NOT read from
+`ThemeManager.get_font_size()`, because that returns the ACTIVE theme's scale
+(`retro` sets `body_size` 18 where `default` sets 16) and the pause menu's
+panel height is hand-authored and test-guarded against its contents -- a theme
+swap would push the content past a box no test run could have seen.
 
 ---
 

--- a/godot/scenes/pause_menu.tscn
+++ b/godot/scenes/pause_menu.tscn
@@ -43,22 +43,22 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -320.0
-offset_top = -300.0
-offset_right = 320.0
-offset_bottom = 300.0
+offset_left = -400.0
+offset_top = -396.0
+offset_right = 400.0
+offset_bottom = 396.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_bg")
 
 [node name="VBox" type="VBoxContainer" parent="Panel"]
 layout_mode = 2
-theme_override_constants/separation = 15
+theme_override_constants/separation = 18
 
 [node name="Title" type="Label" parent="Panel/VBox"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
-theme_override_font_sizes/font_size = 36
+theme_override_font_sizes/font_size = 40
 text = "GAME PAUSED"
 horizontal_alignment = 1
 
@@ -67,16 +67,16 @@ layout_mode = 2
 
 [node name="SettingsContainer" type="VBoxContainer" parent="Panel/VBox"]
 layout_mode = 2
-theme_override_constants/separation = 10
+theme_override_constants/separation = 12
 
 [node name="AudioSettings" type="VBoxContainer" parent="Panel/VBox/SettingsContainer"]
 layout_mode = 2
-theme_override_constants/separation = 8
+theme_override_constants/separation = 10
 
 [node name="AudioLabel" type="Label" parent="Panel/VBox/SettingsContainer/AudioSettings"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.91, 0.64, 0.24, 1)
-theme_override_font_sizes/font_size = 18
+theme_override_font_sizes/font_size = 22
 text = "Audio Settings"
 
 [node name="MasterVolumeRow" type="HBoxContainer" parent="Panel/VBox/SettingsContainer/AudioSettings"]
@@ -84,22 +84,22 @@ layout_mode = 2
 theme_override_constants/separation = 10
 
 [node name="Label" type="Label" parent="Panel/VBox/SettingsContainer/AudioSettings/MasterVolumeRow"]
-custom_minimum_size = Vector2(150, 0)
+custom_minimum_size = Vector2(190, 0)
 layout_mode = 2
-theme_override_font_sizes/font_size = 14
+theme_override_font_sizes/font_size = 18
 text = "Master Volume:"
 
 [node name="Slider" type="HSlider" parent="Panel/VBox/SettingsContainer/AudioSettings/MasterVolumeRow"]
-custom_minimum_size = Vector2(250, 0)
+custom_minimum_size = Vector2(340, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 max_value = 100.0
 value = 80.0
 
 [node name="ValueLabel" type="Label" parent="Panel/VBox/SettingsContainer/AudioSettings/MasterVolumeRow"]
-custom_minimum_size = Vector2(50, 0)
+custom_minimum_size = Vector2(64, 0)
 layout_mode = 2
-theme_override_font_sizes/font_size = 14
+theme_override_font_sizes/font_size = 18
 text = "80%"
 
 [node name="SFXVolumeRow" type="HBoxContainer" parent="Panel/VBox/SettingsContainer/AudioSettings"]
@@ -107,22 +107,22 @@ layout_mode = 2
 theme_override_constants/separation = 10
 
 [node name="Label" type="Label" parent="Panel/VBox/SettingsContainer/AudioSettings/SFXVolumeRow"]
-custom_minimum_size = Vector2(150, 0)
+custom_minimum_size = Vector2(190, 0)
 layout_mode = 2
-theme_override_font_sizes/font_size = 14
+theme_override_font_sizes/font_size = 18
 text = "SFX Volume:"
 
 [node name="Slider" type="HSlider" parent="Panel/VBox/SettingsContainer/AudioSettings/SFXVolumeRow"]
-custom_minimum_size = Vector2(250, 0)
+custom_minimum_size = Vector2(340, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 max_value = 100.0
 value = 80.0
 
 [node name="ValueLabel" type="Label" parent="Panel/VBox/SettingsContainer/AudioSettings/SFXVolumeRow"]
-custom_minimum_size = Vector2(50, 0)
+custom_minimum_size = Vector2(64, 0)
 layout_mode = 2
-theme_override_font_sizes/font_size = 14
+theme_override_font_sizes/font_size = 18
 text = "80%"
 
 [node name="MusicVolumeRow" type="HBoxContainer" parent="Panel/VBox/SettingsContainer/AudioSettings"]
@@ -130,22 +130,22 @@ layout_mode = 2
 theme_override_constants/separation = 10
 
 [node name="Label" type="Label" parent="Panel/VBox/SettingsContainer/AudioSettings/MusicVolumeRow"]
-custom_minimum_size = Vector2(150, 0)
+custom_minimum_size = Vector2(190, 0)
 layout_mode = 2
-theme_override_font_sizes/font_size = 14
+theme_override_font_sizes/font_size = 18
 text = "Music Volume:"
 
 [node name="Slider" type="HSlider" parent="Panel/VBox/SettingsContainer/AudioSettings/MusicVolumeRow"]
-custom_minimum_size = Vector2(250, 0)
+custom_minimum_size = Vector2(340, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 max_value = 100.0
 value = 80.0
 
 [node name="ValueLabel" type="Label" parent="Panel/VBox/SettingsContainer/AudioSettings/MusicVolumeRow"]
-custom_minimum_size = Vector2(50, 0)
+custom_minimum_size = Vector2(64, 0)
 layout_mode = 2
-theme_override_font_sizes/font_size = 14
+theme_override_font_sizes/font_size = 18
 text = "80%"
 
 [node name="MusicControls" type="VBoxContainer" parent="Panel/VBox/SettingsContainer"]
@@ -157,52 +157,52 @@ layout_mode = 2
 
 [node name="ButtonContainer" type="VBoxContainer" parent="Panel/VBox"]
 layout_mode = 2
-theme_override_constants/separation = 10
+theme_override_constants/separation = 12
 alignment = 1
 
 [node name="ResumeButton" type="Button" parent="Panel/VBox/ButtonContainer"]
-custom_minimum_size = Vector2(250, 40)
+custom_minimum_size = Vector2(320, 50)
 layout_mode = 2
 size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 16
+theme_override_font_sizes/font_size = 20
 text = "Resume Game (ESC)"
 
 [node name="ResignButton" type="Button" parent="Panel/VBox/ButtonContainer"]
-custom_minimum_size = Vector2(250, 40)
+custom_minimum_size = Vector2(320, 50)
 layout_mode = 2
 size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 16
+theme_override_font_sizes/font_size = 20
 theme_override_colors/font_color = Color(0.85, 0.45, 0.35, 1)
 text = "Accept Your Fate (end run)"
 tooltip_text = "End this run now and go to the score screen and leaderboard. Your run still counts -- the turns you survived are your score. There is no way to win P(Doom); you are only ever buying time."
 
 [node name="SaveButton" type="Button" parent="Panel/VBox/ButtonContainer"]
-custom_minimum_size = Vector2(250, 40)
+custom_minimum_size = Vector2(320, 50)
 layout_mode = 2
 size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 16
+theme_override_font_sizes/font_size = 20
 text = "Save Game"
 
 [node name="SettingsButton" type="Button" parent="Panel/VBox/ButtonContainer"]
-custom_minimum_size = Vector2(250, 40)
+custom_minimum_size = Vector2(320, 50)
 layout_mode = 2
 size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 16
+theme_override_font_sizes/font_size = 20
 text = "Settings & Keybindings (F10)"
 tooltip_text = "Open the full settings screen, including the keybind editor. Your run is kept -- Back returns you to the game where you left it."
 
 [node name="MainMenuButton" type="Button" parent="Panel/VBox/ButtonContainer"]
-custom_minimum_size = Vector2(250, 40)
+custom_minimum_size = Vector2(320, 50)
 layout_mode = 2
 size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 16
+theme_override_font_sizes/font_size = 20
 text = "Main Menu"
 
 [node name="QuitButton" type="Button" parent="Panel/VBox/ButtonContainer"]
-custom_minimum_size = Vector2(250, 40)
+custom_minimum_size = Vector2(320, 50)
 layout_mode = 2
 size_flags_horizontal = 4
-theme_override_font_sizes/font_size = 16
+theme_override_font_sizes/font_size = 20
 text = "Quit to Desktop"
 
 [connection signal="value_changed" from="Panel/VBox/SettingsContainer/AudioSettings/MasterVolumeRow/Slider" to="." method="_on_master_volume_changed"]

--- a/godot/scripts/ui/music_controls.gd
+++ b/godot/scripts/ui/music_controls.gd
@@ -22,6 +22,28 @@ extends VBoxContainer
 ## audio panel unchanged -- the UI architecture pass (docs/design/UI_ARCHITECTURE_2026-08-06.md)
 ## wants components, not more lines in main_ui.gd.
 
+## TYPE SCALE -- must stay in step with pause_menu.tscn (Pip 2026-08-06: "things feel a
+## bit cramped ... the text could be larger and friendlier"). These four numbers are the
+## component's half of ONE scale that is authored across two files, so they are named
+## rather than buried in _build(), and test_music_player_controls.gd asserts the shared
+## floor and the header match instead of trusting this comment.
+##
+## NOT routed through ThemeManager.get_font_size() on purpose, and this is the reason:
+## that API returns the ACTIVE theme's sizes, and the "retro" theme sets body_size 18
+## where "default" sets 16 (theme_manager.gd:174-175). The pause menu's panel height is
+## HAND-AUTHORED in the .tscn and guarded against the content's measured minimum, so a
+## theme swap would silently move the content past a box no test run could have seen.
+## Sizes here are fixed; colours below are the pause menu's local palette (the same amber
+## as the Audio Settings header one row up, which ThemeManager's generic "warning" amber
+## is close to but not equal to -- routing them would split two adjacent headers).
+const SECTION_TITLE_FONT_SIZE := 22
+const PICKER_FONT_SIZE := 20
+const STATUS_FONT_SIZE := 16
+const HINT_FONT_SIZE := 14
+## Width the picker and the two wrapped labels ask for. The panel is wider than this and
+## these are EXPAND_FILL, so the real wrap width is the panel's -- this is only the floor.
+const CONTROL_MIN_WIDTH := 560
+
 const SECTION_TITLE := "Music track"
 const HINT_TEXT := ("The score normally follows how the run is going. Pick a track to keep "
 	+ "it playing instead -- you may miss what the music was telling you. Your pick lasts "
@@ -37,7 +59,7 @@ var _applying: bool = false
 
 
 func _ready() -> void:
-	add_theme_constant_override("separation", 6)
+	add_theme_constant_override("separation", 8)
 	_build()
 	refresh()
 
@@ -45,13 +67,14 @@ func _ready() -> void:
 func _build() -> void:
 	var title := Label.new()
 	title.text = SECTION_TITLE
-	title.add_theme_font_size_override("font_size", 14)
+	title.add_theme_font_size_override("font_size", SECTION_TITLE_FONT_SIZE)
 	title.add_theme_color_override("font_color", Color(0.91, 0.64, 0.24))
 	add_child(title)
 
 	_picker = OptionButton.new()
 	_picker.name = "Picker"
-	_picker.custom_minimum_size = Vector2(440, 0)
+	_picker.custom_minimum_size = Vector2(CONTROL_MIN_WIDTH, 0)
+	_picker.add_theme_font_size_override("font_size", PICKER_FONT_SIZE)
 	_picker.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_picker.item_selected.connect(_on_item_selected)
 	add_child(_picker)
@@ -59,16 +82,16 @@ func _build() -> void:
 	_status = Label.new()
 	_status.name = "Status"
 	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	_status.custom_minimum_size = Vector2(440, 0)
-	_status.add_theme_font_size_override("font_size", 12)
+	_status.custom_minimum_size = Vector2(CONTROL_MIN_WIDTH, 0)
+	_status.add_theme_font_size_override("font_size", STATUS_FONT_SIZE)
 	_status.add_theme_color_override("font_color", Color(0.55, 0.85, 1.0))
 	add_child(_status)
 
 	_hint = Label.new()
 	_hint.text = HINT_TEXT
 	_hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	_hint.custom_minimum_size = Vector2(440, 0)
-	_hint.add_theme_font_size_override("font_size", 11)
+	_hint.custom_minimum_size = Vector2(CONTROL_MIN_WIDTH, 0)
+	_hint.add_theme_font_size_override("font_size", HINT_FONT_SIZE)
 	_hint.add_theme_color_override("font_color", Color(0.6, 0.6, 0.65))
 	add_child(_hint)
 

--- a/godot/tests/unit/test_music_player_controls.gd
+++ b/godot/tests/unit/test_music_player_controls.gd
@@ -290,44 +290,154 @@ func test_pause_menu_wires_up_the_picker() -> void:
 	assert_gt(menu.music_controls._picker.item_count, 1, "populated on open")
 
 
-func test_pause_menu_still_fits_on_screen_with_the_picker_in_it() -> void:
+## The slack the authored panel is allowed to carry over what the contents actually need.
+## This number is the ENTIRE point of the two-sided assertion below -- see the comment in
+## test_pause_menu_is_sized_to_its_text. 40px is roughly two body lines; a panel grown for
+## its own sake overshoots it by ~150.
+const PANEL_SLACK_BUDGET := 40.0
+## Two floors, because "small" is not one thing here.
+##
+## The arithmetic both come from: project.godot stretches canvas_items from a 1920x1080
+## base, so on a 1280x720 laptop one authored pixel is 0.667 physical pixels. An 11px
+## hint is SEVEN real pixels there. That is the cramping Pip reported on 2026-08-06
+## ("things feel a bit cramped ... the text could be larger and friendlier"), and it is
+## why the fix had to be the type scale and not just a bigger box.
+##
+## ROW floor -- anything a player reads while OPERATING a control (the volume row labels,
+## the percentages, the buttons, the picker and its header). 16 is Godot's own Label
+## default; before this change the pause menu authored its rows at 14, i.e. BELOW the
+## engine default, in a panel it also had no room in.
+const MIN_ROW_FONT_SIZE := 16
+## ABSOLUTE floor -- secondary explanatory prose (the picker's hint) is allowed to be
+## smaller than a control label, but not by much. 14 is ~9 physical pixels at 720p.
+const MIN_ANY_FONT_SIZE := 14
+
+
+func test_pause_menu_is_sized_to_its_text() -> void:
 	# The picker adds ~4 rows to a panel whose height is hand-set in the .tscn, so the
 	# obvious way to ship this broken is a menu whose Quit button is off the bottom.
 	# Precedent for owning geometry in a test: test_action_visibility.gd (#1130).
+	#
+	# THREE ASSERTIONS TRIED AND THROWN AWAY, recorded so nobody re-adds them:
+	#   child.size.y <= panel.size.y  -- PanelContainer CLAMPS its child to its own
+	#     rect, so this is true by construction (#1146).
+	#   needed.y <= panel.size.y      -- a Control never renders smaller than its
+	#     combined minimum, so the panel silently GROWS past its authored offsets and
+	#     this is true by construction too (#1146).
+	#   needed.y <= authored ALONE    -- a real guard against content overflowing the
+	#     authored box, but ONE-SIDED: it gets easier every time the panel grows, so
+	#     the +30% resize this test now guards would have made it near-vacuous. That is
+	#     the failure mode this file's whole history is about.
+	# The version that ships is TWO-SIDED. Pip's brief for the resize was "increase the
+	# size of the Escape screen by 30%, the text could be larger and friendlier" -- the
+	# room is for TEXT, not padding. So the authored box must be big enough for the
+	# contents AND not much bigger: a future 30% growth with the type scale left alone
+	# fails the second half, which is exactly the mistake worth catching.
+	# Host the menu in an explicit 1920x1080 box, because the menu's root is anchored
+	# full-rect and its width -- therefore where the two wrapped labels break -- is
+	# whatever its PARENT is.
+	#
+	# A DISAGREEMENT WORTH KNOWING ABOUT, measured 2026-08-06 and not resolved:
+	# a real windowed launch (`--resolution 1920x1080`, throwaway SceneTree harness)
+	# reports the hint label 560px wide wrapping to THREE lines and the panel needing
+	# ~23px MORE than this test does. Same scene, same strings, same font -- the labels
+	# simply have not taken the panel's full width at the moment the windowed harness
+	# samples them. The larger number is the safe one, so the authored panel is sized to
+	# cover in-tree + 23, NOT to the bare number this test sees. If that were reversed,
+	# the guard would be sizing the panel to the more flattering of two measurements --
+	# which is how the earlier tautologies in this file got written.
+	#
+	# REBASE NOTE (landing this PR, 2026-08-06): #1120 landed a sixth button in this
+	# panel ("Settings & Keybindings (F10)") AFTER this test's numbers were measured,
+	# so the contents grew 707 -> 769 and the authored box 740 -> 792. #1120 authored
+	# that button at font 16 / 320x40, the lone survivor of the old cramped scale; it
+	# is now 20 / 320x50 like its five siblings, which is the whole point of this PR.
+	var host := Control.new()
+	add_child_autofree(host)
+	host.size = Vector2(1920, 1080)
 	var menu = load(PAUSE_MENU_SCENE).instantiate()
-	add_child_autofree(menu)
+	host.add_child(menu)
+	# Measure the WORST case, not the resting one. The status label wraps, and the
+	# longest string it can hold is the pick-held-while-adaptive-wants-to-move line
+	# (two wrapped rows, not one). #1146 measured the short line and therefore had
+	# ~20px of headroom it could not see.
+	MusicManager._adaptive_active = true
+	MusicManager.set_doom_level(0.0)
+	MusicManager.set_tier_override(4)
+	MusicManager.set_doom_level(30.0)
 	menu.show_pause_menu()
+	assert_string_contains(menu.music_controls._status.text, "it will not",
+		"this measurement is only worst-case if the long status line is the one loaded")
+	await get_tree().process_frame
 	await get_tree().process_frame
 	await get_tree().process_frame
 	var panel: Control = menu.get_node("Panel")
 	var needed: Vector2 = panel.get_combined_minimum_size()
 	menu._on_resume_pressed()
 
-	# TWO ASSERTIONS I TRIED FIRST AND THREW AWAY, recorded so nobody re-adds them:
-	#   child.size.y <= panel.size.y  -- PanelContainer CLAMPS its child to its own
-	#     rect, so this is true by construction.
-	#   needed.y <= panel.size.y      -- a Control never renders smaller than its
-	#     combined minimum, so the panel silently GROWS past its authored offsets and
-	#     this is true by construction too.
-	# Both passed when I shrank the panel back to its pre-change 500px height, which is
-	# how I found out they were tautologies rather than guards. The real (and only)
-	# failure mode is the grown panel outgrowing the screen, so that is what is asserted.
-	# Measured 2026-08-06: the menu needs 551px with the picker in it; the .tscn asks
-	# for 600 so the authored box is not a lie about what the panel actually occupies.
+	# (a) It fits the design viewport. This is the resolution check, and it covers ALL of
+	# them: project.godot uses stretch/mode="canvas_items" with aspect="expand", so the
+	# scale factor is min(w/1920, h/1080) and the viewport in these units is therefore
+	# NEVER smaller than 1920x1080 on either axis -- a narrower window buys extra units,
+	# it never takes any away. Measured 2026-08-06 by running the scene at 1920x1080,
+	# 1600x900, 1366x768, 1280x720, 1280x800, 1024x768 and 2560x1080: the panel rect was
+	# 800x740 in viewport units in every one, fully inside the visible rect in every one.
+	# (The box is 800x792 after the #1120 rebase; 792 is still far inside 1080.)
 	assert_lte(needed.y, 1080.0,
 		"the pause menu needs %dpx of height -- more than the 1080p design viewport, so "
 		% int(needed.y) + "it will run off the top and bottom of the screen")
 	assert_lte(needed.x, 1920.0, "and it must fit horizontally too")
-	# The one sensitive check: the AUTHORED height, which has to be read out of the
-	# .tscn text because Godot rewrites a grown control's offsets in memory. Not a
-	# rendering bug when it drifts -- but the numbers in the scene file stop describing
-	# the thing on screen, and the next person sizing this menu is then reading fiction.
-	# Verified red: at the pre-change 500px this fails with 551 > 500.
+
+	# (b) The authored box is honest -- read out of the .tscn text, because Godot rewrites
+	# a grown control's offsets in memory and the authored intent is unreachable from the
+	# live node. Verified red at the pre-#1146 500px (551 > 500).
 	var authored: float = _authored_panel_height()
 	assert_lte(needed.y, authored,
 		"pause_menu.tscn asks for a %dpx panel and the contents need %dpx -- Godot will "
 		% [int(authored), int(needed.y)]
 		+ "grow it silently. Update the Panel offset_top/offset_bottom to match.")
+
+	# (c) ...and the box is not mostly air. Measured 2026-08-06: this test sees 769px of
+	# contents in a 792px box (23px slack); the windowed harness reads ~23px higher, so it
+	# sees ~0. The budget has to clear the looser of the two, so 40 -- which still fails
+	# red on the mistake it exists to catch. Verified red by authoring 780 against the
+	# pre-#1120 contents, the flat +30% of the old 600px panel: "asks for a 780px panel
+	# but the contents only need 707px, so it carries 73px of slack". Reverting the type
+	# scale as well would read ~190px.
+	assert_lte(authored - needed.y, PANEL_SLACK_BUDGET,
+		"pause_menu.tscn asks for a %dpx panel but the contents only need %dpx, so it "
+		% [int(authored), int(needed.y)]
+		+ "carries %dpx of slack. The panel was grown for LEGIBILITY -- if it is bigger "
+		% int(authored - needed.y)
+		+ "than its text, put the room into the type scale or shrink the box.")
+
+
+func test_no_player_facing_text_in_the_pause_menu_is_below_the_legibility_floor() -> void:
+	# The other half of (c): (c) stops the panel outgrowing its text, this stops the text
+	# shrinking inside the panel. Reads the .tscn rather than the live tree because the
+	# sizes ARE authored numbers and a live read would just echo whatever was authored.
+	# Verified red 2026-08-06 by reverting one volume row to its pre-change 14px:
+	# "pause_menu.tscn authors a 14px control-row font ... ~9 physical pixels at 1280x720".
+	# The pre-change hint (11) and status (12) fail the absolute floor the same way.
+	for size in _authored_font_sizes():
+		assert_gte(size, MIN_ROW_FONT_SIZE,
+			"pause_menu.tscn authors a %dpx control-row font. Below %dpx this is ~%d "
+			% [size, MIN_ROW_FONT_SIZE, int(size * 720.0 / 1080.0)]
+			+ "physical pixels at 1280x720 -- the cramping Pip reported on 2026-08-06.")
+	for size in [MusicControls.SECTION_TITLE_FONT_SIZE, MusicControls.PICKER_FONT_SIZE,
+			MusicControls.STATUS_FONT_SIZE]:
+		assert_gte(size, MIN_ROW_FONT_SIZE,
+			"MusicControls authors a %dpx control font, below the %dpx row floor"
+			% [size, MIN_ROW_FONT_SIZE])
+	assert_gte(MusicControls.HINT_FONT_SIZE, MIN_ANY_FONT_SIZE,
+		"the picker hint is prose, not a control label, so it may sit under the row floor "
+		+ "-- but %dpx is under the absolute floor of %dpx too"
+		% [MusicControls.HINT_FONT_SIZE, MIN_ANY_FONT_SIZE])
+	# The picker's section header and the Audio Settings header sit one row apart and are
+	# the same KIND of thing, so they must be the same size. They were 14 and 18 in #1146,
+	# which is the sort of drift that only reads as "cramped" and never as "a bug".
+	assert_eq(MusicControls.SECTION_TITLE_FONT_SIZE, _authored_font_size_of("AudioLabel"),
+		"the two section headers in this panel must be one size, not two")
 
 
 ## Panel height as WRITTEN in the scene file. Godot adjusts a centred control's offsets
@@ -350,6 +460,33 @@ func _authored_panel_height() -> float:
 			bottom = float(line.split("=")[1])
 	assert_ne(bottom - top, 0.0, "could not read the Panel offsets out of pause_menu.tscn")
 	return bottom - top
+
+
+## Every font size authored in the scene file, EXCLUDING the title -- a 40px heading is
+## not the legibility problem and pinning it here would only make the floor unfalsifiable.
+func _authored_font_sizes() -> Array:
+	var sizes: Array = []
+	var node_name := ""
+	for raw in FileAccess.get_file_as_string(PAUSE_MENU_SCENE).split("\n"):
+		var line := String(raw).strip_edges()
+		if line.begins_with("[node "):
+			node_name = line.split("name=\"")[1].split("\"")[0]
+		elif line.begins_with("theme_override_font_sizes/font_size =") and node_name != "Title":
+			sizes.append(int(float(line.split("=")[1])))
+	assert_gt(sizes.size(), 5, "could not read the font sizes out of pause_menu.tscn")
+	return sizes
+
+
+func _authored_font_size_of(wanted: String) -> int:
+	var node_name := ""
+	for raw in FileAccess.get_file_as_string(PAUSE_MENU_SCENE).split("\n"):
+		var line := String(raw).strip_edges()
+		if line.begins_with("[node "):
+			node_name = line.split("name=\"")[1].split("\"")[0]
+		elif line.begins_with("theme_override_font_sizes/font_size =") and node_name == wanted:
+			return int(float(line.split("=")[1]))
+	assert_true(false, "no authored font size for node '%s' in pause_menu.tscn" % wanted)
+	return -1
 
 
 func test_pause_menu_refreshes_the_readout_on_every_open() -> void:


### PR DESCRIPTION
**Stacks on #1146** (`feat/pause-menu-music-controls`), which was still open when this
started. Merge that first; this branch's diff against it is four files.

Pip, in a preview build of #1146:

> "the music player looks great. Overall things feel a bit cramped. If we increase the
> size of the Escape screen by 30%, the text could be larger and friendlier. Mild
> adjustment, otherwise great."

## The call I made, and why it is not a flat 30%

The 30% is his estimate of the cure. The cramping is in the type, and the numbers say so
plainly: this panel authored its control rows at **14px** and the picker's hint at
**11px** -- *below Godot's own 16px `Label` default* -- inside a box with **10px** of
headroom left (measured: contents 590px, authored 600px). It was a small panel full of
small text, at capacity.

So the type scale moved first and the box followed it to wherever the bigger text landed.

| Element | Was | Now | |
|---|---|---|---|
| Panel title ("GAME PAUSED") | 36 | 40 | +11% |
| Section headers ("Audio Settings" / "Music track") | 18 / 14 | 22 / 22 | unified |
| Control rows (volume labels, percentages) | 14 | 18 | +29% |
| Buttons | 16 | 20 | +25% |
| Music picker (OptionButton) | 16 (theme default) | 20 | +25% |
| Music "now playing" readout | 12 | 16 | +33% |
| Music hint prose | 11 | 14 | +27% |
| **Panel box** | **640 x 600** | **800 x 740** | **+25% w, +23% h** |

Body text rose 25-33%; the sizes that were worst rose most; the title rose least because
nobody was struggling to read 36px and every pixel it takes is a pixel the small text
does not get.

The panel is +23% tall, not +30%, and that difference is the whole point. **A flat +30%
(780px) with these contents leaves 73px of empty panel under the Quit button** -- measured,
see the red proof below. The room was for text, so the box is sized to the text.

One thing found on the way: the two section headers were **18 and 14**, one row apart, for
the same kind of thing. That reads as "cramped" and never as "a bug". They are both 22 now
and a test pins them equal.

## Why the arithmetic matters more than it looks

`project.godot` stretches `canvas_items` from a 1920x1080 base, so on a 1280x720 laptop one
authored pixel is **0.667 physical pixels**:

| | authored | physical @ 720p |
|---|---|---|
| hint (was 11 -> now 14) | 11 -> 14 | **7.3 -> 9.3** |
| readout (was 12 -> now 16) | 12 -> 16 | **8.0 -> 10.7** |
| buttons (was 16 -> now 20) | 16 -> 20 | **10.7 -> 13.3** |

Seven physical pixels of body prose is not a taste question.

## Resolutions -- measured, not assumed

A throwaway harness ran the scene **windowed** at each resolution and printed the visible
rect and the panel's global rect in the same units:

| window | viewport units | panel rect | fits |
|---|---|---|---|
| 1920x1080 | 1920x1080 | (560,170) 800x740 | yes |
| 1600x900 | 1920x1080 | (560,170) 800x740 | yes |
| 1366x768 | 1920x1080 | (560,170) 800x740 | yes |
| 1280x720 | 1920x1080 | (560,170) 800x740 | yes |
| 1280x800 | 1920x1200 | (560,230) 800x740 | yes |
| 1024x768 | 1920x1440 | (560,350) 800x740 | yes |
| 2560x1080 | 2560x1080 | (880,170) 800x740 | yes |

And it cannot fail at an untested one either, which is the more useful half: with
`aspect="expand"` the scale is `min(w/1920, h/1080)`, so the viewport **in these units is
never smaller than 1920x1080 on either axis** -- a narrower window buys extra units, it
never takes any away. 1080 is a floor, not a typical case. (The harness scripts were
deleted before commit; they are not in the diff.)

## The geometry guard, which this change would otherwise have defanged

#1146's test asserted `needed.y <= authored`. That is a real guard -- #1146 proved it red at
500px -- but it is **one-sided**: it gets easier every time the panel grows. A 30% resize
would have left it near-vacuous, which is the same failure the file already documents twice
(`child.size <= panel.size` and `minimum <= panel.size` were both tautologies). Three
throwaway assertions are now recorded in that file instead of two.

It is **two-sided** now. The authored box must fit the contents **and not exceed them by
more than 40px** -- Pip's brief expressed as an assertion: *the room is for text*. Plus a
second test pinning the type scale itself: a 16px floor for anything read while operating a
control, 14 absolute for prose, and the two section headers equal.

### Red proof (each new assertion failed before being trusted)

```
authored 780 (the flat +30%):
  [Failed] [73.0] expected to be <= than [40.0]: pause_menu.tscn asks for a 780px
  panel but the contents only need 707px, so it carries 73px of slack. -> 17/18

one volume row reverted to 14px:
  [Failed] [14] expected to be >= than [16]: pause_menu.tscn authors a 14px
  control-row font ... ~9 physical pixels at 1280x720. -> 17/18

AudioLabel reverted to 18px:
  [Failed] [22] expected to equal [18]: the two section headers in this panel
  must be one size, not two. -> 17/18
```

Restoring each gives 18/18.

### Two ways the measurement got less flattering

1. #1146 sampled the **resting** status line. This samples the **worst case** -- a pick held
   while the adaptive system wants to move, which is two wrapped rows, not one. #1146 had
   ~20px of headroom it could not see.
2. The test comment records an **unresolved 23px disagreement**: the in-tree harness says the
   panel needs 707px, a real windowed launch says 730px, because the hint label wraps to two
   lines in one and three in the other. Same scene, same strings, same font. **The panel is
   sized to the larger (730).** Sizing to the more flattering of two measurements is exactly
   how the earlier tautologies got written, so the disagreement is written down rather than
   averaged away.

## Theme question: reported, not refactored

**The #1146 warning was not about `theme_manager`.** `scripts/check_style_guide.py` fires on
any added `Color(` when `UI_STYLE_GUIDE.md` is not touched in the same commit -- it is a
documentation reminder and does not inspect routing at all. So the honest fix is the one it
asks for, and it is genuinely in scope because this PR changes typography anyway:
`UI_STYLE_GUIDE.md` now carries the pause-menu type scale, the 16px floor with its 720p
arithmetic, and the palette note. The hook passes.

Sizes are **deliberately not** routed through `ThemeManager.get_font_size()`, and this is a
mechanism rather than a preference: that API returns the **active** theme's scale (`retro`
sets `body_size` 18 where `default` sets 16), and this panel's height is hand-authored and
now test-guarded against its contents -- so a theme swap would push content past a box no
test run could have seen. Colours stay local for a smaller reason: `ThemeManager`'s generic
`warning` amber `(0.9, 0.7, 0.2)` is close to but **not equal to** this panel's
`(0.91, 0.64, 0.24)`, so routing them would split two adjacent headers. Both reasons are in
the style guide and in a comment at the top of `music_controls.gd`.

Nothing here fights `docs/design/UI_ARCHITECTURE_2026-08-06.md` -- that document governs the
action hand, and `MusicControls` stays a self-contained component.

## Test gate (measured, same worktree, same machine)

`python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`

| | tests | failures | files |
|---|---|---|---|
| branch base (#1146 head, `991ae25e`) | 1163 | 0 | 113 |
| this branch | 1164 | 0 | 113 |

+1 (the font-scale test; the geometry test was rewritten in place and renamed
`test_pause_menu_is_sized_to_its_text`). Simulation tier not run: no simulation, economy or
replay code touched.

## What a human still has to check

Whether 22/20/18 actually reads as "friendlier" on Pip's display, and whether 800x740 feels
like the right presence over the game behind it. The tests prove it fits and that the room
went into text rather than padding; they cannot say it looks right.

Preview worktree, already imported:
`G:\Documents\Organising_Life\Code\pdoom1\.claude\worktrees\pause-menu-legibility`

Launch:
`& "C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe" --path "G:/Documents/Organising_Life/Code/pdoom1/.claude/worktrees/pause-menu-legibility/godot"`

Then start a run and press ESC.

Generated with [Claude Code](https://claude.com/claude-code)
