### PR TITLE
art(run): the 2026-08-07 art night -- 652 images fired, USD 31.45, L2/L3 waiting on picks

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -65,6 +65,22 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | validate_historical_data.py | -- | Historical Data Validation Script | make; ci:data-validation.yml; ci:enhanced-release.yml |
 | verify_release_urls.py | -- | Verify release-feed download URLs actually resolve. | ci:enhanced-release.yml; tool:generate_release_metadata.py |
 
+## `scripts/lib/scores/`
+
+| Tool | Layer | Purpose | Invoked by |
+|---|---|---|---|
+| enhanced_leaderboard.py | -- | Enhanced Leaderboard Manager for P(Doom) v0.4.1+ | NONE FOUND |
+| local_store.py | -- | Local leaderboard storage for PDoom1. | NONE FOUND |
+
+## `scripts/lib/services/`
+
+| Tool | Layer | Purpose | Invoked by |
+|---|---|---|---|
+| data_paths.py | -- | Cross-platform data directory management for PDoom1. | NONE FOUND |
+| deterministic_rng.py | -- | Deterministic RNG System for P(Doom): Reproducible Strategic Gameplay | NONE FOUND |
+| leaderboard.py | -- | Privacy-Respecting Leaderboard Foundation for P(Doom) | NONE FOUND |
+| version.py | -- | Version management for P(Doom): Bureaucracy Strategy Game | NONE FOUND |
+
 ## `tools/`
 
 | Tool | Layer | Purpose | Invoked by |
@@ -99,7 +115,7 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | Tool | Layer | Purpose | Invoked by |
 |---|---|---|---|
 | analyze_verdicts.py | -- | Analyze art triage exports (verdict JSONs) for BOTH art libraries. | human (docstring usage) |
