### PR TITLE
fix(leaderboard): the Operator name was collected and never carried anywhere -- two identity fields, and a truncation that stops amputating

### DIFF
--- a/docs/LEADERBOARD_WEBSITE_INTEGRATION.md
+++ b/docs/LEADERBOARD_WEBSITE_INTEGRATION.md
@@ -145,7 +145,7 @@ python scripts/export_leaderboards.py --verbose
 | Field | Type | Description |
 |-------|------|-------------|
 | `score` | int | Turns survived (primary ranking metric) |
-| `player_name` | string | Lab name displayed on leaderboard |
+| `player_name` | string | **Misnamed: this carries the LAB name, not the player's name.** Max 40 BYTES -- the server cuts the rest with a byte-wise `substr` and says nothing. See "Name budget" below. |
 | `date` | ISO datetime | When score was achieved |
 | `level_reached` | int | Final turn number (same as score) |
 | `game_mode` | string | Economic model version |
@@ -158,6 +158,38 @@ python scripts/export_leaderboards.py --verbose
 | `final_compute` | int | Compute resources |
 | `research_papers_published` | int | Papers published during game |
 | `technical_debt_accumulated` | int | Technical debt accrued |
+
+### Name budget: 40 bytes, measured
+
+The limit was **measured, not assumed**. On 2026-08-08 the live
+`(weekly-2026-w32, L4)` board held this row:
+
+```
+"GRIM (Global Risk Intervention Mechanism"    <- 40 bytes, as stored
+"GRIM (Global Risk Intervention Mechanism)"   <- 41 bytes, as submitted
+```
+
+The server ate exactly one byte and gave no signal. The cut is byte-wise, so a
+non-ASCII name can also be split mid-codepoint and stored as invalid UTF-8.
+
+`score_api.php` is deployed server-side and is **not in `pdoom1-website` or any
+repo here**, so the client cannot change the limit. Instead
+`Leaderboard.fit_board_name()` (`godot/scripts/leaderboard.gd`) fits the value
+before submission -- word-boundary cut plus a visible `...` mark -- so the
+server's `substr` never fires.
+
+### Two identity values, one wire field (open)
+
+Pip ruled on 2026-08-08 that the board should carry **both** an Operator (the
+human) and a Lab (the org), because generated lab names collide and one player
+may run several labs over time. The client now models both
+(`ScoreEntry.lab_name` / `ScoreEntry.operator_name`) and persists both locally.
+
+**The wire still carries only the lab.** Adding a second field is a server
+change (schema + API + public rendering) and is routed through coordination, not
+decided in this repo. `ScoreEntry.to_wire_dict()` deliberately omits
+`operator_name` rather than sending an unknown key blind at the risk of a
+rejected POST losing a score.
 
 ---
 

--- a/docs/LEADERBOARD_WEBSITE_INTEGRATION.md
+++ b/docs/LEADERBOARD_WEBSITE_INTEGRATION.md
@@ -145,7 +145,7 @@ python scripts/export_leaderboards.py --verbose
 | Field | Type | Description |
 |-------|------|-------------|
 | `score` | int | Turns survived (primary ranking metric) |
-| `player_name` | string | **Misnamed: this carries the LAB name, not the player's name.** Max 40 BYTES -- the server cuts the rest with a byte-wise `substr` and says nothing. See "Name budget" below. |
+| `player_name` | string | **Misnamed: this carries the LAB name, and since 2026-08-10 the operator too, composed as `Lab -- Operator`.** Max 40 BYTES -- the server cuts the rest with a byte-wise `substr` and says nothing. A cut that splits a codepoint WIPES THE BOARD; see below. |
 | `date` | ISO datetime | When score was achieved |
 | `level_reached` | int | Final turn number (same as score) |
 | `game_mode` | string | Economic model version |
@@ -172,24 +172,95 @@ The limit was **measured, not assumed**. On 2026-08-08 the live
 The server ate exactly one byte and gave no signal. The cut is byte-wise, so a
 non-ASCII name can also be split mid-codepoint and stored as invalid UTF-8.
 
-`score_api.php` is deployed server-side and is **not in `pdoom1-website` or any
-repo here**, so the client cannot change the limit. Instead
+Confirmed again on 2026-08-10 by direct probe of the deployed API on a throwaway
+board: 41 ASCII bytes submitted -> 40 stored; 40 ASCII bytes -> stored untouched.
+The unit is **bytes, not characters**.
+
 `Leaderboard.fit_board_name()` (`godot/scripts/leaderboard.gd`) fits the value
 before submission -- word-boundary cut plus a visible `...` mark -- so the
 server's `substr` never fires.
 
-### Two identity values, one wire field (open)
+### A split codepoint DESTROYS THE BOARD (measured 2026-08-10)
+
+This is the severe one, and it was found by probing rather than reading.
+
+A submission whose byte-wise cut at 40 splits a UTF-8 codepoint **empties the
+entire board file**. Measured on a throwaway board: 7 rows went to 0 rows while
+the server answered
+
+```
+HTTP 200  {"ok":true,"added":true,"rank":7}
+```
+
+Mechanism, visible in `server/leaderboard/score_api.php`: `substr($s, 0, 40)`
+can leave malformed UTF-8; PHP `json_encode()` returns `false` on malformed
+UTF-8; the handler then does `ftruncate($fp, 0)` and writes that `false` as an
+empty string. Every row is gone and the response still says success.
+
+The trigger is **precisely the split**, not merely being non-ASCII: an over-40
+multi-byte name whose cut lands ON a codepoint boundary (21 x 2-byte = 42 bytes)
+was stored normally in the same probe run.
+
+Consequence for this repo: `fit_board_name()` is a **board-integrity guard**, not
+a cosmetic nicety. Any client that submits an unfitted player-typed name can wipe
+a public league board by accident.
+
+`score_api.php` as deployed is not writable from here. **The server-side fix is
+the real fix** -- see the coordination ask below.
+
+### Two identity values, one wire field (shipped 2026-08-10)
 
 Pip ruled on 2026-08-08 that the board should carry **both** an Operator (the
 human) and a Lab (the org), because generated lab names collide and one player
-may run several labs over time. The client now models both
-(`ScoreEntry.lab_name` / `ScoreEntry.operator_name`) and persists both locally.
+may run several labs over time. He restated it on 2026-08-10 after a second real
+external player landed on the live board: *"It'll be good to bump the board to
+include player name or we're going to get a LOT of colliding labs."*
 
-**The wire still carries only the lab.** Adding a second field is a server
-change (schema + API + public rendering) and is routed through coordination, not
-decided in this repo. `ScoreEntry.to_wire_dict()` deliberately omits
-`operator_name` rather than sending an unknown key blind at the risk of a
-rejected POST losing a score.
+**Measured, so no longer a guess:** an unknown extra key on a POST is *accepted*
+(HTTP 200) and then **silently dropped** by the `$ALLOWED_FIELDS` whitelist --
+absent on read-back. Tested with `operator_name` and with a nonsense control key;
+both behaved identically. So the feared rejection does **not** happen, but a
+second key delivers nothing either.
+
+Since a second key is a no-op, both names now travel **composed inside the one
+frozen `player_name` field**, via `Leaderboard.compose_board_name()`:
+
+```
+GRIM -- Pip
+GRIM (Global Risk... -- Pip
+Kaur, Chen & Lindqvist -- Priya
+AI Safety Lab                      <- no operator: byte-identical to before
+```
+
+Format rules, each forced by a real constraint:
+
+- **Lab first.** The rows already on the board hold a bare lab in this column;
+  leading with the operator would change what the column means halfway down.
+- **`--`, not parentheses.** The one real lab name we have,
+  `GRIM (Global Risk Intervention Mechanism)`, already contains brackets, so
+  `LAB (OPERATOR)` would nest them.
+- **Neither half may erase the other.** The operator is capped at half the
+  composable budget; the lab takes the remainder. The operator exists to break
+  lab-name collisions, so it must not be the half that silently vanishes.
+- **No operator -> unchanged output.** Legacy rows and anonymous players submit
+  exactly as they did before: no separator, no empty parenthetical, and no
+  back-filled identity on read (`from_dict` defaults `operator_name` to `""`).
+
+`to_wire_dict()` still omits an `operator_name` **key**, now for a measured
+reason rather than a cautious one: it is dropped, so sending it would put the
+operator on the wire twice and desync the day the server whitelists it.
+
+### Coordination ask (pdoom1-website / API)
+
+Not decided or changed in this repo. In priority order:
+
+1. **Fix the board-wipe.** Guard the write: either cut on a character boundary
+   (`mb_substr($s, 0, 40, 'UTF-8')`) or refuse to overwrite the board when
+   `json_encode()` returns `false`. Today one malformed name destroys a league.
+2. **Whitelist `operator_name`** in `$ALLOWED_FIELDS` and render it as a second
+   column, so the two names stop sharing 40 bytes.
+3. **Raise the 40-byte limit**, and **return the stored value** in the POST
+   response so the client can tell the player what actually landed.
 
 ---
 

