### PR TITLE
ci(release-reminder): grant issues:write -- the workflow had no permissions block at all (closes #1174)

### DIFF
--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -7,6 +7,18 @@ on:
     tags:
       - 'v*.*.*'
 
+# PERMISSIONS ARE REQUIRED AND WERE ABSENT UNTIL 2026-08-08.
+# Without `issues: write` the checklist step 403s with
+# "Resource not accessible by integration", the job goes RED, and the red is
+# unrelated to the release it appears to gate. On v0.14.0 the release itself was
+# clean -- all three platform zips at first pass, board taking live scores within
+# the half hour -- and the run list still showed a failed check on the tag.
+# A gate that reds on something it does not gate trains the reader to discount
+# reds, which is how a real one gets waved through.
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   release-checklist:
     runs-on: ubuntu-latest

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -66,6 +66,22 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | validate_historical_data.py | -- | Historical Data Validation Script | make; ci:data-validation.yml; ci:enhanced-release.yml |
 | verify_release_urls.py | -- | Verify release-feed download URLs actually resolve. | ci:enhanced-release.yml; tool:generate_release_metadata.py |
 
+## `scripts/lib/scores/`
+
+| Tool | Layer | Purpose | Invoked by |
+|---|---|---|---|
+| enhanced_leaderboard.py | -- | Enhanced Leaderboard Manager for P(Doom) v0.4.1+ | NONE FOUND |
+| local_store.py | -- | Local leaderboard storage for PDoom1. | NONE FOUND |
+
+## `scripts/lib/services/`
+
+| Tool | Layer | Purpose | Invoked by |
+|---|---|---|---|
+| data_paths.py | -- | Cross-platform data directory management for PDoom1. | NONE FOUND |
+| deterministic_rng.py | -- | Deterministic RNG System for P(Doom): Reproducible Strategic Gameplay | NONE FOUND |
+| leaderboard.py | -- | Privacy-Respecting Leaderboard Foundation for P(Doom) | NONE FOUND |
+| version.py | -- | Version management for P(Doom): Bureaucracy Strategy Game | NONE FOUND |
+
 ## `tools/`
 
 | Tool | Layer | Purpose | Invoked by |
@@ -163,10 +179,16 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 
 ## UNKNOWN -- no declaration, no usage hint, no discoverable caller
 
-11 tool(s) that nothing declares, documents, or calls. Each one is either
+17 tool(s) that nothing declares, documents, or calls. Each one is either
 a rot candidate or an undocumented dependency -- find out which (`tools/find_dead_code.py` lane).
 
 - `scripts/ascii_compliance_fixer.py`
+- `scripts/lib/scores/enhanced_leaderboard.py`
+- `scripts/lib/scores/local_store.py`
+- `scripts/lib/services/data_paths.py`
+- `scripts/lib/services/deterministic_rng.py`
+- `scripts/lib/services/leaderboard.py`
+- `scripts/lib/services/version.py`
 - `scripts/logging_system.py`
 - `scripts/monitor-sync.py`
 - `scripts/repo-status.py`
@@ -209,4 +231,4 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 
 23 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
 
-Total: 112 active tools (9 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 91 undeclared); 11 in UNKNOWN; 6 archived.
+Total: 118 active tools (9 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 97 undeclared); 17 in UNKNOWN; 6 archived.


### PR DESCRIPTION
**Two files, one of them not by choice.**

## `release-reminder.yml` — the fix

Measured on the `v0.14.0` tag: `403 Resource not accessible by integration` on `POST /issues`. The workflow declared **no `permissions:` key at all**.

The release itself was clean — three platform zips at first pass, `Pre-Release Checks` green, L4 board taking live scores inside half an hour — and the run list still showed a red X on the tag. That is `5g` in its other polarity: **a gate that reds on something it does not gate teaches you to discount reds.** Filed as #1174.

## `docs/TOOLS.md` — regenerated, and it is a finding

**The tools-index pre-commit hook refused this commit**, because `docs/TOOLS.md` was **already stale on `main`** — 24 lines missing, covering `scripts/lib/scores/` and `scripts/lib/services/`. That staleness predates this change and is unrelated to it.

Included rather than bypassed with `--no-verify`, because the hook blocks **every** commit to this repo until it is resolved. Regenerated with `python scripts/generate_tools_index.py`.

**The guard worked exactly as designed** — it caught a stale derived file on the next commit to touch the repo. That is `5i`'s argument for `--check` gating, demonstrated rather than asserted.

## Left undecided, deliberately

Whether this workflow should create a checklist issue at all. The body it posts is a static template already in the repo; if nobody works those issues, **deleting the step beats granting it a scope.** Not decided here because that is a call about process, not permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