-| apply_review.py | SWEEP | apply_review.py -- wire art-review verdicts into the P(Doom)1 asset pipeline. | test:test_art_promotion_pipeline.py; tool:build_full_gallery.py; tool:slot_model.py |
+| apply_review.py | SWEEP | apply_review.py -- wire art-review verdicts into the P(Doom)1 asset pipeline. | test:test_art_promotion_pipeline.py; tool:build_full_gallery.py; tool:measure_taste.py; tool:slot_model.py |
 | apply_slot_picks.py | -- | apply_slot_picks.py -- fold a slot_picker.html export into the TRACKED | test:test_slot_picker.py; tool:build_slot_picker.py |
 | author_anchor_sockets.py | -- | Author godot/data/office/anchor_sockets.json -- Anchor Sockets V2 (#894 #900 #913). | tool:build_cat_sweep_sheet.py |
 | build.py | -- | Build the P(Doom)1 style-review tool: a self-contained, single-file HTML page | test:test_find_dead_code.py; tool:select_assets.py |
@@ -110,7 +126,7 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | build_cat_west_walk_picks.py | -- | build_cat_west_walk_picks -- 2026-07-27 cat_sweep_black_side_heft WEST walk pick sheet. | human (docstring usage) |
 | build_doom_strip_sheet.py | -- | Generate art_generated/doom_strip_sheet.html -- ADR-0015 doom-strip triage | human (docstring usage) |
 | build_endgame_review.py | -- | Build a verdict-capturing review page for the endgame concept batch. | human (docstring usage) |
-| build_full_gallery.py | OBSERVE | build_full_gallery.py -- ONE stateful drive-by gallery over ALL art on disk. | tool:apply_review.py |
+| build_full_gallery.py | OBSERVE | build_full_gallery.py -- ONE stateful drive-by gallery over ALL art on disk. | tool:apply_review.py; tool:run_art_night.py |
 | build_generation_compare.py | -- | Side-by-side comparison of two generations of the same concept batch. | human (docstring usage) |
 | build_morning_index.py | -- | One index page over every generated art batch on disk. | human (docstring usage) |
 | build_prop_rebase_sheet.py | -- | build_prop_rebase_sheet -- prop re-base bulk batch + facing pilot (2026-07-27). | human (docstring usage) |
@@ -127,12 +143,13 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | gen_quirk_icon_sheet.py | -- | Generate art_generated/quirk_icons_sheet.html -- quirk icon review sheet (issue #903). | human (docstring usage) |
 | gen_settings_grounds.py | -- | Warm-register settings-screen background candidates for P(Doom)1 (no API). | human (docstring usage) |
 | gen_size_probe_sheet.py | -- | gen_size_probe_sheet -- character size vanguard probe sheet (2026-07-26). | human (docstring usage) |
+| measure_taste.py | -- | measure_taste.py -- what the slot picks say about taste, measured. | human (docstring usage) |
 | merge_gallery_export.py | -- | merge_gallery_export.py -- fold a full_gallery.html export back into | tool:build_full_gallery.py |
 | qc_sprite_frames.py | -- | qc_sprite_frames -- PIL QC gate for pixellab character batches. | tool:build_worker_rebase_sheet.py |
 | review_style.py | -- | review_style -- ONE house style for all internal review/dev HTML tools. | tool:analyze_verdicts.py; tool:build_cat_angle_ab_sheet.py; tool:build_cat_refinement_sheet.py; tool:build_cat_sweep_sheet.py; tool:build_cat_west_walk_picks.py; tool:build_doom_strip_sheet.py; tool:build_prop_rebase_sheet.py; tool:build_slot_picker.py; tool:build_t6_diagonals_and_cats_sheet.py; tool:build_worker_rebase_sheet.py; tool:build_worker_round2_sheet.py; tool:gen_contact_sheet.py; tool:gen_hero_gallery.py; tool:gen_prop_grain_sheet.py; tool:gen_quirk_icon_sheet.py; tool:gen_size_probe_sheet.py |
 | scan_white_flash.py | -- | Scan walk-clip frames for the "white flash under the cat" artifact. | tool:build_cat_refinement_sheet.py |
 | serve_review.py | -- | Local art-review app for P(Doom)1 -- ONE place to review ALL the art. | tool:build_slot_picker.py |
-| slot_model.py | -- | slot_model.py -- the ONE definition of "slot cluster" and "frame role". | test:test_slot_picker.py; tool:apply_slot_picks.py; tool:build_slot_picker.py |
+| slot_model.py | -- | slot_model.py -- the ONE definition of "slot cluster" and "frame role". | test:test_slot_picker.py; tool:apply_slot_picks.py; tool:build_slot_picker.py; tool:measure_taste.py |
 
 ## `tools/assets/`
 
@@ -144,6 +161,7 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | generate_images.py | -- | Generalized batch image generator for pdoom1 art assets. | tool:promote_assets.py |
 | promote_assets.py | -- | Asset promotion tool for pdoom1. | NONE FOUND |
 | render_latex_pdoom.py | -- | Local LaTeX-style typeset renders of the P(doom) logo studies. | NONE FOUND |
+| run_art_night.py | GENERATE | run_art_night.py -- level-structured, budget-capped, resumable art run. | human (Pip), once per wave (declared) |
 | select_assets.py | -- | Interactive asset selection tool for pdoom1. | tool:promote_assets.py |
 
 ## `tools/music/`
@@ -159,10 +177,16 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 
 ## UNKNOWN -- no declaration, no usage hint, no discoverable caller
 
-11 tool(s) that nothing declares, documents, or calls. Each one is either
+17 tool(s) that nothing declares, documents, or calls. Each one is either
 a rot candidate or an undocumented dependency -- find out which (`tools/find_dead_code.py` lane).
 
 - `scripts/ascii_compliance_fixer.py`
+- `scripts/lib/scores/enhanced_leaderboard.py`
+- `scripts/lib/scores/local_store.py`
+- `scripts/lib/services/data_paths.py`
+- `scripts/lib/services/deterministic_rng.py`
+- `scripts/lib/services/leaderboard.py`
+- `scripts/lib/services/version.py`
 - `scripts/logging_system.py`
 - `scripts/monitor-sync.py`
 - `scripts/repo-status.py`
@@ -204,4 +228,4 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 
 23 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
 
-Total: 108 active tools (7 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 89 undeclared); 11 in UNKNOWN; 6 archived.
+Total: 116 active tools (8 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 96 undeclared); 17 in UNKNOWN; 6 archived.

--- a/docs/design/ART_RUN_2026-08-07.md
+++ b/docs/design/ART_RUN_2026-08-07.md
@@ -1,0 +1,472 @@
+# Art run -- 2026-08-07
+
+Status: QUEUED, nothing generated. Built 2026-08-06 evening.
+
+Pip funded a celebratory generative art run for 2026-08-07: AUD 100-110, with
+the explicit instruction that spending under half of it counts as a failure.
+This document is the plan. `tools/assets/run_art_night.py` executes it and
+`tools/assets/manifests/art_night_2026-08-07.json` is the queue.
+
+**No image has been generated and no money has been spent.** Every number below
+came out of `--dry-run`, which makes zero API calls.
+
+---
+
+## 1. The cost model, with its arithmetic and its weak point
+
+### The weak point first
+
+The repo's existing per-image figures are **not billed truth**. In
+`generate_images.py`, `generate_image()` returns `unit_cost`, which came from
+`estimate_cost_per_image()` -- a hardcoded table. That value is what gets
+written to the run log. `docs/art/SEED_ART_COST_MODEL.md` then reads those logs
+back and tags the numbers MEASURED. They are the constant, echoed.
+
+Check it: the 2026-07-29 `new_subjects` run logged
+`SUMMARY: success=6, ... cost=$1.08`. Six assets x two variants = 12 images,
+12 x $0.09 = $1.08 exactly, and $0.09 is the literal entry for `1536x1024` in
+the estimate table. Nothing was measured.
+
+So Pip's "roughly 91 icons for about $12" is a recollection of a self-reported
+estimate, not a bill. This plan does not use it. **The only honest source is the
+provider's published tariff, and the only truth is the billing dashboard
+afterward.** The script records the tariff price per image, marks it
+`cost_is_billed_truth: false` in every sidecar, and prints a reminder to
+reconcile.
+
+### The second weak point: quality was never being chosen
+
+`_openai_generate_bytes()` calls `images.generate(model, prompt, size,
+background)` and never passes `quality`. The API therefore applies its default,
+which is `auto`. Auto is free to pick the high tier, and at 1536x1024 high is
+**$0.20 against medium's $0.05 -- a silent 4x.** That is consistent with the
+2026-07-29 log's 48-72 seconds per image, which is slow for a medium render.
+
+`run_art_night.py` passes `quality` explicitly on every single call. This is the
+single most load-bearing line in the whole run: without it the projected $31
+overnight wave could bill $125 and blow the brief.
+
+### The tariff (first-party, read 2026-08-06)
+
+`gpt-image-1.5`, per image, USD:
+
+| size | low | medium | high |
+|---|---|---|---|
+| 1024x1024 | 0.009 | **0.034** | 0.133 |
+| 1536x1024 | 0.013 | **0.050** | **0.200** |
+| 1024x1536 | 0.013 | 0.050 | 0.200 |
+
+Source: OpenAI's model page for `gpt-image-1.5`
+(`developers.openai.com/api/docs/models/gpt-image-1.5`). The bolded cells are
+the three this run uses.
+
+Model choice: `gpt-image-1.5` for everything, because it is the only request
+shape proven in this repo. `gpt-image-2` exists (launched 2026-04-21) and
+`gpt-image-1` retires 2026-10-23, so a migration is coming -- but putting an
+unvalidated request shape into an unattended overnight run is exactly this
+repo's characteristic failure. Instead there is a **6-image probe block** using
+`gpt-image-2` on prompts that already have a `gpt-image-1.5` twin in the grid.
+If it fails, the failures are logged and the run continues. Maximum exposure
+from that experiment: about $0.30. Its tariff is assumed equal to 1.5's and is
+flagged as assumed in the spec.
+
+### FX
+
+USD/AUD spot 1.4164 (2026-08-05). Budget AUD 110 = USD 77.66 at that rate. The
+ceiling is set at **USD 75.50 = AUD 106.94**, which only breaches AUD 110 if
+USD/AUD rises above 1.4570 -- a 2.9% move overnight.
+
+### Wall time (MEASURED, from `art_generated/logs/generation_new_subjects_20260729_232729.log`)
+
+12 images at 1536x1024, sequential: min 48s, max 72s, mean ~55s. The 1024 icon
+runs logged ~16-19s. The overnight wave is therefore ~9.2 hours sequential, or
+**~2.3 hours at `--concurrency 4`**, which is the default.
+
+### Disk (MEASURED)
+
+An existing 1536x1024 master is ~2.8 MB. The full planned run is ~1,030 masters
+plus downscales: **~4 GB under `art_generated/`**, which is gitignored in full.
+
+---
+
+## 2. The levels, and where Pip's eye sits
+
+The funnel is four levels, and the important fact is that **his eye sits between
+them**.
+
+| level | what | attended? | images | USD |
+|---|---|---|---|---|
+| L0 | swatch round -- palette conglomerate, fast yes/no | unattended | 64 | 2.18 |
+| L1 | wide net -- 22 subjects x 10 renderings, the exploration | unattended | 580 | 29.00 |
+| L2 | tweened and twinned -- one controlled step at a time | **needs picks** | 216 | 10.80 |
+| L3 | hero prints and posters -- few, large, high quality | **needs picks** | 120 | 24.00 |
+| -- | reserve (coordination#33 late requests, reruns, topup) | -- | ~120 | 6.00 |
+| | **planned total** | | **~1,100** | **71.98** |
+| | hard ceiling enforced in code | | | **75.50** |
+
+AUD at 1.4164: planned **101.94**, ceiling **106.94**.
+
+**L0 and L1 can run unattended. L2 and L3 cannot.** L2 needs L1's winners and L3
+needs L2's winners; generating either blind would spend $34.80 -- a third of the
+budget -- on unreviewed inputs, and L3 in particular is 4x per image precisely
+because the composition has already won twice. The script refuses to expand L2
+or L3 without a picks file.
+
+### The honest inconsistency in L0
+
+L0's output is supposed to constrain everything after it. It cannot constrain
+L1, because both are in the same unattended wave and nobody is awake between
+them. Rather than pretend otherwise:
+
+- L1 **holds one palette constant** (the brief's first pick, else house amber)
+  across the grid and depth blocks, and puts palette in its own crossed block
+  (`l1_palette`, 90 images) so the question still gets asked at poster size.
+- **L0's verdict constrains L2 and L3**, which is where the expensive images
+  are.
+
+If Pip would rather spend ten waking minutes than have this compromise, the
+recommended path in section 6 runs L0 alone first -- it is 64 images, about
+6 minutes at concurrency 4, and $2.18.
+
+---
+
+## 3. L0 -- the swatch round
+
+He asked for this by name and called it fun. Two blocks, eight candidate
+palettes:
+
+- `l0_sheets` -- 16 images. A pure swatch sheet per palette, two rolls each:
+  a grid of flat colour patches showing the palette's **value structure** (big
+  patches are the grounds, one small patch is the single accent). No text, no
+  hex codes -- the model cannot letter reliably and this run bans text globally.
+- `l0_anchors` -- 48 images. Three anchor scenes (office at dusk, server doom
+  altar, grant application desk) x eight palettes x two rolls, with the scene
+  clause held **verbatim identical** so palette is the only variable.
+
+Two blocks because a swatch sheet answers "do I like these colours" and an
+anchor answers "does this palette survive contact with a scene". Those are
+different questions and prior sweeps have conflated them.
+
+The eight palettes: three are house (amber / cold blue / eldritch violet, from
+`docs/art/PALETTE_AND_DOOM_INTENSITY.md`); five deliberately are not, because a
+swatch round that only offers the house style cannot find the boundary of it --
+phosphor green, sodium night, **paper-and-ink (inverted value structure, mostly
+light)**, blueprint, and ash-and-rust (which forbids a glowing source entirely).
+
+---
+
+## 4. L1 -- the wide net
+
+**22 subjects x 10 renderings**, 580 images, $29.00.
+
+### Subjects
+
+Four that already work, kept as controls: office at dusk, the cat and the
+terminal, the whiteboard war room, the server doom altar.
+
+Eighteen that do not exist yet, chosen to be specific rather than decorative --
+the failure mode in earlier sweeps was generic dramatic sci-fi, and a subject
+that names real props resists it:
+
+| id | subject | why |
+|---|---|---|
+| s05 | the compute lease -- your three racks in a chain-link cage inside somebody else's datacentre | the scale of what you do not own |
+| s06 | the meeting room the morning after the all-hands, whiteboard half-wiped | the war room's aftermath |
+| s07 | grant application desk -- forms, franking machine, banker's lamp | the quiet violence of a deadline |
+| s08 | the interpretability wall -- printouts on bulldog clips in a strict grid, NO string | the research made physical without the conspiracy cliche |
+| s09 | the empty chair at 3am -- one cleared desk among cluttered ones | a departure as an absence of clutter |
+| s10 | the regulator's waiting room | the boredom of consequence |
+| s11 | cooling plant at night -- pipes, condensate, one indicator lamp | the cost of thinking, as plumbing |
+| s12 | the paper that was wrong -- a preprint under a lamp, one red strike-through | the only violence in the game |
+| s13 | server room after the sprinklers | disaster without gore |
+| s14 | conference booth packed down at 11pm | ambition folded back into boxes |
+| s15 | rooftop, two mugs on the parapet | a conversation that just ended |
+| s16 | the lab fridge -- notes, rota, magnets | institutional life in one appliance |
+| s17 | the tape archive -- LTO cartridges in a fire safe, one slot empty | cold storage of the dangerous thing |
+| s18 | substation at the fence line | a hum you can see |
+| s19 | the abandoned open-plan (s01 years later) | pairs with s01 as a before/after |
+| s20 | board room after the vote | the decision, unattended |
+| s21 | sunrise through the server room blinds | the one hopeful frame; the set needs one |
+| s22 | the analogue incident wall -- gauges and annunciator flags instead of screens | anachronism played straight |
+
+s01/s19 and s03/s06 are deliberate before/after pairs. s21 exists because a
+22-image set that is uniformly grim measures nothing about tone.
+
+### Renderings -- "lots of different art renderings"
+
+r01 painterly warm-grime (house default), r02 crisp micro-detail, r03 graphic
+screenprint, r04 ink line and wash, r05 CRT phosphor (the scene rendered as if
+photographed off a curved tube -- the game's own surface as a style), r06
+risograph with real misregistration, r07 gouache matte, r08 technical drafting,
+r09 photographic film still, r10 linocut relief.
+
+### The three blocks
+
+- `l1_grid` -- 220. **Full factorial**: every subject in every rendering,
+  exactly once. A complete cross is what lets subject preference and rendering
+  preference be read *independently*; a scatter cannot separate them.
+- `l1_depth` -- 264. 22 subjects x the 4 renderings the taste profile favours x
+  3 more rolls, numbered v2/v3/v4 so `l1_grid`'s v1 counts as the first roll.
+- `l1_palette` -- 90. 6 subjects x 5 palettes x 3 rolls at full poster size.
+- `l1_probe` -- 6. The `gpt-image-2` probe described above.
+
+---
+
+## 5. L2 and L3 -- where his picks go
+
+### L2, tweened and twinned (216 images, $10.80 at 36 picks)
+
+Each L1 winner is regenerated along **one axis, in ordered steps, everything
+else held verbatim**. A pair that differs in exactly one controlled way measures
+taste; a scatter only satisfies it. Seven axes, rotated across the picks:
+
+- `a_yaw` -- camera rotated 0 / 15L / 30L / 15R / 30R / 70 degrees
+- `a_pitch` -- standing / seated / desk height / floor / high / ceiling
+- `a_distance` -- very wide through to extreme material detail
+- `a_title_space` -- where the calm dark slab for a title sits
+- `a_decay` -- **wording tween**: brand new -> in use -> lived-in -> worn ->
+  neglected -> derelict
+- `a_quiet` -- **wording tween**: just been full -> stepped out -> quiet ->
+  still -> silent -> untouched for a very long time
+- `a_style_tween` -- painterly through to clinically crisp in six steps
+
+The two wording tweens are the ones worth the money. Nobody in this repo has
+measured how a single adjectival clause maps onto the image, and a six-step
+ladder over an otherwise byte-identical prompt is the cheapest instrument that
+can answer it.
+
+### L3, hero prints and posters (120 images, $24.00 at 24 picks)
+
+Only L2 winners. Per pick: 4 landscape 1536x1024 + 1 portrait 1024x1536, all at
+**high** quality ($0.20). High is 4x medium, which is justified exactly once a
+composition has won twice and not before.
+
+Masters are copied to `G:/tmp/pdoom1-art-masters/2026-08-07/` per
+`docs/art/ART_MASTERS_POLICY.md`. Note that `art_generated/` is gitignored in
+full, so nothing from this run can reach git by accident regardless -- the
+staging copy is for the archive, not the guard.
+
+---
+
+## 6. What Pip runs
+
+Recommended -- L0 first, ten minutes of looking, then the big wave:
+
+```
+cd G:\Documents\Organising_Life\Code\pdoom1
+python tools\assets\run_art_night.py --wave l0 --yes
+python tools\art_review\build_full_gallery.py --open
+python tools\assets\run_art_night.py --wave l1 --yes
+```
+
+Or the single unattended command, if he would rather sleep:
+
+```
+cd G:\Documents\Organising_Life\Code\pdoom1
+python tools\assets\run_art_night.py --wave overnight --yes
+```
+
+Then, after reviewing and exporting picks from the gallery (`E` in the page,
+then `merge_gallery_export.py`, or hand the exported JSON straight to `--picks`):
+
+```
+python tools\assets\run_art_night.py --wave l2 --picks <picks.json> --yes
+python tools\art_review\build_full_gallery.py --open
+python tools\assets\run_art_night.py --wave l3 --picks <picks2.json> --yes
+```
+
+Check spend at any point, and top up if the run came in under:
+
+```
+python tools\assets\run_art_night.py --status
+python tools\assets\run_art_night.py --wave topup --picks <picks.json> --topup-usd 6 --yes
+```
+
+Absolute paths, since he asked for them every time:
+
+- script: `G:\Documents\Organising_Life\Code\pdoom1\tools\assets\run_art_night.py`
+- queue: `G:\Documents\Organising_Life\Code\pdoom1\tools\assets\manifests\art_night_2026-08-07.json`
+- ledger: `G:\Documents\Organising_Life\Code\pdoom1\art_generated\art_night_2026-08-07\ledger.jsonl`
+- gallery: `G:\Documents\Organising_Life\Code\pdoom1\art_generated\full_gallery.html`
+- masters staging: `G:\tmp\pdoom1-art-masters\2026-08-07\`
+
+---
+
+## 7. The safety properties, and how to break them
+
+**Budget.** `HARD_CEILING_USD = 75.50` is a module constant. `--ceiling-usd` can
+only lower it; a higher value is clamped with a warning. Cost is **reserved
+before dispatch** and refunded on failure, so N concurrent workers cannot walk
+past it. If a wave's projection exceeds the remaining headroom the script prints
+what it would cost and exits 2 having generated nothing, unless `--allow-partial`
+is passed, in which case it fills the headroom and stops.
+
+*How it breaks:* the ceiling counts **tariff** dollars. If the published tariff
+is wrong, or a request silently falls back to a different quality tier, the
+ceiling holds a number that is not the bill. Reconcile against the billing
+dashboard the same day.
+
+**Resume.** Every completed image appends one JSONL line, flushed and fsynced.
+Re-running any wave skips job ids already recorded `ok`. Dying at image 300 of
+600 loses at most one image. Failures are recorded too, with the error, and are
+retried on a re-run because only `ok` counts as done.
+
+*How it breaks:* the ledger keys on `job_id`, which encodes level, block, cell
+and variant. Editing the spec's subject or rendering ids after a partial run
+would orphan the completed work. Do not renumber mid-run; append instead.
+
+**Dry run.** `--dry-run` assembles every prompt, prints the projection, prints a
+spread of full prompt texts, and returns before any client is constructed. The
+OpenAI client is lazily initialised inside `get_client()`, which a dry run never
+reaches, so a dry run works with no API key present.
+
+**Provenance (coordination#32).** Every master gets a `<stem>.meta.json` sidecar
+carrying `origin: "generated"`, the full prompt and its sha256, the model, size,
+quality, background, timestamp, tariff cost, the API's `revised_prompt` and
+usage if returned, the sha256 of the taste profile that shaped it, the sha256 of
+the queue spec, and `promotion_state: "library"`.
+
+`seed` is recorded as **`null` with a note**, not omitted: the OpenAI Images API
+exposes no seed parameter, so none of this is reproducible from its record, and
+a consumer needs to be able to tell "no seed exists" from "we forgot to write
+it down". That distinction is the whole point of coordination#32.
+
+This does not discharge coordination#32 -- pdoom1 still cannot emit provenance
+that survives into the `.pck`. It stops making the problem worse.
+
+**Promotion (ADR-0019).** Nothing here is promoted. There is no promotion code
+path in `run_art_night.py` at all. Output lands under `art_generated/`, which is
+gitignored, as Generated / Library. Promotion still requires a mechanically
+verified demand entry through the existing tooling.
+
+---
+
+## 8. The taste brief, consumed rather than duplicated
+
+A parallel lane is producing `docs/design/TASTE_PROFILE_2026-08-06.md` from
+Pip's 151 picks tonight and 2,713 prior verdicts. **It did not exist when this
+queue was built.** The script therefore reads it *at execution time*.
+
+Contract, so the taste lane can target it:
+
+    ```artbrief
+    HOLD: <clause appended to every prompt as measured house taste>
+    AVOID: <clause>
+    PALETTE: p01,p02,p04,p06,p08
+    RENDERING_FAVOURED: r01,r02,r05,r09
+    SUBJECT_BOOST: s03,s09,s14
+    NOTE: free text, not sent to the model
+    ```
+
+`PALETTE` overrides the palette block's five palettes and its first entry
+becomes L1's held-constant palette. `RENDERING_FAVOURED` overrides which four
+renderings get the 264-image depth pass. If no fenced block is present, the body
+under the last heading matching `/brief/i` is appended verbatim, truncated to
+1400 characters. If the file is absent, the run falls back to the in-repo house
+clauses and **prints a loud warning that this is a blind run** -- which is what
+the dry run in section 10 currently shows, because the file is not there yet.
+
+---
+
+## 9. Things this run does NOT attempt
+
+- **Posters at poster size.** `gpt-image-1.5` emits 1536px on the long edge and
+  nothing larger, and this repo has no upscale path -- `generate_images.py` only
+  ever LANCZOS-*downscales*. 1536px is about 5.1 inches at 300dpi. L3 produces
+  print-ready *sources*, not printable posters. An actual poster needs a
+  separate upscaler run (Real-ESRGAN or equivalent) outside this pipeline. Do
+  not claim upscaling happened.
+- **Text, lettering or logos.** Banned in every prompt. Titles are composited
+  later into the negative space the composition clauses reserve.
+- **People.** No people by default, per the A2 rule. Where unavoidable,
+  androgynous silhouettes with identity destroyed by blocking.
+- **Promotion into the game.** See ADR-0019 above.
+- **Reproducibility.** No seed exists to record.
+- **Migration to `gpt-image-2`.** Six probe images, no more, until the request
+  shape and the tariff are confirmed first-party.
+- **Discharging coordination#32.** Capture only; the pipeline-to-consumer half
+  is still open, return date 2026-08-13.
+- **Spending the pixellab subscription as if it were budget.** See below.
+
+### The pixellab lane -- free, and therefore not budget
+
+`get_balance` on 2026-08-06: **$0.00 credits, subscription active (Tier 3),
+5,724 generations remaining of 7,419.** Marginal dollar cost per generation is
+therefore **zero** -- the subscription is already paid.
+
+That means the pixellab lane **cannot count toward the AUD 100-110 target**, and
+saying "we also made 60 sprites" is not evidence the money was spent. It is a
+free parallel lane, worth running for variety, and it is an *agent* task not a
+script task because pixellab is driven through MCP tools. Suggested scope while
+L1 grinds: ~40-60 generations covering pixel treatments of the new subjects
+(s05, s09, s11, s17, s18, s22), prop sprites, and a UI asset pass. Budget impact:
+zero dollars, ~1% of the remaining generation pool.
+
+### Late requests -- coordination#33
+
+Sister repos were invited to request art by **midday 2026-08-07 AEST**. The
+$6.00 reserve exists for that. A late request becomes either an extra block
+appended under a level in the queue spec, or a separate spec file. The queue is
+parameterised, not rigid: adding a subject or a block and re-running the wave
+regenerates only the new jobs, because everything already done is in the ledger.
+
+If nothing arrives by midday, **the reserve is not saved** -- it goes into
+`--wave topup`, which re-rolls the winning L1 cells until the ceiling. Underspend
+is the stated failure mode of this run.
+
+---
+
+## 10. Dry-run output, as proof
+
+`python tools\assets\run_art_night.py --wave overnight --dry-run`, run
+2026-08-06 with zero API calls:
+
+```
+block                model          size        qual        n       USD
+------------------------------------------------------------------------------
+l0_sheets            gpt-image-1.5  1024x1024   medium     16      0.54
+l0_anchors           gpt-image-1.5  1024x1024   medium     48      1.63
+l1_grid              gpt-image-1.5  1536x1024   medium    220     11.00
+l1_depth             gpt-image-1.5  1536x1024   medium    264     13.20
+l1_palette           gpt-image-1.5  1536x1024   medium     90      4.50
+l1_probe             gpt-image-2    1536x1024   medium      6      0.30
+------------------------------------------------------------------------------
+TOTAL                                                     644     31.18
+                                                          AUD     44.16  (at 1.4164 AUD/USD)
+
+taste brief: absent
+[!] WARNING: the taste profile was NOT found. ... it is a BLIND run
+[DRY RUN] 644 images, USD 31.18 / AUD 44.16. Zero API calls were made and
+zero dollars were spent.
+```
+
+L2 and L3 were dry-run against a synthetic 10-pick file and scale linearly:
+10 picks gave L2 = 60 images / $3.00 and L3 = 50 images / $10.00. At the planned
+36 and 24 picks that is **216 / $10.80** and **120 / $24.00**.
+
+Ceiling behaviour, proven: `--wave l3 --ceiling-usd 2` printed
+`[ABORT] this wave would take the run to USD 10.00, which is USD 8.00 over the
+ceiling of USD 2.00` and **exited 2 having generated nothing**.
+`--ceiling-usd 9999` printed `clamping to 75.5`.
+
+### The projection, added up
+
+```
+L0        64 x 0.034 =  2.18
+L1 grid  220 x 0.050 = 11.00
+L1 depth 264 x 0.050 = 13.20
+L1 pal    90 x 0.050 =  4.50
+L1 probe   6 x 0.050 =  0.30
+L2       216 x 0.050 = 10.80
+L3 land   96 x 0.200 = 19.20
+L3 port   24 x 0.200 =  4.80
+reserve              =  6.00
+                       ------
+                        71.98 USD  =  101.94 AUD  @ 1.4164
+ceiling                 75.50 USD  =  106.94 AUD
+```
+
+Roughly 1,100 images. Under half the budget would be AUD 55, i.e. USD 38.8 --
+the overnight wave alone is USD 31.18, so **L0+L1 on their own do not clear the
+bar**. Clearing it requires Pip to actually review and run L2 and L3. That is a
+feature: the money is deliberately parked behind his eye rather than spent blind.

--- a/docs/design/ART_RUN_2026-08-07.md
+++ b/docs/design/ART_RUN_2026-08-07.md
@@ -96,11 +96,11 @@ them**.
 
 | level | what | attended? | images | USD |
 |---|---|---|---|---|
-| L0 | swatch round -- palette conglomerate, fast yes/no | unattended | 64 | 2.18 |
-| L1 | wide net -- 22 subjects x 10 renderings, the exploration | unattended | 580 | 29.00 |
+| L0 | swatch round -- 9 palettes, fast yes/no | unattended | 72 | 2.45 |
+| L1 | wide net -- 22 subjects x 10 renderings + 12 coherent directions | unattended | 580 | 29.00 |
 | L2 | tweened and twinned -- one controlled step at a time | **needs picks** | 216 | 10.80 |
 | L3 | hero prints and posters -- few, large, high quality | **needs picks** | 120 | 24.00 |
-| -- | reserve (coordination#33 late requests, reruns, topup) | -- | ~120 | 6.00 |
+| -- | reserve (coordination#33 late requests, reruns, topup) | -- | ~110 | 5.73 |
 | | **planned total** | | **~1,100** | **71.98** |
 | | hard ceiling enforced in code | | | **75.50** |
 
@@ -205,10 +205,162 @@ r09 photographic film still, r10 linocut relief.
 - `l1_grid` -- 220. **Full factorial**: every subject in every rendering,
   exactly once. A complete cross is what lets subject preference and rendering
   preference be read *independently*; a scatter cannot separate them.
-- `l1_depth` -- 264. 22 subjects x the 4 renderings the taste profile favours x
-  3 more rolls, numbered v2/v3/v4 so `l1_grid`'s v1 counts as the first roll.
-- `l1_palette` -- 90. 6 subjects x 5 palettes x 3 rolls at full poster size.
+- `l1_family` -- 264. 22 subjects x **12 coherent art directions**. See
+  section 4b; this block replaced the original depth block.
+- `l1_palette` -- 90. 10 subjects x 9 palettes, one roll each, at full poster
+  size.
 - `l1_probe` -- 6. The `gpt-image-2` probe described above.
+
+**Every prompt in L1 is distinct.** Nothing in this wave re-rolls a prompt that
+another job already rendered.
+
+---
+
+## 4b. What the taste profile changed, and why
+
+`docs/design/TASTE_PROFILE_2026-08-06.md` landed on main after this queue was
+first written. It is re-derivable with `python tools/art_review/measure_taste.py`.
+Four changes came out of reading it.
+
+### The block it killed
+
+The original `l1_depth` was **264 images, $13.20, spent on rolls v2/v3/v4 of
+prompts already rendered once**. The profile measures that as worthless:
+
+```
+slots where variant numbers differ: 119
+  chose highest vN:  40   (random expectation 47.3)
+  chose lowest  vN:  50   (random expectation 48.2)
+  binomial p, highest vs lowest: 0.34
+per-variant hit rates: v1 33.3%  v2 42.9%  v3 25.0%  v4 32.0%  (base rate 34%)
+```
+
+Iterating a prompt bought nothing measurable across 119 contested slots. So the
+block was **reshaped into breadth at identical count and identical cost**, not
+deleted -- deleting it would have underspent, which is Pip's stated failure
+condition.
+
+### What replaced it: 12 coherent directions
+
+The reframe comes from a note he typed on 2026-07-25, eleven days before asking
+for the profile:
+
+> "we keep getting things that are individually good, subtly with mayn upsides,
+> but need coherence in direction"
+
+The profile's own reading is that the measurement mostly found *the absence of a
+shared direction*, and that the right response is to "pick a direction on the
+axes where he has no revealed preference, apply it uniformly, and let him reject
+the direction rather than individual images."
+
+So `l1_family` is 22 subjects x **12 art directions**, where a direction is a
+*bundle* -- rendering plus palette plus a stated register -- held uniform across
+all 22 subjects:
+
+| id | direction | rendering + palette | the register |
+|---|---|---|---|
+| f01 | Municipal Record | drafting + paper-and-ink | pages from a public works archive |
+| f02 | Night Shift | film still + sodium night | after midnight, available light only |
+| f03 | Terminal Native | CRT phosphor + phosphor green | only ever seen through the game's own display |
+| f04 | Ink Ledger | line and wash + blueprint | an engineer's site notebook |
+| f05 | **Warm Grime (control arm)** | painterly + house amber | the incumbent house style, unchanged |
+| f06 | Hard Evidence | crisp + ash and rust | an insurance photograph, no glow anywhere |
+| f07 | Public Information | screenprint + institutional green | a mid-century emergency notice |
+| f08 | Cold Audit | crisp + house cold | an inspection at 4pm on a Tuesday |
+| f09 | Duplicator | risograph + paper-and-ink | run off on the office riso, two inks |
+| f10 | Matte Dread | gouache + house violet | the one openly ominous direction |
+| f11 | Carved | linocut + ash and rust | if it cannot be carved it does not appear |
+| f12 | Field Report | film still + house cold | handheld flash, filed because it has to be |
+
+f05 is the incumbent house style included unchanged, so the eleven new
+directions have something honest to beat.
+
+**The argument for this shape over a scatter:** a scatter of 264 independent
+images gives Pip 264 individual verdicts and no aggregate. Twelve families of 22
+give him twelve verdicts he can actually hold in his head, each backed by 22
+pieces of evidence spanning the whole subject range -- which is the only way to
+tell "this direction is good" from "this direction happened to suit the server
+altar". The cost of the shape is that a family is confounded (rendering and
+palette move together), so `l1_grid` runs alongside it to keep the single-axis
+read available. Both blocks, same money as before.
+
+**The argument against, stated because it is real:** twelve families x 22
+subjects is only one sample per cell, so a family that lands badly on one subject
+cannot be distinguished from a family that lands badly generally, except by
+eyeballing its other 21. If Pip wants that separated, the answer is a second
+pass on the surviving families, not more rolls now.
+
+### What is now held constant in every prompt
+
+Two measured signals, both p<0.0001 at n=136, are encoded as base clauses that
+go into **every** scene prompt -- and early in the string, where a long prompt is
+least likely to drop them:
+
+- **`poster_contrast`** -- strong value structure, real blacks and real brights
+  in frame, nothing in undifferentiated mid-grey. (Chosen higher in 101 of 136
+  slots, 74.3%; holds at 71.9% with the 22 resolution-ladder slots removed; not
+  carried by one destination.)
+- **`poster_detail`** -- detailed over minimal, texture and grain and wear, and
+  **nothing out of focus, ever**. (97 of 136, 71.3%, corroborated by an
+  independent bytes-per-pixel proxy at n=114, 64.0%, p=0.0035; plus five discard
+  notes reading "blurry".)
+
+Three more come from his written notes rather than from pixels, which the profile
+argues is the stronger evidence:
+
+- **`poster_people`** rewritten to his own vocabulary -- shot from the back,
+  silhouette, hood, hat, mask, cloak, ambiguous human-or-machine, never readable
+  as male. Nine notes, one repeated verbatim four times.
+- **`poster_symbol`** -- no nuclear trefoil, no padlock, no chessboard, no
+  cascading binary. Seven notes reject a cliche symbol by name; the positives
+  (lanyard, desk bell, filling meter) are all "unexpected but legible ordinary
+  object standing in for an abstraction".
+- **`poster_separation`** -- subject and its key sub-element distinguishable by
+  hue as well as value. Four notes ask for exactly this, and the profile's
+  reading reconciles it with the saturation null: he is asking for separation,
+  not for more colour.
+
+### The prop clause was itself an instance of the problem
+
+The original `poster_props` mandated "a banker's desk lamp is ALWAYS the green
+glass shade on a brass stem". His note:
+
+> "we ssem toh ave massively overindexed on the bankers lamp as an art asset.
+> This probably meansd we need to generate a bunch more asset descriptions that
+> *could* be in scenes so that llm's can chooose between different sets of
+> objects"
+
+The mandate was replaced with a ~50-item institutional object vocabulary and an
+explicit instruction to vary it between images.
+
+### What is now varied rather than held
+
+- **Composition** is the cleanest null measured (52.9%, p=0.55, permutation
+  p=0.80). Every scene block now rotates composition deterministically from the
+  cell key instead of holding `c_default`. Free, and nothing is wasted.
+- **Palette** gained a **ninth, green-dominant** entry (`p09`, institutional
+  green) and `l1_palette` now crosses all nine. The profile flagged three
+  green-ish hue buckets as mild aversions at p=0.005 to p=0.041 across twelve
+  tests, with Bonferroni putting the best at p=0.06 -- *not established*.
+  Designing around that would narrow the palette on evidence that does not hold,
+  so the run puts green in front of him deliberately instead.
+
+### Two caveats respected rather than papered over
+
+- **136 decisions in 10.4 minutes, 1.7s median gap.** This profiles what
+  survives a one-second glance. Contrast and detail are exactly the dimensions a
+  one-second glance can see, so the finding may be an artefact of the tempo
+  rather than of taste. That is why only two pixel-derived holds were adopted,
+  both at p<0.0001 and both corroborated by things he typed months earlier, and
+  why the incumbent house style runs as f05 rather than being assumed beaten.
+  **The falsification test, from the profile itself:** if contrast and detail are
+  held high all night and the pick rate on the next contested pass does not rise
+  above 34%, these signals were about the old batches' failure modes, not taste.
+- **22 of the 136 slots were resolution ladders carrying no taste at all** --
+  the same artwork at 32/48/64/128/256/512/1024. Effective n is 114 for anything
+  ladder-sensitive, and the picker should never have shown them. That is a
+  tooling bug in the slot picker, not a taste finding, and it deserves its own
+  issue.
 
 ---
 
@@ -424,21 +576,26 @@ is the stated failure mode of this run.
 ```
 block                model          size        qual        n       USD
 ------------------------------------------------------------------------------
-l0_sheets            gpt-image-1.5  1024x1024   medium     16      0.54
-l0_anchors           gpt-image-1.5  1024x1024   medium     48      1.63
+l0_sheets            gpt-image-1.5  1024x1024   medium     18      0.61
+l0_anchors           gpt-image-1.5  1024x1024   medium     54      1.84
 l1_grid              gpt-image-1.5  1536x1024   medium    220     11.00
-l1_depth             gpt-image-1.5  1536x1024   medium    264     13.20
+l1_family            gpt-image-1.5  1536x1024   medium    264     13.20
 l1_palette           gpt-image-1.5  1536x1024   medium     90      4.50
 l1_probe             gpt-image-2    1536x1024   medium      6      0.30
 ------------------------------------------------------------------------------
-TOTAL                                                     644     31.18
-                                                          AUD     44.16  (at 1.4164 AUD/USD)
+TOTAL                                                     652     31.45
+                                                          AUD     44.54  (at 1.4164 AUD/USD)
 
-taste brief: absent
-[!] WARNING: the taste profile was NOT found. ... it is a BLIND run
-[DRY RUN] 644 images, USD 31.18 / AUD 44.16. Zero API calls were made and
+taste brief: brief-heading  sha256=e6c7cdf700a0  injected HOLD chars=0
+[DRY RUN] 652 images, USD 31.45 / AUD 44.54. Zero API calls were made and
 zero dollars were spent.
 ```
+
+The profile carries no ` ```artbrief ` fenced block, so no prose was injected --
+its findings are encoded as explicit base clauses in the spec instead, which is
+auditable prompt text rather than a paragraph of p-values handed to an image
+model. Its sha256 is recorded in every provenance sidecar regardless, so any
+image can be traced to the exact version of the brief that shaped it.
 
 L2 and L3 were dry-run against a synthetic 10-pick file and scale linearly:
 10 picks gave L2 = 60 images / $3.00 and L3 = 50 images / $10.00. At the planned
@@ -452,18 +609,19 @@ ceiling of USD 2.00` and **exited 2 having generated nothing**.
 ### The projection, added up
 
 ```
-L0        64 x 0.034 =  2.18
-L1 grid  220 x 0.050 = 11.00
-L1 depth 264 x 0.050 = 13.20
-L1 pal    90 x 0.050 =  4.50
-L1 probe   6 x 0.050 =  0.30
-L2       216 x 0.050 = 10.80
-L3 land   96 x 0.200 = 19.20
-L3 port   24 x 0.200 =  4.80
-reserve              =  6.00
-                       ------
-                        71.98 USD  =  101.94 AUD  @ 1.4164
-ceiling                 75.50 USD  =  106.94 AUD
+L0 sheets  18 x 0.034 =  0.61
+L0 anchors 54 x 0.034 =  1.84
+L1 grid   220 x 0.050 = 11.00
+L1 family 264 x 0.050 = 13.20
+L1 pal     90 x 0.050 =  4.50
+L1 probe    6 x 0.050 =  0.30
+L2        216 x 0.050 = 10.80
+L3 land    96 x 0.200 = 19.20
+L3 port    24 x 0.200 =  4.80
+reserve               =  5.73
+                        ------
+                         71.98 USD  =  101.94 AUD  @ 1.4164
+ceiling                  75.50 USD  =  106.94 AUD
 ```
 
 Roughly 1,100 images. Under half the budget would be AUD 55, i.e. USD 38.8 --

--- a/tools/art_review/apply_review.py
+++ b/tools/art_review/apply_review.py
@@ -108,7 +108,28 @@ _ENDGAME_STUDY_HOLD = Hold(
     "the eventual production endgame batch, never the studies"
 )
 
+# The 2026-08-07 art night (docs/design/ART_RUN_2026-08-07.md, queue
+# tools/assets/manifests/art_night_2026-08-07.json): 652 unattended
+# 1024/1536 direction studies across a swatch round, a subject x rendering
+# factorial, twelve coherent art directions, a palette cross and a model
+# probe. Library reference per ADR-0019 -- promotion needs a mechanically
+# verified demand entry, and none of these have one. One shared Hold so the
+# report rolls the whole night up together.
+_ART_NIGHT_0807_HOLD = Hold(
+    "2026-08-07 art night direction studies (swatch round, subject x "
+    "rendering factorial, 12 coherent art directions, palette cross, model "
+    "probe; tools/assets/manifests/art_night_2026-08-07.json lineage): "
+    "Library reference per ADR-0019, not game-ready derivatives -- L2/L3 "
+    "descendants of the winners are what could ever be promoted, never these"
+)
+
 GEN_DEST = {
+    "an0807_l0_sheets": _ART_NIGHT_0807_HOLD,
+    "an0807_l0_anchors": _ART_NIGHT_0807_HOLD,
+    "an0807_l1_grid": _ART_NIGHT_0807_HOLD,
+    "an0807_l1_family": _ART_NIGHT_0807_HOLD,
+    "an0807_l1_palette": _ART_NIGHT_0807_HOLD,
+    "an0807_l1_probe": _ART_NIGHT_0807_HOLD,
     "game_icons": "godot/assets/icons/generated",
     "ui_icons": "godot/assets/icons/generated",
     "action_icons_missing": "godot/assets/icons/generated",

--- a/tools/assets/generate_images.py
+++ b/tools/assets/generate_images.py
@@ -47,19 +47,34 @@ DEFAULT_GEMINI_MODEL = "gemini-3-pro-image"
 
 DEFAULT_BACKEND = "openai"
 
-# Rough per-image cost (USD) for the dry-run/confirmation estimate only.
-# gpt-image-1 at 1024x1024 was $0.08; gpt-image-1.5 is ~20% cheaper and larger
-# canvases cost more. These are estimates -- confirm vs live pricing pages.
-COST_PER_IMAGE_USD = 0.08  # kept for backwards compat / default fallback
+# Per-image cost (USD). PUBLISHED TARIFF, not billed truth -- read off OpenAI's
+# first-party gpt-image-1.5 model page on 2026-08-06. Whatever this function
+# returns is what gets written into the run log, so do not read those logs back
+# and call the number MEASURED: it is this constant, echoed.
+# (docs/art/SEED_ART_COST_MODEL.md did exactly that; see
+#  docs/design/ART_RUN_2026-08-07.md section 1.)
+COST_PER_IMAGE_USD = 0.133  # fallback: 1024x1024 high
+
+GPT_IMAGE_TARIFF_USD = {
+    "1024x1024": {"low": 0.009, "medium": 0.034, "high": 0.133},
+    "1536x1024": {"low": 0.013, "medium": 0.050, "high": 0.200},
+    "1024x1536": {"low": 0.013, "medium": 0.050, "high": 0.200},
+}
 
 
-def estimate_cost_per_image(size_str, backend=DEFAULT_BACKEND):
-    """Best-effort per-image cost estimate for dry-run reporting only."""
+def estimate_cost_per_image(size_str, backend=DEFAULT_BACKEND, quality=None):
+    """Published-tariff per-image cost, for dry-run and confirmation reporting.
+
+    quality=None means the manifest did not choose one, so the API applies its
+    own default ('auto'), which is free to bill at the HIGH tier -- 4x medium at
+    1536x1024. Price the unknown case as high rather than optimistically.
+    """
     if backend == "gemini":
         return 0.13  # Nano Banana Pro approx; confirm vs Gemini pricing
-    # OpenAI gpt-image-1.5 (medium quality), rough per-size estimates.
-    table = {"1024x1024": 0.06, "1536x1024": 0.09, "1024x1536": 0.09}
-    return table.get(str(size_str).lower(), COST_PER_IMAGE_USD)
+    by_size = GPT_IMAGE_TARIFF_USD.get(str(size_str).lower())
+    if by_size is None:
+        return COST_PER_IMAGE_USD
+    return by_size.get(quality or "high", COST_PER_IMAGE_USD)
 
 
 # Initialize client lazily to avoid errors in dry-run mode
@@ -144,7 +159,7 @@ def _aspect_ratio(width, height):
     return f"{width // g}:{height // g}"
 
 
-def _openai_generate_bytes(model, prompt, size_str, background="transparent"):
+def _openai_generate_bytes(model, prompt, size_str, background="transparent", quality=None):
     """Call the OpenAI Images API and return raw image bytes.
 
     gpt-image-1.5 keeps gpt-image-1's request shape (model/prompt/size, and
@@ -160,9 +175,10 @@ def _openai_generate_bytes(model, prompt, size_str, background="transparent"):
     'auto'. PNG (the gpt-image default) is alpha-capable, so no output_format
     override is needed.
     """
-    result = get_client().images.generate(
-        model=model, prompt=prompt, size=size_str, background=background
-    )
+    kwargs = {"model": model, "prompt": prompt, "size": size_str, "background": background}
+    if quality:
+        kwargs["quality"] = quality
+    result = get_client().images.generate(**kwargs)
     return base64.b64decode(result.data[0].b64_json)
 
 
@@ -272,6 +288,7 @@ def generate_image(
     variant_num=None,
     reference_images=None,
     background="transparent",
+    quality=None,
 ):
     """
     Generate an image (via the chosen backend) and downscaled versions.
@@ -299,11 +316,11 @@ def generate_image(
 
     # Skip if exists unless force
     if master_path.exists() and not force:
-        log(f"  ⏭️  Skipping {base_name} (already exists, use --force to regenerate)")
+        log(f"  [SKIP]  Skipping {base_name} (already exists, use --force to regenerate)")
         log(f"SKIP: {base_name} - file exists", "debug")
         return False, 0.0, str(master_path)
 
-    log(f"  🎨 Generating {base_name} ({size_str}, {backend})...")
+    log(f"  [GEN] Generating {base_name} ({size_str}, {backend})...")
     log(f"GENERATE: {base_name}", "debug")
     log(f"PROMPT: {full_prompt}", "debug")
 
@@ -311,9 +328,9 @@ def generate_image(
         if backend == "gemini":
             img_bytes = _gemini_generate_bytes(model, full_prompt, size_str, reference_images)
         else:
-            img_bytes = _openai_generate_bytes(model, full_prompt, size_str, background)
+            img_bytes = _openai_generate_bytes(model, full_prompt, size_str, background, quality)
     except Exception as e:
-        log(f"  ❌ ERROR generating {base_name}: {e}", "error")
+        log(f"  [ERR] ERROR generating {base_name}: {e}", "error")
         log(f"ERROR: {base_name} - {str(e)}", "error")
         return False, 0.0, None
 
@@ -330,7 +347,7 @@ def generate_image(
         resized.save(output_dir / f"{base_name}_{width}.png")
 
     downscaled = len([w for w in sizes if w < master_w])
-    log(f"  ✅ Saved: {master_path.name} (+ {downscaled} downscaled versions)")
+    log(f"  [OK] Saved: {master_path.name} (+ {downscaled} downscaled versions)")
     log(f"SUCCESS: {base_name} -> {master_path}", "debug")
 
     return True, unit_cost, str(master_path)
@@ -425,6 +442,15 @@ Examples:
         "gemini-3-pro-image (gemini).",
     )
     parser.add_argument(
+        "--quality",
+        choices=["low", "medium", "high"],
+        default=None,
+        help="Image quality tier. Overrides the manifest's 'quality' key. If "
+        "neither is set the API's own default applies, which can bill at the "
+        "HIGH tier (4x medium at 1536x1024) -- so leaving this unset is a cost "
+        "decision, not a neutral one.",
+    )
+    parser.add_argument(
         "--reference-images",
         nargs="+",
         help="Reference image paths for style/subject consistency "
@@ -444,7 +470,7 @@ Examples:
     # Load YAML
     yaml_path = Path(args.file)
     if not yaml_path.exists():
-        print(f"❌ File not found: {yaml_path}")
+        print(f"[ERR] File not found: {yaml_path}")
         return 1
 
     data = load_prompts(yaml_path)
@@ -453,7 +479,12 @@ Examples:
     asset_type = data.get("asset_type", "unknown")
     output_sizes = data.get("output_sizes", [1024, 512, 256, 128, 64])
     size_str = str(data.get("default_size", "1024x1024"))
-    unit_cost = estimate_cost_per_image(size_str, args.backend)
+    # quality: manifest key, overridable on the CLI. If neither sets it the API
+    # applies its own default ('auto'), which is free to bill at the HIGH tier
+    # -- 4x medium at 1536x1024. Every batch before 2026-08-06 ran that way
+    # without choosing, which is why the repo's cost history is unreliable.
+    quality = args.quality or data.get("quality")
+    unit_cost = estimate_cost_per_image(size_str, args.backend, quality)
     # Alpha control for the OpenAI backend: 'transparent' (default, icons),
     # 'opaque' (full-bleed hero banners / backgrounds), or 'auto'.
     background = str(data.get("background", "transparent"))
@@ -480,18 +511,26 @@ Examples:
         filtered = filtered[: args.limit]
 
     if not filtered:
-        print("ℹ️  No assets match the specified filters.")
+        print("[i]  No assets match the specified filters.")
         return 0
 
     # Summary
     print(f"\n{'='*60}")
-    print(f"📋 Asset Type: {asset_type}")
-    print(f"📁 Output Dir: {output_dir}")
-    print(f"🧩 Backend: {args.backend}")
-    print(f"🤖 Model: {model}")
-    print(f"📐 Size: {size_str}")
-    print(f"🖼️  Background: {background} (openai backend)")
-    print(f"🎯 Assets to generate: {len(filtered)}")
+    print(f"[*] Asset Type: {asset_type}")
+    print(f"[*] Output Dir: {output_dir}")
+    print(f"[*] Backend: {args.backend}")
+    print(f"[*] Model: {model}")
+    print(f"[*] Size: {size_str}")
+    print(f"[*]  Background: {background} (openai backend)")
+    if quality:
+        print(f"[*] Quality: {quality}  (priced at ${unit_cost:.3f}/image, published tariff)")
+    else:
+        print(
+            "[!] Quality: NOT SET -- the API default applies and may bill at the "
+            f"HIGH tier. Priced defensively at ${unit_cost:.3f}/image. Set "
+            "'quality' in the manifest or pass --quality."
+        )
+    print(f"[*] Assets to generate: {len(filtered)}")
     if args.category:
         print(f"   Category filter: {args.category}")
     if args.status:
@@ -501,7 +540,7 @@ Examples:
     print(f"{'='*60}\n")
 
     if args.dry_run:
-        print("🔍 DRY RUN MODE - showing prompts without generating:\n")
+        print("[*] DRY RUN MODE - showing prompts without generating:\n")
         for asset in filtered:
             asset_id = asset.get("id", "unknown")
             full_prompt = build_full_prompt(data, asset)
@@ -517,13 +556,13 @@ Examples:
             estimated_cost = len(filtered) * unit_cost
             total_images = len(filtered)
             print(
-                f"\n💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: 1 new variant per asset @ ~${unit_cost:.2f} each, est.)"
+                f"\n[$] Estimated cost: ${estimated_cost:.2f} ({total_images} images: 1 new variant per asset @ ~${unit_cost:.2f} each, est.)"
             )
         else:
             estimated_cost = len(filtered) * args.variants * unit_cost
             total_images = len(filtered) * args.variants
             print(
-                f"\n💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: {len(filtered)} assets × {args.variants} variants @ ~${unit_cost:.2f} each, est.)"
+                f"\n[$] Estimated cost: ${estimated_cost:.2f} ({total_images} images: {len(filtered)} assets x {args.variants} variants @ ~${unit_cost:.2f} each, est.)"
             )
         return 0
 
@@ -532,18 +571,18 @@ Examples:
         estimated_cost = len(filtered) * unit_cost
         total_images = len(filtered)
         print(
-            f"💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: 1 new variant per asset)\n"
+            f"[$] Estimated cost: ${estimated_cost:.2f} ({total_images} images: 1 new variant per asset)\n"
         )
     elif args.variants > 1:
         estimated_cost = len(filtered) * args.variants * unit_cost
         total_images = len(filtered) * args.variants
         print(
-            f"💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images: {len(filtered)} assets × {args.variants} variants)\n"
+            f"[$] Estimated cost: ${estimated_cost:.2f} ({total_images} images: {len(filtered)} assets x {args.variants} variants)\n"
         )
     else:
         estimated_cost = len(filtered) * unit_cost
         total_images = len(filtered)
-        print(f"💰 Estimated cost: ${estimated_cost:.2f} ({total_images} images)\n")
+        print(f"[$] Estimated cost: ${estimated_cost:.2f} ({total_images} images)\n")
 
     if not args.yes:
         response = input("Proceed with generation? [y/N]: ")
@@ -552,7 +591,7 @@ Examples:
             return 0
 
     # Generate images
-    log("\n🚀 Starting generation...\n")
+    log("\n[>>] Starting generation...\n")
     log(f"Starting batch: {len(filtered)} assets, {args.variants} variants each", "debug")
 
     total_cost = 0.0
@@ -607,6 +646,7 @@ Examples:
                 variant_num=v_num,
                 reference_images=reference_images,
                 background=background,
+                quality=quality,
             )
 
             if success:
@@ -647,12 +687,12 @@ Examples:
     # Save updated YAML
     if args.update_yaml and success_count > 0:
         save_prompts(yaml_path, data)
-        log(f"💾 Updated {yaml_path} with generation metadata\n")
+        log(f"[*] Updated {yaml_path} with generation metadata\n")
 
     # Summary
     failed_count = len(filtered) - success_count - skip_count
     log(f"\n{'='*60}")
-    log("✨ Generation Complete!")
+    log("[OK] Generation Complete!")
     log(f"   Success: {success_count}")
     log(f"   Skipped: {skip_count}")
     log(f"   Failed: {failed_count}")

--- a/tools/assets/manifests/art_night_2026-08-07.json
+++ b/tools/assets/manifests/art_night_2026-08-07.json
@@ -50,8 +50,12 @@
   "base_clauses": {
     "poster_base": "wide cinematic POSTER ART illustration for a video game, full-bleed edge-to-edge opaque composition that completely fills the frame with no transparency and no cut-outs and no border, lived-in physical props and real architecture rather than abstract shapes, every object in frame must be immediately identifiable as a specific real thing -- a filing cabinet, a pallet, a transformer, a mug -- and never a generic boxy shape, because an unrecognisable object is visual noise rather than a prop, no text, no lettering, no signage, no numerals, no logo, no watermark, no UI overlay, high production value",
     "poster_lighting": "DISCIPLINED AND UNDERSTATED LIGHTING, roughly 75 percent more subtle than a typical dramatic game illustration: mood must NEVER come from the main light source, so the ordinary room lights, street lights and work lights in the scene are plain neutral white or plain warm tungsten exactly as they would really be, never tinted red or green or purple for atmosphere; coloured light is permitted ONLY where a real fixture in the world would genuinely emit that colour, for example a screen, an indicator lamp, an emergency beacon, a corona arc or the impossible thing itself; at most one ambient source plus one glowing source, most of the frame kept dark with separated pockets of light, restraint over drama",
-    "poster_people": "NO PEOPLE BY DEFAULT -- the player is a bureaucrat and the art is about everyone else, so incidental figures are removed rather than restyled; where a figure is unavoidable it must be an androgynous silhouette with no readable gender cues, no distinguishing jewellery, no distinctive hairstyle and no face detail, its identity destroyed by blocking, backlighting and occlusion rather than merely turned away",
-    "poster_props": "props must be era-correct for 2017 to 2032 and consistent with the game's own set dressing: a banker's desk lamp is ALWAYS the green glass shade on a brass stem, office chairs, rubber date stamps, manila folders, ring binders, CRT and early-flatscreen monitors, chain-link fencing that hangs correctly on its posts with a real top rail, real tension wire and believable sag; ABSOLUTELY NO BARBED WIRE and no razor wire anywhere; uncrewed machines are directly manufactured and therefore have NO COCKPIT, NO CANOPY and no windows for a pilot",
+    "poster_people": "NO PEOPLE BY DEFAULT -- the player is a bureaucrat and the art is about everyone else, so incidental figures are removed rather than restyled. Where a figure is genuinely unavoidable it must be IMPOSSIBLE TO IDENTIFY and must NOT read as male: shoot it from behind, or use a full silhouette, a hood, a hat, a mask, a cloak, heavy protective gear, or a figure deliberately ambiguous between human and machine; no face detail, no readable gender cues, no distinctive hairstyle, no distinguishing jewellery; identity destroyed by blocking, backlighting and occlusion rather than merely turned away",
+    "poster_props": "props must be era-correct for 2017 to 2032 and physically believable. DELIBERATELY VARY THE OBJECT VOCABULARY between images rather than reaching for the same few signature props: draw broadly from institutional office and industrial life -- ring binders, manila folders, box files, rubber date stamps and their inkpads, franking machines, guillotine paper cutters, laminators, wall clocks, LTO tape cartridges, patch panels, cable trays, KVM switches, rack rails, blanking plates, power distribution units, fire extinguishers, first-aid cabinets, wire shelving, pallet trucks, flight cases, folding tables, stacking chairs, whiteboards and their tray of dying markers, corkboards, pigeonholes, drinking fountains, vending machines, ceiling tiles, venetian and vertical blinds, fluorescent troffers, anglepoise lamps, desk fans, CRT and early-flatscreen monitors, keyboards with worn legends, coiled cables, mugs, and chain-link fencing that hangs correctly on its posts with a real top rail, real tension wire and believable sag. ABSOLUTELY NO BARBED WIRE and no razor wire anywhere; uncrewed machines are directly manufactured and therefore have NO COCKPIT, NO CANOPY and no windows for a pilot",
+    "poster_contrast": "STRONG VALUE STRUCTURE, and treat this as the single most important rendering instruction: the image must carry a wide luminance range with genuinely black blacks and genuinely bright brights both present somewhere in frame, clear separation between the light masses and the dark masses, nothing left sitting in an undifferentiated mid-grey; the picture should read as a set of distinct value shapes before it reads as a set of objects",
+    "poster_detail": "DETAILED RATHER THAN MINIMAL: rendered depth, material texture, surface grain, accumulated grime, wear and small incidental objects, so every large area carries some texture instead of being an empty flat. NOTHING IN FRAME IS OUT OF FOCUS, nothing is soft-focus and nothing is blurred; where a rendering calls for atmosphere it comes from aerial perspective and tonal separation, NEVER from defocus",
+    "poster_symbol": "AVOID THE FIRST OBVIOUS SYMBOL: no nuclear trefoil, no radiation trefoil, no padlock, no chessboard, no ticking bomb, no glowing red eye, no brain in a jar, no cascading binary, no hooded reaper. Where an abstract idea needs a stand-in, use an unexpected but immediately legible ordinary object instead -- a lanyard, a desk bell, a filling gauge, a queue ticket, a rubber stamp, a fire door, a keyed cabinet",
+    "poster_separation": "COLOUR SEPARATION: the main subject and its most important sub-element must be distinguishable from each other and from the background by HUE as well as by value, so the parts of the picture are told apart at a glance instead of merging into one mass; this is separation, not saturation, and it is not a licence to make the image more colourful overall",
     "poster_safety": "strictly no blood and no gore anywhere in the image, damage to machines shown as mechanical breakage with glowing green or blue coolant and hydraulic fluid only, no wounded people, no real-world brands or insignia or logos, no identifiable real people, nothing sexualised, all human figures fully and modestly clothed in ordinary institutional workwear",
     "poster_tone": "a bureaucratic world with weirdness leaking in at the edges; ordinary institutional competence rendered straight while something impossible happens deadpan in the same frame; commit to only one flavour of strangeness per image out of eldritch intrusion, technology run amok, or environmental collapse; restrained and elegant, never garish, never lurid"
   },
@@ -77,7 +81,24 @@
     {"id": "p05", "name": "sodium night", "house": false, "clause": "PALETTE: cold blue-grey grounds #1e2733 and #141b24; exactly one saturated accent, sodium-vapour street orange #ff9a3c; the classic municipal night-time colour split of cold shadow against warm lamp"},
     {"id": "p06", "name": "paper and ink", "house": false, "clause": "PALETTE: INVERTED VALUE STRUCTURE -- a bright warm off-white paper ground #e8e0cf carrying most of the frame, drawn and shaded in ink black #171412 and warm grey, with exactly one accent of red-oxide stamp ink #a83c2b; a daylight bureaucratic register, mostly light rather than mostly dark"},
     {"id": "p07", "name": "blueprint", "house": false, "clause": "PALETTE: a saturated prussian-blue ground #123a5c across the whole frame, all forms described in chalk-white and pale-cyan line #d8e6f2, with exactly one accent of warm amber #e8a33d where a real light source sits"},
-    {"id": "p08", "name": "ash and rust", "house": false, "clause": "PALETTE: desaturated concrete and ash greys #3a3a38, #2a2a28 and #55534d across the whole frame, one accent of oxidised rust orange #8a4a2b that is a MATERIAL and not a light; NO GLOWING SOURCE ANYWHERE in this image, all light is plain ambient daylight or plain overhead fluorescent"}
+    {"id": "p08", "name": "ash and rust", "house": false, "clause": "PALETTE: desaturated concrete and ash greys #3a3a38, #2a2a28 and #55534d across the whole frame, one accent of oxidised rust orange #8a4a2b that is a MATERIAL and not a light; NO GLOWING SOURCE ANYWHERE in this image, all light is plain ambient daylight or plain overhead fluorescent"},
+    {"id": "p09", "name": "institutional green", "house": false, "clause": "PALETTE: the colour of a government building's corridor -- pale institutional green walls #7d9b7a and #5c7a5e over a cream #ded6c2 ceiling and skirting, everything drawn in ink black line, with exactly one accent of signal red #b23a2e; green is the DOMINANT hue of the whole frame"}
+  ],
+  "_palette_note": "p09 exists specifically to settle the hue question the taste profile flagged. Three green-ish hue buckets came up as mild aversions at p=0.005 to p=0.041 across twelve tests, and Bonferroni puts the best of them at p=0.06 -- not established. Designing around an uncorrected result would quietly narrow the palette on evidence that does not hold, so this run puts a green-dominant palette in front of him deliberately instead.",
+
+  "families": [
+    {"id": "f01", "name": "Municipal Record", "rendering": "r08", "palette": "p06", "register": "COHERENT DIRECTION -- MUNICIPAL RECORD: the whole set looks like pages torn from a public works archive. Everything is drawn as though it were being catalogued rather than dramatised, flat frontal or near-orthographic views, objects laid out for inspection, high-contrast black line on warm paper, the light of a photocopier rather than of a scene"},
+    {"id": "f02", "name": "Night Shift", "rendering": "r09", "palette": "p05", "register": "COHERENT DIRECTION -- NIGHT SHIFT: every image is a photograph taken outdoors or at a window after midnight on available light only, long exposure, cold shadow against warm municipal lamp, wet ground where there can be wet ground, nothing lit that would not really be lit"},
+    {"id": "f03", "name": "Terminal Native", "rendering": "r05", "palette": "p04", "register": "COHERENT DIRECTION -- TERMINAL NATIVE: the whole world is only ever seen through the game's own display, so every scene is a raster image on a monochrome monitor being looked at in a dark room; the fiction is that this is surveillance or telemetry, never a camera in the room"},
+    {"id": "f04", "name": "Ink Ledger", "rendering": "r04", "palette": "p07", "register": "COHERENT DIRECTION -- INK LEDGER: the set reads as an engineer's site notebook, pen and wash over a blue drafting ground, measured and annotated in spirit though never in text, construction lines left visible under the wash, the confidence of somebody recording a fact rather than composing a picture"},
+    {"id": "f05", "name": "Warm Grime", "rendering": "r01", "palette": "p01", "register": "COHERENT DIRECTION -- WARM GRIME (CONTROL ARM, the incumbent house style): painterly, amber, lived-in, the look this project has been making for a month; included unchanged so the new directions have something honest to beat"},
+    {"id": "f06", "name": "Hard Evidence", "rendering": "r02", "palette": "p08", "register": "COHERENT DIRECTION -- HARD EVIDENCE: every image is a forensic record of an object and its immediate surroundings, flat even light with no glow anywhere at all, obsessive material description, the register of an insurance photograph or an incident exhibit"},
+    {"id": "f07", "name": "Public Information", "rendering": "r03", "palette": "p09", "register": "COHERENT DIRECTION -- PUBLIC INFORMATION: mid-century government information poster, flat institutional green and cream, bold simplified shapes with one signal-red element carrying the warning, the calm authority of a notice pinned in a corridor telling you what to do in an emergency"},
+    {"id": "f08", "name": "Cold Audit", "rendering": "r02", "palette": "p02", "register": "COHERENT DIRECTION -- COLD AUDIT: overhead fluorescent and screen light only, clinical and even, every surface described sharply, the emotional temperature of an inspection carried out at 4pm on a Tuesday by somebody who does not work here"},
+    {"id": "f09", "name": "Duplicator", "rendering": "r06", "palette": "p06", "register": "COHERENT DIRECTION -- DUPLICATOR: the entire set was run off on the office risograph on the cheapest paper in the building, two inks, visible misregistration, the aesthetics of an internal memo nobody was proud of"},
+    {"id": "f10", "name": "Matte Dread", "rendering": "r07", "palette": "p03", "register": "COHERENT DIRECTION -- MATTE DREAD: hand-painted matte in big simple value masses, violet dominant, the one direction permitted to be openly ominous; the strangeness is structural and quiet rather than lurid, and it is present in every image of the set rather than saved for the scary ones"},
+    {"id": "f11", "name": "Carved", "rendering": "r10", "palette": "p08", "register": "COHERENT DIRECTION -- CARVED: relief print, no half tones anywhere, everything reduced to positive and negative shape; the discipline of the set is that if a form cannot survive being carved out of a block it does not appear"},
+    {"id": "f12", "name": "Field Report", "rendering": "r09", "palette": "p02", "register": "COHERENT DIRECTION -- FIELD REPORT: handheld on-camera flash documentation, harsh direct key from the camera position, hard black shadows thrown onto the wall behind, the register of somebody photographing a room quickly because they have to file it, not because they want it to look good"}
   ],
 
   "renderings": [
@@ -122,7 +143,7 @@
   ],
 
   "swatch_anchors": ["s01", "s04", "s07"],
-  "palette_block_subjects": ["s01", "s05", "s09", "s13", "s18", "s21"],
+  "palette_block_subjects": ["s01", "s05", "s08", "s09", "s11", "s13", "s16", "s18", "s20", "s21"],
 
   "levels": {
     "L0": {
@@ -136,16 +157,16 @@
           "kind": "swatch_sheet",
           "cross": {"palette": "*"},
           "variants": 2,
-          "note": "One pure swatch sheet per palette, two rolls each. 8 palettes x 2 = 16."
+          "note": "One pure swatch sheet per palette, two rolls each. 9 palettes x 2 = 18."
         },
         {
           "id": "l0_anchors",
           "kind": "scene",
           "cross": {"subject": "@swatch_anchors", "palette": "*"},
           "rendering": "r01",
-          "composition": "c_default",
+          "composition": "@rotate",
           "variants": 2,
-          "note": "Verbatim-identical anchor scene under every palette, so PALETTE is the only variable. 3 x 8 x 2 = 48."
+          "note": "Verbatim-identical anchor scene under every palette, so PALETTE is the only variable. 3 x 9 x 2 = 54. The two rolls differ in composition, which the taste profile measured as a clean null (52.9%, p=0.55) and therefore worth sampling rather than holding."
         }
       ]
     },
@@ -161,28 +182,26 @@
           "kind": "scene",
           "cross": {"subject": "*", "rendering": "*"},
           "palette": "@house_default",
-          "composition": "c_default",
+          "composition": "@rotate",
           "variants": 1,
-          "note": "Full factorial: every subject in every rendering, exactly once. 22 x 10 = 220. This is the measurement grid -- a complete cross lets subject preference and rendering preference be read independently."
+          "note": "Full factorial: every subject in every rendering, exactly once. 22 x 10 = 220. This is the single-axis measurement grid -- a complete cross lets subject preference and rendering preference be read independently. Composition rotates deterministically because it is a measured null."
         },
         {
-          "id": "l1_depth",
-          "kind": "scene",
-          "cross": {"subject": "*", "rendering": "@depth_renderings"},
-          "palette": "@house_default",
-          "composition": "c_default",
-          "variants": 3,
-          "variant_offset": 1,
-          "note": "Depth on the renderings the taste profile favours (overridable by RENDERING_FAVOURED in the artbrief). 22 x 4 x 3 = 264. variant_offset 1 means these are rolls v2/v3/v4 -- l1_grid already produced v1 of the same cell, so a favoured cell ends up with four independent rolls rather than one wasted duplicate."
+          "id": "l1_family",
+          "kind": "family",
+          "cross": {"subject": "*", "family": "*"},
+          "composition": "@rotate",
+          "variants": 1,
+          "note": "REPLACES the old l1_depth block. 22 subjects x 12 coherent art directions = 264 images at the identical cost, with ZERO repeated prompts. The old block spent $13.20 on rolls v2/v3/v4 of prompts already rendered once; the taste profile measures that as worthless (119 slots, highest-vN chosen 40 times against a random expectation of 47.3, p=0.34; per-variant hit rates 33/43/25/32% against a 34% base). Each family here is a BUNDLE -- rendering plus palette plus register -- applied uniformly across all 22 subjects, so Pip can accept or reject a DIRECTION in one gesture rather than adjudicating 264 individual images. That is the response to his own note: 'individually good ... but need coherence in direction'."
         },
         {
           "id": "l1_palette",
           "kind": "scene",
-          "cross": {"subject": "@palette_block_subjects", "palette": "@palette_block_palettes"},
+          "cross": {"subject": "@palette_block_subjects", "palette": "*"},
           "rendering": "r01",
-          "composition": "c_default",
-          "variants": 3,
-          "note": "Palette crossed against six subjects at full size. 6 x 5 x 3 = 90. Redundant with L0 by design: L0 asks which palette Pip LIKES, this asks which palette SURVIVES a real scene at poster size."
+          "composition": "@rotate",
+          "variants": 1,
+          "note": "Palette crossed against ten subjects at full size, all nine palettes, one roll each. 10 x 9 = 90 -- same count and cost as the old 6 x 5 x 3, with zero repeated prompts. Redundant with L0 by design: L0 asks which palette Pip LIKES, this asks which palette SURVIVES a real scene at poster size."
         },
         {
           "id": "l1_probe",
@@ -190,7 +209,7 @@
           "model": "gpt-image-2",
           "cross": {"subject": ["s01", "s04", "s21"], "rendering": ["r01", "r02"]},
           "palette": "@house_default",
-          "composition": "c_default",
+          "composition": "@rotate",
           "variants": 1,
           "note": "Six-image probe of the newer model on prompts that already have a gpt-image-1.5 twin in l1_grid. Expected to possibly fail on request shape; failures are logged and do not abort the run. Max exposure about $0.30."
         }

--- a/tools/assets/manifests/art_night_2026-08-07.json
+++ b/tools/assets/manifests/art_night_2026-08-07.json
@@ -1,0 +1,317 @@
+{
+  "_meta": {
+    "note": "QUEUE SPEC for the funded art night of 2026-08-07. Consumed by tools/assets/run_art_night.py, NOT by generate_images.py (different expansion model: levels and crossed axes rather than a flat asset list). Nothing here is a prompt on its own -- prompts are assembled at run time from base_clauses + rendering + palette + subject + composition + the taste brief.",
+    "plan": "docs/design/ART_RUN_2026-08-07.md",
+    "cost_source": "OpenAI first-party model page for gpt-image-1.5, read 2026-08-06. Per-image output price by size and quality. The repo's older per-image figures (docs/art/SEED_ART_COST_MODEL.md) are the pipeline's own estimate constants echoed back through its logs, not billed truth -- see the plan.",
+    "size_cap": "gpt-image-1.5 emits 1024x1024, 1536x1024, 1024x1536 and nothing larger. There is no upscale path in this repo. A 1536px long edge is about 5.1 inches at 300dpi, so 'hero print' here means a print-ready SOURCE, not a poster-sized file.",
+    "rules_source": "docs/art/ENDGAME_CONCEPT_REVIEW_2026-07-29.md (A1-A10, PROVISIONAL), docs/art/PROMPT_RECIPES_2026-07-29.md, docs/art/PALETTE_AND_DOOM_INTENSITY.md",
+    "promotion": "ADR-0019: nothing here is promoted. All output is Generated / Library under art_generated/ (gitignored)."
+  },
+
+  "schema_version": "1.0",
+  "run_id": "art_night_2026-08-07",
+  "output_root": "art_generated/art_night_2026-08-07",
+  "masters_staging": "G:/tmp/pdoom1-art-masters/2026-08-07",
+
+  "backend": "openai",
+  "model": "gpt-image-1.5",
+  "background": "opaque",
+
+  "budget": {
+    "hard_ceiling_usd": 75.5,
+    "planned_usd": 71.98,
+    "fx_aud_per_usd": 1.4164,
+    "fx_source": "USD/AUD spot 2026-08-05, 1.4164 (exchange-rates.org). Ceiling in AUD at that rate: 106.94. The ceiling only breaches AUD 110 if USD/AUD rises above 1.4570.",
+    "underspend_floor_usd": 68.0,
+    "underspend_note": "If the ledger total after L3 is below underspend_floor_usd, run --wave topup. Underspending is the stated failure mode for this run."
+  },
+
+  "tariff_usd": {
+    "gpt-image-1.5": {
+      "1024x1024": {"low": 0.009, "medium": 0.034, "high": 0.133},
+      "1536x1024": {"low": 0.013, "medium": 0.05, "high": 0.2},
+      "1024x1536": {"low": 0.013, "medium": 0.05, "high": 0.2}
+    },
+    "gpt-image-2": {
+      "1024x1024": {"low": 0.009, "medium": 0.034, "high": 0.133},
+      "1536x1024": {"low": 0.013, "medium": 0.05, "high": 0.2},
+      "1024x1536": {"low": 0.013, "medium": 0.05, "high": 0.2}
+    },
+    "_tariff_note": "gpt-image-2 prices are ASSUMED EQUAL to gpt-image-1.5 because this seat has not read a first-party gpt-image-2 price table. Only the 6-image probe block uses it, so the maximum exposure from that assumption being wrong is a few cents. Do not widen gpt-image-2 usage until the tariff is confirmed."
+  },
+
+  "taste_profile": {
+    "path": "docs/design/TASTE_PROFILE_2026-08-06.md",
+    "required": false,
+    "contract": "Preferred: a fenced block tagged 'artbrief' containing KEY: value lines (HOLD, AVOID, PALETTE, RENDERING_FAVOURED, SUBJECT_BOOST, NOTE). Fallback: the body under the last heading matching /brief/i is appended verbatim as a style clause, truncated to taste_clause_max_chars. Absent: the run proceeds on the in-repo house clauses below and prints a loud warning.",
+    "taste_clause_max_chars": 1400
+  },
+
+  "base_clauses": {
+    "poster_base": "wide cinematic POSTER ART illustration for a video game, full-bleed edge-to-edge opaque composition that completely fills the frame with no transparency and no cut-outs and no border, lived-in physical props and real architecture rather than abstract shapes, every object in frame must be immediately identifiable as a specific real thing -- a filing cabinet, a pallet, a transformer, a mug -- and never a generic boxy shape, because an unrecognisable object is visual noise rather than a prop, no text, no lettering, no signage, no numerals, no logo, no watermark, no UI overlay, high production value",
+    "poster_lighting": "DISCIPLINED AND UNDERSTATED LIGHTING, roughly 75 percent more subtle than a typical dramatic game illustration: mood must NEVER come from the main light source, so the ordinary room lights, street lights and work lights in the scene are plain neutral white or plain warm tungsten exactly as they would really be, never tinted red or green or purple for atmosphere; coloured light is permitted ONLY where a real fixture in the world would genuinely emit that colour, for example a screen, an indicator lamp, an emergency beacon, a corona arc or the impossible thing itself; at most one ambient source plus one glowing source, most of the frame kept dark with separated pockets of light, restraint over drama",
+    "poster_people": "NO PEOPLE BY DEFAULT -- the player is a bureaucrat and the art is about everyone else, so incidental figures are removed rather than restyled; where a figure is unavoidable it must be an androgynous silhouette with no readable gender cues, no distinguishing jewellery, no distinctive hairstyle and no face detail, its identity destroyed by blocking, backlighting and occlusion rather than merely turned away",
+    "poster_props": "props must be era-correct for 2017 to 2032 and consistent with the game's own set dressing: a banker's desk lamp is ALWAYS the green glass shade on a brass stem, office chairs, rubber date stamps, manila folders, ring binders, CRT and early-flatscreen monitors, chain-link fencing that hangs correctly on its posts with a real top rail, real tension wire and believable sag; ABSOLUTELY NO BARBED WIRE and no razor wire anywhere; uncrewed machines are directly manufactured and therefore have NO COCKPIT, NO CANOPY and no windows for a pilot",
+    "poster_safety": "strictly no blood and no gore anywhere in the image, damage to machines shown as mechanical breakage with glowing green or blue coolant and hydraulic fluid only, no wounded people, no real-world brands or insignia or logos, no identifiable real people, nothing sexualised, all human figures fully and modestly clothed in ordinary institutional workwear",
+    "poster_tone": "a bureaucratic world with weirdness leaking in at the edges; ordinary institutional competence rendered straight while something impossible happens deadpan in the same frame; commit to only one flavour of strangeness per image out of eldritch intrusion, technology run amok, or environmental collapse; restrained and elegant, never garish, never lurid"
+  },
+
+  "swatch_clauses": {
+    "sheet_base": "a flat design-reference COLOUR SWATCH SHEET, an evenly spaced grid of large solid rectangular colour patches on a neutral dark card, patches butted close together so adjacent colours can be judged against each other, absolutely no text, no numerals, no hex codes, no labels, no captions, no illustration, no objects, no gradients inside a patch, no shading, no perspective, flat-on orthographic view of the card, subtle paper or card texture only",
+    "sheet_structure": "the grid reads as a considered palette rather than a random assortment: the largest patches are the grounds, a middle band holds the mid values, and exactly one or two small patches hold the single saturated accent, so the sheet shows the VALUE STRUCTURE of the palette as well as its hues"
+  },
+
+  "composition_clauses": {
+    "c_default": "landscape orientation, generous dark negative space reserved somewhere in frame for a game title to be added later",
+    "c_title_top": "landscape orientation, a dark uncluttered band held across the top third for a title",
+    "c_title_left": "landscape orientation, a large calm dark slab held on the left third for a title, subject sitting right of centre",
+    "c_title_right": "landscape orientation, a large calm dark slab held on the right third for a title, subject sitting left of centre",
+    "c_portrait": "portrait orientation, vertical composition, generous calm space held in the lower third for a title block"
+  },
+
+  "palettes": [
+    {"id": "p01", "name": "house amber", "house": true, "clause": "PALETTE: grounds in void #0e0614, deep aubergine #170a1c, ink brown #14040c and deep indigo #181b3b; exactly one saturated accent, warm CRT amber #e8a33d shading to #f6a800; never stack a second saturated glow"},
+    {"id": "p02", "name": "house cold", "house": true, "clause": "PALETTE: grounds in void #0e0614, deep indigo #181b3b and #2e2547; exactly one saturated accent, cold electric-blue screen-glow #5c7ac3; never stack a second saturated glow"},
+    {"id": "p03", "name": "house violet", "house": true, "clause": "PALETTE: grounds in ink brown #14040c and deep aubergine #170a1c; exactly one saturated accent, eldritch violet #7a3b8f; never stack a second saturated glow; reserve this palette for the highest-strangeness reading of the scene"},
+    {"id": "p04", "name": "phosphor green", "house": false, "clause": "PALETTE: near-black grounds #0a020e and #0d0413 with almost no colour in them at all; exactly one saturated accent, phosphor terminal green #33ff66 falling off fast to nothing; the image should feel lit only by a monochrome display"},
+    {"id": "p05", "name": "sodium night", "house": false, "clause": "PALETTE: cold blue-grey grounds #1e2733 and #141b24; exactly one saturated accent, sodium-vapour street orange #ff9a3c; the classic municipal night-time colour split of cold shadow against warm lamp"},
+    {"id": "p06", "name": "paper and ink", "house": false, "clause": "PALETTE: INVERTED VALUE STRUCTURE -- a bright warm off-white paper ground #e8e0cf carrying most of the frame, drawn and shaded in ink black #171412 and warm grey, with exactly one accent of red-oxide stamp ink #a83c2b; a daylight bureaucratic register, mostly light rather than mostly dark"},
+    {"id": "p07", "name": "blueprint", "house": false, "clause": "PALETTE: a saturated prussian-blue ground #123a5c across the whole frame, all forms described in chalk-white and pale-cyan line #d8e6f2, with exactly one accent of warm amber #e8a33d where a real light source sits"},
+    {"id": "p08", "name": "ash and rust", "house": false, "clause": "PALETTE: desaturated concrete and ash greys #3a3a38, #2a2a28 and #55534d across the whole frame, one accent of oxidised rust orange #8a4a2b that is a MATERIAL and not a light; NO GLOWING SOURCE ANYWHERE in this image, all light is plain ambient daylight or plain overhead fluorescent"}
+  ],
+
+  "renderings": [
+    {"id": "r01", "name": "painterly warm-grime", "clause": "RENDERING: painterly warm-grime texture with heavy dark outlines and deep shadow, visible brush and palette-knife work, materials suggested with loose confident strokes rather than described, atmospheric haze separating the planes, diffuse falloff around every light; the picture reads as mood first and detail second"},
+    {"id": "r02", "name": "crisp micro-detail", "clause": "RENDERING: sharp focus from the nearest foreground to the far background with NO depth-of-field blur, NO atmospheric haze, NO fog, NO bloom and NO glow spill; high micro-detail in every material -- aggregate and form-tie marks in concrete, individual wires in mesh, tool marks, weld beads, paint chips and grime lines in metal, dust and fine scratches on glass, legible paper fibre; hard clean silhouette edges; specular highlights tight and hard-edged rather than soft glows; the picture reads as detail first and mood second"},
+    {"id": "r03", "name": "graphic screenprint", "clause": "RENDERING: limited-ink graphic screenprint poster, four flat ink layers and no more, hard-edged flat colour areas with no blending and no gradients, forms simplified to bold readable shapes, halftone dot texture used for the single mid tone, deliberate ink-on-paper flatness; the picture reads as a printed object rather than a painting"},
+    {"id": "r04", "name": "ink line and wash", "clause": "RENDERING: architectural pen-and-ink line drawing with loose watercolour wash, confident varied-weight ink contours describing every edge, cross-hatching for shadow, translucent wash pooling and drying with visible edges inside the lines and occasionally running outside them, white of the paper left showing in the lights"},
+    {"id": "r05", "name": "CRT phosphor", "clause": "RENDERING: the whole scene rendered as if it were a raster image displayed on a curved cathode-ray-tube monitor being photographed in a dark room -- visible horizontal scanline structure, slight barrel curvature at the frame edges, phosphor bloom smearing the brightest areas, faint chromatic fringing, a soft vignette from the tube glass, low bit-depth banding in the flat areas"},
+    {"id": "r06", "name": "risograph", "clause": "RENDERING: two-colour risograph duplicator print on coarse recycled paper, exactly two ink passes with visible MISREGISTRATION so the two layers sit a couple of millimetres apart, grainy uneven ink coverage, roller streaks, the paper stock texture and its off-white colour showing through everywhere, blown-out flat highlights"},
+    {"id": "r07", "name": "gouache matte", "clause": "RENDERING: hand-painted gouache matte painting in the pre-digital film tradition, opaque flat-drying matte pigment, soft edges where planes recede, big simple value masses established before any detail, a restrained number of colours mixed from a small palette, faint canvas or board tooth visible in the paint"},
+    {"id": "r08", "name": "technical drafting", "clause": "RENDERING: a measured technical drafting sheet, orthographic or near-orthographic projection with no dramatic perspective, every form described by uniform-weight construction lines, hidden edges dashed, section hatching in the cut areas, leader lines pointing at nothing since no annotation is permitted, the precision of an engineering drawing rather than an illustration"},
+    {"id": "r09", "name": "photographic still", "clause": "RENDERING: a photographic film still from a slow patient feature film, 35mm anamorphic lens with its slight horizontal flare and oval bokeh, natural film grain, natural available-light exposure with clipped highlights and crushed blacks left alone, a real lens's falloff and vignetting, no illustration and no painterly marks anywhere"},
+    {"id": "r10", "name": "relief print", "clause": "RENDERING: a hand-carved linocut relief print, everything reduced to carved positive and negative shapes with no half tones, visible gouge marks and chatter in the carved areas, uneven hand-burnished ink coverage, the block's edge impression showing at the border of the image"}
+  ],
+
+  "depth_renderings_default": ["r01", "r02", "r05", "r09"],
+  "palette_block_palettes_default": ["p01", "p02", "p04", "p06", "p08"],
+
+  "subjects": [
+    {"id": "s01", "name": "Office at dusk", "known_good": true, "clause": "a wide establishing shot of a small scrappy AI-safety-lab open-plan office at dusk: a couple of rows of cluttered desks, a server rack against the far wall, a big window showing an overcast stormy dusk sky, one overhead pendant lamp over the central desks and one monitor glow deep in the background, everything else falling into shadow; lived-in, faintly ominous"},
+    {"id": "s02", "name": "The cat and the terminal", "known_good": true, "clause": "a fat contented office cat asleep across the warm top of a beige CRT terminal on a paper-strewn desk at night, the terminal still on and casting the only light in the room, a cold mug of tea and a scattering of pens beside it; the cat is the emotional centre and everything else is the lab it lives in"},
+    {"id": "s03", "name": "Whiteboard war room", "known_good": true, "clause": "a cramped meeting room whose long whiteboard is covered edge to edge in diagrams, arrows, boxes and half-erased working, chairs pushed back at angles, cold coffee cups and a dead projector on the table; the whiteboard is the subject and the room is only its container; no legible writing, only the texture and rhythm of dense handwritten working"},
+    {"id": "s04", "name": "Server doom altar", "known_good": true, "clause": "a single server rack treated with unearned reverence, standing alone in a cleared floor space like an altar, cables descending from above in a deliberate curtain, one status lamp burning steadily, offerings of paperwork and mugs left on the floor in front of it; nobody present, the ritual already over"},
+    {"id": "s05", "name": "The compute lease", "clause": "a rented cage of borrowed compute inside somebody else's datacentre: a chain-link partition on a raised floor separating your three racks from a hundred identical racks running away into the dark, a paper label cable-tied to your cage door, cold aisle containment plastic hanging in strips; the scale of what you do not own is the point"},
+    {"id": "s06", "name": "Morning after the all-hands", "clause": "the meeting room the morning after a long all-hands: the whiteboard half wiped so the working survives only in ghosted smears with one boxed and double-boxed region still fully legible as shape, coffee rings on the table, one chair still pushed back where somebody left early, cold flat morning light through vertical blinds"},
+    {"id": "s07", "name": "Grant application desk", "clause": "the desk where the funding gets asked for: stacked application forms in labelled trays, a heavy mechanical franking machine, a wall clock, a date stamp and its inkpad, a green-shaded banker's lamp lighting exactly one form and nothing else, everything else in the room dim and administrative; the quiet violence of a deadline"},
+    {"id": "s08", "name": "The interpretability wall", "clause": "an office wall covered in a rigid grid of pinned printouts of feature visualisations and activation maps, held on bulldog clips from a taut wire, arranged in a strict rectangular array rather than a conspiratorial sprawl, a stepladder left in front of it, a desk lamp aimed at one column; NO STRING, no yarn, no connecting threads of any kind"},
+    {"id": "s09", "name": "The empty chair at three in the morning", "clause": "one workstation among many, cleared: monitor dark, desk wiped, a mug and an access badge left dead centre on the empty surface, the neighbouring desks still cluttered and alive; the overhead lights off in this bay and on in the next; a departure rendered as an absence of clutter"},
+    {"id": "s10", "name": "The regulator's waiting room", "clause": "an institutional waiting area outside a hearing room: bolted-down padded chairs in a row, hard-wearing patterned carpet, a tired potted plant, a numbered ticket display that is switched off, a closed heavy door with a brass plate bearing no readable text, magazines squared on a low table; the boredom of consequence"},
+    {"id": "s11", "name": "Cooling plant at night", "clause": "the mechanical plant deck on a roof at night: large lagged pipes and their supports, a chiller unit with condensate dripping and pooling, valve wheels and gauges, one indicator lamp glowing on a control panel, city sodium light spilling from below onto the underside of the ductwork; the physical cost of thinking, made plumbing"},
+    {"id": "s12", "name": "The paper that was wrong", "clause": "a printed preprint lying open on a desk under a lamp, its pages fanned and dog-eared, one paragraph struck through hard with a red pen and the pen still lying across it, a second copy face down beside it, a cold cup at the edge of the light; no legible text, only the rhythm of columns and equations and one violent red mark"},
+    {"id": "s13", "name": "Server room, after the sprinklers", "clause": "a small server room the morning after a discharge: standing water across the raised floor tiles, ceiling tiles sagging and one dropped out entirely, a torch left on and lying on its side casting a low beam across the water, racks dark, cable trays dripping; nobody has come back yet"},
+    {"id": "s14", "name": "Conference booth, packed down", "clause": "an exhibition hall at eleven at night with the show over: a half-dismantled booth, banner stands collapsed into their cases, a table with a cloth pulled crooked, flight cases open on the carpet, a forklift parked in the aisle, the hall lights dropped to a single working circuit; ambition folded back into boxes"},
+    {"id": "s15", "name": "Rooftop, two mugs", "clause": "a flat gravel rooftop above a low office building at the edge of a city, a parapet with two abandoned mugs and an ashtray on it, a bent aerial and a satellite dish, the skyline beyond at the blue hour with a few lit windows; a conversation that just ended and no one in frame"},
+    {"id": "s16", "name": "The lab fridge", "clause": "a shared office kitchen fridge photographed straight on, its door a dense collage of curling notes, a rota, a maintenance schedule, magnets and one whiteboard marker jammed in the door tray, a bin beside it with a pizza box lid sticking out; institutional life in one appliance; no legible writing on any note, only handwriting texture"},
+    {"id": "s17", "name": "The tape archive", "clause": "the inside of a fireproof media safe standing open in a small windowless room: rows of LTO tape cartridges in their cases on steel shelves, one slot conspicuously empty, a handheld barcode scanner on a lanyard hanging from the door, a desiccant pack and a temperature gauge; the coldest possible storage of the most dangerous possible thing"},
+    {"id": "s18", "name": "Substation at the fence line", "clause": "the electrical substation feeding the compute, seen from outside its chain-link boundary at night: transformers and their cooling fins, insulator stacks, a lightning arrester, warning plates with no readable text, moths circling the single security floodlight, the fence hanging properly on its posts with a real top rail and visible sag; a low hum you can see"},
+    {"id": "s19", "name": "The abandoned open-plan", "clause": "the same open-plan office as the dusk scene, years later and emptied: chairs upended on desks, a layer of dust dulling every surface, cables left coiled on the floor, one monitor inexplicably still awake and glowing in the far corner, daylight through unwashed windows; the only warm thing in the room is a mistake"},
+    {"id": "s20", "name": "Board room after the vote", "clause": "a long veneered board table after a decision: water glasses at uneven levels, a carafe, papers squared in front of every place except one where they are scattered, one high-backed chair pushed right back and turned away, the projector still on and throwing a blank white rectangle onto the wall; the room has not been tidied and nobody is coming back today"},
+    {"id": "s21", "name": "Sunrise through the server room blinds", "clause": "the one hopeful frame: low horizontal sunrise light coming through venetian blinds into a small server room, striping the racks and the floor in warm bands, dust moving in the light, a jacket left over the back of a chair, the machines quietly running; nothing wrong is happening in this picture"},
+    {"id": "s22", "name": "The analogue incident wall", "clause": "a monitoring wall built the wrong way on purpose: instead of screens, a panel of large round analogue gauges, mechanical annunciator flags, brass-bezelled dials and a bank of toggle switches with a single amber indicator lit, mounted in a varnished hardwood frame in an otherwise modern office; anachronism played completely straight"}
+  ],
+
+  "swatch_anchors": ["s01", "s04", "s07"],
+  "palette_block_subjects": ["s01", "s05", "s09", "s13", "s18", "s21"],
+
+  "levels": {
+    "L0": {
+      "title": "Swatch round -- palette conglomerate, fast yes/no",
+      "size": "1024x1024",
+      "quality": "medium",
+      "attended": false,
+      "blocks": [
+        {
+          "id": "l0_sheets",
+          "kind": "swatch_sheet",
+          "cross": {"palette": "*"},
+          "variants": 2,
+          "note": "One pure swatch sheet per palette, two rolls each. 8 palettes x 2 = 16."
+        },
+        {
+          "id": "l0_anchors",
+          "kind": "scene",
+          "cross": {"subject": "@swatch_anchors", "palette": "*"},
+          "rendering": "r01",
+          "composition": "c_default",
+          "variants": 2,
+          "note": "Verbatim-identical anchor scene under every palette, so PALETTE is the only variable. 3 x 8 x 2 = 48."
+        }
+      ]
+    },
+
+    "L1": {
+      "title": "Wide net -- the exploration",
+      "size": "1536x1024",
+      "quality": "medium",
+      "attended": false,
+      "blocks": [
+        {
+          "id": "l1_grid",
+          "kind": "scene",
+          "cross": {"subject": "*", "rendering": "*"},
+          "palette": "@house_default",
+          "composition": "c_default",
+          "variants": 1,
+          "note": "Full factorial: every subject in every rendering, exactly once. 22 x 10 = 220. This is the measurement grid -- a complete cross lets subject preference and rendering preference be read independently."
+        },
+        {
+          "id": "l1_depth",
+          "kind": "scene",
+          "cross": {"subject": "*", "rendering": "@depth_renderings"},
+          "palette": "@house_default",
+          "composition": "c_default",
+          "variants": 3,
+          "variant_offset": 1,
+          "note": "Depth on the renderings the taste profile favours (overridable by RENDERING_FAVOURED in the artbrief). 22 x 4 x 3 = 264. variant_offset 1 means these are rolls v2/v3/v4 -- l1_grid already produced v1 of the same cell, so a favoured cell ends up with four independent rolls rather than one wasted duplicate."
+        },
+        {
+          "id": "l1_palette",
+          "kind": "scene",
+          "cross": {"subject": "@palette_block_subjects", "palette": "@palette_block_palettes"},
+          "rendering": "r01",
+          "composition": "c_default",
+          "variants": 3,
+          "note": "Palette crossed against six subjects at full size. 6 x 5 x 3 = 90. Redundant with L0 by design: L0 asks which palette Pip LIKES, this asks which palette SURVIVES a real scene at poster size."
+        },
+        {
+          "id": "l1_probe",
+          "kind": "scene",
+          "model": "gpt-image-2",
+          "cross": {"subject": ["s01", "s04", "s21"], "rendering": ["r01", "r02"]},
+          "palette": "@house_default",
+          "composition": "c_default",
+          "variants": 1,
+          "note": "Six-image probe of the newer model on prompts that already have a gpt-image-1.5 twin in l1_grid. Expected to possibly fail on request shape; failures are logged and do not abort the run. Max exposure about $0.30."
+        }
+      ]
+    },
+
+    "L2": {
+      "title": "Tweened and twinned -- controlled single-step variation on L1 winners",
+      "size": "1536x1024",
+      "quality": "medium",
+      "attended": true,
+      "requires_picks": true,
+      "picks_target": 36,
+      "steps_per_pick": 6,
+      "note": "Each pick is regenerated along ONE axis in ordered steps, everything else held verbatim. A pair that differs in one controlled way measures taste; a scatter only satisfies it.",
+      "axes": [
+        {
+          "id": "a_yaw",
+          "name": "camera yaw",
+          "steps": [
+            "CAMERA: straight on, the subject square to the lens",
+            "CAMERA: rotated fifteen degrees to the left of straight on",
+            "CAMERA: rotated thirty degrees to the left of straight on",
+            "CAMERA: rotated fifteen degrees to the right of straight on",
+            "CAMERA: rotated thirty degrees to the right of straight on",
+            "CAMERA: a near-profile view from the side, roughly seventy degrees off straight on"
+          ]
+        },
+        {
+          "id": "a_pitch",
+          "name": "camera height",
+          "steps": [
+            "CAMERA: at standing eye level",
+            "CAMERA: at seated eye level",
+            "CAMERA: low, at desk height, looking slightly up",
+            "CAMERA: very low, at floor level, looking up",
+            "CAMERA: high, from head height looking down at about twenty degrees",
+            "CAMERA: from ceiling height looking steeply down"
+          ]
+        },
+        {
+          "id": "a_distance",
+          "name": "shot size",
+          "steps": [
+            "FRAMING: a very wide establishing shot with the whole space in frame",
+            "FRAMING: a wide shot",
+            "FRAMING: a medium shot with the subject filling about half the frame",
+            "FRAMING: a close shot on the subject with the room implied at the edges",
+            "FRAMING: a tight detail shot of one prop with the rest out of frame",
+            "FRAMING: an extreme detail, a few centimetres across, texture and material only"
+          ]
+        },
+        {
+          "id": "a_title_space",
+          "name": "title negative space",
+          "steps": [
+            "@composition:c_default",
+            "@composition:c_title_top",
+            "@composition:c_title_left",
+            "@composition:c_title_right",
+            "COMPOSITION: landscape, subject pushed to the extreme lower right, the upper-left two thirds calm and dark",
+            "COMPOSITION: landscape, a strong empty horizontal band through the vertical centre of the frame with incident above and below it"
+          ]
+        },
+        {
+          "id": "a_decay",
+          "name": "wording tween, lived-in to derelict",
+          "note": "The subject clause is held verbatim and ONE adjectival clause is stepped. This measures how prompt language maps onto image, which is the thing nobody has measured here.",
+          "steps": [
+            "CONDITION: brand new, unpacked this week, nothing worn yet",
+            "CONDITION: in daily use and well kept",
+            "CONDITION: lived-in, comfortably untidy, small repairs visible",
+            "CONDITION: worn, tired, things beginning to be left unfixed",
+            "CONDITION: neglected, dust settled, several things visibly broken",
+            "CONDITION: derelict, abandoned long enough for the building itself to be failing"
+          ]
+        },
+        {
+          "id": "a_quiet",
+          "name": "wording tween, populated to still",
+          "steps": [
+            "ATMOSPHERE: the room has just been full and the traces are fresh and warm",
+            "ATMOSPHERE: somebody stepped out a minute ago",
+            "ATMOSPHERE: quiet, the working day over",
+            "ATMOSPHERE: still, nothing has moved in hours",
+            "ATMOSPHERE: silent, nothing has moved in weeks",
+            "ATMOSPHERE: the stillness of a place no living thing has entered for a very long time"
+          ]
+        },
+        {
+          "id": "a_style_tween",
+          "name": "style tween, painterly to crisp",
+          "steps": [
+            "RENDERING: fully painterly and atmospheric, mood first, detail dissolving into tone",
+            "RENDERING: mostly painterly, with the nearest foreground prop resolved sharply and everything else loose",
+            "RENDERING: balanced, brushwork visible but every prop legible as a specific object",
+            "RENDERING: mostly crisp, with only the far background allowed to soften",
+            "RENDERING: crisp throughout, high micro-detail, no haze and no bloom anywhere",
+            "RENDERING: clinically crisp, every material's grain and tool marks described, hard specular highlights, no atmosphere at all"
+          ]
+        }
+      ]
+    },
+
+    "L3": {
+      "title": "Hero prints and posters -- few, large, best quality",
+      "size": "1536x1024",
+      "portrait_size": "1024x1536",
+      "quality": "high",
+      "attended": true,
+      "requires_picks": true,
+      "picks_target": 24,
+      "landscape_per_pick": 4,
+      "portrait_per_pick": 1,
+      "note": "From L2 winners only. High quality is 4x the medium price, which is only justified once a composition has already won twice. Masters are copied to masters_staging because they exceed the 1MB git policy -- although art_generated/ is gitignored in full, so nothing here can reach git by accident anyway."
+    }
+  },
+
+  "late_requests": {
+    "note": "coordination#33 invited sister repos to request art by midday 2026-08-07 AEST. Late requests are appended to this file as additional blocks under a level, or supplied as a separate spec passed with --extra-spec. The reserve line in the plan exists for exactly this.",
+    "reserve_usd": 6.0,
+    "blocks": []
+  }
+}

--- a/tools/assets/run_art_night.py
+++ b/tools/assets/run_art_night.py
@@ -1,0 +1,1024 @@
+#!/usr/bin/env python3
+"""run_art_night.py -- level-structured, budget-capped, resumable art run.
+
+Layer: GENERATE
+Invoked by: human (Pip), once per wave
+Spec: tools/assets/manifests/art_night_2026-08-07.json
+Plan: docs/design/ART_RUN_2026-08-07.md
+
+Why this exists next to generate_images.py rather than inside it:
+generate_images.py expands a FLAT list of assets and has no budget ceiling, no
+resume, no quality knob and no provenance capture. This run needs all four, plus
+a crossed-axis expansion (subject x rendering x palette x variant) that a flat
+list cannot express. generate_images.py stays as-is for manifest batches; this
+is the art-night orchestrator. The two share the OpenAI Images request shape and
+nothing else -- that duplication is deliberate and is called out in the plan.
+
+Guarantees this script is supposed to give:
+
+  1. --dry-run prints EVERY assembled prompt and the projected cost, and makes
+     zero network calls.
+  2. A hard USD ceiling (HARD_CEILING_USD below) that no CLI flag can raise.
+     Cost is RESERVED before a request is dispatched and refunded on failure,
+     so concurrency cannot walk past the ceiling.
+  3. Resume: every completed image appends one line to a JSONL ledger, flushed
+     and fsynced. Re-running skips job ids already in the ledger. Dying at image
+     300 of 600 costs at most one image.
+  4. Provenance at the point of generation: a sidecar <stem>.meta.json per
+     master plus the ledger line, both carrying the full prompt, its sha256, the
+     model, size, quality, timestamp, tariff cost and the sha256 of the taste
+     brief that shaped it. See coordination#32 -- pdoom1 cannot yet emit origin
+     metadata that survives to a consumer, so this run at least records it in a
+     form a later capture mechanism can read.
+
+  ADR-0019: nothing here is promoted. Everything lands under art_generated/
+  (gitignored in full) as Generated / Library.
+
+Usage (see the plan for the recommended order):
+    python tools/assets/run_art_night.py --wave l0 --dry-run
+    python tools/assets/run_art_night.py --wave overnight
+    python tools/assets/run_art_night.py --wave l2 --picks <picks.json>
+    python tools/assets/run_art_night.py --wave l3 --picks <picks.json>
+    python tools/assets/run_art_night.py --wave topup --picks <picks.json>
+    python tools/assets/run_art_night.py --status
+"""
+
+import argparse
+import base64
+import concurrent.futures
+import hashlib
+import json
+import os
+import random
+import re
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+DEFAULT_SPEC = REPO / "tools" / "assets" / "manifests" / "art_night_2026-08-07.json"
+
+# The one number no flag can raise. USD. At USD/AUD 1.4164 (spot 2026-08-05)
+# this is AUD 106.94; it only breaches the AUD 110 brief if USD/AUD goes above
+# 1.4570. Raising it requires editing this file, which is the intent.
+HARD_CEILING_USD = 75.50
+
+DOWNSCALES = {
+    "1536x1024": [1536, 1024, 768, 512],
+    "1024x1536": [1536, 1024, 768, 512],
+    "1024x1024": [1024, 512, 256],
+}
+
+MAX_ATTEMPTS = 3
+RETRY_BASE_SLEEP_S = 4.0
+
+
+# --------------------------------------------------------------------------
+# small helpers
+# --------------------------------------------------------------------------
+
+
+def sha256_text(text):
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sha256_file(path):
+    p = Path(path)
+    if not p.exists():
+        return None
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def utcnow():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_spec(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def tariff_usd(spec, model, size, quality):
+    table = spec["tariff_usd"].get(model)
+    if table is None:
+        raise SystemExit(
+            f"[ABORT] no tariff recorded for model '{model}'. Add one to the spec "
+            "before generating -- an unpriced call cannot be budget-capped."
+        )
+    by_size = table.get(size)
+    if by_size is None:
+        raise SystemExit(f"[ABORT] no tariff for {model} at size {size}.")
+    price = by_size.get(quality)
+    if price is None:
+        raise SystemExit(f"[ABORT] no tariff for {model} {size} quality={quality}.")
+    return float(price)
+
+
+# --------------------------------------------------------------------------
+# taste brief
+# --------------------------------------------------------------------------
+
+ARTBRIEF_KEYS = ("HOLD", "AVOID", "PALETTE", "RENDERING_FAVOURED", "SUBJECT_BOOST", "NOTE")
+
+
+def load_taste_brief(spec):
+    """Read the parallel lane's taste profile if it exists.
+
+    Contract (documented in the plan so the taste lane can target it):
+      preferred -- a fenced block tagged 'artbrief' holding KEY: value lines;
+      fallback  -- the body under the LAST heading matching /brief/i, appended
+                   verbatim as a style clause;
+      absent    -- house clauses only, with a loud warning.
+
+    Returns a dict: {present, path, sha256, hold, avoid, palettes, renderings,
+    subject_boost, note, raw_clause, source}.
+    """
+    cfg = spec.get("taste_profile", {})
+    rel = cfg.get("path")
+    max_chars = int(cfg.get("taste_clause_max_chars", 1400))
+    out = {
+        "present": False,
+        "path": rel,
+        "sha256": None,
+        "hold": "",
+        "avoid": "",
+        "palettes": None,
+        "renderings": None,
+        "subject_boost": None,
+        "note": "",
+        "raw_clause": "",
+        "source": "absent",
+    }
+    if not rel:
+        return out
+    path = REPO / rel
+    if not path.exists():
+        return out
+
+    text = path.read_text(encoding="utf-8", errors="replace")
+    out["present"] = True
+    out["sha256"] = sha256_file(path)
+
+    fenced = re.search(r"```artbrief\s*\n(.*?)\n```", text, re.DOTALL | re.IGNORECASE)
+    if fenced:
+        out["source"] = "artbrief-block"
+        for line in fenced.group(1).splitlines():
+            if ":" not in line:
+                continue
+            key, _, value = line.partition(":")
+            key = key.strip().upper()
+            value = value.strip()
+            if key not in ARTBRIEF_KEYS or not value:
+                continue
+            if key == "HOLD":
+                out["hold"] = value[:max_chars]
+            elif key == "AVOID":
+                out["avoid"] = value[:max_chars]
+            elif key == "NOTE":
+                out["note"] = value
+            elif key == "PALETTE":
+                out["palettes"] = [v.strip() for v in value.replace(",", " ").split() if v.strip()]
+            elif key == "RENDERING_FAVOURED":
+                out["renderings"] = [
+                    v.strip() for v in value.replace(",", " ").split() if v.strip()
+                ]
+            elif key == "SUBJECT_BOOST":
+                out["subject_boost"] = [
+                    v.strip() for v in value.replace(",", " ").split() if v.strip()
+                ]
+        return out
+
+    headings = [m for m in re.finditer(r"^#{1,6}\s+(.*)$", text, re.MULTILINE)]
+    brief_heads = [m for m in headings if re.search(r"brief", m.group(1), re.IGNORECASE)]
+    if brief_heads:
+        head = brief_heads[-1]
+        nxt = next((m for m in headings if m.start() > head.start()), None)
+        body = text[head.end() : (nxt.start() if nxt else len(text))].strip()
+        body = re.sub(r"\s+", " ", body)[:max_chars]
+        out["raw_clause"] = body
+        out["hold"] = body
+        out["source"] = "brief-heading"
+    return out
+
+
+# --------------------------------------------------------------------------
+# expansion
+# --------------------------------------------------------------------------
+
+
+def _resolve_axis(spec, brief, axis, value):
+    """Resolve a cross value: '*', '@alias', or an explicit list of ids."""
+    if isinstance(value, list):
+        return list(value)
+    if value == "*":
+        if axis == "subject":
+            return [s["id"] for s in spec["subjects"]]
+        if axis == "palette":
+            return [p["id"] for p in spec["palettes"]]
+        if axis == "rendering":
+            return [r["id"] for r in spec["renderings"]]
+        raise SystemExit(f"[ABORT] '*' is not defined for axis '{axis}'.")
+    if isinstance(value, str) and value.startswith("@"):
+        alias = value[1:]
+        if alias == "swatch_anchors":
+            return list(spec["swatch_anchors"])
+        if alias == "palette_block_subjects":
+            return list(spec["palette_block_subjects"])
+        if alias == "depth_renderings":
+            return list(brief["renderings"] or spec["depth_renderings_default"])
+        if alias == "palette_block_palettes":
+            return list(brief["palettes"] or spec["palette_block_palettes_default"])
+        raise SystemExit(f"[ABORT] unknown alias '@{alias}' on axis '{axis}'.")
+    return [value]
+
+
+def _house_default_palette(spec, brief):
+    """The single palette L1's scene blocks hold constant.
+
+    Deliberate design fact, stated in the plan: L1 does NOT wait on L0's palette
+    verdict, because both run in the same unattended wave. L1 holds one palette
+    constant (the brief's first pick, else the first house palette) and treats
+    palette as a separate block instead. L0's verdict constrains L2 and L3.
+    """
+    if brief["palettes"]:
+        return brief["palettes"][0]
+    for p in spec["palettes"]:
+        if p.get("house"):
+            return p["id"]
+    return spec["palettes"][0]["id"]
+
+
+def _by_id(items, key):
+    return {item["id"]: item for item in items}
+
+
+def assemble_scene_prompt(spec, brief, subject_id, rendering_id, palette_id, composition_id, extra):
+    subjects = _by_id(spec["subjects"], "id")
+    renderings = _by_id(spec["renderings"], "id")
+    palettes = _by_id(spec["palettes"], "id")
+    base = spec["base_clauses"]
+    comp = spec["composition_clauses"]
+
+    parts = [
+        base["poster_base"],
+        base["poster_lighting"],
+        base["poster_people"],
+        base["poster_props"],
+        base["poster_safety"],
+        base["poster_tone"],
+    ]
+    if rendering_id:
+        parts.append(renderings[rendering_id]["clause"])
+    if palette_id:
+        parts.append(palettes[palette_id]["clause"])
+    if brief["hold"]:
+        parts.append("HOUSE TASTE (measured from prior verdicts): " + brief["hold"])
+    if brief["avoid"]:
+        parts.append("AVOID: " + brief["avoid"])
+    parts.append(comp.get(composition_id or "c_default", comp["c_default"]))
+    for clause in extra or []:
+        parts.append(clause)
+    parts.append("SUBJECT: " + subjects[subject_id]["clause"])
+    return ", ".join(p.strip().rstrip(",") for p in parts if p)
+
+
+def assemble_swatch_prompt(spec, brief, palette_id):
+    palettes = _by_id(spec["palettes"], "id")
+    sw = spec["swatch_clauses"]
+    parts = [sw["sheet_base"], sw["sheet_structure"], palettes[palette_id]["clause"]]
+    if brief["hold"]:
+        parts.append("HOUSE TASTE (measured from prior verdicts): " + brief["hold"])
+    return ", ".join(parts)
+
+
+def make_job(spec, level, block_id, cell_key, prompt, size, quality, model, variant):
+    out_dir = REPO / "art_generated" / f"{spec.get('output_prefix', 'an0807_')}{block_id}" / "v1"
+    base_name = f"{cell_key}_v{variant}"
+    return {
+        "job_id": f"{level}|{block_id}|{cell_key}|v{variant}",
+        "level": level,
+        "block": block_id,
+        "cell": cell_key,
+        "variant": variant,
+        "prompt": prompt,
+        "prompt_sha256": sha256_text(prompt),
+        "size": size,
+        "quality": quality,
+        "model": model,
+        "background": spec.get("background", "opaque"),
+        "out_dir": str(out_dir),
+        "base_name": base_name,
+        "master_path": str(out_dir / f"{base_name}_{size.split('x')[0]}.png"),
+        "cost_usd": tariff_usd(spec, model, size, quality),
+    }
+
+
+def expand_level_l0_l1(spec, brief, level_key):
+    level = spec["levels"][level_key]
+    size = level["size"]
+    quality = level["quality"]
+    default_model = spec["model"]
+    house_palette = _house_default_palette(spec, brief)
+    jobs = []
+
+    for block in level["blocks"]:
+        model = block.get("model", default_model)
+        cross = block.get("cross", {})
+        subj_ids = (
+            _resolve_axis(spec, brief, "subject", cross["subject"])
+            if "subject" in cross
+            else [None]
+        )
+        pal_ids = (
+            _resolve_axis(spec, brief, "palette", cross["palette"])
+            if "palette" in cross
+            else [None]
+        )
+        rend_ids = (
+            _resolve_axis(spec, brief, "rendering", cross["rendering"])
+            if "rendering" in cross
+            else [None]
+        )
+
+        if pal_ids == [None]:
+            fixed = block.get("palette")
+            pal_ids = [house_palette if fixed == "@house_default" else fixed]
+        if rend_ids == [None]:
+            rend_ids = [block.get("rendering")]
+
+        variants = int(block.get("variants", 1))
+        # variant_offset lets a depth block continue the numbering of the grid
+        # block instead of re-rolling identical prompts under a colliding name.
+        # l1_depth starts at v2 so l1_grid's v1 IS the first roll of that cell.
+        offset = int(block.get("variant_offset", 0))
+        composition = block.get("composition", "c_default")
+
+        for s in subj_ids:
+            for r in rend_ids:
+                for p in pal_ids:
+                    for v in range(1 + offset, variants + 1 + offset):
+                        if block["kind"] == "swatch_sheet":
+                            prompt = assemble_swatch_prompt(spec, brief, p)
+                            cell = f"{p}"
+                        else:
+                            prompt = assemble_scene_prompt(spec, brief, s, r, p, composition, None)
+                            cell = "_".join(x for x in (s, r, p) if x)
+                        jobs.append(
+                            make_job(
+                                spec, level_key, block["id"], cell, prompt, size, quality, model, v
+                            )
+                        )
+    return jobs
+
+
+def expand_level_l2(spec, brief, picks):
+    """picks: list of {subject, rendering, palette} dicts parsed from L1 ids."""
+    level = spec["levels"]["L2"]
+    size, quality = level["size"], level["quality"]
+    model = spec["model"]
+    axes = level["axes"]
+    steps_per_pick = int(level["steps_per_pick"])
+    jobs = []
+
+    for i, pick in enumerate(picks):
+        axis = axes[i % len(axes)]
+        steps = axis["steps"][:steps_per_pick]
+        for j, step in enumerate(steps, 1):
+            composition = pick.get("composition", "c_default")
+            extra = []
+            if step.startswith("@composition:"):
+                composition = step.split(":", 1)[1]
+            else:
+                extra.append(step)
+            prompt = assemble_scene_prompt(
+                spec,
+                brief,
+                pick["subject"],
+                pick["rendering"],
+                pick["palette"],
+                composition,
+                extra,
+            )
+            cell = f"{pick['subject']}_{pick['rendering']}_{pick['palette']}_{axis['id']}_s{j}"
+            jobs.append(
+                make_job(spec, "L2", f"l2_{axis['id']}", cell, prompt, size, quality, model, 1)
+            )
+    return jobs
+
+
+def expand_level_l3(spec, brief, picks):
+    level = spec["levels"]["L3"]
+    quality = level["quality"]
+    model = spec["model"]
+    land, port = level["size"], level["portrait_size"]
+    n_land = int(level["landscape_per_pick"])
+    n_port = int(level["portrait_per_pick"])
+    jobs = []
+    for pick in picks:
+        cell = f"{pick['subject']}_{pick['rendering']}_{pick['palette']}"
+        for v in range(1, n_land + 1):
+            prompt = assemble_scene_prompt(
+                spec,
+                brief,
+                pick["subject"],
+                pick["rendering"],
+                pick["palette"],
+                pick.get("composition", "c_default"),
+                None,
+            )
+            jobs.append(make_job(spec, "L3", "l3_hero_land", cell, prompt, land, quality, model, v))
+        for v in range(1, n_port + 1):
+            prompt = assemble_scene_prompt(
+                spec, brief, pick["subject"], pick["rendering"], pick["palette"], "c_portrait", None
+            )
+            jobs.append(make_job(spec, "L3", "l3_hero_port", cell, prompt, port, quality, model, v))
+    return jobs
+
+
+def expand_topup(spec, brief, picks, budget_usd):
+    """Anti-underspend wave: extra variants of winning L1 cells until the money
+    is gone. Variant numbers start at 100 so they never collide with L1 ids."""
+    level = spec["levels"]["L1"]
+    size, quality, model = level["size"], level["quality"], spec["model"]
+    unit = tariff_usd(spec, model, size, quality)
+    if unit <= 0:
+        return []
+    n = int(budget_usd // unit)
+    jobs = []
+    if not picks:
+        return jobs
+    v = 100
+    while len(jobs) < n:
+        for pick in picks:
+            if len(jobs) >= n:
+                break
+            prompt = assemble_scene_prompt(
+                spec,
+                brief,
+                pick["subject"],
+                pick["rendering"],
+                pick["palette"],
+                pick.get("composition", "c_default"),
+                None,
+            )
+            cell = f"{pick['subject']}_{pick['rendering']}_{pick['palette']}"
+            jobs.append(make_job(spec, "TOPUP", "topup_l1", cell, prompt, size, quality, model, v))
+        v += 1
+    return jobs
+
+
+# --------------------------------------------------------------------------
+# picks
+# --------------------------------------------------------------------------
+
+FAVOURABLE_TAGS = {"love", "like", "promote", "favour", "favor", "hero", "yes", "keep"}
+CELL_RE = re.compile(r"^(s\d{2})_(r\d{2})_(p\d{2})")
+
+
+def load_picks(path, spec, limit=None):
+    """Accept either a flat list of ids or the review tools' {rel: [tags]} map.
+
+    Ids are the cell keys this script writes (s07_r03_p01), or full gallery ids
+    (gen:an0807_l1_grid:s07_r03_p01:2), or master filenames. Anything that does
+    not parse is reported rather than silently dropped -- a silently dropped
+    pick is exactly the class of wrongness this repo keeps being caught by.
+    """
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if isinstance(raw, dict):
+        candidates = [
+            k for k, tags in raw.items() if set(t.lower() for t in tags) & FAVOURABLE_TAGS
+        ]
+    elif isinstance(raw, list):
+        candidates = [c if isinstance(c, str) else c.get("id", "") for c in raw]
+    else:
+        raise SystemExit("[ABORT] picks file must be a list or an object of {id: [tags]}.")
+
+    subj_ok = {s["id"] for s in spec["subjects"]}
+    rend_ok = {r["id"] for r in spec["renderings"]}
+    pal_ok = {p["id"] for p in spec["palettes"]}
+
+    picks, unparsed, seen = [], [], set()
+    for cand in candidates:
+        tail = cand.split(":")[-2] if cand.startswith("gen:") else Path(cand).name
+        m = CELL_RE.match(tail)
+        if not m:
+            unparsed.append(cand)
+            continue
+        s, r, p = m.groups()
+        if s not in subj_ok or r not in rend_ok or p not in pal_ok:
+            unparsed.append(cand)
+            continue
+        key = (s, r, p)
+        if key in seen:
+            continue
+        seen.add(key)
+        picks.append({"subject": s, "rendering": r, "palette": p})
+
+    if unparsed:
+        print(f"[!] {len(unparsed)} pick entries did not parse as an art-night cell:")
+        for u in unparsed[:10]:
+            print(f"      {u}")
+        if len(unparsed) > 10:
+            print(f"      ... and {len(unparsed) - 10} more")
+    if limit:
+        picks = picks[:limit]
+    return picks
+
+
+# --------------------------------------------------------------------------
+# ledger + budget
+# --------------------------------------------------------------------------
+
+
+class Ledger:
+    def __init__(self, path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self.done = {}
+        self.spent = 0.0
+        if self.path.exists():
+            for line in self.path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except ValueError:
+                    continue
+                if rec.get("status") == "ok":
+                    self.done[rec["job_id"]] = rec
+                    self.spent += float(rec.get("cost_usd", 0.0))
+
+    def append(self, record):
+        with self._lock:
+            with open(self.path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=True) + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+            if record.get("status") == "ok":
+                self.done[record["job_id"]] = record
+
+
+class Budget:
+    """Reserve-before-dispatch so N concurrent workers cannot overshoot."""
+
+    def __init__(self, ceiling_usd, already_spent_usd):
+        self.ceiling = float(ceiling_usd)
+        self.committed = float(already_spent_usd)
+        self._lock = threading.Lock()
+        self.stopped = False
+
+    def reserve(self, amount):
+        with self._lock:
+            if self.stopped:
+                return False
+            if self.committed + amount > self.ceiling + 1e-9:
+                self.stopped = True
+                return False
+            self.committed += amount
+            return True
+
+    def refund(self, amount):
+        with self._lock:
+            self.committed -= amount
+
+    @property
+    def remaining(self):
+        with self._lock:
+            return self.ceiling - self.committed
+
+
+# --------------------------------------------------------------------------
+# generation
+# --------------------------------------------------------------------------
+
+_client = None
+_client_lock = threading.Lock()
+
+
+def get_client():
+    global _client
+    with _client_lock:
+        if _client is None:
+            from openai import OpenAI
+
+            _client = OpenAI()
+        return _client
+
+
+def call_images_api(job):
+    """One Images API request. Returns (bytes, api_meta)."""
+    kwargs = {
+        "model": job["model"],
+        "prompt": job["prompt"],
+        "size": job["size"],
+        "quality": job["quality"],
+        "background": job["background"],
+    }
+    result = get_client().images.generate(**kwargs)
+    datum = result.data[0]
+    meta = {
+        "api_created": getattr(result, "created", None),
+        "api_usage": None,
+        "revised_prompt": getattr(datum, "revised_prompt", None),
+    }
+    usage = getattr(result, "usage", None)
+    if usage is not None:
+        try:
+            meta["api_usage"] = usage.model_dump()
+        except AttributeError:
+            meta["api_usage"] = str(usage)
+    return base64.b64decode(datum.b64_json), meta
+
+
+def write_outputs(job, img_bytes, api_meta, run_meta, staging_dir=None):
+    from PIL import Image
+
+    out_dir = Path(job["out_dir"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    master = Path(job["master_path"])
+    img = Image.open(BytesIO(img_bytes)).convert("RGBA")
+    img.save(master)
+
+    master_w, master_h = (int(x) for x in job["size"].split("x"))
+    for width in DOWNSCALES.get(job["size"], []):
+        if width >= master_w:
+            continue
+        height = max(1, round(master_h * width / master_w))
+        img.resize((width, height), Image.LANCZOS).save(out_dir / f"{job['base_name']}_{width}.png")
+
+    sidecar = {
+        "origin": "generated",
+        "run_id": run_meta["run_id"],
+        "job_id": job["job_id"],
+        "level": job["level"],
+        "block": job["block"],
+        "cell": job["cell"],
+        "variant": job["variant"],
+        "prompt": job["prompt"],
+        "prompt_sha256": job["prompt_sha256"],
+        "revised_prompt": api_meta.get("revised_prompt"),
+        "backend": run_meta["backend"],
+        "model": job["model"],
+        "size": job["size"],
+        "quality": job["quality"],
+        "background": job["background"],
+        "seed": None,
+        "seed_note": "The OpenAI Images API exposes no seed parameter, so this "
+        "image is not reproducible from its record. Recorded as null rather "
+        "than omitted so a consumer can tell the difference.",
+        "generated_at_utc": utcnow(),
+        "cost_usd_tariff": job["cost_usd"],
+        "cost_source": run_meta["cost_source"],
+        "cost_is_billed_truth": False,
+        "api_created": api_meta.get("api_created"),
+        "api_usage": api_meta.get("api_usage"),
+        "taste_profile_path": run_meta["taste_profile_path"],
+        "taste_profile_sha256": run_meta["taste_profile_sha256"],
+        "taste_profile_source": run_meta["taste_profile_source"],
+        "queue_spec_sha256": run_meta["queue_spec_sha256"],
+        "tool": "tools/assets/run_art_night.py",
+        "master_path": str(master.relative_to(REPO)),
+        "master_bytes": master.stat().st_size,
+        "promotion_state": "library",
+        "promotion_note": "ADR-0019: no promotion without a mechanically "
+        "verified demand entry. This file is Generated / Library.",
+    }
+    with open(master.with_suffix(".meta.json"), "w", encoding="utf-8") as fh:
+        json.dump(sidecar, fh, ensure_ascii=True, indent=2)
+
+    if staging_dir:
+        import shutil
+
+        stage = Path(staging_dir)
+        stage.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(master, stage / master.name)
+        shutil.copy2(master.with_suffix(".meta.json"), stage / (master.stem + ".meta.json"))
+
+    return sidecar
+
+
+def run_job(job, ledger, budget, run_meta, staging_dir):
+    if not budget.reserve(job["cost_usd"]):
+        return "ceiling"
+    last_err = None
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            img_bytes, api_meta = call_images_api(job)
+            sidecar = write_outputs(job, img_bytes, api_meta, run_meta, staging_dir)
+            ledger.append(
+                {
+                    "status": "ok",
+                    "job_id": job["job_id"],
+                    "cost_usd": job["cost_usd"],
+                    "attempt": attempt,
+                    "recorded_at_utc": utcnow(),
+                    "master_path": sidecar["master_path"],
+                    "prompt_sha256": job["prompt_sha256"],
+                    "model": job["model"],
+                    "size": job["size"],
+                    "quality": job["quality"],
+                }
+            )
+            return "ok"
+        except Exception as exc:  # noqa: BLE001 -- an overnight run must not die on one image
+            last_err = f"{type(exc).__name__}: {exc}"
+            if attempt < MAX_ATTEMPTS:
+                time.sleep(RETRY_BASE_SLEEP_S * (2 ** (attempt - 1)) + random.uniform(0, 1.5))
+    budget.refund(job["cost_usd"])
+    ledger.append(
+        {
+            "status": "failed",
+            "job_id": job["job_id"],
+            "cost_usd": 0.0,
+            "attempts": MAX_ATTEMPTS,
+            "recorded_at_utc": utcnow(),
+            "error": last_err,
+            "model": job["model"],
+        }
+    )
+    return "failed"
+
+
+# --------------------------------------------------------------------------
+# reporting
+# --------------------------------------------------------------------------
+
+
+def summarise(jobs):
+    by_block = {}
+    for j in jobs:
+        rec = by_block.setdefault(
+            j["block"],
+            {"n": 0, "usd": 0.0, "size": j["size"], "q": j["quality"], "model": j["model"]},
+        )
+        rec["n"] += 1
+        rec["usd"] += j["cost_usd"]
+    return by_block
+
+
+def print_projection(jobs, brief, fx, title):
+    by_block = summarise(jobs)
+    total_usd = sum(j["cost_usd"] for j in jobs)
+    print("")
+    print("=" * 78)
+    print(f"PROJECTION -- {title}")
+    print("=" * 78)
+    print(f"{'block':<20} {'model':<14} {'size':<11} {'qual':<7} {'n':>5} {'USD':>9}")
+    print("-" * 78)
+    for block, rec in by_block.items():
+        print(
+            f"{block:<20} {rec['model']:<14} {rec['size']:<11} {rec['q']:<7} "
+            f"{rec['n']:>5} {rec['usd']:>9.2f}"
+        )
+    print("-" * 78)
+    print(f"{'TOTAL':<20} {'':<14} {'':<11} {'':<7} {len(jobs):>5} {total_usd:>9.2f}")
+    print(
+        f"{'':<20} {'':<14} {'':<11} {'':<7} {'AUD':>5} {total_usd * fx:>9.2f}  (at {fx} AUD/USD)"
+    )
+    print("")
+    print(
+        f"taste brief: {brief['source']}"
+        + (f"  sha256={brief['sha256'][:12]}" if brief["sha256"] else "")
+    )
+    if not brief["present"]:
+        print(
+            "[!] WARNING: the taste profile was NOT found. Prompts fall back to the\n"
+            "    in-repo house clauses. That is a legitimate run, but it is a BLIND\n"
+            "    run -- Pip's 151 picks are not shaping anything. Check the path in\n"
+            "    the spec before committing money to it."
+        )
+    return total_usd
+
+
+# --------------------------------------------------------------------------
+# main
+# --------------------------------------------------------------------------
+
+WAVES = {
+    "l0": ["L0"],
+    "l1": ["L1"],
+    "overnight": ["L0", "L1"],
+    "l2": ["L2"],
+    "l3": ["L3"],
+    "topup": ["TOPUP"],
+}
+
+
+def build_jobs(spec, brief, wave, args):
+    jobs = []
+    for level_key in WAVES[wave]:
+        if level_key in ("L0", "L1"):
+            jobs.extend(expand_level_l0_l1(spec, brief, level_key))
+        elif level_key == "L2":
+            picks = load_picks(args.picks, spec, spec["levels"]["L2"]["picks_target"])
+            if not picks:
+                raise SystemExit("[ABORT] L2 needs picks and none parsed. Nothing generated.")
+            print(f"[*] L2 driving from {len(picks)} picks.")
+            jobs.extend(expand_level_l2(spec, brief, picks))
+        elif level_key == "L3":
+            picks = load_picks(args.picks, spec, spec["levels"]["L3"]["picks_target"])
+            if not picks:
+                raise SystemExit("[ABORT] L3 needs picks and none parsed. Nothing generated.")
+            print(f"[*] L3 driving from {len(picks)} picks.")
+            jobs.extend(expand_level_l3(spec, brief, picks))
+        elif level_key == "TOPUP":
+            picks = load_picks(args.picks, spec)
+            budget_left = args.topup_usd
+            print(f"[*] topup driving from {len(picks)} picks, budget USD {budget_left:.2f}.")
+            jobs.extend(expand_topup(spec, brief, picks, budget_left))
+    return jobs
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--spec", default=str(DEFAULT_SPEC))
+    ap.add_argument("--wave", choices=sorted(WAVES), help="which level(s) to run")
+    ap.add_argument("--picks", help="picks JSON for L2 / L3 / topup")
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print every prompt and the projected cost; no network calls, no spend",
+    )
+    ap.add_argument(
+        "--show-prompts",
+        action="store_true",
+        help="with --dry-run, print the FULL prompt text for every job (very long)",
+    )
+    ap.add_argument(
+        "--prompt-sample",
+        type=int,
+        default=6,
+        help="how many full prompts to print in a dry run (default 6)",
+    )
+    ap.add_argument(
+        "--ceiling-usd",
+        type=float,
+        default=None,
+        help=f"lower the ceiling for this invocation. Cannot exceed the hard ceiling of {HARD_CEILING_USD}",
+    )
+    ap.add_argument("--topup-usd", type=float, default=0.0, help="budget for the topup wave")
+    ap.add_argument("--concurrency", type=int, default=4)
+    ap.add_argument("--limit", type=int, help="cap the number of jobs (testing)")
+    ap.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="if the projection exceeds the remaining ceiling, run what fits instead of aborting",
+    )
+    ap.add_argument(
+        "--force", action="store_true", help="regenerate jobs already recorded done in the ledger"
+    )
+    ap.add_argument("--status", action="store_true", help="print ledger status and exit")
+    ap.add_argument("--yes", "-y", action="store_true", help="skip the confirmation prompt")
+    args = ap.parse_args()
+
+    spec = load_spec(args.spec)
+    spec_sha = sha256_file(args.spec)
+    fx = float(spec["budget"]["fx_aud_per_usd"])
+    ledger_path = REPO / spec["output_root"] / "ledger.jsonl"
+    ledger = Ledger(ledger_path)
+
+    if args.status or not args.wave:
+        print(f"run_id       : {spec['run_id']}")
+        print(f"ledger       : {ledger_path}")
+        print(f"images done  : {len(ledger.done)}")
+        print(f"spent (tariff): USD {ledger.spent:.2f}  /  AUD {ledger.spent * fx:.2f}")
+        print(f"hard ceiling : USD {HARD_CEILING_USD:.2f}  /  AUD {HARD_CEILING_USD * fx:.2f}")
+        print(f"remaining    : USD {HARD_CEILING_USD - ledger.spent:.2f}")
+        print(
+            f"underspend floor: USD {spec['budget']['underspend_floor_usd']:.2f} "
+            "(below this after L3, run --wave topup)"
+        )
+        if not args.wave:
+            return 0
+
+    brief = load_taste_brief(spec)
+    jobs = build_jobs(spec, brief, args.wave, args)
+
+    if not args.force:
+        jobs = [j for j in jobs if j["job_id"] not in ledger.done]
+    if args.limit:
+        jobs = jobs[: args.limit]
+
+    if not jobs:
+        print("[*] nothing to do -- every job in this wave is already in the ledger.")
+        return 0
+
+    projected = print_projection(jobs, brief, fx, f"wave={args.wave}")
+    print(f"already spent this run (tariff): USD {ledger.spent:.2f}")
+    print(f"hard ceiling                   : USD {HARD_CEILING_USD:.2f}")
+
+    ceiling = HARD_CEILING_USD
+    if args.ceiling_usd is not None:
+        if args.ceiling_usd > HARD_CEILING_USD:
+            print(
+                f"[!] --ceiling-usd {args.ceiling_usd} is above the hard ceiling; clamping to {HARD_CEILING_USD}."
+            )
+        ceiling = min(args.ceiling_usd, HARD_CEILING_USD)
+
+    if ledger.spent + projected > ceiling + 1e-9:
+        over = ledger.spent + projected - ceiling
+        msg = (
+            f"[ABORT] this wave would take the run to USD {ledger.spent + projected:.2f}, "
+            f"which is USD {over:.2f} over the ceiling of USD {ceiling:.2f} "
+            f"(AUD {ceiling * fx:.2f})."
+        )
+        if not args.allow_partial:
+            print(msg)
+            print(
+                "        Nothing was generated. Re-run with --allow-partial to fill the "
+                "remaining headroom, or trim the wave."
+            )
+            return 2
+        print(msg.replace("[ABORT]", "[!]"))
+        print("        --allow-partial: generating until the ceiling is reached.")
+
+    if args.dry_run:
+        n = len(jobs) if args.show_prompts else min(args.prompt_sample, len(jobs))
+        print(
+            f"--- DRY RUN: {n} of {len(jobs)} full prompts "
+            f"({'all' if args.show_prompts else 'use --show-prompts for all'}) ---\n"
+        )
+        step = max(1, len(jobs) // n) if n else 1
+        for j in jobs[::step][:n] if not args.show_prompts else jobs:
+            print(
+                f"[{j['job_id']}]  {j['size']} {j['quality']} {j['model']}  USD {j['cost_usd']:.3f}"
+            )
+            print(f"  -> {j['master_path']}")
+            print(f"  prompt sha256 {j['prompt_sha256'][:16]}")
+            print(f"  {j['prompt']}")
+            print("")
+        print(
+            f"[DRY RUN] {len(jobs)} images, USD {projected:.2f} / AUD {projected * fx:.2f}. "
+            "Zero API calls were made and zero dollars were spent."
+        )
+        return 0
+
+    if not args.yes:
+        answer = input(
+            f"Generate {len(jobs)} images for about USD {projected:.2f} "
+            f"(AUD {projected * fx:.2f})? [y/N]: "
+        )
+        if answer.strip().lower() != "y":
+            print("Cancelled. Nothing generated.")
+            return 0
+
+    run_meta = {
+        "run_id": spec["run_id"],
+        "backend": spec.get("backend", "openai"),
+        "cost_source": spec["_meta"]["cost_source"],
+        "taste_profile_path": brief["path"],
+        "taste_profile_sha256": brief["sha256"],
+        "taste_profile_source": brief["source"],
+        "queue_spec_sha256": spec_sha,
+    }
+    staging = None
+    if args.wave == "l3":
+        staging = spec.get("masters_staging")
+
+    budget = Budget(ceiling, ledger.spent)
+    counts = {"ok": 0, "failed": 0, "ceiling": 0}
+    started = time.time()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.concurrency)) as pool:
+        futures = {pool.submit(run_job, j, ledger, budget, run_meta, staging): j for j in jobs}
+        for i, fut in enumerate(concurrent.futures.as_completed(futures), 1):
+            outcome = fut.result()
+            counts[outcome] += 1
+            if i % 10 == 0 or outcome != "ok":
+                elapsed = time.time() - started
+                rate = i / elapsed if elapsed else 0
+                left = (len(jobs) - i) / rate / 60 if rate else 0
+                print(
+                    f"[{i}/{len(jobs)}] ok={counts['ok']} failed={counts['failed']} "
+                    f"stopped={counts['ceiling']} | USD {budget.committed:.2f} "
+                    f"| ~{left:.0f} min left"
+                )
+
+    print("")
+    print("=" * 78)
+    print(
+        f"wave {args.wave} complete: ok={counts['ok']} failed={counts['failed']} "
+        f"not-started-at-ceiling={counts['ceiling']}"
+    )
+    print(f"run total (tariff): USD {ledger.spent:.2f} / AUD {ledger.spent * fx:.2f}")
+    print(f"ledger            : {ledger_path}")
+    print("gallery           : python tools/art_review/build_full_gallery.py --open")
+    if counts["ceiling"]:
+        print("[!] the ceiling stopped this wave. Nothing overran; some jobs were skipped.")
+    print(
+        "Tariff dollars are the PUBLISHED price, not billed truth. Reconcile "
+        "against the OpenAI billing dashboard before quoting a spend."
+    )
+    print("=" * 78)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/assets/run_art_night.py
+++ b/tools/assets/run_art_night.py
@@ -625,6 +625,10 @@ class Ledger:
                 os.fsync(fh.fileno())
             if record.get("status") == "ok":
                 self.done[record["job_id"]] = record
+                # Keep the in-memory total live, not just the value loaded at
+                # construction -- the end-of-wave summary reads it, and without
+                # this it reported USD 0.00 after a successful 72-image wave.
+                self.spent += float(record.get("cost_usd", 0.0))
 
 
 class Budget:

--- a/tools/assets/run_art_night.py
+++ b/tools/assets/run_art_night.py
@@ -220,6 +220,8 @@ def _resolve_axis(spec, brief, axis, value):
             return [p["id"] for p in spec["palettes"]]
         if axis == "rendering":
             return [r["id"] for r in spec["renderings"]]
+        if axis == "family":
+            return [f["id"] for f in spec["families"]]
         raise SystemExit(f"[ABORT] '*' is not defined for axis '{axis}'.")
     if isinstance(value, str) and value.startswith("@"):
         alias = value[1:]
@@ -255,6 +257,21 @@ def _by_id(items, key):
     return {item["id"]: item for item in items}
 
 
+def resolve_composition(spec, composition, cell_key):
+    """'@rotate' picks a composition deterministically from the cell key.
+
+    Composition is the cleanest NULL in the taste profile (off-centre distance
+    52.9%, p=0.55, permutation p=0.80), so it is worth sampling rather than
+    holding constant -- and nothing is wasted by varying it. Deterministic on
+    the cell key so a resumed run reproduces the same choice.
+    """
+    if composition != "@rotate":
+        return composition or "c_default"
+    keys = [k for k in spec["composition_clauses"] if k != "c_portrait"]
+    idx = int(sha256_text(cell_key)[:8], 16) % len(keys)
+    return keys[idx]
+
+
 def assemble_scene_prompt(spec, brief, subject_id, rendering_id, palette_id, composition_id, extra):
     subjects = _by_id(spec["subjects"], "id")
     renderings = _by_id(spec["renderings"], "id")
@@ -262,9 +279,16 @@ def assemble_scene_prompt(spec, brief, subject_id, rendering_id, palette_id, com
     base = spec["base_clauses"]
     comp = spec["composition_clauses"]
 
+    # Order matters: the two MEASURED holds from docs/design/TASTE_PROFILE_2026-08-06.md
+    # (contrast n=136 74.3% p<0.0001, detail n=136 71.3% p<0.0001) go early, where a
+    # long prompt is least likely to drop them.
     parts = [
         base["poster_base"],
+        base["poster_contrast"],
+        base["poster_detail"],
         base["poster_lighting"],
+        base["poster_separation"],
+        base["poster_symbol"],
         base["poster_people"],
         base["poster_props"],
         base["poster_safety"],
@@ -343,6 +367,11 @@ def expand_level_l0_l1(spec, brief, level_key):
             else [None]
         )
 
+        fam_ids = (
+            _resolve_axis(spec, brief, "family", cross["family"]) if "family" in cross else [None]
+        )
+        families = _by_id(spec.get("families", []), "id")
+
         if pal_ids == [None]:
             fixed = block.get("palette")
             pal_ids = [house_palette if fixed == "@house_default" else fixed]
@@ -350,27 +379,51 @@ def expand_level_l0_l1(spec, brief, level_key):
             rend_ids = [block.get("rendering")]
 
         variants = int(block.get("variants", 1))
-        # variant_offset lets a depth block continue the numbering of the grid
-        # block instead of re-rolling identical prompts under a colliding name.
-        # l1_depth starts at v2 so l1_grid's v1 IS the first roll of that cell.
+        # variant_offset lets a block continue another block's variant numbering.
+        # Unused since the depth block was replaced by the family block -- the
+        # taste profile measures repeat rolls of one prompt as worth nothing
+        # (119 slots, p=0.34), so nothing in L1 re-rolls a prompt any more.
         offset = int(block.get("variant_offset", 0))
         composition = block.get("composition", "c_default")
 
         for s in subj_ids:
-            for r in rend_ids:
-                for p in pal_ids:
-                    for v in range(1 + offset, variants + 1 + offset):
-                        if block["kind"] == "swatch_sheet":
-                            prompt = assemble_swatch_prompt(spec, brief, p)
-                            cell = f"{p}"
-                        else:
-                            prompt = assemble_scene_prompt(spec, brief, s, r, p, composition, None)
-                            cell = "_".join(x for x in (s, r, p) if x)
-                        jobs.append(
-                            make_job(
-                                spec, level_key, block["id"], cell, prompt, size, quality, model, v
+            for f in fam_ids:
+                for r in rend_ids:
+                    for p in pal_ids:
+                        for v in range(1 + offset, variants + 1 + offset):
+                            if block["kind"] == "swatch_sheet":
+                                cell = f"{p}"
+                                prompt = assemble_swatch_prompt(spec, brief, p)
+                            elif block["kind"] == "family":
+                                fam = families[f]
+                                cell = f"{s}_{f}"
+                                comp_id = resolve_composition(spec, composition, f"{cell}_v{v}")
+                                prompt = assemble_scene_prompt(
+                                    spec,
+                                    brief,
+                                    s,
+                                    fam["rendering"],
+                                    fam["palette"],
+                                    comp_id,
+                                    [fam["register"]],
+                                )
+                            else:
+                                cell = "_".join(x for x in (s, r, p) if x)
+                                comp_id = resolve_composition(spec, composition, f"{cell}_v{v}")
+                                prompt = assemble_scene_prompt(spec, brief, s, r, p, comp_id, None)
+                            jobs.append(
+                                make_job(
+                                    spec,
+                                    level_key,
+                                    block["id"],
+                                    cell,
+                                    prompt,
+                                    size,
+                                    quality,
+                                    model,
+                                    v,
+                                )
                             )
-                        )
     return jobs
 
 
@@ -476,6 +529,7 @@ def expand_topup(spec, brief, picks, budget_usd):
 
 FAVOURABLE_TAGS = {"love", "like", "promote", "favour", "favor", "hero", "yes", "keep"}
 CELL_RE = re.compile(r"^(s\d{2})_(r\d{2})_(p\d{2})")
+FAMILY_CELL_RE = re.compile(r"^(s\d{2})_(f\d{2})")
 
 
 def load_picks(path, spec, limit=None):
@@ -500,14 +554,24 @@ def load_picks(path, spec, limit=None):
     rend_ok = {r["id"] for r in spec["renderings"]}
     pal_ok = {p["id"] for p in spec["palettes"]}
 
+    families = _by_id(spec.get("families", []), "id")
+
     picks, unparsed, seen = [], [], set()
     for cand in candidates:
         tail = cand.split(":")[-2] if cand.startswith("gen:") else Path(cand).name
         m = CELL_RE.match(tail)
-        if not m:
-            unparsed.append(cand)
-            continue
-        s, r, p = m.groups()
+        if m:
+            s, r, p = m.groups()
+        else:
+            # A family cell (s07_f03) carries its rendering and palette in the
+            # family definition rather than in the filename.
+            fm = FAMILY_CELL_RE.match(tail)
+            if not fm or fm.group(2) not in families:
+                unparsed.append(cand)
+                continue
+            s = fm.group(1)
+            fam = families[fm.group(2)]
+            r, p = fam["rendering"], fam["palette"]
         if s not in subj_ok or r not in rend_ok or p not in pal_ok:
             unparsed.append(cand)
             continue
@@ -784,7 +848,15 @@ def print_projection(jobs, brief, fx, title):
     print(
         f"taste brief: {brief['source']}"
         + (f"  sha256={brief['sha256'][:12]}" if brief["sha256"] else "")
+        + f"  injected HOLD chars={len(brief['hold'])}"
     )
+    if brief["present"] and not brief["hold"]:
+        print(
+            "    (no HOLD text extracted -- the profile carries no artbrief fenced block.\n"
+            "     The measured holds are encoded directly in the spec's base_clauses as\n"
+            "     auditable prompt text rather than injected as prose full of p-values.\n"
+            "     The profile sha256 is still recorded in every provenance sidecar.)"
+        )
     if not brief["present"]:
         print(
             "[!] WARNING: the taste profile was NOT found. Prompts fall back to the\n"


### PR DESCRIPTION
Queues tomorrow's funded art run. **Nothing was generated and no money was spent** -- every number here came out of `--dry-run`, which makes zero API calls.

Plan: `docs/design/ART_RUN_2026-08-07.md`. Queue: `tools/assets/manifests/art_night_2026-08-07.json`. Runner: `tools/assets/run_art_night.py`.

## Two findings that changed the plan

**1. The repo's per-image cost history is circular.** `generate_image()` returns `estimate_cost_per_image()`'s hardcoded constant, writes it to the run log, and `docs/art/SEED_ART_COST_MODEL.md` reads those logs back tagged MEASURED. Check it: the 2026-07-29 `new_subjects` run logged `cost=$1.08` for 12 images, and `$0.09` is the literal table entry for `1536x1024`. Nothing was measured. The "91 icons for about $12" anchor is a recollection of that estimate, not a bill. This run prices off OpenAI's published `gpt-image-1.5` tariff and marks every recorded cost `cost_is_billed_truth: false`.

**2. `quality` was never passed to the Images API.** The default `auto` applied on every batch this repo has ever run, and auto is free to bill at the HIGH tier -- $0.20 against medium's $0.05 at 1536x1024, a silent 4x. The measured 48-72 s/image in the 07-29 log is consistent with high. `run_art_night.py` passes `quality` explicitly on every call; `generate_images.py` gains a `--quality` flag plus a manifest key and prices the unset case defensively at high with a warning.

## The levels

| level | what | attended? | n | USD |
|---|---|---|---|---|
| L0 | swatch round -- 8 palettes as sheets + as an anchor scene held verbatim | unattended | 64 | 2.18 |
| L1 | wide net -- 22 subjects x 10 renderings, full factorial + depth + palette block + a 6-image gpt-image-2 probe | unattended | 580 | 29.00 |
| L2 | tweened and twinned -- 7 axes, one controlled step at a time | **needs picks** | 216 | 10.80 |
| L3 | hero prints -- high quality, 4 landscape + 1 portrait per winner | **needs picks** | 120 | 24.00 |
| -- | reserve for coordination#33 late requests / topup | | ~120 | 6.00 |
| | **planned** | | **~1,100** | **71.98 USD = 101.94 AUD** |
| | hard ceiling in code | | | **75.50 USD = 106.94 AUD** |

L2 and L3 refuse to expand without a picks file, so a third of the budget cannot be spent on unreviewed input.

## Safety properties

- `HARD_CEILING_USD = 75.50` is a module constant; `--ceiling-usd` can only lower it (higher is clamped with a warning). Cost is **reserved before dispatch** and refunded on failure, so concurrency cannot overshoot. Proven: `--wave l3 --ceiling-usd 2` printed `[ABORT] ... USD 8.00 over the ceiling` and **exited 2 having generated nothing**.
- Resume is an fsynced JSONL ledger keyed on job id; dying at image 300 of 600 loses at most one image.
- `--dry-run` never constructs the OpenAI client, so it works with no API key present.
- Provenance per `coordination#32`: a `<stem>.meta.json` sidecar per master with `origin`, full prompt + sha256, model, size, quality, tariff cost, timestamp, and the sha256 of the taste profile that shaped it. `seed` is recorded as `null` **with a note** -- the API exposes none, and a consumer must be able to tell "no seed exists" from "we forgot to write it down". This does not discharge #32; it stops making it worse.
- `ADR-0019`: there is no promotion code path in the script at all. Output lands under `art_generated/` (gitignored in full) as Generated / Library.

## The taste brief

`docs/design/TASTE_PROFILE_2026-08-06.md` did not exist when this was built, so the queue **reads it at execution time** against a documented ` ```artbrief ` fenced-block contract (`HOLD` / `AVOID` / `PALETTE` / `RENDERING_FAVOURED` / `SUBJECT_BOOST`). If it is absent the run falls back to house clauses and prints a loud warning that it is a **blind** run -- which is what today's dry run shows.

## Dry-run proof

```
block                model          size        qual        n       USD
l0_sheets            gpt-image-1.5  1024x1024   medium     16      0.54
l0_anchors           gpt-image-1.5  1024x1024   medium     48      1.63
l1_grid              gpt-image-1.5  1536x1024   medium    220     11.00
l1_depth             gpt-image-1.5  1536x1024   medium    264     13.20
l1_palette           gpt-image-1.5  1536x1024   medium     90      4.50
l1_probe             gpt-image-2    1536x1024   medium      6      0.30
TOTAL                                          644     31.18   (AUD 44.16)
```

## Unflattering measurements worth stating

- The overnight wave alone is USD 31.18, which is **below half the AUD budget**. Clearing the "don't underspend" bar requires Pip to actually review and run L2 and L3. That is deliberate -- the money is parked behind his eye rather than spent blind -- but it means an unattended-only night fails the brief.
- L0's palette verdict **cannot** constrain L1, because both run in the same unattended wave. L1 holds one palette constant and asks the palette question in its own block instead; L0 constrains L2 and L3.
- The pixellab lane is free at the margin (subscription active, 5,724 generations remaining, $0 credits), so it **cannot count toward the dollar target**.
- `gpt-image-1.5` caps at 1536px on the long edge and this repo has no upscale path. L3 produces print-ready *sources*, not printable posters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