--- a/godot/autoload/leaderboard_sync.gd
+++ b/godot/autoload/leaderboard_sync.gd
@@ -225,7 +225,11 @@ func submit_score(entry, seed: String, version: String) -> void:
 		submit_completed.emit(false, false, 0, "")
 		return
 
-	var body := build_post_body(entry.to_dict(), seed, version)
+	# to_WIRE_dict, not to_dict: the wire shape is exactly the frozen server
+	# contract with the lab name pre-fitted to the board's measured byte budget,
+	# so the server's silent substr never fires. to_dict() is the richer LOCAL
+	# shape and carries the operator name, which the server cannot yet take.
+	var body := build_post_body(entry.to_wire_dict(), seed, version)
 	_outbox_add(body)  # persist FIRST -- survives a crash between here and the server ack
 
 	_dispatch_post(body, func(ok: bool, added: bool, rank: int, result: int, code: int):

--- a/godot/scripts/leaderboard.gd
+++ b/godot/scripts/leaderboard.gd
@@ -5,6 +5,54 @@ extends Node
 
 class_name Leaderboard
 
+# --- Remote board name budget (MEASURED, not assumed) -------------------------
+# The remote score API stores at most this many BYTES of a submitted name and
+# cuts the rest with a byte-wise substr. Measured on 2026-08-08 by reading the
+# live (weekly-2026-w32, L4) board: Pip's lab went up as the 41-byte
+# "GRIM (Global Risk Intervention Mechanism)" and came back as the 40-byte
+# "GRIM (Global Risk Intervention Mechanism" -- amputated mid-word, closing
+# bracket eaten, on the public board.
+#
+# BYTES rather than characters on purpose: a byte-wise server cut can also split
+# a multi-byte UTF-8 codepoint and store an invalid string. The client fits the
+# value itself (see fit_board_name) so the server's cut never fires at all.
+#
+# score_api.php lives on the server and is in no repo here, so raising this
+# limit or adding a field is a server change -- routed through coordination,
+# not decided here.
+const BOARD_NAME_MAX_BYTES := 40
+const BOARD_NAME_CUT_MARK := "..."
+
+static func fit_board_name(raw: String) -> String:
+	"""Fit a name inside the remote board's byte budget, LEGIBLY.
+
+	The server cuts at a byte offset and says nothing, which is how
+	"GRIM (Global Risk Intervention Mechanism)" became
+	"GRIM (Global Risk Intervention Mechanism" on the public board -- a name
+	that reads as a typo rather than as a truncation. Three rules:
+
+	  1. a name that fits is returned untouched (a cut mark on an uncut name is
+	     its own small lie);
+	  2. a cut name ends in a visible mark, so the player can SEE it was cut;
+	  3. the cut prefers a word boundary, so whole words are dropped rather than
+	     words being sliced -- unless the boundary is so early that most of the
+	     name would vanish, in which case a hard cut keeps more identity.
+
+	Pure and static: no state, no I/O, unit-tested directly."""
+	if raw.to_utf8_buffer().size() <= BOARD_NAME_MAX_BYTES:
+		return raw
+	var budget: int = BOARD_NAME_MAX_BYTES - BOARD_NAME_CUT_MARK.to_utf8_buffer().size()
+	# Shrink by CHARACTERS while measuring in BYTES, so a multi-byte codepoint is
+	# dropped whole and the result is always valid UTF-8 (the server's byte-wise
+	# substr is exactly what can split one, and this stops it ever running).
+	var cut := raw
+	while cut.length() > 0 and cut.to_utf8_buffer().size() > budget:
+		cut = cut.substr(0, cut.length() - 1)
+	var space := cut.rfind(" ")
+	if space >= int(budget * 0.5):
+		cut = cut.substr(0, space)
+	return cut.strip_edges() + BOARD_NAME_CUT_MARK
+
 # Score entry data structure
 class ScoreEntry:
 	# ADR-0002: the score is the tuple (score, doom_integral) where `score` is
@@ -13,7 +61,13 @@ class ScoreEntry:
 	# the UI, which already treats it as turns.
 	var score: int  # Turns survived (primary metric)
 	var doom_integral: int  # Doom-integral tiebreak (ADR-0002)
-	var player_name: String  # Lab name
+	# TWO identity values, never conflated (Pip's ruling 2026-08-08). Generated
+	# lab names COLLIDE -- that is why the #1133 generator exists at all -- so a
+	# lab name alone cannot identify a person; and one player running several
+	# labs over several months is a feature, which a single conflated field
+	# would destroy permanently.
+	var lab_name: String  # The org the player runs. What the frozen wire key `player_name` has always carried.
+	var operator_name: String  # The human (GameConfig.player_name, "Operator:" in the prompt). Local-only so far.
 	var date: String  # ISO timestamp
 	var level_reached: int  # Final turn number (== score; kept for back-compat)
 	var game_mode: String  # Game version, e.g. "v0.11.0"
@@ -22,10 +76,13 @@ class ScoreEntry:
 	var baseline_score: int  # Baseline (no-action) turns survived for comparison (Issue #372)
 	var baseline_doom_integral: int  # Baseline doom-integral tiebreak
 
-	func _init(p_score: int, p_player_name: String, p_level: int, p_mode: String, p_duration: float, p_baseline: int = 0, p_doom_integral: int = 0, p_baseline_integral: int = 0):
+	# p_operator_name is appended LAST and optional so every existing positional
+	# caller (from_dict, tests, dev tools) keeps working unchanged.
+	func _init(p_score: int, p_lab_name: String, p_level: int, p_mode: String, p_duration: float, p_baseline: int = 0, p_doom_integral: int = 0, p_baseline_integral: int = 0, p_operator_name: String = ""):
 		score = p_score
 		doom_integral = p_doom_integral
-		player_name = p_player_name
+		lab_name = p_lab_name
+		operator_name = p_operator_name
 		date = Time.get_datetime_string_from_system()
 		level_reached = p_level
 		game_mode = p_mode
@@ -35,10 +92,18 @@ class ScoreEntry:
 		baseline_doom_integral = p_baseline_integral
 
 	func to_dict() -> Dictionary:
+		"""LOCAL persistence shape. Carries BOTH names.
+
+		`player_name` stays the key for the lab because every local board file
+		already on disk uses it -- renaming the key would orphan existing rows.
+		The GDScript field is now honestly named; the KEY is the frozen contract.
+		Full, unfitted values: the local board is the complete record, and the
+		remote budget is a remote problem (see to_wire_dict)."""
 		return {
 			"score": score,
 			"doom_integral": doom_integral,
-			"player_name": player_name,
+			"player_name": lab_name,  # frozen key; holds the LAB (see to_wire_dict)
+			"operator_name": operator_name,
 			"date": date,
 			"level_reached": level_reached,
 			"game_mode": game_mode,
@@ -47,6 +112,21 @@ class ScoreEntry:
 			"baseline_score": baseline_score,
 			"baseline_doom_integral": baseline_doom_integral
 		}
+
+	func to_wire_dict() -> Dictionary:
+		"""REMOTE submission shape: exactly the frozen server contract, nothing else.
+
+		Two deliberate differences from to_dict():
+		  1. the lab name is pre-fitted to the board's measured byte budget, so
+		     the server's own substr never fires and never amputates mid-word;
+		  2. `operator_name` is NOT sent. score_api.php is server-side and in no
+		     repo here, so its tolerance for unknown keys is unmeasured -- and a
+		     rejected POST loses a score. Carrying the operator to the server is
+		     a coordination item, not a client change."""
+		var body := to_dict()
+		body["player_name"] = Leaderboard.fit_board_name(lab_name)
+		body.erase("operator_name")
+		return body
 
 	static func from_dict(data: Dictionary) -> ScoreEntry:
 		var entry = ScoreEntry.new(
@@ -57,7 +137,11 @@ class ScoreEntry:
 			data.get("duration_seconds", 0.0),
 			data.get("baseline_score", 0),  # Issue #372
 			data.get("doom_integral", 0),
-			data.get("baseline_doom_integral", 0)
+			data.get("baseline_doom_integral", 0),
+			# Absent on every pre-existing row (local files AND the live board).
+			# Defaults EMPTY on purpose: a legacy row genuinely has no operator,
+			# and back-filling the lab into it would fabricate an identity.
+			data.get("operator_name", "")
 		)
 		entry.date = data.get("date", "")
 		entry.entry_uuid = data.get("entry_uuid", "")
@@ -111,7 +195,7 @@ func add_score(entry: ScoreEntry) -> Dictionary:
 	Add a score to the leaderboard.
 	Returns: {added: bool, rank: int}
 	"""
-	print("Adding score: ", entry.score, " for ", entry.player_name)
+	print("Adding score: ", entry.score, " for ", entry.lab_name)
 
 	# #700: dedupe by entry_uuid, mirroring the remote endpoint (score_api.php
 	# refuses a re-POST with duplicate:true). Without this a re-add appended a
@@ -162,7 +246,7 @@ func rename_entry(uuid: String, new_name: String) -> bool:
 		return false
 	for entry in entries:
 		if entry.entry_uuid == uuid:
-			entry.player_name = name
+			entry.lab_name = name
 			_save_leaderboard()
 			return true
 	return false

--- a/godot/scripts/leaderboard.gd
+++ b/godot/scripts/leaderboard.gd
@@ -23,7 +23,64 @@ class_name Leaderboard
 const BOARD_NAME_MAX_BYTES := 40
 const BOARD_NAME_CUT_MARK := "..."
 
-static func fit_board_name(raw: String) -> String:
+# Separator between the lab and the operator in the single board field. ASCII
+# double-hyphen per the house rule (issue #744), and NOT parentheses: the one
+# real lab name we have -- "GRIM (Global Risk Intervention Mechanism)" --
+# already contains brackets, so "LAB (OPERATOR)" would nest them.
+const BOARD_NAME_SEPARATOR := " -- "
+
+static func compose_board_name(lab: String, operator_name: String) -> String:
+	"""Both names inside the ONE field the server actually stores.
+
+	Measured 2026-08-10 against the deployed API: an unknown extra key is
+	accepted (HTTP 200) and then silently dropped by $ALLOWED_FIELDS. So an
+	`operator_name` key delivers nothing, and the only route to a public board
+	is composition inside `player_name`.
+
+	Format: `LAB -- OPERATOR`. Three reasons, each a real constraint:
+	  1. LAB FIRST, because the rows already on the board hold a bare lab in
+	     this column. Leading with the operator would change what the column
+	     means halfway down the page.
+	  2. `--`, not parentheses. The one real lab name we have,
+	     "GRIM (Global Risk Intervention Mechanism)", already contains
+	     brackets, so `LAB (OPERATOR)` nests them.
+	  3. NEITHER half may erase the other. The operator exists to break lab-name
+	     collisions -- Pip 2026-08-10, "we're going to get a LOT of colliding
+	     labs" -- so it cannot be the half that silently vanishes; and a board
+	     row with no lab is not what the column is for. The operator is capped
+	     at half the composable budget and the lab takes the remainder, so a
+	     long name shortens itself rather than the other one.
+
+	Fitting is CLIENT-SIDE and mandatory, not cosmetic. Measured the same day:
+	a submission whose byte-wise cut at 40 splits a UTF-8 codepoint takes the
+	ENTIRE board to zero rows while the server answers ok:true -- PHP
+	json_encode() returns false on malformed UTF-8, so the board file is
+	truncated and rewritten with nothing. Composition is what first puts
+	PLAYER-TYPED text into that byte-cut field, so this is the guard that keeps
+	an accented operator name from destroying a public board."""
+	var lab_clean := _collapse_separator(lab.strip_edges())
+	var op_clean := _collapse_separator(operator_name.strip_edges())
+	# No operator -> byte-identical to what this client already submits. Every
+	# legacy row and every anonymous player is unaffected.
+	if op_clean == "":
+		return fit_board_name(lab_clean)
+	if lab_clean == "":
+		return fit_board_name(op_clean)
+	var composable: int = BOARD_NAME_MAX_BYTES - BOARD_NAME_SEPARATOR.to_utf8_buffer().size()
+	var op_fitted := fit_board_name(op_clean, int(composable / 2))
+	var lab_fitted := fit_board_name(lab_clean, composable - op_fitted.to_utf8_buffer().size())
+	return lab_fitted + BOARD_NAME_SEPARATOR + op_fitted
+
+static func _collapse_separator(s: String) -> String:
+	"""Keep the separator unambiguous: a name containing ' -- ' would otherwise
+	make the composed string un-splittable back into two names by anyone reading
+	the board."""
+	var out := s
+	while out.contains(BOARD_NAME_SEPARATOR):
+		out = out.replace(BOARD_NAME_SEPARATOR, " - ")
+	return out
+
+static func fit_board_name(raw: String, max_bytes: int = BOARD_NAME_MAX_BYTES) -> String:
 	"""Fit a name inside the remote board's byte budget, LEGIBLY.
 
 	The server cuts at a byte offset and says nothing, which is how
@@ -38,10 +95,20 @@ static func fit_board_name(raw: String) -> String:
 	     words being sliced -- unless the boundary is so early that most of the
 	     name would vanish, in which case a hard cut keeps more identity.
 
+	`max_bytes` defaults to the whole board budget. compose_board_name passes a
+	SHARE of it, so the same fitting rules apply to each half of a composed name.
+
 	Pure and static: no state, no I/O, unit-tested directly."""
-	if raw.to_utf8_buffer().size() <= BOARD_NAME_MAX_BYTES:
+	if raw.to_utf8_buffer().size() <= max_bytes:
 		return raw
-	var budget: int = BOARD_NAME_MAX_BYTES - BOARD_NAME_CUT_MARK.to_utf8_buffer().size()
+	var budget: int = max_bytes - BOARD_NAME_CUT_MARK.to_utf8_buffer().size()
+	if budget <= 0:
+		# No room for even the cut mark. Shrink by CHARACTERS so the result is
+		# still valid UTF-8, and drop the mark rather than return only a mark.
+		var bare := raw
+		while bare.length() > 0 and bare.to_utf8_buffer().size() > max_bytes:
+			bare = bare.substr(0, bare.length() - 1)
+		return bare
 	# Shrink by CHARACTERS while measuring in BYTES, so a multi-byte codepoint is
 	# dropped whole and the result is always valid UTF-8 (the server's byte-wise
 	# substr is exactly what can split one, and this stops it ever running).
@@ -119,12 +186,14 @@ class ScoreEntry:
 		Two deliberate differences from to_dict():
 		  1. the lab name is pre-fitted to the board's measured byte budget, so
 		     the server's own substr never fires and never amputates mid-word;
-		  2. `operator_name` is NOT sent. score_api.php is server-side and in no
-		     repo here, so its tolerance for unknown keys is unmeasured -- and a
-		     rejected POST loses a score. Carrying the operator to the server is
-		     a coordination item, not a client change."""
+		  2. `operator_name` is NOT sent as its own key. MEASURED 2026-08-10
+		     against the deployed API on a throwaway board: an unknown key is
+		     accepted (HTTP 200) and then SILENTLY DROPPED by the server's
+		     $ALLOWED_FIELDS whitelist. Not rejected -- but not stored either,
+		     so a separate key delivers nothing. Until the server whitelists it,
+		     both names travel COMPOSED inside the one frozen field."""
 		var body := to_dict()
-		body["player_name"] = Leaderboard.fit_board_name(lab_name)
+		body["player_name"] = Leaderboard.compose_board_name(lab_name, operator_name)
 		body.erase("operator_name")
 		return body
 

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -28,6 +28,12 @@ static func _hex(c: Color) -> String:
 	used on this screen so a colour can never be spelled two ways."""
 	return c.to_html(false)
 
+# What the identity prompt is allowed to promise. The prompt collects an
+# Operator name AND a Lab name; the remote board's frozen contract carries one
+# string, and it is the lab. Until the server takes both (coordination item),
+# the prompt says which one goes public rather than implying both do.
+const IDENTITY_PROMPT_BOARD_NOTE := "The global board shows your Lab name. Your Operator name is saved with the run on this machine -- one Operator can run many labs, and the board will carry both once the server does."
+
 @onready var panel_container = $CenterContainer/PanelContainer
 @onready var title_label = $CenterContainer/PanelContainer/MarginContainer/VBox/TitleLabel
 @onready var subtitle_label = $CenterContainer/PanelContainer/MarginContainer/VBox/SubtitleLabel
@@ -341,6 +347,11 @@ func _persist_and_submit_score(final_state: Dictionary, game_seed: String) -> vo
 		sync_status_label.add_theme_color_override("font_color", Color(1.0, 0.75, 0.25))
 		return
 	var duration = Time.get_ticks_msec() / 1000.0 - game_start_time
+	# BOTH identity values (Pip's ruling 2026-08-08). Until this, only the lab
+	# was passed -- into a field then named `player_name` -- so #1133 could
+	# collect an Operator name that no code path ever carried anywhere. A player
+	# who typed their name saw it nowhere. The operator reaches the LOCAL board
+	# now; the remote wire still carries the lab alone (see ScoreEntry.to_wire_dict).
 	var entry = Leaderboard.ScoreEntry.new(
 		final_turns,
 		GameConfig.lab_name,
@@ -349,7 +360,8 @@ func _persist_and_submit_score(final_state: Dictionary, game_seed: String) -> vo
 		duration,
 		baseline_turns,  # Baseline turns for comparison (Issue #372); 0 when not ready
 		final_doom_integral,  # ADR-0002 tiebreak
-		baseline_doom_integral
+		baseline_doom_integral,
+		GameConfig.player_name  # the Operator -- the human, distinct from the lab
 	)
 
 	# ---- local save (authoritative: the score must exist locally regardless of network) --
@@ -500,6 +512,16 @@ func _show_default_identity_prompt(entry, game_seed: String, flow: String) -> vo
 	)
 	vbox.add_child(info)
 
