### PR TITLE
fix(leaderboard): a declined player saw NOTHING at game over -- say where the score went

### DIFF
--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -340,7 +340,27 @@ func _continue_consent_flow(flow: String, entry, game_seed: String) -> void:
 		"remind":
 			_show_identity_reminder()
 		_:
-			pass  # "silent": remembered decline, or anonymous + already nudged
+			# "silent" covers TWO different players and they need different screens
+			# (Pip's v0.14.0 playtest, 2026-08-07: three ranked runs in a row showed
+			# nothing at all, and read as a broken leaderboard).
+			#   - REMEMBERED DECLINE: say where the score went and how to change it.
+			#     The decline moment itself already renders this line; every run
+			#     after it rendered a bare `pass`, so the one setting that explains
+			#     the missing board became invisible from the only screen that
+			#     depends on it. Shown, never silent (#1027).
+			#   - ANONYMOUS + ALREADY NUDGED: genuinely stay quiet. The remind-once
+			#     ruling is that one nudge is the whole budget.
+			if GameConfig.leaderboard_consent_asked and not GameConfig.submit_scores_global:
+				_show_local_only_notice()
+
+func _show_local_only_notice() -> void:
+	"""Standing (every-run) restatement of a remembered decline. Same wording as the
+	decline moment in _show_consent_prompt, same grey -- this is a state, not a
+	warning, so it does not borrow the amber that means 'off the record'."""
+	_ensure_sync_status_label()
+	sync_status_label.visible = true
+	sync_status_label.text = "Global leaderboard: OFF -- score saved locally only (turn on in Settings)"
+	sync_status_label.add_theme_color_override("font_color", Color(0.75, 0.75, 0.75))
 
 func _has_submittable_identity() -> bool:
 	"""A submission would be meaningful only with a non-empty player + lab name

--- a/godot/tests/unit/test_game_over_optout_visible.gd
+++ b/godot/tests/unit/test_game_over_optout_visible.gd
@@ -1,0 +1,94 @@
+extends GutTest
+## Regression (Pip's v0.14.0 playtest, 2026-08-07): a RANKED run on a profile that
+## had previously declined the global leaderboard showed the player NOTHING at
+## game over -- no submit, no notice, no error. Three runs, three silent screens,
+## read as "the leaderboard is broken".
+##
+## Measured cause: consent_flow_state(asked=true, opted_in=false, ...) returns
+## "silent", and _continue_consent_flow's default branch was a bare `pass`. The
+## decline moment itself DOES render "Global leaderboard: local only (change in
+## Settings)" -- but every run after it rendered nothing at all, so the setting
+## became invisible and unfindable from the only screen that depends on it.
+##
+## This is the project's signature failure mode (#1027): a score that simply
+## never appears. The score IS saved locally; the screen must say so.
+
+const SCENE_PATH := "res://scenes/ui/game_over_screen.tscn"
+
+var _prev_enabled: bool
+var _prev_base: String
+var _prev_token: String
+var _prev_optin: bool
+var _prev_asked: bool
+var _prev_reminded: bool
+var _prev_scenario: String
+
+func before_each():
+	_prev_enabled = LeaderboardSync.enabled
+	_prev_base = LeaderboardSync.base_url
+	_prev_token = LeaderboardSync.token
+	_prev_optin = GameConfig.submit_scores_global
+	_prev_asked = GameConfig.leaderboard_consent_asked
+	_prev_reminded = GameConfig.leaderboard_reminder_shown
+	_prev_scenario = GameConfig.scenario_id
+	# A RANKED run, stated explicitly (a machine with a scenario or a sticky Alpha
+	# Tools flag would otherwise take the unranked branch for unrelated reasons).
+	GameConfig.scenario_id = ""
+	GameConfig.reset_alpha_tools_flag()
+	LeaderboardSync.enabled = true
+	LeaderboardSync.base_url = "http://127.0.0.1:9"  # refuses fast; never used here
+	LeaderboardSync.token = "test-token"
+
+func after_each():
+	LeaderboardSync.enabled = _prev_enabled
+	LeaderboardSync.base_url = _prev_base
+	LeaderboardSync.token = _prev_token
+	GameConfig.submit_scores_global = _prev_optin
+	GameConfig.leaderboard_consent_asked = _prev_asked
+	GameConfig.leaderboard_reminder_shown = _prev_reminded
+	GameConfig.scenario_id = _prev_scenario
+
+func _defeat_state() -> Dictionary:
+	return {
+		"game_over": true, "victory": false, "turn": 147, "doom": 100.0,
+		"reputation": 0, "money": 5000, "compute": 3.0, "research": 4.0, "papers": 1,
+	}
+
+func _run_to_game_over() -> Control:
+	var screen: Control = (load(SCENE_PATH) as PackedScene).instantiate()
+	add_child_autofree(screen)
+	screen.show_game_over(false, _defeat_state())
+	return screen
+
+func test_remembered_decline_still_tells_the_player_where_the_score_went():
+	# The exact profile state measured in Pip's config.cfg on the failing night:
+	# submit_scores_global=false, consent_asked=true.
+	GameConfig.leaderboard_consent_asked = true
+	GameConfig.submit_scores_global = false
+	assert_eq(LeaderboardSync.consent_flow_state(true, false, true, false), "silent",
+		"precondition: a remembered decline resolves to the silent flow")
+
+	var screen := _run_to_game_over()
+
+	assert_ne(screen.leaderboard_entry_uuid, "",
+		"precondition: the score IS saved locally -- the local board is never gated by consent")
+	var label = screen.sync_status_label
+	assert_true(is_instance_valid(label),
+		"a declined player must still SEE something: silence is indistinguishable from a broken leaderboard")
+	assert_true(label.visible, "the status label must be visible, not merely constructed")
+	assert_string_contains(label.text.to_lower(), "settings",
+		"the notice must point at the setting that turns submission back on")
+
+func test_anonymous_already_nudged_stays_quiet():
+	# The OTHER "silent" case must not become a nag: an anonymous player who has
+	# already had their one gracious nudge is exercising a legitimate choice.
+	GameConfig.leaderboard_consent_asked = false
+	GameConfig.submit_scores_global = false
+	GameConfig.leaderboard_reminder_shown = true
+	GameConfig.player_name = ""
+	GameConfig.lab_name = ""
+
+	var screen := _run_to_game_over()
+
+	assert_false(is_instance_valid(screen.sync_status_label),
+		"remind-once ruling: an already-nudged anonymous player is never nagged again")


### PR DESCRIPTION
Pip's v0.14.0 playtest: three ranked runs in a row (one of 147 turns) ended with no submit, no notice, no error. Read as "the global leaderboard is broken".

## Measured cause (from his config.cfg + session logs, not from reading)

```
submit_scores_global=false
consent_asked=true
-> LeaderboardSync.consent_flow_state(...) == "silent"
-> _continue_consent_flow default branch was a bare `pass`
```

His logs show the local save landing every time -- `[GameOverScreen] Score saved locally - Rank: 3`, board `weekly-2026-w32__L4` -- with no submit line after it. Nothing was broken. The screen just never mentioned the one setting that explains the missing board.

The decline MOMENT already renders "Global leaderboard: local only (change in Settings)". Every run after it rendered nothing. That asymmetry is the bug.

## Change

"silent" covers two different players and now gets two different screens:

- remembered decline -> standing grey notice naming Settings
- anonymous + already nudged -> still quiet (remind-once ruling unchanged)

`consent_flow_state` itself is deliberately untouched. No scoring / replay / determinism surface: this adds one Label to the game-over view.

## Evidence

Guard proven RED first -- `test_game_over_optout_visible.gd` failed on "a declined player must still SEE something" against the unfixed screen (1/2 passing), then green.

Fast gate: **1214 tests, 0 failures, 120/120 files collected.**

## Not fixed here (reported separately)

- `godot/data/patch_notes.json` stops at 0.11.0, which is why v0.14.0 shows "No detailed patch notes available for this version". `public/releases/` also has no `v0.14.0.json`.
- Alpha Tools flag audited in both directions and found CLEAN (details in the investigation report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
