### PR TITLE
feat(credits): a credits screen the cat people can actually reach

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,6 +120,17 @@ repos:
         files: '^(godot/data/actions/.*\.json|godot/scripts/ui/(action_bar_renderer|submenu_controller)\.gd|docs/ACTION_TAXONOMY\.md|scripts/generate_action_taxonomy\.py)$'
         pass_filenames: false
 
+      # godot/data/credits.json is GENERATED from CREDITS.md (same anti-rot pattern
+      # as the DQ/ADR/tools indexes). CREDITS.md is where a name gets fixed; this
+      # blocks the commit where someone edits it and forgets the game copy, which is
+      # exactly how a contributor ends up credited in the repo and not in the product.
+      - id: credits-json-check
+        name: in-game credits.json regenerated from CREDITS.md
+        entry: python scripts/generate_credits.py --check
+        language: system
+        files: '^(CREDITS\.md|godot/data/credits\.json|scripts/generate_credits\.py)$'
+        pass_filenames: false
+
       - id: scene-nav-check
         name: Scene navigation routes through SceneTransition
         entry: python tools/check_scene_nav.py

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -2,20 +2,59 @@
 
 P(Doom)1 -- a turn-based AI-safety strategy game.
 
-> This file is a repo document (it lives at the repo root, outside `godot/`, so
-> it is not bundled into the shipped build). Some fields are marked
-> **[Pip to fill]** -- placeholders for names/attributions only Pip can confirm.
-> An in-game credits screen, if wanted, is a separate follow-up.
+> **This file is the SOURCE OF TRUTH for the in-game credits screen.** It still
+> lives at the repo root, outside `godot/`, so it is not itself bundled -- instead
+> `scripts/generate_credits.py` derives `godot/data/credits.json` from it, and a
+> pre-commit `--check` blocks a stale copy (same anti-rot pattern as
+> `DQ_INDEX.md`). Edit THIS file; never hand-edit the JSON.
+>
+> Fields marked **[Pip to fill]** / **[Pip to confirm]** are placeholders only Pip
+> can resolve. The generator DROPS any entry still carrying a placeholder, so an
+> unresolved TODO can never reach a player's screen -- it just silently does not
+> appear. Resolving one is what makes it ship.
 
 ## Game
 
 - **Design, direction, and development:** Pip Foweraker  *(adjust name form as preferred)*
 - **Engine:** [Godot Engine](https://godotengine.org) 4.5.1 (MIT License)
 
+## Cats
+
+The office cat in your lab is a real cat. Eight were contributed by their people,
+with permission, and `office_cat.gd` picks one at random per run -- so every one
+of them reaches players.
+
+Table columns are load-bearing: `Cat` is the display name, `Photo by` is the
+credit line shown in game, `Asset` must match a key of `CAT_NAMES` in
+`godot/scripts/ui/office_cat.gd` (a GUT test fails if the two rosters drift). A
+`Photo by` cell still carrying a `[Pip to confirm ...]` marker renders the cat
+WITHOUT a credit line rather than printing the marker.
+
+| Cat | Photo by | Asset |
+|---|---|---|
+| Arwen | Matilda | web-arwen.jpg |
+| Arwen & Chuck | Matilda | web-arwen-chuck.jpg |
+| Chucky | Nicki T. | web-chucky.jpg |
+| Doom Cat | [Pip to confirm -- inventory records custodian "Office (default/mascot)", not a person] | web-doom-cat.jpg |
+| Luna | Nicki T. | web-luna.jpg |
+| Mando | Nicki T. | web-mando.jpg |
+| Missy | Spicy | web-missy.jpg |
+| Nigel | Nicki T. | web-nigel.jpg |
+
+Credit names are transcribed verbatim from
+`art_source/cats_incoming/INVENTORY.md` (the "Custodian" field), which is the
+only record this repo holds. Nobody has confirmed these are the forms the
+contributors want to be credited under -- see the Pip checklist below. Change the
+name HERE and the game picks it up on the next generate.
+
 ## Music
 
 **Original adaptive score** (the composed five-tier doom-band soundtrack + the
-victory, defeat, and menu cues that ship today):
+run-end and menu cues that ship today):
+
+Wording note, not shipped: this section is PLAYER-FACING now, so it obeys ADR-0002
+and must not name a "victory" cue -- `test_no_win_condition_copy.gd` scans
+`godot/data/credits.json` and fails if it does.
 
 - **Composition, direction, and taste authority:** Pip Foweraker -- the musician
   and director; every note judged by ear over the workshop sessions.
@@ -29,8 +68,8 @@ development, now retired but preserved in `archive/audio/`):
 
 - **Written and performed by:** **[Pip to fill -- friend's name / handle / "prefers anonymity"]**
   -- DJ-session ambient tracks, generously given to the project. Pip authored
-  the (AI-safety pun) track titles; project holds full usage rights.
-- With thanks for setting the sonic tone the composed score grew out of.
+  the (AI-safety pun) track titles; project holds full usage rights. With thanks
+  for setting the sonic tone the composed score grew out of.
 
 ## Playtesting
 
@@ -47,8 +86,9 @@ development, now retired but preserved in `archive/audio/`):
 
 The score learned from, but did not copy, a set of north-star artists (Master
 Musicians of Bukkake, Philip Glass, and others). They are inspirations only,
-with no affiliation or endorsement; the lineage is documented in
-`docs/audio/REFERENCE_TRACKS.md`.
+with no affiliation or endorsement.
+
+The full lineage is documented in `docs/audio/REFERENCE_TRACKS.md`.
 
 ---
 
@@ -63,4 +103,14 @@ with no affiliation or endorsement; the lineage is documented in
 - [ ] Decide how prominent the AI-collaboration credit should be -- the wording
       above is honest-and-plain; dial up or down to taste.
 - [ ] Fill the art-pipeline attributions (owned by the art lane, not this session).