+	# HONESTY (2026-08-08): the prompt collects two values and the global board
+	# carries only one of them today. Saying so is the whole point -- a prompt
+	# that implies both appear publicly is lying to the player about what they
+	# just typed.
+	var board_note := Label.new()
+	board_note.text = IDENTITY_PROMPT_BOARD_NOTE
+	board_note.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	board_note.add_theme_color_override("font_color", Color(0.72, 0.72, 0.72))
+	vbox.add_child(board_note)
+
 	var name_row := HBoxContainer.new()
 	var name_label := Label.new()
 	name_label.text = "Operator:"  # nomenclature ruling (#957): the player is the Operator
@@ -562,9 +584,12 @@ func _apply_identity_from_prompt(name_text: String, lab_text: String, entry, gam
 	GameConfig.save_config()
 	print("[GameOverScreen] Identity claimed at default-name prompt: %s -- %s"
 		% [GameConfig.player_name, GameConfig.lab_name])
-	if new_lab != "" and entry != null and "player_name" in entry:
-		# The ScoreEntry's display field carries the LAB name (leaderboard.gd).
-		entry.player_name = new_lab
+	# The claimed OPERATOR name is retrofitted too -- it is stored on the entry
+	# and on the local board, and is the value waiting for the server to carry it.
+	if entry != null and "operator_name" in entry and new_name != "":
+		entry.operator_name = new_name
+	if new_lab != "" and entry != null and "lab_name" in entry:
+		entry.lab_name = new_lab
 		# The LOCAL row was saved before the dialog (rule 2: durable first), under
 		# the old default -- rename it in place so the player can recognise their
 		# run on their own board too. Name-only; rank order untouched.

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -32,7 +32,7 @@ static func _hex(c: Color) -> String:
 # Operator name AND a Lab name; the remote board's frozen contract carries one
 # string, and it is the lab. Until the server takes both (coordination item),
 # the prompt says which one goes public rather than implying both do.
-const IDENTITY_PROMPT_BOARD_NOTE := "The global board shows your Lab name. Your Operator name is saved with the run on this machine -- one Operator can run many labs, and the board will carry both once the server does."
+const IDENTITY_PROMPT_BOARD_NOTE := "The global board shows both, as 'Lab -- Operator'. One Operator can run many labs, and lab names collide, so the Operator name is what tells two identical labs apart. Long names are shortened with '...' to fit the board."
 
 @onready var panel_container = $CenterContainer/PanelContainer
 @onready var title_label = $CenterContainer/PanelContainer/MarginContainer/VBox/TitleLabel

--- a/godot/scripts/ui/leaderboard_screen.gd
+++ b/godot/scripts/ui/leaderboard_screen.gd
@@ -674,7 +674,7 @@ func _create_entry_row(entry, rank: int) -> HBoxContainer:
 	# Player Name
 	var player_label = Label.new()
 	player_label.custom_minimum_size = Vector2(250, 0)
-	player_label.text = entry.player_name
+	player_label.text = entry.lab_name
 	player_label.add_theme_font_size_override("font_size", 14)
 	player_label.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
 	row.add_child(player_label)

--- a/godot/tests/unit/test_default_identity_prompt.gd
+++ b/godot/tests/unit/test_default_identity_prompt.gd
@@ -106,15 +106,15 @@ func test_rename_entry_renames_in_place_name_only():
 	board.add_score(other)
 
 	assert_true(board.rename_entry(entry.entry_uuid, "Paperclip Holdings"))
-	assert_eq(entry.player_name, "Paperclip Holdings")
-	assert_eq(other.player_name, "Rival Lab", "only the targeted row is renamed")
+	assert_eq(entry.lab_name, "Paperclip Holdings")
+	assert_eq(other.lab_name, "Rival Lab", "only the targeted row is renamed")
 	assert_eq(board.get_top_scores(1)[0].entry_uuid, other.entry_uuid,
 		"rename is name-only: rank order untouched")
 
 	# Guards: unknown uuid and empty name are refused.
 	assert_false(board.rename_entry("no-such-uuid", "X"))
 	assert_false(board.rename_entry(entry.entry_uuid, "   "))
-	assert_eq(entry.player_name, "Paperclip Holdings")
+	assert_eq(entry.lab_name, "Paperclip Holdings")
 
 	board.clear()
 	board.free()

--- a/godot/tests/unit/test_leaderboard_identity_fields.gd
+++ b/godot/tests/unit/test_leaderboard_identity_fields.gd
@@ -22,9 +22,28 @@ extends GutTest
 ## a 41-byte submission. pdoom1 cannot change the server, so the client fits the
 ## value deliberately and the server's cut never fires.
 ##
-## What these tests deliberately do NOT assert: that the operator name reaches
-## the SERVER. The wire contract is frozen and server-side (score_api.php is not
-## in any repo here), so sending an unknown key blind is not a tonight change.
+## THIRD defect, measured 2026-08-10 against the DEPLOYED api.pdoom1.com on a
+## throwaway board (never the live one). #1176 stopped short of the wire because
+## the server's tolerance was unmeasured. Measured, it is this:
+##
+##   * the limit is 40 BYTES, not characters. 41 ASCII bytes -> 40 stored;
+##     40 ASCII bytes -> stored untouched.
+##   * an unknown extra key (`operator_name`, and a nonsense control key) is
+##     ACCEPTED with HTTP 200 and then SILENTLY DROPPED -- absent on read-back.
+##     So the feared rejection does not happen, but a separate key delivers
+##     nothing, which is why both names now travel COMPOSED in the one field.
+##   * a name whose byte-wise cut at 40 SPLITS a UTF-8 codepoint DESTROYS THE
+##     WHOLE BOARD. Measured: a 7-row board went to 0 rows while the server
+##     answered {"ok":true,"added":true,"rank":7}. An over-40 multibyte name
+##     whose cut lands ON a codepoint boundary is stored normally, so the
+##     trigger is precisely the split, not merely being non-ASCII.
+##
+## That last one turns fit_board_name from a cosmetic nicety into a board
+## INTEGRITY guard, and it is why composition must fit CLIENT-SIDE: composing
+## puts player-typed text into the byte-cut field for the first time.
+##
+## What these tests still do NOT assert: that a separate `operator_name` KEY
+## reaches the server. Measured to be dropped; that is a coordination ask.
 
 # The exact string sitting on the live public board, byte for byte. If a future
 # change ever reproduces this value the guard fails and names why.
@@ -176,24 +195,25 @@ func test_local_dict_keeps_the_legacy_key_readable():
 # ---- the frozen wire contract ------------------------------------------------
 
 func test_wire_dict_keeps_the_frozen_player_name_key_carrying_the_lab():
-	# score_api.php is server-side and in no repo here; its documented contract
-	# (docs/LEADERBOARD_WEBSITE_INTEGRATION.md:148) defines `player_name` as
-	# "Lab name displayed on leaderboard". Renaming the KEY is a server change.
+	# score_api.php's whitelist is the frozen contract; renaming the KEY is a
+	# server change. The key still leads with the lab, so the column keeps the
+	# same meaning it has on the 10 rows already up there.
 	var entry := Leaderboard.ScoreEntry.new(
 		42, "GRIM", 42, "v0.14.0", 1.0, 0, 100, 0, "Pip")
 	var wire := entry.to_wire_dict()
-	assert_eq(wire.get("player_name"), "GRIM",
-		"the frozen wire key must keep carrying the lab -- the server reads it")
+	assert_true(str(wire.get("player_name")).begins_with("GRIM"),
+		"the frozen wire key must still LEAD with the lab -- the server reads it")
 
 
-func test_wire_dict_does_not_send_the_operator_blind():
-	# Deliberate omission, not an oversight: the server's tolerance for unknown
-	# keys is unmeasured, and a rejected POST loses a score. Sending the operator
-	# is the coordination item, not a tonight change.
+func test_wire_dict_does_not_send_the_operator_as_its_own_key():
+	# Not caution any more: MEASURED. An unknown key round-trips as HTTP 200 and
+	# is then dropped by $ALLOWED_FIELDS, so a separate key delivers nothing.
+	# Sending one anyway would put the operator on the wire TWICE (once composed,
+	# once ignored) and desync the day the server whitelists it.
 	var entry := Leaderboard.ScoreEntry.new(
 		42, "GRIM", 42, "v0.14.0", 1.0, 0, 100, 0, "Pip")
 	assert_false(entry.to_wire_dict().has("operator_name"),
-		"operator_name must not go on the wire until the server is known to take it")
+		"operator_name must not go on the wire as its own key -- measured to be dropped")
 
 
 func test_wire_dict_fits_the_board_limit_so_the_server_never_cuts():
