### PR TITLE
fix(art-review): the gallery keyboard was dead for 3 days -- one stray newline; plus study/compare modes and notes-as-brief

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -100,7 +100,7 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | Tool | Layer | Purpose | Invoked by |
 |---|---|---|---|
 | analyze_verdicts.py | -- | Analyze art triage exports (verdict JSONs) for BOTH art libraries. | human (docstring usage) |
-| apply_review.py | SWEEP | apply_review.py -- wire art-review verdicts into the P(Doom)1 asset pipeline. | test:test_art_promotion_pipeline.py; tool:build_full_gallery.py; tool:slot_model.py |
+| apply_review.py | SWEEP | apply_review.py -- wire art-review verdicts into the P(Doom)1 asset pipeline. | test:test_art_promotion_pipeline.py; tool:build_full_gallery.py; tool:measure_taste.py; tool:slot_model.py |
 | apply_slot_picks.py | -- | apply_slot_picks.py -- fold a slot_picker.html export into the TRACKED | test:test_slot_picker.py; tool:build_slot_picker.py |
 | author_anchor_sockets.py | -- | Author godot/data/office/anchor_sockets.json -- Anchor Sockets V2 (#894 #900 #913). | tool:build_cat_sweep_sheet.py |
 | build.py | -- | Build the P(Doom)1 style-review tool: a self-contained, single-file HTML page | test:test_find_dead_code.py; tool:select_assets.py |
@@ -111,11 +111,11 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | build_cat_west_walk_picks.py | -- | build_cat_west_walk_picks -- 2026-07-27 cat_sweep_black_side_heft WEST walk pick sheet. | human (docstring usage) |
 | build_doom_strip_sheet.py | -- | Generate art_generated/doom_strip_sheet.html -- ADR-0015 doom-strip triage | human (docstring usage) |
 | build_endgame_review.py | -- | Build a verdict-capturing review page for the endgame concept batch. | human (docstring usage) |
-| build_full_gallery.py | OBSERVE | build_full_gallery.py -- ONE stateful drive-by gallery over ALL art on disk. | tool:apply_review.py |
+| build_full_gallery.py | OBSERVE | build_full_gallery.py -- ONE stateful gallery over ALL art on disk, in three | tool:apply_review.py |
 | build_generation_compare.py | -- | Side-by-side comparison of two generations of the same concept batch. | human (docstring usage) |
 | build_morning_index.py | -- | One index page over every generated art batch on disk. | human (docstring usage) |
 | build_prop_rebase_sheet.py | -- | build_prop_rebase_sheet -- prop re-base bulk batch + facing pilot (2026-07-27). | human (docstring usage) |
-| build_slot_picker.py | -- | build_slot_picker.py -- the SLOT PICKER page. | human (docstring usage) |
+| build_slot_picker.py | -- | build_slot_picker.py -- the SLOT PICKER page. | tool:build_full_gallery.py |
 | build_t6_diagonals_and_cats_sheet.py | -- | build_t6_diagonals_and_cats_sheet -- lane T6 review sheet, 2026-07-27. | human (docstring usage) |
 | build_worker_rebase_sheet.py | -- | build_worker_rebase_sheet -- worker re-base at the 64px standard (2026-07-26). | human (docstring usage) |
 | build_worker_round2_sheet.py | -- | build_worker_round2_sheet -- 2026-07-27 worker reroll + fresh worker (A+B). | human (docstring usage) |
@@ -128,12 +128,14 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | gen_quirk_icon_sheet.py | -- | Generate art_generated/quirk_icons_sheet.html -- quirk icon review sheet (issue #903). | human (docstring usage) |
 | gen_settings_grounds.py | -- | Warm-register settings-screen background candidates for P(Doom)1 (no API). | human (docstring usage) |
 | gen_size_probe_sheet.py | -- | gen_size_probe_sheet -- character size vanguard probe sheet (2026-07-26). | human (docstring usage) |
-| merge_gallery_export.py | -- | merge_gallery_export.py -- fold a full_gallery.html export back into | tool:build_full_gallery.py |
+| measure_taste.py | -- | measure_taste.py -- what the slot picks say about taste, measured. | human (docstring usage) |
+| merge_gallery_export.py | -- | merge_gallery_export.py -- fold a full_gallery.html export back into | tool:build_full_gallery.py; tool:notes_brief.py |
+| notes_brief.py | -- | notes_brief.py -- turn the reviewer's notes into the brief for the next round. | tool:build_full_gallery.py |
 | qc_sprite_frames.py | -- | qc_sprite_frames -- PIL QC gate for pixellab character batches. | tool:build_worker_rebase_sheet.py |
 | review_style.py | -- | review_style -- ONE house style for all internal review/dev HTML tools. | tool:analyze_verdicts.py; tool:build_cat_angle_ab_sheet.py; tool:build_cat_refinement_sheet.py; tool:build_cat_sweep_sheet.py; tool:build_cat_west_walk_picks.py; tool:build_doom_strip_sheet.py; tool:build_prop_rebase_sheet.py; tool:build_slot_picker.py; tool:build_t6_diagonals_and_cats_sheet.py; tool:build_worker_rebase_sheet.py; tool:build_worker_round2_sheet.py; tool:gen_contact_sheet.py; tool:gen_hero_gallery.py; tool:gen_prop_grain_sheet.py; tool:gen_quirk_icon_sheet.py; tool:gen_size_probe_sheet.py |
 | scan_white_flash.py | -- | Scan walk-clip frames for the "white flash under the cat" artifact. | tool:build_cat_refinement_sheet.py |
 | serve_review.py | -- | Local art-review app for P(Doom)1 -- ONE place to review ALL the art. | tool:build_slot_picker.py |
-| slot_model.py | -- | slot_model.py -- the ONE definition of "slot cluster" and "frame role". | test:test_slot_picker.py; tool:apply_slot_picks.py; tool:build_slot_picker.py |
+| slot_model.py | -- | slot_model.py -- the ONE definition of "slot cluster" and "frame role". | test:test_slot_picker.py; tool:apply_slot_picks.py; tool:build_slot_picker.py; tool:measure_taste.py |
 
 ## `tools/assets/`
 
@@ -184,6 +186,7 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 - `scripts/health_automation.py` -- docstring mentions CI; no workflow calls it
 - `scripts/logging_system.py` -- docstring mentions CI; no workflow calls it
 - `tools/art_review/apply_review.py` -- docstring mentions pre-commit; no pre-commit hook calls it
+- `tools/art_review/notes_brief.py` -- docstring mentions pre-commit; no pre-commit hook calls it
 - `tools/capture_cinematic.py` -- docstring mentions CI; no workflow calls it
 - `tools/commit.py` -- docstring mentions pre-commit; no pre-commit hook calls it
 - `tools/find_dead_code.py` -- docstring mentions pre-commit; no pre-commit hook calls it
@@ -205,4 +208,4 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 
 23 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
 
-Total: 109 active tools (8 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 89 undeclared); 11 in UNKNOWN; 6 archived.
+Total: 111 active tools (8 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 91 undeclared); 11 in UNKNOWN; 6 archived.

--- a/docs/art/NOTES_BRIEF.md
+++ b/docs/art/NOTES_BRIEF.md
@@ -1,0 +1,262 @@
+<!-- GENERATED FILE -- DO NOT HAND-EDIT.
+Regenerate: python tools/art_review/notes_brief.py
+Source of truth: tools/art_review/review_state.json (the note field).
+Edit a note by re-reviewing the asset in art_generated/full_gallery.html and
+merging the export with tools/art_review/merge_gallery_export.py -- editing this
+file directly is lost work, because the next regeneration overwrites it. -->
+
+# Art notes -- the brief for the next generation round
+
+Every line below is something the reviewer typed while looking at a specific
+picture. Notes are grouped by verdict, then by the batch the asset came from,
+because "the value structure is muddy in the aubergine palette" is only
+actionable if you can see it was said about eleven images in one block and not
+once about anything else.
+
+Read the ITERATE section first when writing the next prompt queue: those are
+pictures judged worth having but not as generated.
+
+**111 notes** across 2713 judged assets (4 percent of judgements carry a note).
+
+## Recurring words
+
+How many separate notes mention each craft term. A term near the top is a standing instruction the next prompt should carry, not a one-off reaction.
+
+| term | notes mentioning it |
+| --- | --- |
+| colour | 8 |
+| silhouette | 4 |
+| signalling | 4 |
+| blurry | 4 |
+| contrast | 3 |
+| transparent | 3 |
+| lighting | 2 |
+| edge | 2 |
+| face | 2 |
+| reading | 2 |
+| composition | 1 |
+| dark | 1 |
+| grain | 1 |
+| coherence | 1 |
+| texture | 1 |
+| washed | 1 |
+| figure | 1 |
+| person | 1 |
+
+## KEEP -- what is working, preserve it (32)
+
+### art_generated/endgame_concepts (1)
+
+- `gen:endgame_concepts:attention_stack_buried_desk:v2` -- human too identifiable, otherwise, good, backgroundf weirdness good also
+
+### art_generated/game_icons (4)
+
+- `gen:game_icons:doom_meter_frame:v2` -- I have no idea what this is for and will watch out for it
+- `gen:game_icons:doom_meter_frame:v3` -- this ouroborous like flavour is intersting, explore it more with a few other variants?
+- `gen:game_icons:icon_acquire_startup:v1` -- This icon style is different and interesting, LLM, describe the prompts and so on to me that generated these?
+- `gen:game_icons:indicator_status_critical:v3` -- DINg this bell is very good pickup, bureaucratic, I like it
+
+### art_generated/iconset_round2 (2)
+
+- `gen:iconset_round2:gen_type_pdoom_us:v1` -- There is something emerging with an emergent P from a doom meter filling up becoming the P in p(Doom) here that is strongly attractive, excellent. Keep and use this as a basis for more re-rolls as an avolutionary step.
+- `gen:iconset_round2:gen_type_pdoom_us:v2` -- motifs playing in with a p shape in pdoom is a good directional step, iterate on this and sprad out widely, feed notes back up to style guide and refresh llm instructions accordingly. Exceptional.
+
+### art_generated/treatment_sweep (1)
+
+- `gen:treatment_sweep:treat_print_poster:v2` -- It would be good to get versions of this with some other colour schemes, this was very striking and well liked
+
+### art_generated/ui_icons (3)
+
+- `gen:ui_icons:action_research_robustness:v2` -- ok for now
+- `gen:ui_icons:button_upgrade_normal:v2` -- exccellent
+- `gen:ui_icons:employee_role_security:v2` -- This being on a lanyard is amazing. Strong positive note. COnsider us using this in other employee_role icons. Consider propogating this up into design documents. Amazing. A++
+
+### art_source/cats_incoming (2)
+
+- `px:cats_incoming/office_cat_base` -- This will do as first iteration, but I want like a dozen children now we have this to go off
+- `px:cats_incoming/small-doom-cat` -- This feels like an upload of an ancient thing we generated last year, this is mostly for archive and inspo at this point although some of the hints around doom-glow are showing which is nice
+
+### art_source/pixellab_2026-07-16 (5)
+
+- `px:pixellab_2026-07-16/sweep/props/kitchen_bench_scummy_3.png` -- needs to be delineated as a corner asset
+- `px:pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_2.png` -- better descriptor names in future pls
+- `px:pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_3.png` -- better descriptor names in future pls
+- `px:pixellab_2026-07-16/sweep/ui_filler_map_object/ui_panel_frame_4.png` -- better descriptor names in future pls
+- `px:pixellab_2026-07-16/sweep/ui_filler_map_object/ui_texture_tile_1.png` -- better descriptor names in future pls
+
+### art_source/pixellab_2026-07-17 (5)
+
+- `px:pixellab_2026-07-17/reroll/objects/meeting_table_1` -- super grand meeting table
+- `px:pixellab_2026-07-17/reroll/objects/meeting_table_2` -- good medium sized meeting table
+- `px:pixellab_2026-07-17/reroll/objects/pc_mega_2` -- noting orientation amybe as tag
+- `px:pixellab_2026-07-17/reroll/objects/pc_mega_3` -- noting orientation amybe as tag, this is the best
+- `px:pixellab_2026-07-17/reroll/objects/pc_mega_4` -- noting orientation amybe as tag
+
+### art_source/pixellab_2026-07-19 (7)
+
+- `px:pixellab_2026-07-19/props/desk_lamp_1` -- experimeting with tags, like the lamp
+- `px:pixellab_2026-07-19/props/desk_mega_1` -- This is a very particular corner desk orientation, which might be relevant
+- `px:pixellab_2026-07-19/props/exit_sign_1` -- Amazing
+- `px:pixellab_2026-07-19/props/filing_cabinet_tall_1` -- We will want TODO logic about where these spawn and pathing
+- `px:pixellab_2026-07-19/props/office_phone_1` -- Amazing, candidate for future animation
+- `px:pixellab_2026-07-19/props/printer_mega_copier_1` -- Very cool copier
+- `px:pixellab_2026-07-19/props/snack_table_1` -- I note this is very top-down perspective
+
+### art_source/pixellab_2026-07-21-rerolls (1)
+
+- `px:pixellab_2026-07-21-rerolls/kitchen/kitchen_bench_scummy_1` -- note this is corner / diagonal asset
+
+### art_source/vignettes_2026-07-28 (1)
+
+- `px:vignettes_2026-07-28/01_cat-in-the-alley.png` -- This will do for now but please give me, like, 10 variants to choose from? Maybe some vesrions where the cat's arrival is doom-portentous and some where it's saviour-portentous?
+
+## ITERATE -- what to change in the next round (66)
+
+### art_generated/action_icons_missing (1)
+
+- `gen:action_icons_missing:lobby_government:v1` -- briefcase needs to be colour and visually distinct from foreground
+
+### art_generated/game_icons (12)
+
+- `gen:game_icons:action_funding_grant_proposal:v1` -- The yellow is a little unsubtle, this could maybe have the tick come down in intensity a little
+- `gen:game_icons:action_funding_grant_proposal:v2` -- the background of this is inconsistnent
+- `gen:game_icons:action_management_team_building:v2` -- Avoid cockleg problems, this is very funny though
+- `gen:game_icons:action_strategic_acquire_startup:v2` -- too dark, brighten, decrease grain slightly
+- `gen:game_icons:action_strategic_acquire_startup:v3` -- Brighten, increase contrast, consider lighting some of the windows gently
+- `gen:game_icons:action_strategic_lobby_government:v1` -- different colour beifcase, try lighting some windows
+- `gen:game_icons:action_strategic_sabotage:v1` -- Needs a bit more lightness and colour, slightly increase contrast around interior edge of hood
+- `gen:game_icons:action_strategic_sabotage:v2` -- slightly incrase contrast around lower edge of hood for better delineation withou revealing face
+- `gen:game_icons:doom_bg_critical:v3` -- Not nuclear symbol. Experiment with new, geometric abstract represtation of doom escalation
+- `gen:game_icons:doom_bg_safe:v1` -- Not a lock. try a more symbolic reprsentation in the abstract. Consider an alien culture's represetion of safe from boba principles.
+- `gen:game_icons:doom_glow_effect:v3` -- I'm not sure if these are meant to be glow effect samples for us to base things off or somehting else, but I feel like the doom glow effecst we have decided will be applied as mechanistic filters and so an LLM should revisit the necessity for these assets in particular
+- `gen:game_icons:doom_meter_frame:v1` -- This might not need an icon, revert to instructions and confirm back to user if needed
+
+### art_generated/hero_banners (7)
+
+- `gen:hero_banners:hero_founder_silhouette:v1` -- silhouette too boviously male, too obviously signalling Operator
+- `gen:hero_banners:hero_founder_silhouette:v2` -- silhouette too boviously male, too obviously signalling Operator
+- `gen:hero_banners:hero_founder_silhouette:v3` -- silhouette too boviously male, too obviously signalling Operator
+- `gen:hero_banners:hero_founder_silhouette:v4` -- silhouette too boviously male, too obviously signalling Operator
+- `gen:hero_banners:hero_paperwork_saves_world:v1` -- let's iterate on this iudea and go for something a bit less literal, maybe? try anorger 5 very diverse variants and we'll see where we end up
+- `gen:hero_banners:hero_server_doom_altar:v1` -- Let's try with one more androgynous operator? If this is late game they might have a cool cloak with a collar or a hood or something
+- `gen:hero_banners:hero_server_doom_altar:v2` -- andogynous operator please, otherwise, good, maybe give them a cape or cloak or be carrying equipment or san umbrella or protective gear or somesuch
+
+### art_generated/iconset_round2 (2)
+
+- `gen:iconset_round2:gen_cat_evil:v3` -- eyes too well defined
+- `gen:iconset_round2:gen_cat_evil:v4` -- eyes have too mcuh definition, breaks immersion
+
+### art_generated/round3_rerolls (2)
+
+- `gen:round3_rerolls:grant_proposal_r3:v1` -- Entirely rebase instructions for this, reading LLM, and branch out into several variats so we can move away from cliche
+- `gen:round3_rerolls:grant_proposal_r3:v2` -- Entirely rebase instructions for this, reading LLM, and branch out into several variats so we can move away from cliche
+
+### art_generated/scene_art_wave2 (2)
+
+- `file:art_generated/scene_art_wave2/v1/event_opportunity_v1.webp` -- make figures less obviously men?
+- `file:art_generated/scene_art_wave2/v1/event_opportunity_v2.webp` -- Try making fihgures more androgynous and less obvious, otherwise, good
+
+### art_generated/screen_backgrounds (7)
+
+- `gen:screen_backgrounds:bg_defeat:v1` -- All these seeem wildly incorrect, investgiate but I think this is just a misfiring of what we're after
+- `gen:screen_backgrounds:bg_main_grid:v1` -- All these seeem wildly incorrect, investgiate but I think this is just a misfiring of what we're after
+- `gen:screen_backgrounds:bg_panel_texture:v1` -- All these seeem wildly incorrect, investgiate but I think this is just a misfiring of what we're after
+- `gen:screen_backgrounds:bg_settings:v1` -- All these seeem wildly incorrect, investgiate but I think this is just a misfiring of what we're after
+- `gen:screen_backgrounds:bg_tartan_stripe:v1` -- All these seeem wildly incorrect, investgiate but I think this is just a misfiring of what we're after
+- `gen:screen_backgrounds:bg_victory:v1` -- All these seeem wildly incorrect, investgiate but I think this is just a misfiring of what we're after
+- `gen:screen_backgrounds:bg_welcome_lab:v1` -- All these seeem wildly incorrect, investgiate but I think this is just a misfiring of what we're after
+
+### art_generated/ui_icons (16)
+
+- `gen:ui_icons:action_facility_data_center:v2` -- This would be fine for a high spooky thing but a more realistic icon would be great.
+- `gen:ui_icons:action_facility_security_upgrade:v1` -- Good, try a second colour for the camera. Meta note: I think we want to craete some style design rules about, like primary and secondary clour groupings in our icons for a next-generation coherence pass because we keep getting things that are individually good, subtly with mayn upsides, but need coherence in direction. We can extract this from pulling detailed analysis of the little features of images I like and striving for collapsing into coherence from there. This is otherwise an excellent image.
+- `gen:ui_icons:action_facility_upgrade_compute:v2` -- a bit too simple, try with more depth and texture and richness, decrease arrow size by 15%
+- `gen:ui_icons:action_policy_audit_requirement:v1` -- this fits a dull and washed out scheme, tag it as such asnd keep as back up or for a sample of tone review
+- `gen:ui_icons:action_research_alignment:v1` -- Make the arrow and bottom cog one colour and the upper cog a differnet colour to highlight difference
+- `gen:ui_icons:action_research_alignment:v2` -- this will do for now, uninspired
+- `gen:ui_icons:action_research_capability_control:v2` -- try a represntation of a mechanical governor device or some other astute enginerring reference
+- `gen:ui_icons:action_research_red_teaming:v1` -- one red team one blue team, not chess
+- `gen:ui_icons:action_research_red_teaming:v2` -- one red team one blue team, combat, not chess, can be engineers facing each other off
+- `gen:ui_icons:action_research_robustness:v1` -- try incraesing saturation slightly and emboldening shield, otherwise, good
+- `gen:ui_icons:button_upgrade_hover:v2` -- too bendy
+- `gen:ui_icons:employee_role_engineer:v1` -- I think with role types we want a human as persona in the icon to emphssisse this is a role, this is true across all employee_role icons in this batchm, these will do as backups or paceholders
+- `gen:ui_icons:employee_role_researcher:v1` -- try with a more ML neural net image in the beacon
+- `gen:ui_icons:employee_status_burned_out:v1` -- this si danerously close to a mtg symbol. think about better repersentaiton for emotinal burnout
+- `gen:ui_icons:ui_governance_oversight:v1` -- needs more colour differentiation, ask or increase scope of style guide for assistance
+- `gen:ui_icons:ui_governance_oversight:v2` -- needs more colour differentiation, ask or increase scope of style guide for assistance
+
+### art_generated/wanasai_calls (1)
+
+- `gen:wanasai_calls:atrium_face_smiling:v1` -- Having a human face makes it weird, see what happens if we give the figure (a) a mask, so it could be human or robot, (b) a copy of (a) but mybe make one of the arms or the person be ambiguouss or hinting at possibly being robotis as well, (c) have the figure still be fairly non-human but with more religious overtones as well as (d) a version of (c) but with more state-propoganda overtines
+
+### art_source/cats_incoming (1)
+
+- `px:cats_incoming/web-doom-cat.jpg` -- This is a genreated inage of a cat, it's not an actual named cat like the others
+
+### art_source/pixellab_2026-07-16 (2)
+
+- `px:pixellab_2026-07-16/props/cat_bed_basket.png` -- this needsd to be a cat bed basked without a cat in it
+- `px:pixellab_2026-07-16/props/cat_litter_box.png` -- littler box without a cat in it
+
+### art_source/pixellab_2026-07-17 (4)
+
+- `px:pixellab_2026-07-17/reroll/objects/meeting_table_3` -- needs chairs both sides or no chairs
+- `px:pixellab_2026-07-17/reroll/objects/pc_mega_1` -- this looks more like a medium or bad PC
+- `px:pixellab_2026-07-17/reroll/objects/printer_1` -- weirdly wonky
+- `px:pixellab_2026-07-17/reroll/tilesets/wall_scummy` -- Can we try a mostly bare garage wall
+
+### art_source/pixellab_2026-07-19 (9)
+
+- `px:pixellab_2026-07-19/props/fire_extinguisher_1` -- This looks very front-on, we want some logic in the game about where a fire extinguisher should go TODO
+- `px:pixellab_2026-07-19/props/monitor_doomcurve_1` -- this monitor is weirdly angled
+- `px:pixellab_2026-07-19/props/monitor_dual_1` -- Unsure on colours or if we are going with trnasparent screens or not?
+- `px:pixellab_2026-07-19/props/monitor_mega_1` -- I feel like transparent screens lets us add sneaky responsive UI elements in underneath cheaply
+- `px:pixellab_2026-07-19/props/monitor_single_1` -- I feel like transparent screens lets us add sneaky responsive UI elements in underneath cheaply
+- `px:pixellab_2026-07-19/props/pc_mega_1` -- The angle on this seems weird in terms of perspective, this might not map correctly but would be cool if it was eventually ugpraded into a many-directional asset
+- `px:pixellab_2026-07-19/props/printer_small_1` -- Test deploy this and we'll see
+- `px:pixellab_2026-07-19/props/recycling_bin_1` -- This looks a little flat, and can really only be deplyoed against flat backgrounds
+- `px:pixellab_2026-07-19/props/server_cluster_mega_1` -- This has some transparent shadows and positioning that needs to be carefully aligned and thought about, we might review on deploy
+
+## DISCARD -- what to stop generating (4)
+
+### art_source/pixellab_2026-07-26_size_probe (1)
+
+- `px:pixellab_2026-07-26_size_probe/size_48/rotations/south-east.png` -- blurrrrry
+
+### art_source/pixellab_2026-07-27_prop_rebase (3)
+
+- `px:pixellab_2026-07-27_prop_rebase/native/desk_decent_r1.png` -- blurry
+- `px:pixellab_2026-07-27_prop_rebase/native/desk_decent_r1_nearest.png` -- blurry?
+- `px:pixellab_2026-07-27_prop_rebase/native/desk_front_decent_r1_nearest.png` -- blurry
+
+## UNJUDGED -- noted but no verdict yet (9)
+
+### art_generated/crisp_sweep (1)
+
+- `gen:crisp_sweep:cheerful_propaganda_atrium_crisp:v2` -- the banker's lamp seems to have suffused into everything here for some reason
+
+### art_generated/endgame_concepts (1)
+
+- `gen:endgame_concepts:intro_bus_strangers_help:v1` -- this was a good composition but more recent versions have better approaches to keeping the protagonist unidentified - shoot from the back, silhouettes for either gender only, hoods, hats
+
+### art_generated/endgame_concepts_gen2 (1)
+
+- `gen:endgame_concepts_gen2:same_desire_two_field_strengths:v1` -- this is getting better but we ssem toh ave massively overindexed on the bankers lamp as an art asset./ This probably meansd we need to generate a bunch more asset descriptions that *could* be in scenes so that llm's can chooose between different sets of objects to populate scenes with
+
+### art_generated/people_policy (1)
+
+- `gen:people_policy:people_silhouette:v1` -- Silhouettes look a little fake
+
+### art_source/pixellab_2026-07-17 (1)
+
+- `px:pixellab_2026-07-17/reroll/cats/cat_eldritch_1.png` -- the eldritch cat was an early idea that is now mostly being discarded, we will in game doom enhance cats rather than mbaking it into their walk animations. This applies to the rest of the eldritch cats in this set.
+
+### art_source/pixellab_2026-07-27_prop_rebase (3)
+
+- `px:pixellab_2026-07-27_prop_rebase/large_source/desk_side_scummy_r1.png` -- this is a 3/4 shot side view, is that correct notation?
+- `px:pixellab_2026-07-27_prop_rebase/large_source/server_cluster_r2.png` -- I think this type of picture needs to be differentiated somehow that it goes on a corner or facing a direction? LLM, advise me how we have planned on solving for this?
+- `px:pixellab_2026-07-27_prop_rebase/native/water_cooler_scummy_r2_nearest.png` -- mostly discarded for being blurry
+
+### art_source/vignettes_2026-07-28 (1)
+
+- `px:vignettes_2026-07-28/04_conference-return.png` -- this operator seems too visible and obviously a man, maybe try making the scene more abstract, luggage on bed, overstuffed mailbox at an apartment door with packages buiding up outside, what's in the fridge, etc, try a gfew different scenes and options

--- a/tools/art_review/apply_review.py
+++ b/tools/art_review/apply_review.py
@@ -108,7 +108,28 @@ _ENDGAME_STUDY_HOLD = Hold(
     "the eventual production endgame batch, never the studies"
 )
 
+# The 2026-08-07 art night (docs/design/ART_RUN_2026-08-07.md, queue
+# tools/assets/manifests/art_night_2026-08-07.json): 652 unattended
+# 1024/1536 direction studies across a swatch round, a subject x rendering
+# factorial, twelve coherent art directions, a palette cross and a model
+# probe. Library reference per ADR-0019 -- promotion needs a mechanically
+# verified demand entry, and none of these have one. One shared Hold so the
+# report rolls the whole night up together.
+_ART_NIGHT_0807_HOLD = Hold(
+    "2026-08-07 art night direction studies (swatch round, subject x "
+    "rendering factorial, 12 coherent art directions, palette cross, model "
+    "probe; tools/assets/manifests/art_night_2026-08-07.json lineage): "
+    "Library reference per ADR-0019, not game-ready derivatives -- L2/L3 "
+    "descendants of the winners are what could ever be promoted, never these"
+)
+
 GEN_DEST = {
+    "an0807_l0_sheets": _ART_NIGHT_0807_HOLD,
+    "an0807_l0_anchors": _ART_NIGHT_0807_HOLD,
+    "an0807_l1_grid": _ART_NIGHT_0807_HOLD,
+    "an0807_l1_family": _ART_NIGHT_0807_HOLD,
+    "an0807_l1_palette": _ART_NIGHT_0807_HOLD,
+    "an0807_l1_probe": _ART_NIGHT_0807_HOLD,
     "game_icons": "godot/assets/icons/generated",
     "ui_icons": "godot/assets/icons/generated",
     "action_icons_missing": "godot/assets/icons/generated",

--- a/tools/art_review/build_full_gallery.py
+++ b/tools/art_review/build_full_gallery.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""build_full_gallery.py -- ONE stateful drive-by gallery over ALL art on disk.
+"""build_full_gallery.py -- ONE stateful gallery over ALL art on disk, in three
+task-shaped modes: TRIAGE, STUDY, COMPARE.
 
 Layer: OBSERVE
 Invoked by: human
@@ -10,9 +11,60 @@ is a hand-curated map of eight named batches and is deliberately verdict-free
 nothing can be invisible (the 3-percent-coverage failure), and it captures
 verdicts. Different generator, different lifecycle; both stay.
 
+THREE MODES, SPLIT BY TASK NOT BY LAYOUT (2026-08-07)
+-----------------------------------------------------
+The first version of this page was built for one job: narrow 600 images fast.
+It did that job well -- 136 decisions in 10.4 minutes, 1.7s median gap. Then Pip
+opened it on the 652-image art_night_2026-08-07 run and the job changed: "These
+are so gorgeous I want to be able to enjoy the fine detail and start giving
+specific comments." Studying is not triaging. A dense keyboard-first grid is the
+wrong surface for saying something specific about one picture, and a big single
+picture is the wrong surface for narrowing 600.
+
+So the modes are split by what the reviewer is DOING, and each keeps the
+affordances that job needs:
+
+  TRIAGE  (default, key 1) -- the original dense grid. One keystroke per
+      decision, reviewed items can leave the working set, batch sweeps. This is
+      how 600 becomes 60. Deliberately unchanged.
+  STUDY   (key 2) -- one image large, left/right steps through the working set
+      ("a gallery-rotate rather than scroll"), zoom/pan on the same magnifier
+      surface the slot picker uses, a MULTI-LINE note box always on screen, and
+      the generation record (direction, palette, subject, model) beside the
+      picture so a note can name what it is reacting to.
+  COMPARE (key 3) -- one facet group tiled at judging size. The l1_family block
+      is 12 style DIRECTIONS x 22 subjects: it was generated so a direction can
+      be accepted or rejected as a direction. Adjudicating that one image at a
+      time throws away the reason it was generated that way.
+
+Rejected: a fourth "lightbox-only" mode, and a separate study PAGE. The
+magnifier is a control, not a task -- it belongs inside triage and study rather
+than being a mode of its own; and a second page would fork the verdict store,
+which is the failure this repo has already paid for twice.
+
+THE MAGNIFIER IS PORTED, NOT REINVENTED
+---------------------------------------
+The zoom/pan surface here is the one from build_slot_picker.py (fit/100/200/400,
+wheel to zoom, drag to pan, keyboard ownership while open so number keys do not
+leak to the grid underneath). That component shipped 2026-08-06, was used in
+anger, and was called "the funnest art picking". Growing a second magnifier here
+would guarantee the two drift.
+
+FACETS COME FROM THE .meta.json SIDECARS
+----------------------------------------
+art_night_2026-08-07 writes a sidecar per image carrying block, cell, model,
+quality, cost and the full prompt. The named style direction lives inside the
+prompt ("COHERENT DIRECTION -- MUNICIPAL RECORD:"), as do the RENDERING, PALETTE
+and SUBJECT clauses. Those are parsed out and interned into a small string table
+so the page can group by DIRECTION rather than by the opaque cell code `f07`.
+Full prompts are NOT embedded -- they are ~5 KB each and would add ~13 MB to the
+page for text nobody reads in a grid. The sidecar path is embedded instead, and
+the record panel shows the parsed clauses.
+
 Coverage: every image file (png/jpg/jpeg/webp) under art_generated/ and
 art_source/, grouped into batches by top-level directory, newest batch first.
 Read-only on assets -- this script writes exactly one file, the HTML output.
+review_state.json is read, never written.
 
 Statefulness (the honest file:// story):
   - The page keeps verdicts/notes in browser localStorage, so they survive
@@ -22,7 +74,12 @@ Statefulness (the honest file:// story):
   - "E" in the page downloads a JSON export; merge it back with
         python tools/art_review/merge_gallery_export.py <downloaded.json>
     which folds it into review_state.json (the single verdict store that
-    apply_review.py consumes). No second verdict store is invented.
+    apply_review.py consumes). No second verdict store is invented, and NOTES
+    ride the same path -- review_state.json is tracked in git, so a note is
+    diffable the moment it is merged, and
+        python tools/art_review/notes_brief.py
+    renders them into docs/art/NOTES_BRIEF.md, the brief the next generation
+    round reads.
 
 asset_id compatibility with apply_review.py / review_state.json:
   gen:<category>:<base_id>:<variant>  for art_generated/<category>/v1 files
@@ -38,16 +95,20 @@ asset_id compatibility with apply_review.py / review_state.json:
       filename kept verbatim.
 
 Usage:
-    python tools/art_review/build_full_gallery.py [--open]
+    python tools/art_review/build_full_gallery.py [--open] [--art-root DIR]
 Output:
-    art_generated/full_gallery.html   (gitignored; open via file://)
+    <art-root>/art_generated/full_gallery.html   (gitignored; open via file://)
 """
 
 import argparse
 import html
 import json
+import os
 import re
+import shutil
+import subprocess
 import sys
+import tempfile
 import time
 import webbrowser
 from pathlib import Path
@@ -58,6 +119,12 @@ from pathlib import Path
 import apply_review
 
 REPO = Path(__file__).resolve().parents[2]
+# ART_GEN / ART_SRC / OUT are rebound by main() when --art-root is given. Agents
+# work in git worktrees, and art_generated/ is gitignored, so a worktree sees
+# ~500 legacy tracked PNGs and none of tonight's 652 -- the file-locality trap
+# this repo has already lost a day to. --art-root points the walk at the one
+# checkout that actually holds the art. STATE stays with the CODE, because the
+# verdict store is tracked and belongs to the branch you are on.
 ART_GEN = REPO / "art_generated"
 ART_SRC = REPO / "art_source"
 STATE = REPO / "tools" / "art_review" / "review_state.json"
@@ -109,6 +176,8 @@ def _is_skipped(rel_parts):
 
 
 def iter_images(root):
+    if not root.is_dir():
+        return
     for p in sorted(root.rglob("*")):
         if not (p.is_file() and p.suffix.lower() in IMAGE_EXTS):
             continue
@@ -117,8 +186,94 @@ def iter_images(root):
         yield p
 
 
+# --------------------------------------------------------------------------
+# Facets -- parsed from the .meta.json sidecars written by the art_night runner
+# --------------------------------------------------------------------------
+# Grouping by `f07` tells the reviewer nothing. Grouping by "MUNICIPAL RECORD"
+# tells them exactly what they are accepting or rejecting. The named direction
+# is not a JSON field -- it is a clause inside the prompt -- so it is parsed
+# here rather than being invented as a hand-maintained side-map of cell -> name
+# (that map would rot the first time a block is regenerated).
+DIRECTION_RE = re.compile(r"COHERENT DIRECTION\s*--\s*([A-Z][A-Z0-9 '/&-]{2,40}?)\s*:")
+CLAUSE_RE = {
+    "rendering": re.compile(r"(?:^|,\s)RENDERING:\s*(.+?)(?=,\s(?:PALETTE|SUBJECT|COHERENT)\b|$)"),
+    "palette": re.compile(r"(?:^|,\s)PALETTE:\s*(.+?)(?=,\s(?:RENDERING|SUBJECT|COHERENT)\b|$)"),
+    "subject": re.compile(r"(?:^|,\s)SUBJECT:\s*(.+?)$"),
+}
+
+
+def _short(text, words=9, chars=64):
+    """First clause of a long prompt segment, trimmed to a chip-sized label."""
+    text = re.sub(r"\s+", " ", (text or "")).strip()
+    # the first comma/semicolon usually ends the naming part of the clause
+    head = re.split(r"[;,]", text)[0].strip()
+    if not head:
+        return ""
+    parts = head.split(" ")
+    if len(parts) > words:
+        head = " ".join(parts[:words])
+    if len(head) > chars:
+        head = head[: chars - 3].rstrip() + "..."
+    return head
+
+
+def facets_from_meta(meta):
+    """Return {facet_name: label} for one sidecar dict. Empty labels dropped."""
+    out = {}
+    prompt = meta.get("prompt") or ""
+    if prompt:
+        m = DIRECTION_RE.search(prompt)
+        if m:
+            out["direction"] = m.group(1).strip().title()
+        for name, rx in CLAUSE_RE.items():
+            cm = rx.search(prompt)
+            if cm:
+                lbl = _short(cm.group(1))
+                if lbl:
+                    out[name] = lbl
+        # when no NAMED direction exists (the palette/grid blocks), the rendering
+        # clause IS the direction the reviewer is judging
+        if "direction" not in out and out.get("rendering"):
+            out["direction"] = out["rendering"]
+    q = meta.get("quality")
+    if q:
+        out["quality"] = str(q)
+    mdl = meta.get("model")
+    if mdl:
+        out["model"] = str(mdl)
+    return {k: v for k, v in out.items() if v}
+
+
+def read_meta_for(paths, cache):
+    """Find and parse the sidecar for an asset group. One read per cell.
+
+    Sidecars are per-FILE (s01_f01_v1_1536.meta.json) but every size of one cell
+    carries the same prompt, so the parse is cached on the sidecar path.
+    """
+    for p in paths:
+        side = p.with_name(p.stem + ".meta.json")
+        if not side.is_file():
+            continue
+        key = str(side)
+        if key in cache:
+            return cache[key]
+        try:
+            meta = json.loads(side.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            cache[key] = ({}, "")
+            return cache[key]
+        try:
+            rel = side.relative_to(REPO).as_posix()
+        except ValueError:
+            rel = side.name
+        rec = (facets_from_meta(meta), rel)
+        cache[key] = rec
+        return rec
+    return ({}, "")
+
+
 class AssetGroup:
-    __slots__ = ("id", "name", "files", "thumb", "full")
+    __slots__ = ("id", "name", "files", "thumb", "full", "facets", "meta_rel")
 
     def __init__(self, asset_id, name):
         self.id = asset_id
@@ -126,6 +281,8 @@ class AssetGroup:
         self.files = []  # (path, size_or_None)
         self.thumb = None
         self.full = None
+        self.facets = {}
+        self.meta_rel = ""
 
 
 def scan(state):
@@ -163,6 +320,7 @@ def scan(state):
     batches.sort(key=lambda b: b["mtime"], reverse=True)
 
     # ---- group each batch's files into assets with canonical ids ----
+    meta_cache = {}
     for b in batches:
         groups = {}
         order = []
@@ -183,6 +341,7 @@ def scan(state):
             else:
                 g.thumb = g.files[0][0]
                 g.full = g.files[-1][0]
+            g.facets, g.meta_rel = read_meta_for([p for p, _ in g.files], meta_cache)
             assets.append(g)
         b["assets"] = assets
         del b["files"]
@@ -217,6 +376,24 @@ def classify(p, kind, state):
     return (f"px:{rel}", p.name, None)
 
 
+# Facet order is the order the filter bar shows them, coarsest first.
+FACET_ORDER = ["direction", "palette", "subject", "rendering", "quality", "model"]
+
+
+class Interner:
+    """String table so 6000 cards carry a few small ints, not long strings."""
+
+    def __init__(self):
+        self.strings = []
+        self._idx = {}
+
+    def __call__(self, s):
+        if s not in self._idx:
+            self._idx[s] = len(self.strings)
+            self.strings.append(s)
+        return self._idx[s]
+
+
 def build_page(batches, state):
     baseline = {}
     sections = []
@@ -224,6 +401,9 @@ def build_page(batches, state):
     total_assets = 0
     total_files = 0
     matched = 0
+    intern = Interner()
+    facet_values = {f: {} for f in FACET_ORDER}  # facet -> {label_index: count}
+    card_meta = {}  # asset_id -> small record shown in the STUDY side panel
 
     for bi, b in enumerate(batches):
         cards = []
@@ -240,14 +420,33 @@ def build_page(batches, state):
                         matched += 1
             thumb_href = href_of(g.thumb)
             full_href = href_of(g.full)
+            fdata = {}
+            for f in FACET_ORDER:
+                lbl = g.facets.get(f)
+                if not lbl:
+                    continue
+                li = intern(lbl)
+                fdata[f] = li
+                facet_values[f][li] = facet_values[f].get(li, 0) + 1
+            card_meta[g.id] = {
+                "batch": b["title"],
+                "meta": g.meta_rel,
+                "n": len(g.files),
+            }
             nfiles = f'<span class="nf">x{len(g.files)}</span>' if len(g.files) > 1 else ""
+            fattr = "".join(f' data-f-{f}="{fdata[f]}"' for f in FACET_ORDER if f in fdata)
+            chip = ""
+            if "direction" in g.facets:
+                chip = f'<span class="chip">{html.escape(g.facets["direction"])}</span>'
             cards.append(
-                f'<div class="card" data-id="{html.escape(g.id, quote=True)}" data-b="{bi}">'
+                f'<div class="card" data-id="{html.escape(g.id, quote=True)}" '
+                f'data-b="{bi}"{fattr}>'
                 f'<a href="{full_href}" target="_blank" tabindex="-1">'
                 f'<img loading="lazy" decoding="async" src="{thumb_href}" '
                 f'alt="{html.escape(g.name, quote=True)}"></a>'
                 f'<div class="meta"><span class="nm" title="{html.escape(g.id, quote=True)}">'
                 f"{html.escape(g.name)}</span>{nfiles}</div>"
+                f"{chip}"
                 f'<div class="vrow"><span class="badge"></span><span class="notetxt"></span></div>'
                 f"</div>"
             )
@@ -264,10 +463,25 @@ def build_page(batches, state):
             f'<span class="bs" id="bi{bi}">{len(b["assets"])}</span></a>'
         )
 
+    # filter bar: only offer a facet that actually discriminates (>1 value)
+    facet_opts = {}
+    for f in FACET_ORDER:
+        vals = facet_values[f]
+        if len(vals) < 2:
+            continue
+        facet_opts[f] = sorted(
+            ([li, intern.strings[li], n] for li, n in vals.items()),
+            key=lambda t: (-t[2], t[1]),
+        )
+
     page = TEMPLATE
     page = page.replace("__SECTIONS__", "\n".join(sections))
     page = page.replace("__BATCHINDEX__", "\n".join(batch_index))
     page = page.replace("__BASELINE__", json.dumps(baseline, ensure_ascii=True))
+    page = page.replace("__STRINGS__", json.dumps(intern.strings, ensure_ascii=True))
+    page = page.replace("__FACETOPTS__", json.dumps(facet_opts, ensure_ascii=True))
+    page = page.replace("__FACETORDER__", json.dumps(FACET_ORDER, ensure_ascii=True))
+    page = page.replace("__CARDMETA__", json.dumps(card_meta, ensure_ascii=True))
     page = page.replace("__NBATCH__", str(len(batches)))
     page = page.replace("__BUILT__", time.strftime("%Y-%m-%d %H:%M"))
     return page, total_assets, total_files, matched
@@ -300,9 +514,198 @@ def preflight_mapping(batches):
     return unmapped
 
 
+# --------------------------------------------------------------------------
+# The JS syntax gate -- the reason this whole rebuild happened
+# --------------------------------------------------------------------------
+# 2026-08-04..08-07: this page shipped with an UNTERMINATED STRING LITERAL. A
+# `\n\n` written into the non-raw TEMPLATE was compiled by Python into two real
+# newlines INSIDE a JavaScript string, so the browser threw "Invalid or
+# unexpected token" at parse time and the ENTIRE <script> block never ran. Every
+# key was dead, no badge was painted, no card was selectable. Nothing in the
+# build said a word: the file was 4 MB, every <img> resolved, every section was
+# present. This is exactly the repo's silent-wrongness pattern -- the artefact
+# LOOKED right, and only the behaviour was gone.
+#
+# Two fixes, because the second one is the only one that survives the next edit:
+#   1. TEMPLATE is now a RAW string, so a JS `\n` stays a JS `\n`.
+#   2. The build PARSES the emitted script before writing the file. `node
+#      --check` when node exists; a narrower raw-newline-in-string-literal
+#      scanner when it does not. A build that cannot prove its own script
+#      parses fails loudly rather than writing a page whose keyboard is dead.
+SCRIPT_RE = re.compile(r"<script>(.*?)</script>", re.S)
+
+
+def extract_script(page):
+    m = SCRIPT_RE.search(page)
+    return m.group(1) if m else ""
+
+
+# A `/` starts a REGEX literal only where a value is expected. The standard
+# cheap heuristic: look at the previous significant character. After a name, a
+# number, `)` or `]` a slash is division; after an operator, `(`, `,`, `=`, `:`
+# or a statement start it opens a regex.
+_REGEX_OK_AFTER = set("(,=:[!&|?{};+-*%~^<>")
+
+
+def fallback_js_scan(js):
+    """Detect a raw newline inside a single- or double-quoted JS string.
+
+    Deliberately narrow: it looks for the ONE defect class that killed this page
+    rather than pretending to be a parser. Template literals (backticks) legally
+    span lines and are skipped; this codebase does not use them.
+
+    It MUST also understand comments and regex literals, because both can hold a
+    lone quote character. The first version of this scanner did not, and flagged
+    the perfectly good line
+
+        .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+    as an unterminated string -- a gate that blocks every build is worse than
+    the bug it was added to catch. See _scanner_self_test.
+    """
+    problems = []
+    quote = None
+    esc = False
+    line = 1
+    start_line = 0
+    prev_sig = ""  # previous significant char, for the regex/division call
+    i = 0
+    n = len(js)
+    while i < n:
+        ch = js[i]
+        if quote:
+            if ch == "\n":
+                problems.append(
+                    f"line {start_line}: unterminated {quote}-quoted string "
+                    f"(raw newline inside a JS string literal)"
+                )
+                quote = None
+                line += 1
+                esc = False
+            elif esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch == "\n":
+            line += 1
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n:
+            nxt = js[i + 1]
+            if nxt == "/":  # line comment
+                while i < n and js[i] != "\n":
+                    i += 1
+                continue
+            if nxt == "*":  # block comment
+                j = js.find("*/", i + 2)
+                if j < 0:
+                    j = n
+                line += js.count("\n", i, j)
+                i = j + 2
+                continue
+            if prev_sig == "" or prev_sig in _REGEX_OK_AFTER:  # regex literal
+                i += 1
+                resc = False
+                cls = False
+                while i < n:
+                    c = js[i]
+                    if resc:
+                        resc = False
+                    elif c == "\\":
+                        resc = True
+                    elif c == "[":
+                        cls = True
+                    elif c == "]":
+                        cls = False
+                    elif c == "/" and not cls:
+                        i += 1
+                        break
+                    elif c == "\n":
+                        break
+                    i += 1
+                prev_sig = "/"
+                continue
+        if ch in "\"'":
+            quote = ch
+            start_line = line
+            i += 1
+            continue
+        if not ch.isspace():
+            prev_sig = ch
+        i += 1
+    return problems
+
+
+# Two fixtures the scanner must get right. If it fails them, the build STOPS
+# TRUSTING IT rather than blocking on a verdict it cannot justify.
+_SELF_TEST_GOOD = 'var re = /"/g;\nvar s = "ok"; // don\'t\nvar d = a / b;\n'
+_SELF_TEST_BAD = 'var s = "oops\nstill";\n'
+
+
+def _scanner_self_test():
+    return not fallback_js_scan(_SELF_TEST_GOOD) and bool(fallback_js_scan(_SELF_TEST_BAD))
+
+
+def check_js(page):
+    """Return (ok, method, problems)."""
+    js = extract_script(page)
+    if not js.strip():
+        return False, "none", ["no <script> block found in the emitted page"]
+    node = shutil.which("node")
+    if node:
+        tmp = Path(tempfile.gettempdir()) / f"pdoom1_gallery_jscheck_{os.getpid()}.js"
+        tmp.write_text(js, encoding="utf-8", newline="\n")
+        try:
+            r = subprocess.run(
+                [node, "--check", str(tmp)], capture_output=True, text=True, timeout=60
+            )
+            if r.returncode == 0:
+                return True, "node --check", []
+            msg = (r.stderr or r.stdout or "").strip().splitlines()
+            return False, "node --check", msg[:12]
+        except (OSError, subprocess.SubprocessError) as e:
+            return True, f"node unavailable ({e.__class__.__name__}); skipped", []
+        finally:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+    if not _scanner_self_test():
+        return (
+            True,
+            "NOT CHECKED -- node not found and the built-in scanner failed its "
+            "own fixtures, so its verdict is not trustworthy. Install node and "
+            "rebuild before relying on this page's keyboard.",
+            [],
+        )
+    problems = fallback_js_scan(js)
+    return (not problems), "built-in scanner (node not found)", problems
+
+
 def main():
+    global ART_GEN, ART_SRC, OUT
+
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--open", action="store_true")
+    ap.add_argument(
+        "--art-root",
+        default=None,
+        help="checkout holding art_generated/ and art_source/ (default: this "
+        "script's repo). Set it when running from a git WORKTREE -- "
+        "art_generated/ is gitignored, so a worktree sees only the legacy "
+        "tracked art and none of the current batch.",
+    )
+    ap.add_argument(
+        "--no-js-check",
+        action="store_true",
+        help="skip the emitted-script syntax gate (do not: a script that does "
+        "not parse produces a page with a completely dead keyboard and no "
+        "other visible symptom -- that shipped once already)",
+    )
     ap.add_argument(
         "--allow-unmapped",
         action="store_true",
@@ -311,6 +714,15 @@ def main():
         "default is to refuse so the map gets its one-line entry first).",
     )
     args = ap.parse_args()
+
+    if args.art_root:
+        root = Path(args.art_root).resolve()
+        if not root.is_dir():
+            sys.exit(f"error: --art-root {root} is not a directory")
+        ART_GEN = root / "art_generated"
+        ART_SRC = root / "art_source"
+        OUT = ART_GEN / "full_gallery.html"
+        print(f"[*] art root: {root}")
 
     t0 = time.time()
     state = load_state()
@@ -336,6 +748,21 @@ def main():
         print("    --allow-unmapped given: building anyway.")
 
     page, n_assets, n_files, n_matched = build_page(batches, state)
+
+    if not args.no_js_check:
+        ok, method, problems = check_js(page)
+        print(f"[*] script syntax gate: {method}")
+        if not ok:
+            print("[!] the emitted <script> DOES NOT PARSE. Refusing to write.")
+            for p in problems:
+                print("    " + p)
+            print(
+                "    A page with a broken script still renders every image and "
+                "looks correct -- but no key works and no verdict is painted. "
+                "That exact defect shipped 2026-08-04 and was live for 3 days."
+            )
+            return 3
+
     OUT.write_text(page, encoding="utf-8", newline="\n")
     dt = time.time() - t0
 
@@ -361,9 +788,12 @@ def main():
     return 0
 
 
-TEMPLATE = """<!doctype html>
+# NOTE: RAW string. A JS backslash escape inside this template must reach the
+# browser verbatim -- see the syntax-gate comment above for what happens when it
+# does not. Do not remove the r prefix.
+TEMPLATE = r"""<!doctype html>
 <meta charset="utf-8">
-<title>P(Doom)1 full art gallery -- stateful drive-by review</title>
+<title>P(Doom)1 full art gallery -- triage, study, compare</title>
 <style>
   :root{--bg:#15151a;--fg:#e9e7e2;--dim:#96938c;--line:#33323b;--card:#1d1d24;
         --acc:#d9955c;--keep:#5fae6e;--iter:#d9b95c;--disc:#c96a5f;--sel:#7aa2d9}
@@ -389,6 +819,19 @@ TEMPLATE = """<!doctype html>
   #bindex a{display:block;color:var(--dim);text-decoration:none;padding:1px 0}
   #bindex a:hover{color:var(--acc)}
   #bindex .bs{color:var(--acc)}
+  /* ---- mode switch + filters ------------------------------------------- */
+  #modes{display:flex;gap:6px;align-items:center;margin-top:6px;flex-wrap:wrap}
+  #modes button,#filters button{background:var(--card);color:var(--fg);
+        border:1px solid var(--line);border-radius:3px;padding:2px 9px;
+        font:11px ui-monospace,Consolas,monospace;cursor:pointer}
+  #modes button.on{background:var(--acc);border-color:var(--acc);color:#15151a;
+        font-weight:700}
+  #filters{display:flex;gap:6px;align-items:center;margin-top:5px;flex-wrap:wrap;
+        font-size:11px;color:var(--dim)}
+  #filters select,#filters input{background:var(--card);color:var(--fg);
+        border:1px solid var(--line);border-radius:3px;padding:2px 5px;
+        font:11px ui-monospace,Consolas,monospace;max-width:230px}
+  #fcount{color:var(--acc)}
   .batch{border-top:1px solid var(--line);padding-top:10px;margin-bottom:22px;
          content-visibility:auto;contain-intrinsic-size:auto 600px}
   h2{font-size:13px;margin:0 0 8px;color:var(--acc)}
@@ -404,6 +847,8 @@ TEMPLATE = """<!doctype html>
   .nm{font-size:10px;color:var(--dim);overflow:hidden;text-overflow:ellipsis;
       white-space:nowrap}
   .nf{font-size:10px;color:var(--dim)}
+  .chip{display:block;font-size:9px;color:var(--acc);overflow:hidden;
+        text-overflow:ellipsis;white-space:nowrap;letter-spacing:.04em}
   .vrow{min-height:14px;margin-top:2px;display:flex;gap:6px;align-items:baseline}
   .badge{font-size:10px;font-weight:700;letter-spacing:.05em}
   .badge.keep{color:var(--keep)} .badge.iterate{color:var(--iter)}
@@ -412,7 +857,77 @@ TEMPLATE = """<!doctype html>
            white-space:nowrap}
   .card.keep{border-color:var(--keep)} .card.iterate{border-color:var(--iter)}
   .card.discard{border-color:var(--disc)}
+  .card.hasnote{box-shadow:inset 3px 0 0 var(--sel)}
   body.hiderev .card.rev{display:none}
+  .card.filtered{display:none}
+  section.batch.empty{display:none}
+  /* COMPARE mode: bigger tiles, one facet group at a time. A style DIRECTION is
+     judged as a direction, so the tiles have to be big enough to see the
+     direction and numerous enough to see it repeat. */
+  body.mode-compare .grid{grid-template-columns:repeat(auto-fill,minmax(360px,1fr));
+        gap:14px}
+  /* height:auto, not a fixed box. A fixed 260px box around a 3:2 picture spends
+     a third of every tile on empty letterbox bands -- visible as grey slabs in
+     the 08-07 screenshot -- which is exactly the space a compare view cannot
+     afford. Same-aspect sets (which is what you compare) still line up. */
+  body.mode-compare .card img{height:auto;max-height:420px;background:none}
+  body.mode-compare #bindex{display:none}
+  /* STUDY mode: the page becomes one picture. */
+  body.mode-study #bindex,body.mode-study .batch{display:none}
+  #study{display:none}
+  body.mode-study #study{display:flex;gap:12px;height:calc(100vh - 210px);
+        min-height:420px}
+  #stage{flex:1;overflow:auto;background:var(--card);border:1px solid var(--line);
+        border-radius:4px;position:relative;cursor:grab;display:flex;
+        align-items:center;justify-content:center}
+  #stage.drag{cursor:grabbing}
+  #stageimg{display:block;image-rendering:auto}
+  #stageimg.fit{max-width:98%;max-height:98%}
+  /* #side must NOT scroll as a whole. It did, and focusing the note box
+     scrolled the zoom and verdict controls off the top -- the reviewer typed a
+     note and the L/I/X buttons vanished. Only the record panel scrolls. */
+  #side{width:330px;flex:0 0 330px;display:flex;flex-direction:column;gap:8px;
+        overflow:hidden}
+  #side h3{font-size:11px;margin:0;color:var(--acc);letter-spacing:.06em}
+  #srec{font-size:11px;color:var(--dim);border:1px solid var(--line);
+        border-radius:4px;padding:8px;line-height:1.55;overflow:auto;flex:1;
+        min-height:60px}
+  #srec b{color:var(--fg);font-weight:400}
+  #srec .k{color:var(--acc);display:inline-block;min-width:74px}
+  #snote{width:100%;height:150px;resize:vertical;background:var(--card);
+        color:var(--fg);border:1px solid var(--acc);border-radius:4px;padding:8px;
+        font:12px/1.5 ui-monospace,Consolas,monospace}
+  #snotehint{font-size:10px;color:var(--dim)}
+  #sverd{display:flex;gap:6px}
+  #sverd button{flex:1;background:var(--card);color:var(--fg);
+        border:1px solid var(--line);border-radius:3px;padding:5px 0;
+        font:11px ui-monospace,Consolas,monospace;cursor:pointer}
+  #sverd button.on.keep{background:var(--keep);border-color:var(--keep);color:#0d1a0c}
+  #sverd button.on.iterate{background:var(--iter);border-color:var(--iter);color:#1a160c}
+  #sverd button.on.discard{background:var(--disc);border-color:var(--disc);color:#1a0c0c}
+  .zrow{display:flex;gap:4px;align-items:center;font-size:11px;color:var(--dim);
+        flex-wrap:wrap}
+  .zrow button{background:var(--card);color:var(--fg);border:1px solid var(--line);
+        border-radius:3px;padding:1px 7px;font:11px ui-monospace,Consolas,monospace;
+        cursor:pointer}
+  .zrow button.on{background:var(--acc);border-color:var(--acc);color:#15151a}
+  /* ---- the MAGNIFIER, ported from build_slot_picker.py --------------------
+     Same component, same keys, same wheel/drag behaviour, and it owns the
+     keyboard while open so number keys cannot leak to the grid underneath. */
+  #lb{position:fixed;inset:0;background:#000e;z-index:90;display:none;
+      flex-direction:column}
+  #lbbar{display:flex;gap:10px;align-items:center;flex-wrap:wrap;padding:8px 12px;
+      background:var(--bg);border-bottom:1px solid var(--line);font-size:12px}
+  #lbbar button{background:var(--card);color:var(--fg);border:1px solid var(--line);
+      border-radius:3px;padding:1px 7px;font:11px ui-monospace,Consolas,monospace;
+      cursor:pointer}
+  #lbbar button.on{background:var(--acc);border-color:var(--acc);color:#15151a}
+  #lbstage{flex:1;overflow:auto;position:relative;cursor:grab;display:flex;
+      align-items:center;justify-content:center}
+  #lbstage.drag{cursor:grabbing}
+  #lbimg{display:block}
+  #lbimg.fit{max-width:98%;max-height:98%}
+  #lblabel{color:var(--fg)} #lbdims{color:var(--dim)}
   #notebox{position:fixed;left:50%;bottom:60px;transform:translateX(-50%);
            width:min(640px,90vw);display:none;z-index:20}
   #notebox input{width:100%;padding:8px 10px;font:13px ui-monospace,Consolas,monospace;
@@ -422,32 +937,82 @@ TEMPLATE = """<!doctype html>
         border-top:1px solid var(--line);padding:6px 16px;font-size:11px;
         color:var(--dim);z-index:10}
   #foot b{color:var(--fg)}
-  #help{position:fixed;inset:0;background:#000a;z-index:30;display:none}
+  #help{position:fixed;inset:0;background:#000a;z-index:95;display:none;
+        overflow:auto}
   #help .in{background:var(--card);border:1px solid var(--line);border-radius:6px;
-        max-width:640px;margin:8vh auto;padding:20px 26px;font-size:12px;line-height:1.7}
-  #help h3{margin:0 0 8px;color:var(--acc)}
+        max-width:680px;margin:6vh auto;padding:20px 26px;font-size:12px;line-height:1.7}
+  #help h3{margin:14px 0 6px;color:var(--acc)}
+  #help h3:first-child{margin-top:0}
   #help kbd{background:var(--bg);border:1px solid var(--line);border-radius:3px;
         padding:0 5px;font-family:inherit}
   #unsaved{color:var(--iter);font-weight:700}