-- [ ] Decide whether an in-game credits screen is wanted (separate feature).
+- [x] In-game credits screen: BUILT. Welcome menu -> `Credits`, generated from
+      this file. Cats get the top section.
+- [ ] **Cats: confirm each contributor's preferred credit form.** The eight names
+      above are transcribed from INVENTORY.md's "Custodian" field, which was
+      internal metadata, not a stated credit preference. Ask each contributor how
+      they want to appear (full name / first name / handle / "prefers
+      anonymity"), then edit the table. Until then the game ships the inventory
+      form.
+- [ ] **Doom Cat has no recorded contributor** -- inventory lists the custodian as
+      "Office (default/mascot)". If it came from a person, name them; if it is the
+      project's own image, say so and the placeholder can go.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -37,11 +37,12 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | cleanup_project.py | -- | Project Cleanup Automation Script | make |
 | content_publisher.py | -- | P(Doom) Content Publisher - Multi-Platform Publishing System | human (docstring usage) |
 | devblog_automation.py | -- | Dev Blog Automation System with Metadata | tool:content_publisher.py |
-| enforce_standards.py | -- | P(Doom) Development Standards Enforcement Script | pre-commit; ci:enhanced-cicd-pipeline.yml; ci:quality-checks.yml; tool:intelligent_ascii_converter.py; tool:pre_version_bump.py |
+| enforce_standards.py | -- | P(Doom) Development Standards Enforcement Script | pre-commit; ci:enhanced-cicd-pipeline.yml; ci:quality-checks.yml; tool:generate_credits.py; tool:intelligent_ascii_converter.py; tool:pre_version_bump.py |
 | find_duplicates.py | -- | Duplicate File Detector | human (docstring usage) |
 | generate_action_taxonomy.py | GENERATE | Generate docs/ACTION_TAXONOMY.md and check the action taxonomy for rot. | pre-commit; test:test_generate_action_taxonomy.py |
 | generate_adr_index.py | GENERATE | Generate docs/game-design/decisions/README.md from the ADR files themselves. | pre-commit; tool:generate_action_taxonomy.py; tool:generate_tools_index.py |
-| generate_dq_index.py | GENERATE | Generate docs/game-design/DQ_INDEX.md from WORKSHOP_2_BACKLOG.md. | pre-commit; tool:enforce_standards.py; tool:generate_release_metadata.py; tool:intelligent_ascii_converter.py |
+| generate_credits.py | GENERATE | Generate godot/data/credits.json from CREDITS.md. | pre-commit |
+| generate_dq_index.py | GENERATE | Generate docs/game-design/DQ_INDEX.md from WORKSHOP_2_BACKLOG.md. | pre-commit; tool:enforce_standards.py; tool:generate_credits.py; tool:generate_release_metadata.py; tool:intelligent_ascii_converter.py |
 | generate_mechanics_docs.py | GENERATE | Generate mechanics documentation from game code. | ci:docs-sync.yml |
 | generate_release_manifest.py | GENERATE | Generate release_manifest.json -- the machine-readable release descriptor. | ci:enhanced-release.yml; test:test_generate_release_manifest.py |
 | generate_release_metadata.py | GENERATE | Generate release metadata for website integration. | pre-commit; ci:enhanced-release.yml; tool:generate_release_manifest.py |
@@ -204,4 +205,4 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 
 23 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
 
-Total: 108 active tools (7 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 89 undeclared); 11 in UNKNOWN; 6 archived.
+Total: 109 active tools (8 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 89 undeclared); 11 in UNKNOWN; 6 archived.

--- a/godot/assets/cats/README.md
+++ b/godot/assets/cats/README.md
@@ -14,6 +14,16 @@
 > - There is no contributor sync. `godot/data/contributors.json` (an empty stub)
 >   was deleted 2026-08-04; the sync script that was meant to fill it never ran.
 >   See issue #1115.
+>
+> **UPDATE 2026-08-06 -- recognition now EXISTS, by a different route.** The
+> abandoned design (a synced `contributors.json` + a `ContributorManager`) is
+> still dead and should not be revived as written. What replaced it:
+> `CREDITS.md` at the repo root is the source of truth, `scripts/generate_credits.py`
+> derives `godot/data/credits.json`, and `godot/scenes/credits_screen.tscn`
+> (welcome menu -> Credits) renders every cat with its contributor. The in-run
+> cat gained a hover tooltip naming the same person. `office_cat.gd` still owns
+> `CAT_NAMES`; a GUT test (`tests/unit/test_credits_data.gd`) fails if that
+> roster and the CREDITS.md table ever disagree. Doom variants remain unbuilt.
 
 This directory contains office cat images for the contributor recognition system.
 

--- a/godot/data/credits.json
+++ b/godot/data/credits.json
@@ -1,0 +1,107 @@
+{
+  "_generated": "GENERATED from CREDITS.md by scripts/generate_credits.py -- do not hand-edit. Run the script; a pre-commit --check blocks staleness.",
+  "cats": [
+    {
+      "name": "Arwen",
+      "credited_to": "Matilda",
+      "asset": "web-arwen.jpg"
+    },
+    {
+      "name": "Arwen & Chuck",
+      "credited_to": "Matilda",
+      "asset": "web-arwen-chuck.jpg"
+    },
+    {
+      "name": "Chucky",
+      "credited_to": "Nicki T.",
+      "asset": "web-chucky.jpg"
+    },
+    {
+      "name": "Doom Cat",
+      "credited_to": "",
+      "asset": "web-doom-cat.jpg"
+    },
+    {
+      "name": "Luna",
+      "credited_to": "Nicki T.",
+      "asset": "web-luna.jpg"
+    },
+    {
+      "name": "Mando",
+      "credited_to": "Nicki T.",
+      "asset": "web-mando.jpg"
+    },
+    {
+      "name": "Missy",
+      "credited_to": "Spicy",
+      "asset": "web-missy.jpg"
+    },
+    {
+      "name": "Nigel",
+      "credited_to": "Nicki T.",
+      "asset": "web-nigel.jpg"
+    }
+  ],
+  "sections": [
+    {
+      "title": "Game",
+      "entries": [
+        {
+          "kind": "item",
+          "text": "Design, direction, and development: Pip Foweraker (adjust name form as preferred)"
+        },
+        {
+          "kind": "item",
+          "text": "Engine: Godot Engine 4.5.1 (MIT License)"
+        }
+      ]
+    },
+    {
+      "title": "Music",
+      "entries": [
+        {
+          "kind": "note",
+          "text": "Original adaptive score (the composed five-tier doom-band soundtrack + the run-end and menu cues that ship today):"
+        },
+        {
+          "kind": "item",
+          "text": "Composition, direction, and taste authority: Pip Foweraker -- the musician and director; every note judged by ear over the workshop sessions."
+        },
+        {
+          "kind": "item",
+          "text": "Composed with: Claude (Anthropic's Claude Code, \"Fable\"), as the live-coding instrument and studio hand, under Pip's direction. The score was workshopped in Strudel patches and rendered to the game's audio beds."
+        },
+        {
+          "kind": "item",
+          "text": "Authoring tool: Strudel (live-codeable music in the browser)."
+        }
+      ]
+    },
+    {
+      "title": "Tools and third-party components",
+      "entries": [
+        {
+          "kind": "item",
+          "text": "Godot Engine -- game engine (MIT)"
+        },
+        {
+          "kind": "item",
+          "text": "GUT -- Godot unit test framework (dev/CI, MIT)"
+        },
+        {
+          "kind": "item",
+          "text": "Strudel -- music authoring (composition sessions)"
+        }
+      ]
+    },
+    {
+      "title": "Aesthetic gratitude",
+      "entries": [
+        {
+          "kind": "note",
+          "text": "The score learned from, but did not copy, a set of north-star artists (Master Musicians of Bukkake, Philip Glass, and others). They are inspirations only, with no affiliation or endorsement."
+        }
+      ]
+    }
+  ]
+}

--- a/godot/scenes/credits_screen.tscn
+++ b/godot/scenes/credits_screen.tscn
@@ -1,0 +1,93 @@
+[gd_scene load_steps=3 format=3 uid="uid://bcredits1screen"]
+
+[ext_resource type="Script" path="res://scripts/ui/credits_screen.gd" id="1_credits"]
+[ext_resource type="Theme" uid="uid://dmenuthemepd001" path="res://theme/menu_theme.tres" id="2_theme"]
+
+[node name="CreditsScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("2_theme")
+script = ExtResource("1_credits")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.09, 0.04, 0.11, 1)
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -550.0
+offset_top = -430.0
+offset_right = 550.0
+offset_bottom = 430.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBox" type="VBoxContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 30.0
+offset_top = 30.0
+offset_right = -30.0
+offset_bottom = -30.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 14
+
+[node name="Title" type="Label" parent="Panel/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.914, 0.949, 0.949, 1)
+theme_override_font_sizes/font_size = 42
+text = "CREDITS"
+horizontal_alignment = 1
+
+[node name="Subtitle" type="Label" parent="Panel/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.78, 0.86, 1)
+theme_override_font_sizes/font_size = 16
+text = "The cats are real. Their people said yes."
+horizontal_alignment = 1
+
+[node name="HSeparator" type="HSeparator" parent="Panel/VBox"]
+layout_mode = 2
+
+[node name="ContentScroll" type="ScrollContainer" parent="Panel/VBox"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Content" type="VBoxContainer" parent="Panel/VBox/ContentScroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 10
+
+[node name="Footer" type="HBoxContainer" parent="Panel/VBox"]
+layout_mode = 2
+alignment = 1
+theme_override_constants/separation = 16
+
+[node name="WebsiteButton" type="Button" parent="Panel/VBox/Footer"]
+custom_minimum_size = Vector2(280, 44)
+layout_mode = 2
+theme_override_font_sizes/font_size = 18
+text = "[W] Open pdoom1.com"
+
+[node name="BackButton" type="Button" parent="Panel/VBox/Footer"]
+custom_minimum_size = Vector2(280, 44)
+layout_mode = 2
+theme_override_font_sizes/font_size = 18
+text = "[ESC] Back"

--- a/godot/scenes/welcome.tscn
+++ b/godot/scenes/welcome.tscn
@@ -131,6 +131,12 @@ theme_override_colors/font_pressed_color = Color(0.059, 0.647, 0.627, 1)
 theme_override_font_sizes/font_size = 24
 text = "AI Safety Info"
 
+[node name="CreditsButton" type="Button" parent="VBox/MenuContainer"]
+custom_minimum_size = Vector2(400, 50)
+layout_mode = 2
+theme_override_font_sizes/font_size = 24
+text = "Credits"
+
 [node name="ExitButton" type="Button" parent="VBox/MenuContainer"]
 custom_minimum_size = Vector2(400, 50)
 layout_mode = 2

--- a/godot/scripts/data/credits_data.gd
+++ b/godot/scripts/data/credits_data.gd
@@ -1,0 +1,75 @@
+class_name CreditsData
+extends RefCounted
+## Read-only accessor for res://data/credits.json.
+##
+## That JSON is GENERATED from CREDITS.md by scripts/generate_credits.py and a
+## pre-commit --check blocks a stale copy. Nothing in the game should hand-write
+## a credit string: two copies of a contributor's name is how one of them ends
+## up wrong and nobody notices (the decisions/README.md failure mode).
+##
+## Two callers today: credits_screen.gd (the whole surface) and office_cat.gd
+## (the in-run "who is this cat" tooltip). Both go through here so the cat ->
+## person mapping exists exactly once.
+
+const CREDITS_PATH := "res://data/credits.json"
+
+static var _cache: Dictionary = {}
+static var _loaded: bool = false
+
+
+## Parsed credits document. Returns an empty-but-shaped dictionary if the file
+## is missing or malformed -- a credits screen with nothing on it is a bad day,
+## a crash on the way to the main menu is a worse one.
+static func data() -> Dictionary:
+	if _loaded:
+		return _cache
+	_loaded = true
+	_cache = {"cats": [], "sections": []}
+
+	# ResourceLoader/FileAccess note: unlike an imported .jpg, a .json in
+	# res://data IS shipped verbatim in the .pck, so FileAccess is correct here
+	# (this is the opposite of the #796 texture trap in office_cat.gd).
+	if not FileAccess.file_exists(CREDITS_PATH):
+		push_warning("[CreditsData] missing " + CREDITS_PATH)
+		return _cache
+	var file := FileAccess.open(CREDITS_PATH, FileAccess.READ)
+	if file == null:
+		push_warning("[CreditsData] could not open " + CREDITS_PATH)
+		return _cache
+	var parsed: Variant = JSON.parse_string(file.get_as_text())
+	file.close()
+	if typeof(parsed) != TYPE_DICTIONARY:
+		push_warning("[CreditsData] " + CREDITS_PATH + " did not parse as an object")
+		return _cache
+	var doc: Dictionary = parsed
+	_cache = {
+		"cats": doc.get("cats", []),
+		"sections": doc.get("sections", []),
+	}
+	return _cache
+
+
+## Every contributed cat: [{name, credited_to, asset}]. `credited_to` is "" when
+## the preferred credit form is still unconfirmed in CREDITS.md -- callers must
+## render the cat WITHOUT a credit line rather than printing a placeholder.
+static func cats() -> Array:
+	return data().get("cats", [])
+
+
+static func sections() -> Array:
+	return data().get("sections", [])
+
+
+## Credit line for one cat asset file name (e.g. "web-luna.jpg"), or "" if the
+## asset is unknown or its credit form is unconfirmed.
+static func credit_for_asset(asset: String) -> String:
+	for entry in cats():
+		if typeof(entry) == TYPE_DICTIONARY and str(entry.get("asset", "")) == asset:
+			return str(entry.get("credited_to", ""))
+	return ""
+
+
+## Test hook: drop the cache so a test can re-read after touching the file.
+static func reset_cache() -> void:
+	_cache = {}
+	_loaded = false

--- a/godot/scripts/data/credits_data.gd.uid
+++ b/godot/scripts/data/credits_data.gd.uid
@@ -1,0 +1,1 @@
+uid://c2mrs8wojh08f

--- a/godot/scripts/ui/credits_screen.gd
+++ b/godot/scripts/ui/credits_screen.gd
@@ -1,0 +1,176 @@
+extends Control
+## Credits screen -- the one place in the product where contributors are named.
+##
+## Everything here is rendered from res://data/credits.json, which is GENERATED
+## from CREDITS.md. Do not add a hardcoded name to this file; add it to
+## CREDITS.md and run scripts/generate_credits.py.
+##
+## The cats go FIRST, deliberately. Eight people gave their cat's photo, one of
+## the eight appears in every run, and until now the product had nowhere to say
+## thank you. It is also the section a person would screenshot, which is the
+## honest reason it is at the top rather than filed under "assets".
+
+const CAT_IMAGES_PATH := "res://assets/cats/simple/"
+const CAT_TILE_SIZE := Vector2(150, 150)
+
+## Website link policy (docs/copy/README.md): the game NEVER depends on the
+## website. This is the site ROOT, which exists today (UpdateCheck already reads
+## https://pdoom1.com/data/version.json), not a deep link to a "meet the cats"
+## page that may or may not be built. A hardcoded deep link would make this
+## screen quietly wrong the moment the website reorganised, and the game has no
+## way to find that out.
+const WEBSITE_URL := "https://pdoom1.com"
+
+@onready var content: VBoxContainer = $Panel/VBox/ContentScroll/Content
+@onready var back_button: Button = $Panel/VBox/Footer/BackButton
+@onready var website_button: Button = $Panel/VBox/Footer/WebsiteButton
+
+
+func _ready() -> void:
+	back_button.pressed.connect(_on_back_pressed)
+	website_button.pressed.connect(_on_website_pressed)
+	website_button.tooltip_text = "Opens the project website in your browser"
+	_build()
+	back_button.grab_focus()
+	print("[CreditsScreen] Rendered %d cats, %d sections" % [
+		CreditsData.cats().size(), CreditsData.sections().size()
+	])
+
+
+func _build() -> void:
+	for child in content.get_children():
+		child.queue_free()
+	_build_cats()
+	for section in CreditsData.sections():
+		if typeof(section) == TYPE_DICTIONARY:
+			_build_section(section)
+
+
+func _build_cats() -> void:
+	var cats: Array = CreditsData.cats()
+	if cats.is_empty():
+		return
+	_add_heading("THE CATS")
+	_add_paragraph(
+		"One of these cats is in your office every run, picked at random."
+		+ " They are real cats, contributed by their people with permission."
+	)
+	var flow := HFlowContainer.new()
+	flow.add_theme_constant_override("h_separation", 18)
+	flow.add_theme_constant_override("v_separation", 14)
+	content.add_child(flow)
+	for entry in cats:
+		if typeof(entry) == TYPE_DICTIONARY:
+			flow.add_child(_build_cat_card(entry))
+
+
+func _build_cat_card(entry: Dictionary) -> Control:
+	var card := VBoxContainer.new()
+	card.add_theme_constant_override("separation", 2)
+
+	var frame := PanelContainer.new()
+	frame.custom_minimum_size = CAT_TILE_SIZE
+	var picture := TextureRect.new()
+	picture.custom_minimum_size = CAT_TILE_SIZE
+	picture.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	picture.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
+	picture.texture = _load_cat_texture(str(entry.get("asset", "")))
+	frame.add_child(picture)
+	card.add_child(frame)
+
+	var name_label := Label.new()
+	name_label.text = str(entry.get("name", ""))
+	name_label.custom_minimum_size.x = CAT_TILE_SIZE.x
+	name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	name_label.add_theme_font_size_override("font_size", 17)
+	card.add_child(name_label)
+
+	# An unconfirmed credit form renders as NOTHING, never as a placeholder
+	# string. generate_credits.py blanks the field; this is the second half of
+	# that contract.
+	var credit := str(entry.get("credited_to", ""))
+	if credit != "":
+		var credit_label := Label.new()
+		credit_label.text = "photo by " + credit
+		credit_label.custom_minimum_size.x = CAT_TILE_SIZE.x
+		credit_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		credit_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		credit_label.add_theme_font_size_override("font_size", 14)
+		credit_label.add_theme_color_override("font_color", Color(0.70, 0.78, 0.86, 1.0))
+		card.add_child(credit_label)
+
+	return card
+
+
+## Same import-system lesson as office_cat.gd (#796): ResourceLoader.exists(),
+## never FileAccess.file_exists(), because the exported .pck holds the imported
+## .ctex and not the source .jpg. A missing cat degrades to a muted swatch, not
+## to the engine's magenta checkerboard.
+func _load_cat_texture(asset: String) -> Texture2D:
+	if asset != "":
+		var path := CAT_IMAGES_PATH + asset
+		if ResourceLoader.exists(path):
+			var texture := load(path) as Texture2D
+			if texture != null:
+				return texture
+		push_warning("[CreditsScreen] cat image not found: " + path)
+	var image := Image.create(64, 64, false, Image.FORMAT_RGBA8)
+	image.fill(Color(0.16, 0.17, 0.20, 1.0))
+	return ImageTexture.create_from_image(image)
+
+
+func _build_section(section: Dictionary) -> void:
+	var entries: Array = section.get("entries", [])
+	if entries.is_empty():
+		return
+	_add_heading(str(section.get("title", "")).to_upper())
+	for entry in entries:
+		if typeof(entry) != TYPE_DICTIONARY:
+			continue
+		var text := str(entry.get("text", ""))
+		if text == "":
+			continue
+		if str(entry.get("kind", "")) == "item":
+			_add_paragraph("  >>  " + text)
+		else:
+			_add_paragraph(text)
+
+
+func _add_heading(text: String) -> void:
+	var spacer := Control.new()
+	spacer.custom_minimum_size.y = 10
+	content.add_child(spacer)
+	var label := Label.new()
+	label.text = text
+	label.add_theme_font_size_override("font_size", 24)
+	label.add_theme_color_override("font_color", Color(0.91, 0.64, 0.24, 1.0))
+	content.add_child(label)
+	content.add_child(HSeparator.new())
+
+
+func _add_paragraph(text: String) -> void:
+	var label := Label.new()
+	label.text = text
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	label.custom_minimum_size.x = 960
+	label.add_theme_font_size_override("font_size", 17)
+	content.add_child(label)
+
+
+func _on_back_pressed() -> void:
+	SceneTransition.go_to("res://scenes/welcome.tscn")
+
+
+func _on_website_pressed() -> void:
+	OS.shell_open(WEBSITE_URL)
+
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventKey and event.pressed and not event.echo:
+		if event.keycode == KEY_ESCAPE:
+			_on_back_pressed()
+			get_viewport().set_input_as_handled()
+		elif event.keycode == KEY_W:
+			_on_website_pressed()
+			get_viewport().set_input_as_handled()

--- a/godot/scripts/ui/credits_screen.gd.uid
+++ b/godot/scripts/ui/credits_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://cfhnv1afrepqu

--- a/godot/scripts/ui/office_cat.gd
+++ b/godot/scripts/ui/office_cat.gd
@@ -46,6 +46,31 @@ func select_random_cat() -> void:
 	var image_path = CAT_IMAGES_PATH + cat_file
 	set_cat_image(image_path)
 	contributor_label.text = current_cat_name
+	_apply_contributor_credit(cat_file)
+
+
+## The in-run "who is this cat" affordance -- a HOVER TOOLTIP, and deliberately
+## nothing more.
+##
+## The visible label keeps showing the CAT's name; the person's name arrives only
+## if the player asks for it by hovering. A click-to-open panel was the obvious
+## alternative and was rejected: a modal mid-run interrupts the plan phase for a
+## purely decorative reason, and there is no route back from a credits SCENE
+## without abandoning the run. The full surface lives at the welcome menu
+## (Credits); this is the pointer, not the destination.
+##
+## The credit string comes from the generated credits data, never from a second
+## hardcoded table -- CAT_NAMES owns the cat names, CREDITS.md owns the people.
+func _apply_contributor_credit(cat_file: String) -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	var credit := CreditsData.credit_for_asset(cat_file)
+	# An unconfirmed credit form shows nothing at all rather than a placeholder.
+	if credit == "":
+		tooltip_text = "%s\n\nOffice cat. See Credits on the main menu." % current_cat_name
+	else:
+		tooltip_text = "%s\n\nPhoto by %s.\nAll eight cats are on the Credits screen." % [
+			current_cat_name, credit
+		]
 
 ## Update doom level (currently does nothing, kept for compatibility)
 ## @param doom_percentage: Current doom level (0.0 to 1.0)
@@ -105,4 +130,4 @@ func cycle_contributor() -> void:
 
 ## Get current cat info (for tooltips, etc.)
 func get_current_contributor_info() -> String:
-	return "%s\n\nOffice Cat - Keeping morale high!\n\nClick to see another cat!" % current_cat_name
+	return tooltip_text

--- a/godot/scripts/ui/welcome_screen.gd
+++ b/godot/scripts/ui/welcome_screen.gd
@@ -13,6 +13,14 @@ extends Control
 @onready var leaderboard_button = $VBox/MenuContainer/LeaderboardButton
 @onready var whats_new_button = $VBox/MenuContainer/WhatsNewButton
 @onready var ai_safety_button = $VBox/MenuContainer/AISafetyButton
+# Credits takes the TENTH and last visible slot. Measured before adding it: nine
+# buttons render (Load Game is instantiated but hidden, see below), so this stays
+# inside Pip's cap-of-10 instinct from #1132 -- but it CONSUMES the spare. The
+# next meta surface should not be an eleventh button; it should force the
+# grouping decision (an "About" door holding Credits / AI Safety Info / What's
+# New), which belongs to the UI architecture effort in
+# docs/design/UI_ARCHITECTURE_2026-08-06.md, not to this change.
+@onready var credits_button = $VBox/MenuContainer/CreditsButton
 @onready var exit_button = $VBox/MenuContainer/ExitButton
 @onready var version_label = $Version
 
@@ -57,6 +65,7 @@ func _ready():
 		leaderboard_button,
 		whats_new_button,
 		ai_safety_button,
+		credits_button,
 		exit_button
 	]
 
@@ -70,6 +79,7 @@ func _ready():
 	leaderboard_button.pressed.connect(_on_leaderboard_pressed)
 	whats_new_button.pressed.connect(_on_whats_new_pressed)
 	ai_safety_button.pressed.connect(_on_ai_safety_pressed)
+	credits_button.pressed.connect(_on_credits_pressed)
 	exit_button.pressed.connect(_on_exit_pressed)
 
 	# DEPRECATED (v0.11.0): the single-slot quicksave "Load Game" is HIDDEN pending a proper
@@ -198,6 +208,10 @@ func _on_leaderboard_pressed():
 func _on_ai_safety_pressed():
 	print("[WelcomeScreen] Opening AI Safety Info...")
 	OS.shell_open("https://aisafety.info/")
+
+func _on_credits_pressed():
+	print("[WelcomeScreen] Opening credits...")
+	SceneTransition.go_to("res://scenes/credits_screen.tscn")
 
 func _on_exit_pressed():
 	print("[WelcomeScreen] Exiting game...")

--- a/godot/tests/unit/test_credits_data.gd
+++ b/godot/tests/unit/test_credits_data.gd
@@ -1,0 +1,174 @@
+extends GutTest
+## Guards the in-game credits surface. Three failure modes, all of which are
+## SILENT -- the game runs perfectly with any of them and the only symptom is a
+## contributor who is not credited, or is credited wrongly, and never finds out.
+##
+## 1. THE ROSTER DRIFTS. office_cat.gd's CAT_NAMES decides which cats a player
+##    sees; CREDITS.md decides who gets named for them. Add a cat to one and not
+##    the other and the game happily ships an uncredited cat forever.
+## 2. THE SCREEN BECOMES UNREACHABLE. A credits screen nobody can open is the
+##    same as no credits screen. This asserts the welcome menu still has the
+##    button and still points at the scene.
+## 3. A PLACEHOLDER SHIPS. CREDITS.md carries "[Pip to fill]" / "[Pip to
+##    confirm]" markers by design. generate_credits.py drops them; if that drop
+##    ever regresses, a player sees a TODO where a person's name belongs.
+##
+## Honest limitation: none of this proves a cat photo reached a screen, or that
+## a contributor is happy with the name form used. The first needs a human
+## looking at an exported build; the second needs Pip asking them (tracked in
+## the CREDITS.md checklist).
+
+const OFFICE_CAT_SCRIPT_PATH := "res://scripts/ui/office_cat.gd"
+const WELCOME_SCENE_PATH := "res://scenes/welcome.tscn"
+const WELCOME_SCRIPT_PATH := "res://scripts/ui/welcome_screen.gd"
+const CREDITS_SCENE_PATH := "res://scenes/credits_screen.tscn"
+const CAT_IMAGES_PATH := "res://assets/cats/simple/"
+
+# Eight cats shipped in v0.13.2. Floored so an empty roster cannot pass this
+# file vacuously (same reasoning as test_office_cat_assets.gd).
+const MIN_CATS := 8
+
+
+func before_each() -> void:
+	CreditsData.reset_cache()
+
+
+func _read(path: String) -> String:
+	var f := FileAccess.open(path, FileAccess.READ)
+	assert_not_null(f, "could not read " + path)
+	if f == null:
+		return ""
+	var text := f.get_as_text()
+	f.close()
+	return text
+
+
+func _cat_names() -> Dictionary:
+	var script: GDScript = load(OFFICE_CAT_SCRIPT_PATH)
+	assert_not_null(script, "could not load " + OFFICE_CAT_SCRIPT_PATH)
+	return script.get_script_constant_map().get("CAT_NAMES", {})
+
+
+func test_credits_data_loads_with_cats_and_sections():
+	assert_true(
+		FileAccess.file_exists(CreditsData.CREDITS_PATH),
+		"credits.json is missing -- run: python scripts/generate_credits.py"
+	)
+	assert_true(
+		CreditsData.cats().size() >= MIN_CATS,
+		"expected at least %d credited cats, found %d" % [MIN_CATS, CreditsData.cats().size()]
+	)
+	assert_gt(CreditsData.sections().size(), 0, "credits.json carries no credit sections at all")
+
+
+func test_cat_roster_matches_office_cat():
+	# The load-bearing reconciliation. CAT_NAMES is what players SEE;
+	# credits.json is who gets NAMED. They must describe the same eight cats.
+	var in_game: Dictionary = _cat_names()
+	var credited := {}
+	for entry in CreditsData.cats():
+		credited[str(entry.get("asset", ""))] = str(entry.get("name", ""))
+
+	for asset in in_game.keys():
+		assert_true(
+			credited.has(asset),
+			"cat '%s' ships in office_cat.gd but has no row in CREDITS.md -- it would"
+			% asset
+			+ " appear in game with nobody credited for it. Add it to the Cats table."
+		)
+	for asset in credited.keys():
+		assert_true(
+			in_game.has(asset),
+			"CREDITS.md credits '%s' but office_cat.gd never shows it -- either the"
+			% asset
+			+ " asset was dropped from the game or the table has a typo."
+		)
+	for asset in credited.keys():
+		if in_game.has(asset):
+			assert_eq(
+				str(credited[asset]),
+				str(in_game[asset]),
+				"cat display name disagrees between CREDITS.md and office_cat.gd for " + asset
+			)
+
+
+func test_every_credited_cat_asset_resolves():
+	# ResourceLoader, never FileAccess: the exported .pck holds the imported
+	# .ctex, not the source .jpg (#796).
+	for entry in CreditsData.cats():
+		var path: String = CAT_IMAGES_PATH + str(entry.get("asset", ""))
+		assert_true(
+			ResourceLoader.exists(path),
+			"credited cat asset does not resolve through the import system: " + path
+		)
+
+
+func test_no_unresolved_placeholder_reaches_a_player():
+	var raw := _read(CreditsData.CREDITS_PATH).to_lower()
+	for marker in ["to fill", "to confirm", "[pip"]:
+		assert_false(
+			raw.contains(marker),
+			"credits.json contains the unresolved marker '%s'." % marker
+			+ " generate_credits.py is meant to DROP any entry still carrying one;"
+			+ " a player would otherwise read a TODO where a contributor's name goes."
+		)
+
+
+func test_credits_screen_is_reachable_from_the_welcome_menu():
+	# Failure mode 2: the surface exists but nothing opens it.
+	assert_true(
+		ResourceLoader.exists(CREDITS_SCENE_PATH), "missing scene: " + CREDITS_SCENE_PATH
+	)
+	var welcome_scene := _read(WELCOME_SCENE_PATH)
+	assert_true(
+		welcome_scene.contains("CreditsButton"),
+		"welcome.tscn no longer has a CreditsButton -- the credits screen is unreachable."
+	)
+	var welcome_script := _read(WELCOME_SCRIPT_PATH)
+	assert_true(
+		welcome_script.contains(CREDITS_SCENE_PATH),
+		"welcome_screen.gd no longer routes to " + CREDITS_SCENE_PATH
+	)
+
+
+func test_credits_screen_actually_renders_every_cat():
+	# The only test here that runs the real screen. A data file can be perfect
+	# while the surface that reads it renders an empty box -- which is how the
+	# slot picker shipped with overlapping cards: nobody opened it.
+	var packed: PackedScene = load(CREDITS_SCENE_PATH)
+	assert_not_null(packed, "could not load " + CREDITS_SCENE_PATH)
+	if packed == null:
+		return
+	var screen: Control = packed.instantiate()
+	add_child_autofree(screen)
+	await get_tree().process_frame
+
+	var content: VBoxContainer = screen.get_node("Panel/VBox/ContentScroll/Content")
+	assert_gt(content.get_child_count(), 0, "the credits screen rendered nothing at all")
+
+	var cards := 0
+	for child in content.get_children():
+		if child is HFlowContainer:
+			cards = child.get_child_count()
+	assert_eq(
+		cards,
+		CreditsData.cats().size(),
+		"the cat grid rendered %d cards for %d credited cats" % [cards, CreditsData.cats().size()]
+	)
+
+
+func test_office_cat_credit_lookup_is_not_a_second_hardcoded_table():
+	# The cat -> person mapping must exist exactly once. If office_cat.gd ever
+	# grows its own name table, one of the two copies will go stale silently.
+	var src := _read(OFFICE_CAT_SCRIPT_PATH)
+	assert_true(
+		src.contains("CreditsData.credit_for_asset"),
+		"office_cat.gd should look its contributor credit up through CreditsData,"
+		+ " not carry a second copy of the names."
+	)
+	# And the lookup must actually answer for a real shipped asset.
+	var answered := 0
+	for asset in _cat_names().keys():
+		if CreditsData.credit_for_asset(str(asset)) != "":
+			answered += 1
+	assert_gt(answered, 0, "CreditsData.credit_for_asset answered for none of the shipped cats")

--- a/godot/tests/unit/test_credits_data.gd.uid
+++ b/godot/tests/unit/test_credits_data.gd.uid
@@ -1,0 +1,1 @@
+uid://dbkh3wldcpjk3

--- a/scripts/generate_credits.py
+++ b/scripts/generate_credits.py
@@ -1,0 +1,208 @@
+"""Generate godot/data/credits.json from CREDITS.md.
+
+Layer: GENERATE
+
+CREDITS.md (repo root) is the single source of truth for who gets credited.
+It sits OUTSIDE godot/, so it is not bundled into the .pck; this script derives
+a shipped, ASCII-only JSON copy that the in-game credits screen renders. Same
+anti-rot pattern as generate_dq_index.py / generate_adr_index.py: a
+hand-maintained second copy of the credits is exactly how decisions/README.md
+went stale.
+
+Usage:
+    python scripts/generate_credits.py          # (re)write godot/data/credits.json
+    python scripts/generate_credits.py --check  # exit 1 if the JSON is stale
+
+Three rules decide what reaches a player's screen. They exist because a credits
+screen that prints "[Pip to fill]" at a contributor is worse than one that omits
+the line:
+
+1. PLACEHOLDER DROP. Any bullet or paragraph still carrying a
+   "[... to fill ...]" / "[... to confirm ...]" marker is omitted entirely.
+   For a CAT row, only the credit line is dropped -- the cat itself still shows,
+   because the photo shipped whether or not the credit form is confirmed.
+2. MAINTAINER-NOTE SKIP. A bullet or paragraph containing a `backticked`
+   identifier is prose aimed at maintainers (file paths, symbol names), not at
+   players, and is not shipped. This is why the source file can carry parsing
+   instructions next to the table without leaking them into the game.
+3. NOTES-FOR-PIP CUTOFF. Everything from the "### Notes for Pip" heading down is
+   a working checklist and never ships.
+
+The cats table is the load-bearing part: `Asset` values are reconciled against
+CAT_NAMES in godot/scripts/ui/office_cat.gd by
+godot/tests/unit/test_credits_data.gd, so a cat added to one and not the other
+fails the fast gate rather than silently going uncredited.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "CREDITS.md"
+OUT = ROOT / "godot" / "data" / "credits.json"
+
+CATS_SECTION = "Cats"
+CUTOFF = re.compile(r"^###\s+Notes for Pip", re.IGNORECASE)
+PLACEHOLDER = re.compile(r"\[[^\]]*\bto (?:fill|confirm)\b[^\]]*\]", re.IGNORECASE)
+CODE_SPAN = re.compile(r"`[^`]+`")
+
+# Written as escapes, not as literal characters: scripts/enforce_standards.py
+# rejects any non-ASCII codepoint in a .py file, and a transliteration table is
+# the one place where the source naturally wants to contain the very characters
+# the gate forbids. (generate_dq_index.py carries the literal form and predates
+# the incremental check, so it is never re-scanned -- do not copy it.)
+ASCII_MAP = {
+    "\u00b7": "-",  # middle dot
+    "\u2013": "--",  # en dash
+    "\u2014": "--",  # em dash
+    "\u2018": "'",  # left single quote
+    "\u2019": "'",  # right single quote
+    "\u201c": '"',  # left double quote
+    "\u201d": '"',  # right double quote
+    "\u2264": "<=",
+    "\u2265": ">=",
+    "\u2026": "...",  # ellipsis
+}
+
+
+def to_ascii(text: str) -> str:
+    for src, dst in ASCII_MAP.items():
+        text = text.replace(src, dst)
+    return text.encode("ascii", "replace").decode("ascii")
+
+
+def plain(text: str) -> str:
+    """Strip the markdown a Label cannot render, keeping the words."""
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1", text)  # links -> text
+    text = text.replace("**", "").replace("`", "")
+    text = re.sub(r"(?<!\w)\*([^*]+)\*(?!\w)", r"\1", text)  # italics
+    return to_ascii(re.sub(r"\s+", " ", text).strip())
+
+
+def has_placeholder(text: str) -> bool:
+    return bool(PLACEHOLDER.search(text))
+
+
+def is_maintainer_note(text: str) -> bool:
+    return bool(CODE_SPAN.search(text))
+
+
+def split_sections(lines: list[str]) -> list[tuple[str, list[str]]]:
+    sections: list[tuple[str, list[str]]] = []
+    title = ""
+    body: list[str] = []
+    for line in lines:
+        if CUTOFF.match(line):
+            break
+        if line.startswith("## "):
+            if title:
+                sections.append((title, body))
+            title = to_ascii(line[3:].strip())
+            body = []
+        elif title:
+            body.append(line)
+    if title:
+        sections.append((title, body))
+    return sections
+
+
+def parse_blocks(body: list[str]) -> list[dict]:
+    """Group a section body into bullets and paragraphs, then filter."""
+    blocks: list[tuple[str, list[str]]] = []
+    for raw in body:
+        line = raw.rstrip()
+        stripped = line.strip()
+        is_rule = bool(stripped) and set(stripped) <= set("-*_") and len(stripped) >= 3
+        if not stripped or is_rule or stripped.startswith(">") or stripped.startswith("|"):
+            blocks.append(("break", []))
+            continue
+        if stripped.startswith("- "):
+            blocks.append(("item", [stripped[2:]]))
+        elif line.startswith(" ") and blocks and blocks[-1][0] in ("item", "note"):
+            blocks[-1][1].append(stripped)  # continuation of the previous block
+        elif blocks and blocks[-1][0] == "note":
+            blocks[-1][1].append(stripped)
+        else:
+            blocks.append(("note", [stripped]))
+
+    entries: list[dict] = []
+    for kind, parts in blocks:
+        if kind == "break":
+            continue
+        text = " ".join(parts)
+        if has_placeholder(text) or is_maintainer_note(text):
+            continue
+        rendered = plain(text)
+        if rendered:
+            entries.append({"kind": kind, "text": rendered})
+    return entries
+
+
+def parse_cats(body: list[str]) -> list[dict]:
+    cats: list[dict] = []
+    for raw in body:
+        line = raw.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) != 3:
+            continue
+        name, credit, asset = cells
+        if name.lower() == "cat" or set(name) <= set("-: "):
+            continue  # header / separator row
+        cats.append(
+            {
+                "name": plain(name),
+                "credited_to": "" if has_placeholder(credit) else plain(credit),
+                "asset": plain(asset),
+            }
+        )
+    return cats
+
+
+def build() -> dict:
+    lines = SRC.read_text(encoding="utf-8").splitlines()
+    sections: list[dict] = []
+    cats: list[dict] = []
+    for title, body in split_sections(lines):
+        if title == CATS_SECTION:
+            cats = parse_cats(body)
+            entries = [e for e in parse_blocks(body) if e["kind"] == "note"]
+        else:
+            entries = parse_blocks(body)
+        if entries:
+            sections.append({"title": title, "entries": entries})
+    return {
+        "_generated": (
+            "GENERATED from CREDITS.md by scripts/generate_credits.py -- "
+            "do not hand-edit. Run the script; a pre-commit --check blocks staleness."
+        ),
+        "cats": cats,
+        "sections": sections,
+    }
+
+
+def render() -> str:
+    text = json.dumps(build(), indent=2, ensure_ascii=True) + "\n"
+    non_ascii = [c for c in text if ord(c) > 127]
+    if non_ascii:
+        raise SystemExit(f"generate_credits: non-ASCII leaked into the output: {non_ascii[:5]}")
+    return text
+
+
+def main() -> int:
+    content = render()
+    if "--check" in sys.argv:
+        if not OUT.exists() or OUT.read_text(encoding="utf-8") != content:
+            print("godot/data/credits.json is stale. Run: python scripts/generate_credits.py")
+            return 1
+        return 0
+    OUT.write_text(content, encoding="utf-8", newline="\n")
+    print(f"Wrote {OUT.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this is

Eight contributed cat photos ship in `godot/assets/cats/simple/` and `office_cat.gd`
picks one at random per run, so all eight reach players. Until this PR the product
had **nowhere to name anyone**: `CREDITS.md` sits at the repo root outside `godot/`
and its own header said it was not bundled, `office_cat.tscn`'s `ContributorLabel`
shows the CAT's name, and the designed recognition pipeline
(`contributor_manager.gd` + `contributors.json`) was deleted 2026-08-04 for having
zero callers (#1115).

## Where the surface lives, and why

**Welcome menu -> `Credits`, taking the tenth and last visible slot.**

A correction to the commission's numbers first: the welcome menu is described as
ten items, but **nine buttons actually render** -- `LoadGameButton` is instantiated
and then hidden (`welcome_screen.gd:82`, the deprecated quicksave). So Credits is
the tenth visible button, not an eleventh, and it lands inside Pip's cap-of-10
instinct from #1132.

It does consume the spare, and I would rather say so than let the next lane
discover it. The right next move -- named in a comment at the call site -- is an
"About" door holding Credits / AI Safety Info / What's New, which is exactly what
the competition test in `docs/design/UI_ARCHITECTURE_2026-08-06.md` Part A would
produce for meta surfaces. That is a menu-restructure decision belonging to that
effort, not to a Friday job.

Why top-level at all, rather than nested in the Player Guide: the growth half of
this commission only works if a contributor who launches the game to find their
cat can find the page without hunting. Buried under a manual, they would not.

**Cats get their own section, first, above the general credits** -- rendered as a
photo grid rather than a list of names. That is the part someone screenshots, and
pretending otherwise while filing them under "assets" would be the cynical version
of this feature.

## Generated from CREDITS.md, and gated

`CREDITS.md` is now the source of truth. `scripts/generate_credits.py` derives
`godot/data/credits.json`; a new pre-commit hook `credits-json-check` runs
`--check`. Same anti-rot pattern as `generate_dq_index.py` / `generate_adr_index.py`
/ `generate_tools_index.py`.

Three filters decide what reaches a player:

1. **Placeholder drop.** `CREDITS.md` legitimately carries `[Pip to fill]` /
   `[Pip to confirm]` markers. Any bullet or paragraph still carrying one is
   omitted entirely -- a credits screen that prints a TODO at a contributor is
   worse than one that omits the line. For a **cat row** only the credit line is
   dropped: the cat still shows, because the photo shipped whether or not the
   credit form is confirmed.
2. **Maintainer-note skip.** A block containing a backticked identifier is prose
   for maintainers, not players, and is not shipped. This is what lets the source
   file carry parsing instructions right next to the table.
3. **Notes-for-Pip cutoff.** The working checklist never ships.

`CREDITS.md` had **no cats section at all**; one was added. Contributor names are
transcribed verbatim from the `Custodian` field in
`art_source/cats_incoming/INVENTORY.md`, the only record this repo holds. Nothing
was invented, altered, or guessed. Two entries are explicitly unresolved and left
marked for Pip in the checklist: whether each contributor wants that name form at
all, and one cat whose inventory custodian is not a person.

## The in-run cat

It gained a **hover tooltip** naming the contributor, and deliberately nothing
more. A click-to-open panel was the obvious alternative and was rejected: a modal
mid-run interrupts the plan phase for a decorative reason, and there is no route
back from a credits *scene* without abandoning the run. The visible label still
shows the cat's name; the person's name arrives only if the player asks by
hovering. The credit string comes from the generated data via `CreditsData`, never
a second hardcoded table.

## Red/green proof

Every guard was installed, watched **fail** against the real absence, then watched
pass. Fixtures were applied and reverted; none of them are in the branch.

| Guard | Red against | Observed failure |
|---|---|---|
| `generate_credits.py --check` (pre-commit) | a `CREDITS.md` edit with no regenerate | `credits.json is stale. Run: python scripts/generate_credits.py` (exit 1) |
| roster reconciliation | a table row with no matching `CAT_NAMES` entry | `CREDITS.md credits 'web-rogue.jpg' but office_cat.gd never shows it` |
| asset resolution | same fixture | `credited cat asset does not resolve through the import system` |
| placeholder leak | generator's placeholder drop disabled | red on all three markers (`to fill`, `to confirm`, `[pip`) |
| reachability | `CreditsButton` renamed out of `welcome.tscn` | `welcome.tscn no longer has a CreditsButton -- the credits screen is unreachable` |
| render | cat grid stubbed out | `the cat grid rendered 0 cards for 8 credited cats` |

An **existing** guard also earned its keep, unprompted: `test_no_win_condition_copy.gd`
went red because the music credit named a "victory cue" -- true of the audio files,
but the string became player-facing the moment it was generated into the `.pck`.
Reworded to "run-end", per ADR-0002. That is the whole argument for generating into
the game rather than keeping a second copy: the repo's copy gates start applying.

**Fast gate, measured:**
- before: `1205 tests, 118 files, 0 fail`
- after: `1212 tests, 119 files, 0 fail`

## Website

No deep link. The footer button opens the **pdoom1.com root**, which already exists
(`UpdateCheck` reads `https://pdoom1.com/data/version.json`). `docs/copy/README.md`
is ACTIVE POLICY that the game never depends on the website; a hardcoded
`/cats` URL would be exactly that dependency, and would go quietly wrong the moment
the site reorganised with the game having no way to learn it. If a cats page lands
later, this screen needs no change to benefit from it.

## Honest limitations

- No test proves a cat photo reaches a screen in an **exported build**; that needs
  a human looking at one. The tests prove the assets resolve through the import
  system and the grid builds eight cards.
- No test can prove a contributor is happy with the name form used. That is a
  conversation, tracked in the `CREDITS.md` checklist.
- The `--check` hook is scoped to `CREDITS.md` / `credits.json` /
  `generate_credits.py`, so it does not fire on unrelated commits. A rename of one
  of those paths would silently disable it.

Closes nothing automatically -- squash-merge does not fire closes-keywords in this
repo.

Generated with [Claude Code](https://claude.com/claude-code)