@@ -215,6 +235,182 @@ func test_wire_dict_carries_the_full_contract_fields():
 			"duration_seconds", "entry_uuid", "baseline_score",
 			"doom_integral", "baseline_doom_integral"]:
 		assert_true(wire.has(key), "wire body lost contract field '%s'" % key)
+
+
+# ---- composition: both names, one frozen field -------------------------------
+#
+# The server drops unknown keys (measured), so the only way the operator reaches
+# a public board today is inside `player_name`.
+
+## Reproduce the server's own cut, exactly: PHP substr($s, 0, 40) is BYTE-wise.
+## Returns true when the result is still valid UTF-8 -- i.e. when the submission
+## would NOT wipe the board.
+func _survives_server_substr(name: String) -> bool:
+	var bytes := name.to_utf8_buffer()
+	if bytes.size() <= Leaderboard.BOARD_NAME_MAX_BYTES:
+		return true  # substr is a no-op; nothing to split
+	var cut := bytes.slice(0, Leaderboard.BOARD_NAME_MAX_BYTES)
+	# Validity by BYTE ROUND-TRIP, not by an empty-string check: Godot's
+	# get_string_from_utf8 substitutes replacement characters for a split
+	# codepoint rather than failing, so decoding alone silently "succeeds".
+	# Re-encoding only reproduces the original bytes when they were valid --
+	# and it is exactly malformed bytes that make PHP json_encode() return
+	# false and empty the board file.
+	return cut.get_string_from_utf8().to_utf8_buffer() == cut
+
+
+func test_composed_name_carries_both_names():
+	# The whole point. Pip 2026-08-10: "we're going to get a LOT of colliding
+	# labs" -- the operator is the disambiguator, so it must actually be there.
+	var composed := Leaderboard.compose_board_name("GRIM", "Pip")
+	assert_true(composed.contains("GRIM"), "the lab must appear on the board")
+	assert_true(composed.contains("Pip"), "the operator must appear on the board")
+	assert_true(composed.begins_with("GRIM"),
+		"lab FIRST: the 10 rows already on the board hold a bare lab in this "
+		+ "column, and leading with the operator would change what the column means")
+
+
+func test_composed_name_never_exceeds_the_measured_byte_budget():
+	# RED before the budget split: naive concatenation of a real lab and a real
+	# operator blows straight past 40 bytes and hands the server its substr.
+	var battery := [
+		[LIVE_FULL_LAB, "Pip"],
+		[LIVE_FULL_LAB, "Kaur, Chen & Lindqvist"],
+		["Institute for the Study of Extremely Long Organisational Names", "Pip"],
+		["A".repeat(200), "B".repeat(200)],
+		["GRIM", "Pip"],
+	]
+	for pair in battery:
+		var composed: String = Leaderboard.compose_board_name(pair[0], pair[1])
+		assert_true(composed.to_utf8_buffer().size() <= Leaderboard.BOARD_NAME_MAX_BYTES,
+			"compose_board_name('%s', '%s') = %d bytes, over the measured %d-byte budget"
+				% [pair[0].substr(0, 16), pair[1], composed.to_utf8_buffer().size(),
+					Leaderboard.BOARD_NAME_MAX_BYTES])
+
+
+func test_a_composed_name_can_never_wipe_the_board():
+	# THE measured catastrophe, encoded. On 2026-08-10 a submission whose
+	# byte-wise cut at 40 split a UTF-8 codepoint took a 7-row throwaway board to
+	# 0 rows, while the server answered {"ok":true,"added":true,"rank":7}: PHP
+	# json_encode() returns false on malformed UTF-8, so the board file was
+	# ftruncate(0)'d and then written with nothing.
+	#
+	# Composition is what makes this urgent -- it puts PLAYER-TYPED text into the
+	# byte-cut field for the first time. An accented operator name is not exotic;
+	# the newest real player on the live board is "Kaur, Chen & Lindqvist".
+	var operators := ["Pip", "Bjorn Lindqvist", "Zoe" + char(0x00E9),
+		char(0x00E9).repeat(30), "Chen " + char(0x00FC).repeat(20)]
+	var labs := [LIVE_FULL_LAB, "GRIM", char(0x00E9).repeat(25),
+		"C".repeat(39) + char(0x00E9), "A".repeat(200)]
+	for lab in labs:
+		for op in operators:
+			var composed: String = Leaderboard.compose_board_name(lab, op)
+			assert_true(_survives_server_substr(composed),
+				("compose_board_name would hand the server a name whose byte-wise "
+				+ "cut splits a codepoint -- that WIPES THE WHOLE BOARD (measured). "
+				+ "lab=%d bytes op=%d bytes composed=%d bytes")
+					% [lab.to_utf8_buffer().size(), op.to_utf8_buffer().size(),
+						composed.to_utf8_buffer().size()])
+
+
+func test_the_multibyte_split_really_is_the_wipe_trigger():
+	# Calibrates the helper above against the two measured outcomes, so a future
+	# reader can see the guard is testing the real boundary and not a proxy.
+	# Cut lands ON a codepoint boundary (21 x 2-byte = 42 bytes) -> board survived.
+	assert_true(_survives_server_substr(char(0x00E9).repeat(21)),
+		"an over-40 multibyte name cut on a boundary was stored normally")
+	# Cut lands INSIDE a codepoint (39 ASCII + 1 x 2-byte = 41 bytes) -> board died.
+	assert_false(_survives_server_substr("C".repeat(39) + char(0x00E9)),
+		"the measured wipe case must be recognised as unsafe")
+
+
+func test_neither_name_can_erase_the_other():
+	# A long operator must not swallow the lab, and a long lab must not swallow
+	# the operator -- the operator is the collision-breaker, so it cannot be the
+	# thing that silently vanishes.
+	var composed: String = Leaderboard.compose_board_name(
+		LIVE_FULL_LAB, "Kaur, Chen & Lindqvist")
+	assert_true(composed.begins_with("GRIM"), "the lab must still be recognisable")
+	assert_true(composed.contains(Leaderboard.BOARD_NAME_SEPARATOR),
+		"both halves must still be present, separated")
+	var halves := composed.split(Leaderboard.BOARD_NAME_SEPARATOR)
+	assert_eq(halves.size(), 2, "exactly one separator between the two names")
+	assert_true(halves[0].length() >= 4, "the lab half must not be reduced to nothing")
+	assert_true(halves[1].length() >= 4, "the operator half must not be reduced to nothing")
+
+
+func test_a_name_containing_the_separator_cannot_forge_a_second_name():
+	# Otherwise "Evil -- Pip" as a LAB name composes to "Evil -- Pip -- Someone"
+	# and nobody reading the public board can tell which half is the operator.
+	var composed: String = Leaderboard.compose_board_name("Evil -- Corp", "Pip")
+	assert_eq(composed.split(Leaderboard.BOARD_NAME_SEPARATOR).size(), 2,
+		"exactly one separator may survive into the composed name; got '%s'" % composed)
+	assert_true(composed.ends_with("Pip"), "the real operator is still the last half")
+
+
+func test_a_cut_half_is_legibly_cut():
+	# Same rule as fit_board_name: an amputation that reads as a typo is the
+	# defect. If a half had to be shortened, it says so.
+	var composed: String = Leaderboard.compose_board_name(LIVE_FULL_LAB, "Pip")
+	assert_true(composed.contains(Leaderboard.BOARD_NAME_CUT_MARK),
+		"a lab that had to be shortened must show the '%s' mark, not be amputated"
+			% Leaderboard.BOARD_NAME_CUT_MARK)
+	assert_false(composed.contains(LIVE_AMPUTATED),
+		"must never reproduce the live mid-word amputation")
+
+
+func test_no_operator_composes_to_exactly_todays_behaviour():
+	# DEGRADE-SAFELY guard. Every one of the 10 rows already on the board, and
+	# every player who never typed a name, must be byte-identical to before --
+	# no separator, no empty parenthetical, no fabricated identity.
+	for lab in ["GRIM", "AI Safety Lab", LIVE_FULL_LAB, "", "   "]:
+		var composed: String = Leaderboard.compose_board_name(lab, "")
+		assert_eq(composed, Leaderboard.fit_board_name(lab.strip_edges()),
+			"a lab with no operator must submit exactly as it does today")
+		assert_false(composed.contains(Leaderboard.BOARD_NAME_SEPARATOR),
+			"'%s' has no operator -- it must not grow a dangling separator" % lab)
+
+
+func test_a_legacy_row_read_back_is_never_given_a_fabricated_operator():
+	# The other half of degrading safely: reading. A row on the board today holds
+	# a bare lab under `player_name`. Round-tripping it must not invent a human.
+	var legacy := {"score": 44, "player_name": "Kaur, Chen & Lindqvist",
+		"level_reached": 44, "duration_seconds": 1546.0}
+	var back := Leaderboard.ScoreEntry.from_dict(legacy)
+	assert_eq(back.operator_name, "", "a legacy row has no operator, and stays that way")
+	assert_eq(back.to_wire_dict().get("player_name"), "Kaur, Chen & Lindqvist",
+		"re-submitting a legacy row must not mutate the name it already has")
+
+
+# ---- what a rejected POST does to the score ----------------------------------
+
+func test_a_rejected_post_keeps_the_score_in_the_outbox():
+	# Measured question 3. leaderboard_sync writes the body to the outbox BEFORE
+	# dispatch and removes it ONLY on ok (RESULT_SUCCESS + HTTP 200 + ok:true),
+	# so a 4xx retains the score and the next launch retries it. Proving the
+	# retention primitive: a remove for a DIFFERENT uuid -- which is what a
+	# non-ack looks like, since remove is simply never called -- keeps the row.
+	var sync = load("res://autoload/leaderboard_sync.gd").new()
+	sync._write_outbox([])
+	sync._outbox_add({"entry_uuid": "kept-me", "score": 44, "player_name": "GRIM -- Pip"})
+	sync._outbox_remove("some-other-uuid")
+	var queued: Array = sync._read_outbox()
+	assert_eq(queued.size(), 1, "a score the server never acked must stay queued")
+	assert_eq(str(queued[0].get("entry_uuid", "")), "kept-me",
+		"the unacked score, not some other one, is what survives")
+	sync._write_outbox([])
+	sync.free()
+
+
+func test_every_failure_message_says_the_score_was_kept():
+	# The player-facing half of the same property: no rejection may read as
+	# "my run was lost", because it never is.
+	var LS = load("res://autoload/leaderboard_sync.gd")
+	for code in [400, 401, 403, 404, 413, 429, 500, 503]:
+		var msg: String = LS.submit_status_message(
+			false, 0, HTTPRequest.RESULT_SUCCESS, code)
+		assert_true(msg.contains("saved locally"),
+			"HTTP %d must still tell the player the score is kept; got '%s'" % [code, msg])
 
 
 # ---- the real call site ------------------------------------------------------