+  #toast{position:fixed;top:10px;right:14px;background:var(--keep);color:#0d1a0c;
+        padding:6px 12px;border-radius:3px;z-index:99;display:none;font-size:12px}
 </style>
 
 <div id="top">
   <h1>Full art gallery</h1>
   <span id="prog"></span> <span id="curb"></span>
   <div id="bar"><div id="barfill"></div></div>
+  <div id="modes">
+    <span style="color:var(--dim);font-size:11px">mode:</span>
+    <button id="m1" data-mode="triage">1 TRIAGE</button>
+    <button id="m2" data-mode="study">2 STUDY</button>
+    <button id="m3" data-mode="compare">3 COMPARE</button>
+    <span id="modehint" style="color:var(--dim);font-size:11px"></span>
+  </div>
+  <div id="filters">
+    <span>filter:</span>
+    <select id="f-batch"><option value="">all batches</option></select>
+    <span id="facetsel"></span>
+    <input type="text" id="f-q" placeholder="name contains..." size="16">
+    <select id="f-rev">
+      <option value="">any verdict</option>
+      <option value="none">unreviewed only</option>
+      <option value="keep">keep</option>
+      <option value="iterate">iterate</option>
+      <option value="discard">discard</option>
+      <option value="noted">has a note</option>
+    </select>
+    <button id="f-clear">clear</button>
+    <span id="fcount"></span>
+  </div>
   <div id="statewarn"><b>State lives in THIS browser's localStorage</b> (plus the
     baked-in baseline from review_state.json, built __BUILT__). A browser data
     clear loses unexported verdicts -- press <b>E</b> to export, then run
     <b>python tools/art_review/merge_gallery_export.py &lt;download&gt;</b> to fold
     them into review_state.json. Unexported changes: <span id="unsaved">0</span></div>