@@ -242,6 +438,12 @@ func test_identity_prompt_is_honest_about_what_reaches_the_board():
 		"IDENTITY_PROMPT_BOARD_NOTE", "")
 	assert_true(note.contains("Lab"), "the note must name the Lab name")
 	assert_true(note.contains("Operator"), "the note must name the Operator name")
+	# The note used to say the Operator name was "saved with the run on this
+	# machine". Now that the wire composes both, that sentence would be a
+	# PRIVACY misstatement: it would tell a player a name stays local while the
+	# client publishes it. Understating what is shared is not a safe default.
+	assert_false(note.contains("on this machine"),
+		"the note must not still claim the Operator name stays local -- it is published now")
 	for i in note.length():
 		assert_true(note.unicode_at(i) < 128,
 			"player-facing string must be ASCII-only (house rule, issue #744)")

--- a/godot/tests/unit/test_leaderboard_identity_fields.gd
+++ b/godot/tests/unit/test_leaderboard_identity_fields.gd
@@ -1,0 +1,258 @@
+extends GutTest
+## Leaderboard identity: the operator and the lab are TWO values, not one.
+##
+## The defect (Pip, playing the shipped build 2026-08-07): "we still haven't
+## solved player names on the leaderboard?" -- game_over_screen.gd built the
+## submitted entry as
+##     Leaderboard.ScoreEntry.new(final_turns, GameConfig.lab_name, ...)
+## where the receiving field was named `player_name`. GameConfig has carried a
+## real `player_name` since #1133 and the game-over identity prompt collects it
+## under the label "Operator:", but no code path ever moved it toward the board.
+## A player who typed their name saw it nowhere.
+##
+## Pip's ruling (2026-08-08) is BOTH, as separate values, with his reasoning:
+## generated lab names COLLIDE (that is why #1133 exists), so a lab name alone
+## cannot identify a person; and one player running several labs over several
+## months is a feature, so a single conflated field destroys that permanently.
+##
+## Second measured defect: the remote board stores 40 bytes and cuts the rest.
+## The live (weekly-2026-w32, L4) board holds Pip's lab as
+##     "GRIM (Global Risk Intervention Mechanism"
+## -- exactly 40 bytes, amputated mid-word with the closing bracket eaten, from
+## a 41-byte submission. pdoom1 cannot change the server, so the client fits the
+## value deliberately and the server's cut never fires.
+##
+## What these tests deliberately do NOT assert: that the operator name reaches
+## the SERVER. The wire contract is frozen and server-side (score_api.php is not
+## in any repo here), so sending an unknown key blind is not a tonight change.
+
+# The exact string sitting on the live public board, byte for byte. If a future
+# change ever reproduces this value the guard fails and names why.
+const LIVE_AMPUTATED := "GRIM (Global Risk Intervention Mechanism"
+const LIVE_FULL_LAB := "GRIM (Global Risk Intervention Mechanism)"
+
+const GAME_OVER_SRC := "res://scripts/ui/game_over_screen.gd"
+
+
+func _read(path: String) -> String:
+	var f := FileAccess.open(path, FileAccess.READ)
+	assert_not_null(f, "cannot open %s" % path)
+	if f == null:
+		return ""
+	var text := f.get_as_text()
+	f.close()
+	return text
+
+
+# ---- the measured truncation limit ------------------------------------------
+
+func test_measured_limit_matches_the_live_board():
+	# Provenance of the number: measured off the live board on 2026-08-08, not
+	# taken on trust. 41 bytes submitted, 40 bytes stored.
+	assert_eq(LIVE_AMPUTATED.to_utf8_buffer().size(), 40,
+		"the live amputated row is 40 bytes -- that IS the limit")
+	assert_eq(LIVE_FULL_LAB.to_utf8_buffer().size(), 41,
+		"the submission was 41 bytes; the server ate exactly one")
+	assert_eq(Leaderboard.BOARD_NAME_MAX_BYTES, 40,
+		"the client must encode the MEASURED limit, not an assumed one")
+
+
+func test_fit_board_name_never_exceeds_the_limit():
+	# Bytes, not characters: the server's cut is byte-wise, so a byte-wise cut is
+	# what the client must stay inside. A character-wise budget would still
+	# overflow on any non-ASCII name and hand the server a split codepoint.
+	var battery := [
+		LIVE_FULL_LAB,
+		"A".repeat(200),
+		"word ".repeat(40),
+		"Institute for the Study of Extremely Long Organisational Names",
+	]
+	for raw in battery:
+		var fitted: String = Leaderboard.fit_board_name(raw)
+		assert_true(fitted.to_utf8_buffer().size() <= Leaderboard.BOARD_NAME_MAX_BYTES,
+			"fit_board_name('%s...') returned %d bytes, over the %d-byte board limit"
+				% [raw.substr(0, 20), fitted.to_utf8_buffer().size(), Leaderboard.BOARD_NAME_MAX_BYTES])
+
+
+func test_fit_board_name_passes_short_names_through_untouched():
+	# The common case must be lossless and unmarked -- a cut mark on a name that
+	# was never cut is its own lie.
+	for raw in ["GRIM", "Pip", "AI Safety Lab", ""]:
+		assert_eq(Leaderboard.fit_board_name(raw), raw,
+			"'%s' fits and must pass through unchanged" % raw)
+
+
+func test_the_live_amputation_is_never_reproduced():
+	# The real defect, named: this exact output is what is on the public board.
+	var fitted: String = Leaderboard.fit_board_name(LIVE_FULL_LAB)
+	assert_ne(fitted, LIVE_AMPUTATED,
+		"fit_board_name reproduced the live mid-word amputation")
+	assert_true(fitted.ends_with(Leaderboard.BOARD_NAME_CUT_MARK),
+		"a cut name must be LEGIBLY cut (ends with '%s'), not silently amputated"
+			% Leaderboard.BOARD_NAME_CUT_MARK)
+	assert_false(fitted.begins_with(LIVE_AMPUTATED),
+		"the fitted name must not merely re-mark the same mid-word cut")
+
+
+func test_cut_names_break_on_a_word_boundary_when_one_is_available():
+	var fitted: String = Leaderboard.fit_board_name(LIVE_FULL_LAB)
+	# "Mechanism)" is dropped whole rather than sliced into "Mechani".
+	assert_eq(fitted, "GRIM (Global Risk Intervention...",
+		"a name with spaces must cut at a space, not through a word")
+
+
+func test_a_single_unbroken_word_still_gets_cut_rather_than_dropped():
+	# Boundary: no space to break on. Dropping to empty would lose the identity
+	# entirely, so a hard cut with the mark is correct here.
+	var fitted: String = Leaderboard.fit_board_name("A".repeat(200))
+	assert_true(fitted.to_utf8_buffer().size() <= Leaderboard.BOARD_NAME_MAX_BYTES)
+	assert_true(fitted.length() > 10, "an unbroken word must survive, not vanish")
+	assert_true(fitted.ends_with(Leaderboard.BOARD_NAME_CUT_MARK))
+
+
+func test_fit_board_name_is_ascii_safe_on_multibyte_input():
+	# A player typing an accented name is the case where a byte-wise server cut
+	# produces an INVALID string. The client must never hand the server one.
+	var raw := "Fondation de Recherche en Securite Avancee de l'Intelligence"
+	var fitted: String = Leaderboard.fit_board_name(raw)
+	assert_true(fitted.to_utf8_buffer().size() <= Leaderboard.BOARD_NAME_MAX_BYTES)
+	# Round-trips through UTF-8 without corruption.
+	assert_eq(fitted.to_utf8_buffer().get_string_from_utf8(), fitted,
+		"fitted name must be valid UTF-8")
+
+
+# ---- the two fields ----------------------------------------------------------
+
+func test_score_entry_carries_operator_and_lab_separately():
+	# The core of Pip's ruling: two values, never conflated.
+	var entry := Leaderboard.ScoreEntry.new(
+		42, "GRIM", 42, "v0.14.0", 1.0, 0, 100, 0, "Pip")
+	assert_eq(entry.lab_name, "GRIM", "the lab slot holds the lab")
+	assert_eq(entry.operator_name, "Pip", "the operator slot holds the human")
+
+
+func test_operator_name_defaults_empty_and_never_borrows_the_lab():
+	# Silent-wrongness guard: an absent operator must read as absent, not quietly
+	# inherit the lab name and look like a claimed identity.
+	var entry := Leaderboard.ScoreEntry.new(42, "GRIM", 42, "v0.14.0", 1.0)
+	assert_eq(entry.operator_name, "",
+		"a missing operator name must stay empty, never fall back to the lab")
+
+
+func test_the_field_name_and_its_contents_agree():
+	# The defect in schema form. leaderboard.gd carried
+	#     var player_name: String  # Lab name
+	# -- a field whose own comment admitted it was misnamed, feeding a public
+	# column of the same wrong name.
+	var entry := Leaderboard.ScoreEntry.new(42, "GRIM", 42, "v0.14.0", 1.0, 0, 0, 0, "Pip")
+	assert_false("player_name" in entry,
+		"ScoreEntry must not expose a `player_name` field that holds a lab name")
+
+
+# ---- local persistence carries both ------------------------------------------
+
+func test_local_dict_round_trips_both_names():
+	var entry := Leaderboard.ScoreEntry.new(
+		42, "GRIM", 42, "v0.14.0", 1.0, 0, 100, 0, "Pip")
+	var back := Leaderboard.ScoreEntry.from_dict(entry.to_dict())
+	assert_eq(back.lab_name, "GRIM", "lab survives the local round trip")
+	assert_eq(back.operator_name, "Pip", "operator survives the local round trip")
+
+
+func test_local_dict_keeps_the_legacy_key_readable():
+	# Every local board file already on disk, and every row already on the live
+	# board, stores the lab under the key `player_name`. Reading must keep
+	# working, and such a row must present as lab-only -- NOT as an operator.
+	var legacy := {
+		"score": 12, "player_name": "GRIM", "level_reached": 12,
+		"game_mode": "v0.13.2", "duration_seconds": 5.0,
+	}
+	var back := Leaderboard.ScoreEntry.from_dict(legacy)
+	assert_eq(back.lab_name, "GRIM", "a legacy `player_name` value IS a lab name")
+	assert_eq(back.operator_name, "",
+		"a legacy row has no operator; inventing one would fabricate identity")
+
+
+# ---- the frozen wire contract ------------------------------------------------
+
+func test_wire_dict_keeps_the_frozen_player_name_key_carrying_the_lab():
+	# score_api.php is server-side and in no repo here; its documented contract
+	# (docs/LEADERBOARD_WEBSITE_INTEGRATION.md:148) defines `player_name` as
+	# "Lab name displayed on leaderboard". Renaming the KEY is a server change.
+	var entry := Leaderboard.ScoreEntry.new(
+		42, "GRIM", 42, "v0.14.0", 1.0, 0, 100, 0, "Pip")
+	var wire := entry.to_wire_dict()
+	assert_eq(wire.get("player_name"), "GRIM",
+		"the frozen wire key must keep carrying the lab -- the server reads it")
+
+
+func test_wire_dict_does_not_send_the_operator_blind():
+	# Deliberate omission, not an oversight: the server's tolerance for unknown
+	# keys is unmeasured, and a rejected POST loses a score. Sending the operator
+	# is the coordination item, not a tonight change.
+	var entry := Leaderboard.ScoreEntry.new(
+		42, "GRIM", 42, "v0.14.0", 1.0, 0, 100, 0, "Pip")
+	assert_false(entry.to_wire_dict().has("operator_name"),
+		"operator_name must not go on the wire until the server is known to take it")
+
+
+func test_wire_dict_fits_the_board_limit_so_the_server_never_cuts():
+	var entry := Leaderboard.ScoreEntry.new(
+		42, LIVE_FULL_LAB, 42, "v0.14.0", 1.0, 0, 100, 0, "Pip")
+	var wire := entry.to_wire_dict()
+	var sent := str(wire.get("player_name"))
+	assert_true(sent.to_utf8_buffer().size() <= Leaderboard.BOARD_NAME_MAX_BYTES,
+		"the wire value must already fit, so the server's substr never fires")
+	assert_ne(sent, LIVE_AMPUTATED, "must not hand the server the amputated form")
+
+
+func test_wire_dict_carries_the_full_contract_fields():
+	# Fitting the name must not have dropped anything else the server reads.
+	var entry := Leaderboard.ScoreEntry.new(
+		42, "GRIM", 42, "v0.14.0", 1.0, 7, 100, 9, "Pip")
+	var wire := entry.to_wire_dict()
+	for key in ["score", "player_name", "date", "level_reached", "game_mode",
+			"duration_seconds", "entry_uuid", "baseline_score",
+			"doom_integral", "baseline_doom_integral"]:
+		assert_true(wire.has(key), "wire body lost contract field '%s'" % key)
+
+
+# ---- the real call site ------------------------------------------------------
+
+func test_game_over_screen_submits_the_operator_name_too():
+	# Names the defect site directly: game_over_screen.gd:280 passed only
+	# GameConfig.lab_name into an entry whose identity slot was `player_name`.
+	var src := _read(GAME_OVER_SRC)
+	var idx := src.find("ScoreEntry.new(")
+	assert_true(idx >= 0, "could not find the submission site in game_over_screen.gd")
+	var call_block := src.substr(idx, 500)
+	assert_true(call_block.contains("GameConfig.lab_name"),
+		"the submission must still carry the lab name")
+	assert_true(call_block.contains("GameConfig.player_name"),
+		"game_over_screen must pass the OPERATOR name into the entry -- #1133 collects it and nothing carried it")
+
+
+func test_identity_prompt_is_honest_about_what_reaches_the_board():
+	# The prompt collects "Operator:" and "Lab:". Until the wire carries both,
+	# a prompt that implies both appear publicly is lying to the player.
+	var src := _read(GAME_OVER_SRC)
+	assert_true(src.contains("IDENTITY_PROMPT_BOARD_NOTE"),
+		"the identity prompt must state which of the two values the board shows today")
+	var note: String = load(GAME_OVER_SRC).get_script_constant_map().get(
+		"IDENTITY_PROMPT_BOARD_NOTE", "")
+	assert_true(note.contains("Lab"), "the note must name the Lab name")
+	assert_true(note.contains("Operator"), "the note must name the Operator name")
+	for i in note.length():
+		assert_true(note.unicode_at(i) < 128,
+			"player-facing string must be ASCII-only (house rule, issue #744)")
+
+
+func test_prompt_retrofit_applies_both_names_to_the_pending_entry():
+	# _apply_identity_from_prompt retrofitted only the lab onto the entry, so a
+	# name claimed at the prompt could never reach the entry at all.
+	var src := _read(GAME_OVER_SRC)
+	var idx := src.find("func _apply_identity_from_prompt")
+	assert_true(idx >= 0, "could not find _apply_identity_from_prompt")
+	var body := src.substr(idx, 1200)
+	assert_true(body.contains("operator_name"),
+		"the claimed operator name must be retrofitted onto the pending entry")

--- a/godot/tests/unit/test_leaderboard_identity_fields.gd.uid
+++ b/godot/tests/unit/test_leaderboard_identity_fields.gd.uid
@@ -1,0 +1,1 @@
+uid://brjtaujg8pkin

--- a/godot/tests/unit/test_leaderboard_sync.gd
+++ b/godot/tests/unit/test_leaderboard_sync.gd
@@ -103,7 +103,7 @@ func test_parse_board_entries_ok():
 	assert_eq(entries.size(), 2, "both entries parsed")
 	# ScoreEntry-shaped: property access is what leaderboard_screen relies on.
 	assert_eq(entries[0].score, 99)
-	assert_eq(entries[0].player_name, "Alpha")
+	assert_eq(entries[0].lab_name, "Alpha")
 	assert_eq(entries[0].baseline_score, 40)
 	assert_eq(entries[0].entry_uuid, "u1")
 	assert_eq(entries[1].score, 88)


### PR DESCRIPTION
Branched from `fix/leaderboard-visibility-set` (PR #1173, still open at time of writing), not from `main`.

## What the board displays today vs what is collected

Measured against the live `(weekly-2026-w32, L4)` board on 2026-08-08, not assumed:

| | Collected by the game | Reaches the board |
|---|---|---|
| Operator name (`GameConfig.player_name`, default `"Researcher"`) | Yes -- persisted, loaded, settable, and asked for by the #1133 prompt under the label `Operator:` | **No. Nowhere. No code path ever moved it.** |
| Lab name (`GameConfig.lab_name`) | Yes, with a generator and a Reroll button | Yes -- in a field named `player_name` |

The receiving field declared itself:

```gdscript
var player_name: String  # Lab name
```

A field whose own comment admitted it was misnamed, feeding a public column of the same wrong name. That is the silent-wrongness pattern in a schema, and the website renders that column.

`docs/LEADERBOARD_WEBSITE_INTEGRATION.md:148` documented the same thing as if it were fine: `` `player_name` | string | Lab name displayed on leaderboard ``.

## The truncation limit: 40 bytes, measured

I did not trust the figure of 40. I fetched the live board and measured it:

```
GET https://api.pdoom1.com/score_api.php?seed=weekly-2026-w32&version=L4&limit=50

'GRIM (Global Risk Intervention Mechanism'  len=40   <- Pip, amputated
'GRIM'                                      len=4
'GRIM'                                      len=4
''                                          len=0
''                                          len=0
```

Submitted `"GRIM (Global Risk Intervention Mechanism)"` = 41 bytes. Stored = 40. **The server ate exactly one byte, silently.** The limit is 40, confirmed by the boundary rather than by the doc.

Two things that measurement adds beyond the number:

- The cut is **byte-wise**. A non-ASCII name (a player typing an accented name) can be split mid-codepoint and stored as invalid UTF-8. Fitting client-side prevents that too.
- **Two of the five live rows have an EMPTY name.** `_has_submittable_identity()` requires both fields non-empty, so those rows did not come through the current consent path. I have not chased this; flagging it as unexplained, not fixed.

`score_api.php` is deployed server-side and is **not in `pdoom1-website` or any repo on this machine** (I checked). The only truncation code in that repo is `bug-submit.php`, unrelated. So the limit cannot be raised from here.

## The decision, and what I did with it

Pip ruled mid-task, so this PR builds the answer rather than a card:

> "can we submit both? players will collide on lab names and player names are also cool because then a player can have different labs?"

**BOTH, as separate values.** Lab names collide -- that is *why* the #1133 generator exists -- so a lab alone cannot identify a person; and one Operator running several labs over several months is a feature that a single conflated field would destroy permanently.

He also said *"I'm not asking for it now it just feels silly"* -- naming the absurdity, not setting a deadline. So this PR stops short of anything that migrates live data or needs a server change.

## What is implemented

1. **The field name and its contents now agree.** `ScoreEntry.player_name` -> `ScoreEntry.lab_name`, plus a new `ScoreEntry.operator_name`. The old name is **gone, not repurposed** -- a stale reader errors loudly instead of silently returning the wrong name. Two pre-existing tests broke on exactly that, which is the property working rather than a regression.

   The JSON **key** stays `player_name`, because every local board file on disk and every row on the live board uses it. The GDScript field is honest; the wire key is the frozen contract, now documented as misnamed.

2. **Truncation is legible and client-side.** `Leaderboard.fit_board_name()` -- pure, static, unit-tested -- fits to the measured 40-byte budget, cutting on a word boundary and marking the cut with ASCII `...`. Applied in `to_wire_dict()`, so the server's `substr` never fires.

   Pip's lab now goes up as `GRIM (Global Risk Intervention...` instead of `GRIM (Global Risk Intervention Mechanism`.

   A name that fits passes through untouched -- a cut mark on an uncut name is its own small lie.

3. **The prompt no longer overpromises.** `IDENTITY_PROMPT_BOARD_NOTE` states that the global board shows the Lab name and the Operator name is saved with the run locally. The prompt was collecting two values while one of them went nowhere.

4. **Local/remote split made explicit.** `to_dict()` = the full local record (both names). `to_wire_dict()` = exactly the frozen server contract, name pre-fitted, `operator_name` **deliberately omitted**.

## What I deliberately did NOT do

- **Did not send `operator_name` on the wire.** The server's tolerance for unknown keys is unmeasured and a rejected POST loses a score. Sending it blind at 01:00 against a live public board is the wrong trade.
- **Did not touch a single row on the live board.**
- **Did not render both names on the leaderboard screen.** Remote rows will never carry an operator until the server does, so the screen would render a ragged mix.
- No `version.txt` / `ladder_version.txt` / tag change. Ladder stays L4; the board key does not move. Nothing here touches RNG, economy or replay determinism.

## What happens to the rows already on the live board

`from_dict` defaults `operator_name` to `""` for any row lacking it -- which is every row that exists today, local and remote.

- Existing rows present as **lab-only, rendered honestly**. No backfill.
- Backfilling the lab into the operator field would **fabricate an identity** -- asserting that a human is named "GRIM". There is a test asserting it does not happen.
- Pip's amputated row stays amputated. Fixing it is a server-side edit; only future submissions are fitted.

## Open, for coordination (pdoom1-website / API territory)

1. **Add a second identity field to the score API** (schema + endpoint + public rendering) so the Operator name can be carried. This PR has the client value sitting ready.
2. **Either raise the 40-byte limit or make the server's cut legible**, and return the stored value so the client can tell the player what actually landed. The client now fits to 40 regardless.
3. **Why do two live rows have empty names?** Unexplained.

Written up in `docs/LEADERBOARD_WEBSITE_INTEGRATION.md` so it survives this PR.

## Red/green proof

Every guard proven to fail first, against the real defect behaviour -- not merely against a missing symbol.

The compile-level red (API absent) was real but weak, so I staged the seam with `fit_board_name` **deliberately reproducing the server's own `substr`**, making the guards fail behaviourally with counts:

| | Tests | Failures |
|---|---|---|
| Baseline, before any change | 1233 | 0 |
| **RED** -- guards vs. defect behaviour | 1252 | **9** |
| **GREEN** -- after the fix | 1252 | **0** |

The 9 red, named:

- `test_the_live_amputation_is_never_reproduced` -- reproduced the exact live public string
- `test_cut_names_break_on_a_word_boundary_when_one_is_available`
- `test_a_single_unbroken_word_still_gets_cut_rather_than_dropped`
- `test_wire_dict_fits_the_board_limit_so_the_server_never_cuts`
- `test_game_over_screen_submits_the_operator_name_too` -- names the defect site, `game_over_screen.gd`
- `test_identity_prompt_is_honest_about_what_reaches_the_board`
- `test_prompt_retrofit_applies_both_names_to_the_pending_entry`
- `test_rename_entry_renames_in_place_name_only` (pre-existing, red on the rename)
- `test_parse_board_entries_ok` (pre-existing, red on the rename)

The last two are the rename proving itself total.

Fast gate: `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> 1252 tests, 0 fail, 125/125 files collected. Simulation tier not run: nothing here touches simulation, economy or replay.

## Containment

Every Godot invocation ran under `APPDATA=C:/Users/Pip/AppData/Local/Temp/claude/godot-iso-identity`, proven before any test run:

```
USER_DATA_DIR=C:/Users/Pip/AppData/Local/Temp/claude/godot-iso-identity/Godot/app_userdata/P(Doom)
```

Nothing under Pip's Roaming profile was read or written.

---

Generated with [Claude Code](https://claude.com/claude-code)

---

Ladder-Impact: none -- identity/display-name change only (lab+operator composition, byte-fit for the board field); no RNG, score, doom_integral, or replay-determinism code touched.