-  <div id="bindings"><b>J/K</b> or arrows move | <b>L</b> like/keep |
-    <b>I</b> iterate/remix | <b>X</b> discard | <b>U</b> clear | <b>N</b> note |
-    <b>B</b>/<b>Shift+B</b> batch jump | <b>H</b> hide reviewed |
-    <b>Shift+L/I/X</b> WHOLE BATCH (unreviewed only) |
+  <div id="bindings"><b>1/2/3</b> mode | <b>J/K</b> or arrows move |
+    <b>L</b> keep | <b>I</b> iterate | <b>X</b> discard | <b>U</b> clear |
+    <b>N</b> note | <b>F</b> magnify | <b>B</b>/<b>Shift+B</b> batch jump |
+    <b>H</b> hide reviewed | <b>Shift+L/I/X</b> whole batch (or compare group) |
     <b>Enter/O</b> open full | <b>E</b> export | <b>?</b> help</div>
 </div>
 
 <nav id="bindex">__BATCHINDEX__</nav>
+
+<div id="study">
+  <div id="stage"><img id="stageimg" class="fit" alt=""></div>
+  <div id="side">
+    <div class="zrow"><span>zoom:</span>
+      <button class="sz on" data-s="fit">fit</button>
+      <button class="sz" data-s="1">100%</button>
+      <button class="sz" data-s="2">200%</button>
+      <button class="sz" data-s="4">400%</button>
+      <span>wheel = zoom, drag = pan</span></div>
+    <div id="sverd">
+      <button data-v="keep" class="keep">L keep</button>
+      <button data-v="iterate" class="iterate">I iterate</button>
+      <button data-v="discard" class="discard">X discard</button>
+    </div>
+    <h3>NOTE -- a brief for the next round</h3>
+    <textarea id="snote" placeholder="What is right or wrong about THIS picture? Notes are read back as the brief for the next generation round, so name the thing: the value structure, the palette, the prop vocabulary, the light."></textarea>
+    <div id="snotehint">saves as you type (localStorage) -- press <b>E</b> to
+      export, then merge into review_state.json</div>
+    <h3>GENERATION RECORD</h3>
+    <div id="srec"></div>
+  </div>
+</div>
 
 __SECTIONS__
 
@@ -455,36 +1020,78 @@ __SECTIONS__
 <div id="foot">Selected: <b id="selname">(none -- press J)</b>
   <span id="selverdict"></span></div>
 
+<div id="lb">
+  <div id="lbbar">
+    <button id="lbclose">[ESC] close</button>
+    <span id="lblabel"></span><span id="lbdims"></span>
+    <span>zoom:</span>
+    <button class="lbz on" data-s="fit">fit</button>
+    <button class="lbz" data-s="1">100%</button>
+    <button class="lbz" data-s="2">200%</button>
+    <button class="lbz" data-s="4">400%</button>
+    <span style="color:var(--dim)">wheel = zoom &middot; drag = pan &middot;
+      [ and ] step &middot; L/I/X still judge</span>
+  </div>
+  <div id="lbstage"><img id="lbimg" class="fit" alt=""></div>
+</div>
+
+<div id="toast"></div>
+
 <div id="help"><div class="in">
-  <h3>Drive-by review -- keys</h3>
+  <h3>Three modes, split by what you are doing</h3>
+  <kbd>1</kbd> <b>TRIAGE</b> -- dense grid, one keystroke per decision. How 600
+  images become 60.<br>
+  <kbd>2</kbd> <b>STUDY</b> -- one image large, arrows rotate through the working
+  set, multi-line note beside it, generation record underneath. For saying
+  something specific.<br>
+  <kbd>3</kbd> <b>COMPARE</b> -- big tiles. Filter to one direction or one
+  subject and judge the whole family as a family.<br><br>
+  The <b>filter bar</b> sets the working set for ALL THREE modes: what you filter
+  to in triage is what study rotates through and what compare tiles.
+  <h3>Keys</h3>
   <kbd>J</kbd>/<kbd>K</kbd> or arrow keys: next / previous asset<br>
-  <kbd>L</kbd> like -> verdict <b>keep</b> (promotable) |
-  <kbd>I</kbd> -> <b>iterate</b> (remix/regenerate) |
-  <kbd>X</kbd> -> <b>discard</b> (off-brief) | <kbd>U</kbd> clear verdict<br>
-  <kbd>N</kbd> note on selected asset | <kbd>Enter</kbd>/<kbd>O</kbd> open
-  full-size | <kbd>B</kbd>/<kbd>Shift+B</kbd> next/prev batch |
-  <kbd>H</kbd> hide reviewed | <kbd>E</kbd> export JSON<br>
-  Verdicts auto-advance to the next visible asset. Click a card to select it.<br><br>
-  <h3>Whole-batch verdicts</h3>
+  <kbd>L</kbd> keep (promotable) | <kbd>I</kbd> iterate (remix/regenerate) |
+  <kbd>X</kbd> discard (off-brief) | <kbd>U</kbd> clear verdict<br>
+  <kbd>N</kbd> note on selected asset (in STUDY the note box is always there) |
+  <kbd>F</kbd> magnify full-screen | <kbd>Enter</kbd>/<kbd>O</kbd> open full-size
+  in a new tab | <kbd>B</kbd>/<kbd>Shift+B</kbd> next/prev batch |
+  <kbd>H</kbd> hide reviewed | <kbd>E</kbd> export JSON | <kbd>/</kbd> jump to
+  the name filter<br>
+  Verdicts auto-advance to the next visible asset. Click a card to select it.
+  <h3>The magnifier</h3>
+  <kbd>F</kbd> opens the full-screen magnifier -- the same component the slot
+  picker uses. fit / 100% / 200% / 400%, wheel to zoom, drag to pan,
+  <kbd>[</kbd> and <kbd>]</kbd> to step through the working set without leaving
+  it. It owns the keyboard while open, so nothing leaks to the grid underneath.
+  <kbd>L</kbd>/<kbd>I</kbd>/<kbd>X</kbd> still judge from inside it.
+  <h3>Bulk verdicts</h3>
   <kbd>Shift+L</kbd> / <kbd>Shift+I</kbd> / <kbd>Shift+X</kbd> apply keep /
-  iterate / discard to <b>every UNREVIEWED asset in the current batch</b>, after a
-  confirm showing the count. For rotation sets and walk cycles, where eight files
-  are one artistic decision.<br>
-  <b>Assets you have already judged are never overwritten</b> -- a sweep only fills
-  gaps, so it can follow a careful pass without undoing it.<br><br>
+  iterate / discard to <b>every UNREVIEWED asset</b> in the current batch (TRIAGE
+  and STUDY) or in the whole visible working set (COMPARE), after a confirm
+  showing the count. For rotation sets and walk cycles, where eight files are one
+  artistic decision -- and in COMPARE, for a style direction you have decided
+  about as a direction.<br>
+  <b>Assets you have already judged are never overwritten</b> -- a sweep only
+  fills gaps, so it can follow a careful pass without undoing it.
   <h3>Where state lives</h3>
-  Verdicts persist in this browser's localStorage immediately on keypress.
+  Verdicts and notes persist in this browser's localStorage immediately.
   They are NOT in the repo until you press <kbd>E</kbd> (downloads
   gallery_verdicts_*.json) and run<br>
   <b>python tools/art_review/merge_gallery_export.py path/to/download.json</b><br>
-  which merges into tools/art_review/review_state.json (newer timestamp wins,
-  backup written). apply_review.py report / promote / reroll then work as usual.
-  Press <kbd>?</kbd> to close.
+  which merges into tools/art_review/review_state.json -- which IS tracked in
+  git, so your notes become diffable history the moment you merge them.
+  <b>python tools/art_review/notes_brief.py</b> then rewrites
+  docs/art/NOTES_BRIEF.md, the generated brief the next generation round reads.
+  Press <kbd>?</kbd> or <kbd>Esc</kbd> to close.
 </div></div>
 
 <script>
 "use strict";
 var BASELINE = __BASELINE__;
+var STRINGS = __STRINGS__;
+var FACETOPTS = __FACETOPTS__;
+var FACETORDER = __FACETORDER__;
+var CARDMETA = __CARDMETA__;
 var NBATCH = __NBATCH__;
 var LS_KEY = "pdoom1_full_gallery_v1";
 var LS_EXP = "pdoom1_full_gallery_last_export";
@@ -500,8 +1107,13 @@ function eff(id) {
   var b = BASELINE[id];
   return b ? { v: b.v || "", n: b.n || "" } : { v: "", n: "" };
 }
+function esc(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;")
+                  .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
 
 var cards = Array.prototype.slice.call(document.querySelectorAll(".card"));
+var sections = Array.prototype.slice.call(document.querySelectorAll("section.batch"));
 var batchIds = [];   // per batch: array of unique ids
 var idBatch = {};    // id -> batch number (first seen)
 for (var i = 0; i < NBATCH; i++) batchIds.push([]);
@@ -521,8 +1133,9 @@ function paintCard(c) {
   badge.className = "badge " + e.v;
   note.textContent = e.n;
   note.title = e.n;
-  c.classList.remove("keep", "iterate", "discard", "rev");
+  c.classList.remove("keep", "iterate", "discard", "rev", "hasnote");
   if (e.v) { c.classList.add(e.v, "rev"); }
+  if (e.n) { c.classList.add("hasnote"); }
 }
 function paintAll() { cards.forEach(paintCard); refreshCounts(); }
 
@@ -554,23 +1167,130 @@ function refreshUnsaved() {
   window.__unsaved = n;
 }
 
+// ---- filtering: ONE working set, shared by all three modes ----------------
+// The reason grouping and the modes are the same feature: "show me every
+// MUNICIPAL RECORD image" is useless if it only holds in one layout. Filter in
+// triage, switch to compare, and you are looking at the same 22 pictures.
+var FILT = { batch: "", facets: {}, q: "", rev: "" };
+
+function facetAttr(f) {
+  return "f" + f.charAt(0).toUpperCase() + f.slice(1);
+}
+
+function buildFacetSelects() {
+  var host = document.getElementById("facetsel");
+  var out = [];
+  FACETORDER.forEach(function (f) {
+    var opts = FACETOPTS[f];
+    if (!opts || !opts.length) return;
+    var h = '<select class="ffac" data-f="' + f + '"><option value="">all ' +
+            esc(f) + 's</option>';
+    opts.forEach(function (o) {
+      h += '<option value="' + o[0] + '">' + esc(STRINGS[o[0]]) +
+           " (" + o[2] + ")</option>";
+    });
+    out.push(h + "</select>");
+  });
+  host.innerHTML = out.join(" ");
+  Array.prototype.forEach.call(host.querySelectorAll(".ffac"), function (s) {
+    s.addEventListener("change", function () {
+      var v = s.value;
+      if (v === "") delete FILT.facets[s.dataset.f];
+      else FILT.facets[s.dataset.f] = v;
+      applyFilter();
+    });
+  });
+  var bsel = document.getElementById("f-batch");
+  for (var b = 0; b < NBATCH; b++) {
+    var h2 = sections[b] ? sections[b].querySelector("h2") : null;
+    var title = h2 ? h2.childNodes[0].nodeValue : "batch " + (b + 1);
+    var o = document.createElement("option");
+    o.value = String(b);
+    o.textContent = title + " (" + batchIds[b].length + ")";
+    bsel.appendChild(o);
+  }
+}
+
+function cardPasses(c) {
+  if (FILT.batch !== "" && c.dataset.b !== FILT.batch) return false;
+  for (var f in FILT.facets) {
+    if (c.dataset[facetAttr(f)] !== FILT.facets[f]) return false;
+  }
+  if (FILT.q) {
+    var chip = c.querySelector(".chip");
+    var hay = c.dataset.id + " " + (c.querySelector(".nm").textContent || "") +
+              " " + (chip ? chip.textContent : "");
+    if (hay.toLowerCase().indexOf(FILT.q) < 0) return false;
+  }
+  if (FILT.rev) {
+    var e = eff(c.dataset.id);
+    if (FILT.rev === "none" && e.v) return false;
+    if (FILT.rev === "noted" && !e.n) return false;
+    if (FILT.rev !== "none" && FILT.rev !== "noted" && e.v !== FILT.rev) return false;
+  }
+  return true;
+}
+function applyFilter(keepSel) {
+  var n = 0;
+  cards.forEach(function (c) {
+    var ok = cardPasses(c);
+    c.classList.toggle("filtered", !ok);
+    if (ok) n++;
+  });
+  // hide a section that has nothing left, so the page is not a field of headers
+  sections.forEach(function (s) {
+    s.classList.toggle("empty", !s.querySelector(".card:not(.filtered)"));
+  });
+  document.getElementById("fcount").textContent =
+    n === cards.length ? "" : (n + " of " + cards.length + " shown");
+  if (!keepSel && (sel < 0 || !visible(cards[sel]))) { sel = -1; move(1); }
+  syncStudy();
+}
+
 // ---- selection ----
 var sel = -1;
-function visible(c) { return c.offsetParent !== null; }
+// "In the working set" is a PROPERTY OF THE DATA, not of the layout.
+//
+// This used to be `c.offsetParent !== null`, and a real browser found two ways
+// that is wrong (2026-08-07, Edge/Chromium):
+//   1. `.batch` carries `content-visibility:auto`. Chromium SKIPS the contents
+//      of an off-screen section, and a skipped subtree's children report
+//      offsetParent === null. So J/K silently refused to walk into any batch
+//      that was not already scrolled near -- traversal depended on where the
+//      page happened to be scrolled.
+//   2. STUDY mode hides the whole grid by design, which made EVERY card
+//      "invisible" and froze the arrow keys completely.
+// Both vanish once membership is asked of the classes that actually define it.
+// It is also cheaper: offsetParent forces a layout flush per card, 6205 times.
+function visible(c) {
+  if (!c) return false;
+  if (c.classList.contains("filtered")) return false;
+  if (document.body.classList.contains("hiderev") && c.classList.contains("rev"))
+    return false;
+  return true;
+}
+function workingSet() {
+  return cards.filter(visible);
+}
 function select(i, scroll) {
   if (i < 0 || i >= cards.length) return;
-  if (sel >= 0) cards[sel].classList.remove("sel");
+  // Clear by QUERY, not by remembered index. applyFilter resets `sel` to -1 to
+  // force a re-pick, which stranded the outline on the old card -- two cards
+  // showed as selected at once (seen by eye in a browser screenshot, 08-07).
+  Array.prototype.forEach.call(document.querySelectorAll(".card.sel"),
+    function (c) { c.classList.remove("sel"); });
   sel = i;
   var c = cards[sel];
   c.classList.add("sel");
-  if (scroll !== false) c.scrollIntoView({ block: "center" });
+  if (scroll !== false && MODE !== "study") c.scrollIntoView({ block: "center" });
   var e = eff(c.dataset.id);
   var b = +c.dataset.b;
   document.getElementById("selname").textContent = c.dataset.id;
   document.getElementById("selverdict").textContent =
-    (e.v ? " [" + e.v + "]" : "") + (e.n ? " note: " + e.n : "");
+    (e.v ? " [" + e.v + "]" : "") + (e.n ? " note: " + e.n.split("\n")[0] : "");
   document.getElementById("curb").textContent =
     "| batch " + (b + 1) + " of " + NBATCH;
+  syncStudy();
 }
 function move(step) {
   var i = sel;
@@ -606,50 +1326,58 @@ cards.forEach(function (c, i) {
 
 // ---- verdict + note writes ----
 function save() { localStorage.setItem(LS_KEY, JSON.stringify(local)); }
-function setVerdict(v) {
-  if (sel < 0) return;
-  var id = cards[sel].dataset.id;
-  var cur = eff(id);
-  local[id] = { verdict: v, note: cur.n, tags: [],
+function writeEntry(id, verdict, note) {
+  local[id] = { verdict: verdict, note: note, tags: [],
                 updated_at: new Date().toISOString() };
   save();
   cardsFor(id).forEach(paintCard);
   refreshCounts();
+}
+function setVerdict(v) {
+  if (sel < 0) return;
+  var id = cards[sel].dataset.id;
+  writeEntry(id, v, eff(id).n);
   select(sel, false);
   if (v) move(1);
 }
-// ---- BATCH verdicts -------------------------------------------------------
+// ---- BATCH / GROUP verdicts ----------------------------------------------
 // Pip, 2026-08-04: "I don't like the idea of having to manually review all the
 // frames of a walking animation, or if I do, there should be a batch selection
 // option." A rotation set is ONE artistic decision spread over 8 files; making
 // the reviewer press a key 8 times does not make the judgement any better, it
 // just makes the pile look bigger than it is.
 //
+// In COMPARE the unit is the visible working set instead of the batch, because
+// that is the whole point of compare: you filtered to one style direction and
+// you are deciding about the DIRECTION.
+//
 // Applies only to cards with NO existing verdict, so a considered per-asset call
 // is never overwritten by a sweep. Confirms with a count first -- a bulk action
 // that fires silently is how you lose an hour of judgement to one keystroke.
 function setBatchVerdict(v) {
   if (sel < 0) return;
+  var groupIsWorkingSet = (MODE === "compare");
   var b = cards[sel].dataset.b;
   var targets = [];
   var seen = {};
-  for (var i = 0; i < cards.length; i++) {
-    if (cards[i].dataset.b !== b) continue;
-    var id = cards[i].dataset.id;
+  var pool = groupIsWorkingSet ? workingSet() : cards;
+  for (var i = 0; i < pool.length; i++) {
+    if (!groupIsWorkingSet && pool[i].dataset.b !== b) continue;
+    var id = pool[i].dataset.id;
     if (seen[id]) continue;
     if (eff(id).v) continue;            // never stomp an existing verdict
     seen[id] = 1;
     targets.push(id);
   }
   if (!targets.length) {
-    alert("Nothing unreviewed left in this batch.");
+    alert("Nothing unreviewed left in " +
+          (groupIsWorkingSet ? "the visible group." : "this batch."));
     return;
   }
   var label = v ? v.toUpperCase() : "CLEAR";
+  var scope = groupIsWorkingSet ? "the VISIBLE GROUP" : "this batch";
   if (!confirm("Set " + label + " on " + targets.length +
-               " UNREVIEWED asset(s) in this batch?
-
-" +
+               " UNREVIEWED asset(s) in " + scope + "?\n\n" +
                "Already-judged assets are left alone.")) return;
   var now = new Date().toISOString();
   targets.forEach(function (id) {
@@ -665,6 +1393,7 @@ var notebox = document.getElementById("notebox");
 var notein = document.getElementById("notein");
 function openNote() {
   if (sel < 0) return;
+  if (MODE === "study") { document.getElementById("snote").focus(); return; }
   notein.value = eff(cards[sel].dataset.id).n;
   notebox.style.display = "block";
   notein.focus();
@@ -673,12 +1402,7 @@ notein.addEventListener("keydown", function (ev) {
   ev.stopPropagation();
   if (ev.key === "Enter") {
     var id = cards[sel].dataset.id;
-    var cur = eff(id);
-    local[id] = { verdict: cur.v, note: notein.value, tags: [],
-                  updated_at: new Date().toISOString() };
-    save();
-    cardsFor(id).forEach(paintCard);
-    refreshCounts();
+    writeEntry(id, eff(id).v, notein.value);
     select(sel, false);
     notebox.style.display = "none";
   } else if (ev.key === "Escape") {
@@ -686,7 +1410,187 @@ notein.addEventListener("keydown", function (ev) {
   }
 });
 
+// ---- STUDY mode -----------------------------------------------------------
+// "maybe an in-house preview frame so I'm not popping open new windows... a kind
+// of gallery-rotate rather than scroll?" -- Pip, 2026-08-07. Rotate, not scroll:
+// the picture stays put and the CONTENT changes under it, so the eye never has
+// to re-find the frame between two images. That is also what makes A-vs-B
+// comparison possible at all in a single-image view: flicking left and right
+// between two images in the same rectangle shows differences that side-by-side
+// at different screen positions hides.
+var MODE = "triage";
+var stageScale = "fit";
+var stageImg = document.getElementById("stageimg");
+var snote = document.getElementById("snote");
+
+function setMode(m) {
+  MODE = m;
+  document.body.classList.remove("mode-triage", "mode-study", "mode-compare");
+  document.body.classList.add("mode-" + m);
+  ["m1", "m2", "m3"].forEach(function (bid) {
+    var el = document.getElementById(bid);
+    el.classList.toggle("on", el.dataset.mode === m);
+  });
+  document.getElementById("modehint").textContent =
+    m === "triage" ? "dense grid, one keystroke per decision" :
+    m === "study" ? "arrows rotate through the working set; note box is live" :
+    "big tiles -- filter to one direction and judge the family";
+  if (sel < 0 || !visible(cards[sel])) move(1);
+  syncStudy();
+  if (m !== "study") window.scrollTo(0, 0);
+}
+function syncStudy() {
+  if (MODE !== "study") return;
+  if (sel < 0 || !cards[sel]) { stageImg.removeAttribute("src"); return; }
+  var id = cards[sel].dataset.id;
+  var cm = CARDMETA[id] || {};
+  var a = cards[sel].querySelector("a");
+  var want = a ? a.getAttribute("href") : "";
+  // Guard the assignment: syncStudy runs on every note keystroke, and
+  // re-assigning .src restarts decode and flashes the picture the reviewer is
+  // in the middle of describing.
+  if (stageImg.getAttribute("src") !== want) { stageImg.src = want; }
+  applyStageScale();
+  var e = eff(id);
+  if (snote.value !== e.n) snote.value = e.n;
+  Array.prototype.forEach.call(document.querySelectorAll("#sverd button"),
+    function (b) { b.classList.toggle("on", b.dataset.v === e.v); });
+  var ws = workingSet();
+  var pos = ws.indexOf(cards[sel]) + 1;
+  var rows = [
+    ["asset", id],
+    ["batch", cm.batch || ""],
+    ["files", (cm.n || 1) + " size(s)"],
+    ["position", pos + " of " + ws.length + " in the working set"]
+  ];
+  // Blocks with no NAMED direction fall back to the rendering clause, which
+  // then prints the same long sentence twice. Show each distinct value once.
+  var shownVals = {};
+  FACETORDER.forEach(function (f) {
+    var v = cards[sel].dataset[facetAttr(f)];
+    if (v === undefined || shownVals[v]) return;
+    shownVals[v] = 1;
+    rows.push([f, STRINGS[+v]]);
+  });
+  if (cm.meta) rows.push(["record", cm.meta]);
+  rows.push(["origin", "MACHINE-GENERATED (see the sidecar record)"]);
+  document.getElementById("srec").innerHTML = rows.map(function (r) {
+    return '<div><span class="k">' + esc(r[0]) + "</span> <b>" + esc(r[1]) + "</b></div>";
+  }).join("");
+}
+function applyStageScale() {
+  if (stageScale === "fit") { stageImg.className = "fit"; stageImg.style.width = ""; }
+  else {
+    stageImg.className = "";
+    stageImg.style.width = ((stageImg.naturalWidth || 1024) * stageScale) + "px";
+  }
+  Array.prototype.forEach.call(document.querySelectorAll(".sz"), function (b) {
+    b.classList.toggle("on", String(stageScale) === b.dataset.s);
+  });
+}
+function setStageScale(s) {
+  stageScale = (s === "fit") ? "fit" : parseFloat(s);
+  applyStageScale();
+}
+// The note box writes on every keystroke. A note the reviewer typed and lost
+// because they pressed the arrow key before some explicit save is exactly the
+// kind of loss this tool exists to prevent.
+snote.addEventListener("input", function () {
+  if (sel < 0) return;
+  var id = cards[sel].dataset.id;
+  writeEntry(id, eff(id).v, snote.value);
+  select(sel, false);
+});
+snote.addEventListener("keydown", function (ev) {
+  ev.stopPropagation();
+  if (ev.key === "Escape") { snote.blur(); }
+});
+Array.prototype.forEach.call(document.querySelectorAll("#sverd button"),
+  function (b) { b.addEventListener("click", function () { setVerdict(b.dataset.v); }); });
+Array.prototype.forEach.call(document.querySelectorAll(".sz"),
+  function (b) { b.addEventListener("click", function () { setStageScale(b.dataset.s); }); });
+
+// ---- the MAGNIFIER (ported from build_slot_picker.py) ---------------------
+var lb = { open: false, scale: "fit" };
+var lbimg = document.getElementById("lbimg");
+function lbOpen() {
+  if (sel < 0) return;
+  lb.open = true; lb.scale = "fit";
+  document.getElementById("lb").style.display = "flex";
+  lbPaint();
+}
+function lbClose() {
+  lb.open = false;
+  document.getElementById("lb").style.display = "none";
+}
+function lbPaint() {
+  if (!lb.open || sel < 0) return;
+  var c = cards[sel];
+  var a = c.querySelector("a");
+  var want = a ? a.getAttribute("href") : "";
+  if (lbimg.getAttribute("src") !== want) { lbimg.src = want; }
+  if (lb.scale === "fit") { lbimg.className = "fit"; lbimg.style.width = ""; }
+  else {
+    lbimg.className = "";
+    lbimg.style.width = ((lbimg.naturalWidth || 1024) * lb.scale) + "px";
+  }
+  var e = eff(c.dataset.id);
+  var ws = workingSet();
+  document.getElementById("lblabel").textContent =
+    c.dataset.id + "  (" + (ws.indexOf(c) + 1) + "/" + ws.length + ")" +
+    (e.v ? "  [" + e.v.toUpperCase() + "]" : "");
+  var cm = CARDMETA[c.dataset.id] || {};
+  document.getElementById("lbdims").textContent =
+    "  " + (cm.batch || "") + "  " + (lbimg.naturalWidth || "?") + "x" +
+    (lbimg.naturalHeight || "?");
+  Array.prototype.forEach.call(document.querySelectorAll(".lbz"), function (b) {
+    b.classList.toggle("on", String(lb.scale) === b.dataset.s);
+  });
+}
+function lbSetScale(s) {
+  lb.scale = (s === "fit") ? "fit" : parseFloat(s);
+  lbPaint();
+}
+lbimg.addEventListener("load", function () { if (lb.open) lbPaint(); });
+stageImg.addEventListener("load", function () { applyStageScale(); });
+Array.prototype.forEach.call(document.querySelectorAll(".lbz"),
+  function (b) { b.addEventListener("click", function () { lbSetScale(b.dataset.s); }); });
+document.getElementById("lbclose").addEventListener("click", lbClose);
+
+function wirePanZoom(stageId, getScale, setScale) {
+  var stage = document.getElementById(stageId);
+  stage.addEventListener("wheel", function (ev) {
+    ev.preventDefault();
+    var cur = getScale();
+    cur = (cur === "fit") ? 1 : cur;
+    setScale(ev.deltaY < 0 ? Math.min(8, cur * 1.25) : Math.max(0.25, cur / 1.25));
+  }, { passive: false });
+  var down = false, sx = 0, sy = 0, ol = 0, ot = 0;
+  stage.addEventListener("mousedown", function (ev) {
+    down = true; sx = ev.clientX; sy = ev.clientY;
+    ol = stage.scrollLeft; ot = stage.scrollTop;
+    stage.classList.add("drag"); ev.preventDefault();
+  });
+  document.addEventListener("mousemove", function (ev) {
+    if (!down) return;
+    stage.scrollLeft = ol - (ev.clientX - sx);
+    stage.scrollTop = ot - (ev.clientY - sy);
+  });
+  document.addEventListener("mouseup", function () {
+    down = false; stage.classList.remove("drag");
+  });
+}
+wirePanZoom("lbstage", function () { return lb.scale; }, lbSetScale);
+wirePanZoom("stage", function () { return stageScale; }, setStageScale);
+
 // ---- export ----
+var toastEl = document.getElementById("toast"), toastT = 0;
+function toast(msg) {
+  toastEl.textContent = msg;
+  toastEl.style.display = "block";
+  clearTimeout(toastT);
+  toastT = setTimeout(function () { toastEl.style.display = "none"; }, 2600);
+}
 function doExport() {
   var blob = new Blob([JSON.stringify(local, null, 2)],
                       { type: "application/json" });
@@ -699,49 +1603,120 @@ function doExport() {
   a.remove();
   localStorage.setItem(LS_EXP, new Date().toISOString());
   refreshUnsaved();
+  toast("exported -- now run merge_gallery_export.py");
 }
 window.addEventListener("beforeunload", function (ev) {
   if (window.__unsaved > 0) { ev.preventDefault(); ev.returnValue = ""; }
 });
 
 // ---- keys ----
+// The guard is on the ELEMENT KIND, not on one known input. The filter bar added
+// a text box and six <select>s; a handler that only knew about #notein would
+// have let every keystroke typed into a filter also fire a verdict.
+function isTyping(t) {
+  if (!t) return false;
+  var tag = t.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" ||
+         t.isContentEditable;
+}
 document.addEventListener("keydown", function (ev) {
-  if (ev.target === notein) return;
+  if (isTyping(ev.target)) return;
   if (ev.ctrlKey || ev.metaKey || ev.altKey) return;
   var k = ev.key;
   var handled = true;
+  var helpEl = document.getElementById("help");
+
+  // The magnifier OWNS the keyboard while it is open. Letting the page's keys
+  // fire underneath it is how "3" both magnifies and switches mode.
+  if (lb.open) {
+    if (k === "Escape" || k === "f" || k === "F") lbClose();
+    else if (k === "[" || k === "k" || k === "K" || k === "ArrowLeft") { move(-1); lbPaint(); }
+    else if (k === "]" || k === "j" || k === "J" || k === "ArrowRight") { move(1); lbPaint(); }
+    else if (k === "l" || k === "L") { setVerdict("keep"); lbPaint(); }
+    else if (k === "i" || k === "I") { setVerdict("iterate"); lbPaint(); }
+    else if (k === "x" || k === "X") { setVerdict("discard"); lbPaint(); }
+    else if (k === "u" || k === "U") { setVerdict(""); lbPaint(); }
+    else if (k === "1") lbSetScale("fit");
+    else if (k === "2") lbSetScale(1);
+    else if (k === "3") lbSetScale(2);
+    else if (k === "4") lbSetScale(4);
+    else handled = false;
+    if (handled) ev.preventDefault();
+    return;
+  }
+  if (helpEl.style.display === "block" && (k === "Escape" || k === "?")) {
+    helpEl.style.display = "none";
+    ev.preventDefault();
+    return;
+  }
+
   if (k === "j" || k === "J" || k === "ArrowRight" || k === "ArrowDown") move(1);
   else if (k === "k" || k === "K" || k === "ArrowLeft" || k === "ArrowUp") move(-1);
-  else if (k === "l" || k === "1") setVerdict("keep");
-  else if (k === "i" || k === "2") setVerdict("iterate");
-  else if (k === "x" || k === "3") setVerdict("discard");
+  else if (k === "l") setVerdict("keep");
+  else if (k === "i") setVerdict("iterate");
+  else if (k === "x") setVerdict("discard");
   else if (k === "u" || k === "U" || k === "0") setVerdict("");
   else if (k === "n" || k === "N") openNote();
+  else if (k === "f" || k === "F") lbOpen();
+  else if (k === "1") setMode("triage");
+  else if (k === "2") setMode("study");
+  else if (k === "3") setMode("compare");
   else if (k === "b") jumpBatch(1);
   else if (k === "B") jumpBatch(-1);
   else if (k === "L") setBatchVerdict("keep");
   else if (k === "I") setBatchVerdict("iterate");
   else if (k === "X") setBatchVerdict("discard");
+  else if (k === "/") { document.getElementById("f-q").focus(); }
   else if (k === "h" || k === "H") {
     document.body.classList.toggle("hiderev");
     if (sel >= 0 && !visible(cards[sel])) move(1);
+    syncStudy();
   }
   else if (k === "e" || k === "E") doExport();
   else if (k === "Enter" || k === "o" || k === "O") {
     if (sel >= 0) window.open(cards[sel].querySelector("a").href, "_blank");
   }
   else if (k === "?") {
-    var h = document.getElementById("help");
-    h.style.display = h.style.display === "block" ? "none" : "block";
+    helpEl.style.display = helpEl.style.display === "block" ? "none" : "block";
   }
   else handled = false;
   if (handled) ev.preventDefault();
 });
-document.getElementById("help").addEventListener("click", function () {
-  this.style.display = "none";
+document.getElementById("help").addEventListener("click", function (ev) {
+  if (ev.target === this) this.style.display = "none";
+});
+["m1", "m2", "m3"].forEach(function (bid) {
+  document.getElementById(bid).addEventListener("click", function () {
+    setMode(this.dataset.mode);
+  });
+});
+document.getElementById("f-batch").addEventListener("change", function () {
+  FILT.batch = this.value; applyFilter();
+});
+document.getElementById("f-q").addEventListener("input", function () {
+  FILT.q = this.value.trim().toLowerCase(); applyFilter();
+});
+document.getElementById("f-q").addEventListener("keydown", function (ev) {
+  ev.stopPropagation();
+  if (ev.key === "Escape" || ev.key === "Enter") this.blur();
+});
+document.getElementById("f-rev").addEventListener("change", function () {
+  FILT.rev = this.value; applyFilter();
+});
+document.getElementById("f-clear").addEventListener("click", function () {
+  FILT = { batch: "", facets: {}, q: "", rev: "" };
+  document.getElementById("f-batch").value = "";
+  document.getElementById("f-q").value = "";
+  document.getElementById("f-rev").value = "";
+  Array.prototype.forEach.call(document.querySelectorAll(".ffac"),
+    function (s) { s.value = ""; });
+  applyFilter();
 });
 
+buildFacetSelects();
 paintAll();
+setMode("triage");
+applyFilter(true);
 </script>
 """
 

--- a/tools/art_review/notes_brief.py
+++ b/tools/art_review/notes_brief.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""notes_brief.py -- turn the reviewer's notes into the brief for the next round.
+
+Layer: OBSERVE -> DECIDE
+Invoked by: human, after merge_gallery_export.py
+
+WHY THIS EXISTS
+---------------
+A note in review_state.json is a comment field: real, tracked, diffable, and
+completely invisible unless someone greps for it. The 2026-08-06 taste
+measurement found that the single most useful artifact in the whole art loop was
+a note Pip typed ELEVEN DAYS EARLIER asking for a coherence pass -- it was right,
+it was actionable, and it sat unread for eleven days because nothing ever read
+notes back. Verdicts have four consumers (apply_review report/promote/reroll,
+the gallery baseline, the taste measurement, the slot model). Notes had none.
+
+So notes are promoted to an output. This script reads the ONE verdict store and
+writes ONE generated markdown file, grouped so the next generation round can act
+on it: what to keep doing, what to change, and what was thrown out and why.
+
+ANTI-ROT (the DQ_INDEX pattern)
+-------------------------------
+docs/art/NOTES_BRIEF.md is GENERATED and carries a do-not-hand-edit header, the
+same shape as docs/game-design/DQ_INDEX.md. `--check` fails if the tracked file
+is stale, so it can gate pre-commit later without anyone having to remember.
+This is deliberately NOT a third store: the note itself lives only in
+review_state.json. This file is a VIEW, and a stale view is a build failure
+rather than a slow lie -- which is the failure mode of the hand-maintained
+decisions/README.md index.
+
+Usage:
+    python tools/art_review/notes_brief.py           # rewrite the brief
+    python tools/art_review/notes_brief.py --check   # fail if stale
+    python tools/art_review/notes_brief.py --stdout  # print, write nothing
+"""
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+STATE = REPO / "tools" / "art_review" / "review_state.json"
+OUT = REPO / "docs" / "art" / "NOTES_BRIEF.md"
+
+VERDICT_MIGRATE = {"maybe": "iterate", "reroll": "iterate"}
+VERDICTS = ("keep", "iterate", "discard")
+# Section order is the order the brief should be READ in: what to preserve
+# first, what to fix second, what to stop doing last.
+SECTIONS = [
+    ("keep", "KEEP -- what is working, preserve it"),
+    ("iterate", "ITERATE -- what to change in the next round"),
+    ("discard", "DISCARD -- what to stop generating"),
+    ("", "UNJUDGED -- noted but no verdict yet"),
+]
+
+HEADER = """<!-- GENERATED FILE -- DO NOT HAND-EDIT.
+Regenerate: python tools/art_review/notes_brief.py
+Source of truth: tools/art_review/review_state.json (the note field).
+Edit a note by re-reviewing the asset in art_generated/full_gallery.html and
+merging the export with tools/art_review/merge_gallery_export.py -- editing this
+file directly is lost work, because the next regeneration overwrites it. -->
+
+# Art notes -- the brief for the next generation round
+
+Every line below is something the reviewer typed while looking at a specific
+picture. Notes are grouped by verdict, then by the batch the asset came from,
+because "the value structure is muddy in the aubergine palette" is only
+actionable if you can see it was said about eleven images in one block and not
+once about anything else.
+
+Read the ITERATE section first when writing the next prompt queue: those are
+pictures judged worth having but not as generated.
+"""
+
+
+def migrate(v):
+    v = (v or "").strip().lower()
+    if v in VERDICTS:
+        return v
+    return VERDICT_MIGRATE.get(v, "")
+
+
+def batch_of(asset_id):
+    """Best-effort human batch name from an asset id, matching the gallery."""
+    if asset_id.startswith("gen:"):
+        return "art_generated/" + asset_id.split(":", 2)[1]
+    if asset_id.startswith("px:"):
+        rel = asset_id[3:]
+        return "art_source/" + rel.split("/", 1)[0]
+    if asset_id.startswith("file:"):
+        rel = asset_id[5:]
+        parts = rel.split("/")
+        return "/".join(parts[:2]) if len(parts) > 1 else rel
+    return "(unclassified)"
+
+
+def collect(state):
+    """{verdict: {batch: [(asset_id, note)]}} plus a flat count."""
+    out = defaultdict(lambda: defaultdict(list))
+    n = 0
+    for aid, entry in sorted(state.items()):
+        if not isinstance(entry, dict):
+            continue
+        note = (entry.get("note") or "").strip()
+        if not note:
+            continue
+        n += 1
+        out[migrate(entry.get("verdict"))][batch_of(aid)].append((aid, note))
+    return out, n
+
+
+# Words that carry a craft judgement. Counting them is a cheap way to surface
+# "you have said `muddy` fourteen times" -- a theme the reviewer never wrote
+# down as a theme, because each note was about one picture.
+THEME_WORDS = re.compile(
+    r"\b(mud+y|flat|noisy|busy|washed|blur+y|soft|dark|bright|contrast|value|"
+    r"palette|colou?r|light|lighting|composition|texture|grain|detail|prop|"
+    r"legib\w*|read\w*|coheren\w*|consisten\w*|silhouette|edge|crop|face|"
+    r"people|person|figure|text|letter\w*|logo|sign\w*|emoji|border|"
+    r"transparen\w*|tile|seam|aliasing|banding)\b",
+    re.I,
+)
+
+
+def themes(state, top=18):
+    c = Counter()
+    for entry in state.values():
+        if not isinstance(entry, dict):
+            continue
+        seen = set()
+        for w in THEME_WORDS.findall(entry.get("note") or ""):
+            w = w.lower()
+            if w not in seen:  # count DOCUMENTS not occurrences
+                seen.add(w)
+                c[w] += 1
+    return c.most_common(top)
+
+
+def render(state):
+    grouped, n_notes = collect(state)
+    lines = [HEADER.rstrip(), ""]
+    n_assets = len([k for k, v in state.items() if isinstance(v, dict)])
+    lines.append(
+        f"**{n_notes} notes** across {n_assets} judged assets "
+        f"({(100.0 * n_notes / n_assets):.0f} percent of judgements carry a note)."
+        if n_assets
+        else "**0 notes.**"
+    )
+    lines.append("")
+
+    th = themes(state)
+    if th:
+        lines.append("## Recurring words")
+        lines.append("")
+        lines.append(
+            "How many separate notes mention each craft term. A term near the top "
+            "is a standing instruction the next prompt should carry, not a "
+            "one-off reaction."
+        )
+        lines.append("")
+        lines.append("| term | notes mentioning it |")
+        lines.append("| --- | --- |")
+        for w, c in th:
+            lines.append(f"| {w} | {c} |")
+        lines.append("")
+
+    for verdict, title in SECTIONS:
+        by_batch = grouped.get(verdict)
+        if not by_batch:
+            continue
+        total = sum(len(v) for v in by_batch.values())
+        lines.append(f"## {title} ({total})")
+        lines.append("")
+        for batch in sorted(by_batch):
+            items = by_batch[batch]
+            lines.append(f"### {batch} ({len(items)})")
+            lines.append("")
+            for aid, note in items:
+                flat = " ".join(note.split())
+                lines.append(f"- `{aid}` -- {flat}")
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--check", action="store_true", help="fail if the file is stale")
+    ap.add_argument("--stdout", action="store_true", help="print, write nothing")
+    args = ap.parse_args(argv)
+
+    if not STATE.is_file():
+        sys.exit(f"error: {STATE} not found")
+    state = json.loads(STATE.read_text(encoding="utf-8"))
+    if not isinstance(state, dict):
+        sys.exit(f"error: {STATE} is not an object")
+
+    text = render(state)
+    if args.stdout:
+        sys.stdout.write(text)
+        return 0
+    if args.check:
+        if not OUT.is_file():
+            print(f"[!] {OUT.relative_to(REPO)} does not exist -- run notes_brief.py")
+            return 1
+        if OUT.read_text(encoding="utf-8") != text:
+            print(
+                f"[!] {OUT.relative_to(REPO)} is STALE. "
+                f"Run: python tools/art_review/notes_brief.py"
+            )
+            return 1
+        print(f"[+] {OUT.relative_to(REPO)} is current")
+        return 0
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(text, encoding="utf-8", newline="\n")
+    n_notes = sum(
+        1 for e in state.values() if isinstance(e, dict) and (e.get("note") or "").strip()
+    )
+    print(f"[+] wrote {OUT} ({n_notes} notes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The keyboard defect -- the real cause

Reproduced in a real browser **before** changing anything, as asked.

The emitted page held an **unterminated string literal**. `build_full_gallery.py`
kept its page in a *non-raw* Python triple-quoted `TEMPLATE`, and a `\n\n` written
into a JavaScript `confirm()` string was compiled **by Python** into two real
newlines that landed inside the JS string:

```js
confirm("Set " + label + " on " + targets.length +
        " UNREVIEWED asset(s) in this batch?
<-- an actual newline, inside the string literal
" + "Already-judged assets are left alone.")
```

Edge/Chromium: `SyntaxError: Invalid or unexpected token`, thrown at **parse
time**, so the entire `<script>` block never executed.

```
typeof BASELINE   = undefined
typeof cards      = undefined
typeof setVerdict = undefined
press "j" -> .card.sel count = 0
badges painted    = 0
```

So it was not the keyboard specifically -- **nothing** ran. That also answers
"the little cards don't seem to have things": `paintAll()` never fired, so no
badge, note or verdict colour was ever painted on any card.

Nothing looked wrong from the build side. 4 MB file, all 11,524 images resolved,
every section present. Silent-wrongness, and the same escape-mangling class
`CLAUDE.md` already records for heredocs -- this time via a non-raw Python string
rather than a shell heredoc.

### Fixed twice, because only the second survives the next edit

1. `TEMPLATE` is a **raw** string, so a JS escape reaches the browser verbatim.
2. The build **parses its own emitted script** before writing the file:
   `node --check` where node exists, else a built-in scanner. A build that cannot
   prove its script parses now **fails** rather than writing a page with a dead
   keyboard. Proven -- reintroducing the exact defect is rejected by both gates.

The built-in scanner needed comment and regex-literal handling: its first version
flagged the perfectly good line `.replace(/"/g, "&quot;")`. It now runs two
fixtures **on itself** first, and if it fails them it reports `NOT CHECKED`
instead of blocking. A gate that blocks every build on a false positive is worse
than the bug it was added for.

## View structure shipped

Split by **task**, one page, one verdict store.

| mode | key | for |
|---|---|---|
| **TRIAGE** | `1` | the original dense grid, deliberately unchanged. How 600 becomes 60. |
| **STUDY** | `2` | one image large, arrows rotate the working set -- the "gallery-rotate rather than scroll" -- multi-line note box always on screen, generation record beside the picture. |
| **COMPARE** | `3` | big tiles over one facet group. `Shift+L/I/X` sweeps the visible group instead of the batch. |

One filter bar feeds all three: filter in triage, switch to compare, same
pictures. `l1_family` is 12 named style **directions** x 22 subjects -- it was
generated so a direction could be judged as a direction, and compare mode is
where that happens.

**The magnifier is ported from `build_slot_picker.py`, not reinvented.**
fit/100/200/400, wheel zoom, drag pan, `[` and `]` to step, and it owns the
keyboard while open so number keys cannot leak to the grid underneath.

**Rejected:** a separate study *page* (would fork the verdict store -- a failure
this repo has already paid for), and a lightbox-only fourth mode (the magnifier
is a control, not a task).

## Grouping

Facets are parsed from the `.meta.json` sidecars. The named style direction lives
*inside the prompt* (`COHERENT DIRECTION -- MUNICIPAL RECORD:`), so it is parsed
out rather than kept as a hand-maintained `cell -> name` map that would rot the
first time a block is regenerated. Surfaced: **22 directions, 9 palettes, 23
subjects, 11 renderings, 3 models**. Labels are interned; full prompts are not
embedded (~13 MB of text nobody reads in a grid).

## Where notes persist

**`tools/art_review/review_state.json`** -- unchanged, one store, tracked in git,
reached by the existing `E` export -> `merge_gallery_export.py` path. No third
store, no side-map. (That file is now tracked, so the "one disk failure away"
risk is closed.) This PR only ever **reads** it.

But a note nothing reads back is a comment field, and the taste measurement found
the single most useful artifact in the art loop was a note typed eleven days
earlier that nothing ever surfaced. So notes become an output:

`python tools/art_review/notes_brief.py` -> **`docs/art/NOTES_BRIEF.md`**,
generated with a do-not-hand-edit header and a `--check` staleness gate (the
`DQ_INDEX` anti-rot pattern). 111 existing notes surface immediately, grouped
keep/iterate/discard by batch, plus a recurring-craft-term count -- themes nobody
wrote down as themes because each note was about one picture.

## Verified by eye

**A browser was available and I used it.** Playwright driving real
Edge/Chromium (`channel="msedge"`; the bundled Chromium was not installed).
**53 assertions over real key events on the real 6,205-asset page, all green,
zero console errors**, plus screenshots of triage, study, compare and the
magnifier that I actually looked at.

Three defects were caught **only by looking**, not by any assertion I had
written: two cards carrying the selection outline at once; the sidebar scrolling
the L/I/X buttons out of view when the note box took focus; and compare tiles
spending a third of their area on grey letterbox bands. Each now has a
regression assertion.

Also found by the browser and not by reading code: `visible()` used
`offsetParent`, which is `null` both for children of a `content-visibility:auto`
section Chromium has skipped **and** for the whole grid in study mode. J/K
traversal silently depended on scroll position, and study-mode arrows were frozen
outright. Membership is now a class predicate.

## Not regressed

Reviewed items leaving the working set, batch selection, section questions, the
overflow fix, the `--allow-unmapped` preflight, the export/merge path. All still
present, and hide-reviewed plus the batch sweep are covered by assertions.

## One dependency worth flagging

`apply_review.py` gains the `an0807` Hold. The gallery **refuses** to index a
batch with no mapping outcome, so without it these 652 images cannot be reviewed
at all. The Hold text is copied **byte-identical** from the unmerged
`art/run-2026-08-07-queue`, which declares the same thing -- so whichever lands
first, the other merges clean instead of conflicting in the same dict.

## Social serialisation

Everything in this batch is **machine-generated**. `coordination#32` records that
pdoom1 cannot yet emit `origin` metadata that survives to a consumer -- the
sidecars do carry `"origin": "generated"`, but that dies at the PNG boundary, so
a posted image arrives with nothing attached. **Anything posted publicly should
say so plainly, in the post text, because the file cannot say it.**

The study panel now shows `origin: MACHINE-GENERATED (see the sidecar record)`
next to every picture, so the fact is in front of the person choosing what to
post.

**Proposed, not built** (per instructions): a `share set` affordance -- press `S`
to add the selected asset to a set, then export a folder of the largest-under-cap
renders plus a `CREDITS.txt` carrying the model, date and a plain
machine-generated line per image. It is cheap (it reuses the export plumbing
already here) and it makes the disclosure the default rather than something to
remember at posting time. Say the word and it is a small follow-up.

## Run it

```
python tools/art_review/build_full_gallery.py --open
```

Absolute path to the page:
`G:\Documents\Organising_Life\Code\pdoom1\art_generated\full_gallery.html`

Regenerate command (absolute):
`python G:\Documents\Organising_Life\Code\pdoom1\tools\art_review\build_full_gallery.py --open`

The notes brief:
`G:\Documents\Organising_Life\Code\pdoom1\docs\art\NOTES_BRIEF.md`
regenerated with
`python G:\Documents\Organising_Life\Code\pdoom1\tools\art_review\notes_brief.py`

New `--art-root` flag: `art_generated/` is gitignored, so an agent in a worktree
sees the legacy tracked art and none of the current batch. Point it at the real
checkout -- the file-locality trap already recorded in the repo notes.

No art asset was moved, deleted or promoted. `review_state.json` was read only.

Press `?` in the page for the full key list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
