### PR TITLE
ci(release): ask whether pdoom1.com actually serves the release we published

### DIFF
--- a/.github/workflows/live-site-release-freshness.yml
+++ b/.github/workflows/live-site-release-freshness.yml
@@ -1,0 +1,321 @@
+name: Live site release freshness
+
+# Answers ONE question on a schedule: is pdoom1.com serving the release we
+# actually published?
+#
+# WHY THIS IS NOT ALREADY COVERED. release-sync-monitor.yml looks like this
+# check and is not. It reads
+# `repos/PipFoweraker/pdoom1-website/contents/data/current-game-version.json`
+# through the GitHub API -- a file in the website REPO. pdoom1-website#285
+# recorded those two things diverging in production on the v0.14.0 cut: the
+# repo held v0.14.0 while pdoom1.com served v0.13.2, for roughly 70 minutes,
+# with correct-looking green ticks throughout, while Pip was already sharing
+# the link.
+#
+# TWO DIFFERENT ASSERTIONS. Stating both, because conflating them is the whole
+# bug:
+#   A) the website REPO has been updated  -- release-sync-monitor.yml (daily)
+#   B) the LIVE SITE serves that update   -- this workflow
+# B can be false while A is true: the commit landed but the deploy did not run,
+# or ran and a CDN edge is still handing out the previous object. The live read
+# below therefore goes over HTTPS to pdoom1.com with a CACHE-BUSTER, not to the
+# GitHub API. A read without a cache-buster can be answered from an object
+# minted before the release existed -- which is precisely the mistake made on
+# 2026-08-07, when a single curl taken BEFORE the release was published was
+# used to assert for eight hours that the site was stale.
+#
+# It lives in pdoom1 rather than pdoom1-website because it is OUR release that
+# goes stale on their site, so the alarm should reach the people who cut it.
+#
+# READ-ONLY. One GET against a public JSON file, plus a read of this repo's own
+# releases. Writes nothing to either repo except the rolling issue below.
+
+on:
+  schedule:
+    # EVERY TWO HOURS, offset off the hour (this repo family's habit -- see
+    # release-sync-monitor.yml '17 6 * * *' and pdoom1-website's '17 */6 * * *').
+    # The offset is not cosmetic: top-of-hour is when GitHub's scheduler is most
+    # congested and scheduled runs are most delayed, and a freshness check that
+    # is itself late is a poor witness.
+    #
+    # Cadence is chosen against the ALARM THRESHOLD below, not against how fast
+    # anyone would like to know. With an 8h threshold, 2-hourly gives four
+    # samples inside the window, so the first run that can legitimately fire
+    # does fire within 2h of the condition becoming true. Polling every 15
+    # minutes would not detect anything sooner -- it would just re-ask a
+    # question whose answer cannot change verdict for hours. pdoom1-website's
+    # board-liveness.yml learned that directly: it went hourly for league night,
+    # reverted, and the standing note is "polling faster re-asks the same wrong
+    # question more often".
+    - cron: '43 */2 * * *'
+  workflow_dispatch:
+    inputs:
+      tolerance_minutes:
+        description: 'Minutes of lag to tolerate before failing (default 480)'
+        required: false
+        default: '480'
+        type: string
+
+# EXPLICIT, and issues:write is load-bearing. The alert job below opens or
+# comments on an issue; without this block the default token would be read-only
+# under the org's restricted default and the alert would 403 -- an alarm that
+# cannot be heard is worse than no alarm, because it also reports green.
+# This repo shipped exactly that: release-reminder.yml ran with NO permissions
+# block until #1177 (commit 5c83d034, 2026-08-08).
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: live-site-release-freshness
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Compare pdoom1.com against the published release
+    runs-on: ubuntu-latest
+    if: github.repository == 'PipFoweraker/pdoom1'
+    outputs:
+      verdict: ${{ steps.check.outputs.verdict }}
+      live_version: ${{ steps.check.outputs.live_version }}
+      expected_version: ${{ steps.check.outputs.expected_version }}
+      age_minutes: ${{ steps.check.outputs.age_minutes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # `gh release view` with no tag is GitHub's own "latest": newest
+      # non-draft, non-prerelease. This is deliberately the exact command
+      # pdoom1-website#285 names in its closing condition, so that a green run
+      # here is evidence about that issue and not about a lookalike.
+      - name: Read the latest published release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh release view --repo "$GITHUB_REPOSITORY" \
+                --json tagName,publishedAt > release.json; then
+            echo "::warning::No published release found. Nothing to compare against."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TAG=$(jq -r '.tagName' release.json)
+          PUB=$(jq -r '.publishedAt' release.json)
+          echo "tag=$TAG"
+          echo "published_at=$PUB"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "published_at=$PUB" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      # Exit codes are the pdoom1-website board-liveness.yml convention, adopted
+      # here on purpose so the two repos' guards read the same way:
+      #   0 in sync, or lagging within tolerance -> green
+      #   1 stale beyond tolerance               -> RED, alert fires
+      #   2 UNKNOWN (unreachable / unreadable)   -> green, warning only.
+      # Quoting that workflow: "we cannot tell" is not the same as "we are
+      # losing scores". Same here: an outage at pdoom1.com, a DNS blip or a
+      # truncated response tells us nothing about whether the version is right,
+      # and failing on it would train everyone to ignore this job.
+      - name: Compare the live site against the release
+        id: check
+        if: steps.release.outputs.skip != 'true'
+        env:
+          EXPECTED: ${{ steps.release.outputs.tag }}
+          PUBLISHED_AT: ${{ steps.release.outputs.published_at }}
+          TOLERANCE: ${{ inputs.tolerance_minutes || '480' }}
+        run: |
+          set +e
+          python scripts/check_site_release_freshness.py \
+            --expected-version "$EXPECTED" \
+            --published-at "$PUBLISHED_AT" \
+            --tolerance-minutes "$TOLERANCE" | tee freshness.log
+          code=${PIPESTATUS[0]}
+          set -e
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          echo "script exit code: $code"
+
+          # Loud every run, in the place a human actually looks.
+          {
+            echo "## Live site release freshness"
+            echo ""
+            echo '```'
+            cat freshness.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "$code" in
+            2)
+              echo "::warning::pdoom1.com could not be read. UNKNOWN, not a mismatch -- this run proves nothing either way."
+              exit 0 ;;
+            1)
+              echo "::error::pdoom1.com is advertising a version other than the latest release, and has been for longer than $TOLERANCE minutes. The website's 6-hourly backstop should already have closed this."
+              exit 1 ;;
+            *)
+              exit 0 ;;
+          esac
+
+  # ---------------------------------------------------------------------------
+  # THE THRESHOLD, AND WHY IT IS NOT THE 10 MINUTES IN pdoom1-website#285.
+  #
+  # #285 proposes "within 10 minutes of a release publishing". That is the right
+  # CLOSING CONDITION for #285 -- it describes how fast a push-driven pipeline
+  # ought to be once built. It is the wrong ALARM THRESHOLD today, and shipping
+  # it as one would make this workflow useless on arrival.
+  #
+  # The mechanism the site currently has is a cron: auto-update-data.yml on
+  # pdoom1-website runs '0 */6 * * *' (verified 2026-08-08). So the honest
+  # worst case for a correctly functioning estate is ~6h of cron wait, plus
+  # GitHub's scheduled-run delay (routinely 5-20 min under load), plus the
+  # website's deploy job, plus CDN propagation -- call it 6h45m. An alarm at 10
+  # minutes would therefore fire on EVERY SINGLE RELEASE, be correct every time,
+  # and self-heal within six hours without anyone doing anything. That is the
+  # precise shape of alarm this repo family has already decided it does not
+  # want: board-liveness.yml, on reverting its hourly cadence, records that "a
+  # guard firing about a settled question trains people to stop reading it",
+  # and on its push-retry loop that "a red square that always goes green on its
+  # own trains people to stop reading it".
+  #
+  # 480 minutes (8h) is set so that firing means THE BACKSTOP ITSELF FAILED --
+  # at least one full 6-hourly cycle has come and gone without fixing it, with
+  # ~75 minutes of headroom over the honest worst case. Nothing automatic will
+  # clear it, so every alert is an alert a human must act on. That is the test
+  # a threshold has to pass: not "how soon could we know" but "will the person
+  # who gets this still be reading it in a month".
+  #
+  # WHEN #285 IS ACTUALLY FIXED (release publish drives the update rather than
+  # the clock), this number should drop hard -- to 30 or 60 minutes -- and the
+  # comment above becomes the reason it was ever this high. Until then, 8h.
+  #
+  # NOT triggered on `release: published`. A release published seconds ago has
+  # provably not propagated, so such a run could only ever report "lagging,
+  # tolerated" -- a green tick carrying no information, which is the category of
+  # reassurance that caused #285 in the first place.
+  # ---------------------------------------------------------------------------
+
+  alert:
+    name: Alert -- the live site is serving a stale release
+    needs: check
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          # Values from a live HTTP response go through env, never spliced into
+          # the script body.
+          LIVE: ${{ needs.check.outputs.live_version }}
+          EXPECTED: ${{ needs.check.outputs.expected_version }}
+          AGE: ${{ needs.check.outputs.age_minutes }}
+        with:
+          script: |
+            const title = 'pdoom1.com is serving a stale release';
+            const label = 'release';
+            const live = process.env.LIVE || 'unknown';
+            const expected = process.env.EXPECTED || 'unknown';
+            const age = process.env.AGE || '?';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              '`https://pdoom1.com/data/version.json` (read live, with a cache-buster)',
+              `advertises **${live}**. The latest published release is **${expected}**,`,
+              `published **${age} minutes ago**.`,
+              '',
+              'This is past the tolerated window, which means the website\'s own 6-hourly',
+              '`auto-update-data.yml` backstop has had at least one full cycle and did not',
+              'fix it. Nothing automatic is going to clear this.',
+              '',
+              '**Anyone following a version-pinned link on pdoom1.com right now downloads',
+              'the wrong build.** Unversioned aliases (`/releases/latest`, `PDoom-Windows.zip`)',
+              'are unaffected -- see pdoom1-website#285.',
+              '',
+              '### Check it yourself',
+              '```bash',
+              'curl -s "https://pdoom1.com/data/version.json?cb=$(date +%s)" | jq -r .latest_release.version',
+              'gh release view --repo PipFoweraker/pdoom1 --json tagName --jq .tagName',
+              '```',
+              '',
+              '### Likely causes, cheapest first',
+              '1. `auto-update-data.yml` on pdoom1-website is failing -- check its runs.',
+              '2. It committed but the deploy did not run, or ran and failed.',
+              '3. It deployed and a CDN edge is still serving the previous object.',
+              '',
+              'Note that `release-sync-monitor.yml` can be GREEN while this is true: it',
+              'reads the website REPO file, not the served site. Those are different',
+              'assertions and pdoom1-website#285 records them diverging.',
+              '',
+              `Run: ${runUrl}`,
+              '',
+              '_Single rolling issue -- reused, not duplicated, per run. Closed',
+              'automatically by the same workflow when the site catches up._',
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label, per_page: 100,
+            });
+            const found = existing.data.find(i => i.title === title);
+            if (found) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: found.number,
+                body: `Still true as of ${new Date().toUTCString()}: site says \`${live}\`, release is \`${expected}\` (${age} min old).\n\nRun: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: [label, 'pdoom-website', 'priority:high'],
+              });
+            }
+
+  # An alert with no close path is the documented failure mode next door:
+  # pdoom1-website#149, #204 and #230 all sat open describing conditions that
+  # had already resolved, because something opened them and nothing ever closed
+  # them. An open issue here should always describe a live condition. If the
+  # condition recurs, a FRESH issue is filed rather than this one reopened.
+  resolve:
+    name: Close the rolling issue when the site catches up
+    needs: check
+    if: needs.check.outputs.verdict == 'in-sync'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          LIVE: ${{ needs.check.outputs.live_version }}
+        with:
+          script: |
+            const title = 'pdoom1.com is serving a stale release';
+            const label = 'release';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label, per_page: 100,
+            });
+            const found = existing.data.find(i => i.title === title);
+            if (!found) { core.info('No open rolling issue to close.'); return; }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: found.number,
+              body: [
+                `**Resolved automatically** -- pdoom1.com now serves \`${process.env.LIVE}\`,`,
+                `matching the latest published release, as of ${new Date().toUTCString()}.`,
+                '',
+                'Read live with a cache-buster, not from the website repo.',
+                '',
+                `Run: ${runUrl}`,
+              ].join('\n'),
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: found.number, state: 'closed', state_reason: 'completed',
+            });
+            core.info('Closed #' + found.number + '.');

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -32,6 +32,7 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | branch_manager.py | -- | Automated Branch Management System for P(Doom) | human (docstring usage) |
 | build_all_platforms.py | -- | Build P(Doom) for all platforms (Windows, Linux, macOS). | ci:enhanced-release.yml; test:test_build_all_platforms.py; tool:generate_release_metadata.py |
 | check_no_emoji.py | PROVE | Blocking no-emoji / ASCII enforcement for the Godot tree (issue #744). | pre-commit |
+| check_site_release_freshness.py | -- | Is pdoom1.com advertising the release we actually published? | ci:live-site-release-freshness.yml |
 | check_style_guide.py | -- | Style Guide Enforcement Check | pre-commit |
 | ci_health_integration.py | -- | CI/CD Health Integration - GitHub Actions Integration | ci:enhanced-cicd-pipeline.yml; ci:quality-checks.yml |
 | cleanup_project.py | -- | Project Cleanup Automation Script | make |
@@ -65,22 +66,6 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | token-setup-guide.py | -- | Quick GitHub Token Setup Guide for P(Doom) Cross-Repository Sync | NONE FOUND |
 | validate_historical_data.py | -- | Historical Data Validation Script | make; ci:data-validation.yml; ci:enhanced-release.yml |
 | verify_release_urls.py | -- | Verify release-feed download URLs actually resolve. | ci:enhanced-release.yml; tool:generate_release_metadata.py |
-
-## `scripts/lib/scores/`
-
-| Tool | Layer | Purpose | Invoked by |
-|---|---|---|---|
-| enhanced_leaderboard.py | -- | Enhanced Leaderboard Manager for P(Doom) v0.4.1+ | NONE FOUND |
-| local_store.py | -- | Local leaderboard storage for PDoom1. | NONE FOUND |
-
-## `scripts/lib/services/`
-
-| Tool | Layer | Purpose | Invoked by |
-|---|---|---|---|
-| data_paths.py | -- | Cross-platform data directory management for PDoom1. | NONE FOUND |
-| deterministic_rng.py | -- | Deterministic RNG System for P(Doom): Reproducible Strategic Gameplay | NONE FOUND |
-| leaderboard.py | -- | Privacy-Respecting Leaderboard Foundation for P(Doom) | NONE FOUND |
-| version.py | -- | Version management for P(Doom): Bureaucracy Strategy Game | NONE FOUND |
 
 ## `tools/`
 
@@ -179,16 +164,10 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 
 ## UNKNOWN -- no declaration, no usage hint, no discoverable caller
 
-17 tool(s) that nothing declares, documents, or calls. Each one is either
+11 tool(s) that nothing declares, documents, or calls. Each one is either
 a rot candidate or an undocumented dependency -- find out which (`tools/find_dead_code.py` lane).
 
 - `scripts/ascii_compliance_fixer.py`
-- `scripts/lib/scores/enhanced_leaderboard.py`
-- `scripts/lib/scores/local_store.py`
-- `scripts/lib/services/data_paths.py`
-- `scripts/lib/services/deterministic_rng.py`
-- `scripts/lib/services/leaderboard.py`
-- `scripts/lib/services/version.py`
 - `scripts/logging_system.py`
 - `scripts/monitor-sync.py`
 - `scripts/repo-status.py`
@@ -229,6 +208,6 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 
 ## Not indexed: HTML tools
 
-23 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
+25 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/SUNDAY-postmortem-2026-08-07.html`, `tools/runsheet/chronicle-2026-08-06_07.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
 
-Total: 118 active tools (9 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 97 undeclared); 17 in UNKNOWN; 6 archived.
+Total: 113 active tools (9 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 92 undeclared); 11 in UNKNOWN; 6 archived.

--- a/scripts/check_site_release_freshness.py
+++ b/scripts/check_site_release_freshness.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Is pdoom1.com advertising the release we actually published?
+
+WHY THIS EXISTS
+---------------
+`.github/workflows/release-sync-monitor.yml` already compares the latest release
+against the website, but it reads
+`repos/PipFoweraker/pdoom1-website/contents/data/current-game-version.json`
+through the GitHub API -- a file in the website REPO. That is not the same
+assertion as "the live site serves it", and pdoom1-website#285 recorded the two
+diverging in production on the v0.14.0 cut: the repo held v0.14.0 while
+pdoom1.com served v0.13.2, and every check in the estate was green throughout.
+
+This script makes the OTHER assertion: fetch the bytes a visitor's browser
+would fetch, through a cache-buster, and compare those to the published
+release tag.
+
+TWO DIFFERENT ASSERTIONS, STATED PLAINLY:
+  A) the website repo has been updated   -- release-sync-monitor.yml checks this
+  B) the live site SERVES the update     -- this script checks this
+B can be false while A is true (repo committed, deploy not run, or CDN still
+serving the old object). A can be false while B is true only transiently.
+
+EXIT CODES (deliberately mirroring pdoom1-website's board-liveness.yml, which
+established this convention in this repo family):
+  0  in sync, OR mismatched but still inside the tolerated lag window
+  1  MISMATCH beyond tolerance -- a human must act
+  2  UNKNOWN -- the site was unreachable or its JSON was unreadable.
+     "We cannot tell" is NOT "we are wrong". Callers keep this GREEN.
+
+Read-only. Issues one GET and writes nothing anywhere.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+DEFAULT_URL = "https://pdoom1.com/data/version.json"
+
+# See the workflow comment for the full justification. Summary: the website's
+# only automatic path to freshness is a 6-hourly cron
+# (pdoom1-website .github/workflows/auto-update-data.yml, `0 */6 * * *`), so any
+# lag shorter than that is the system working as designed, not a fault.
+DEFAULT_TOLERANCE_MINUTES = 480
+
+EXIT_OK = 0
+EXIT_MISMATCH = 1
+EXIT_UNKNOWN = 2
+
+
+def _fetch_live_json(url: str, timeout: int) -> dict:
+    """GET the live site's version.json, defeating every cache we can name.
+
+    The cache-buster is not decoration. A plain GET of this URL can be answered
+    from a CDN edge object minted before the release existed, which is exactly
+    the reading that produced eight hours of confident wrong prose on
+    2026-08-07: a single curl taken BEFORE the release was published, then
+    treated as evidence about a period after it.
+    """
+    busted = "{}{}cb={}".format(url, "&" if "?" in url else "?", int(time.time()))
+    request = urllib.request.Request(
+        busted,
+        headers={
+            "Cache-Control": "no-cache, no-store, max-age=0",
+            "Pragma": "no-cache",
+            "User-Agent": "pdoom1-live-site-freshness-check",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        raw = response.read().decode("utf-8")
+    return json.loads(raw)
+
+
+def _parse_iso8601(value: str) -> datetime:
+    """Parse a GitHub API timestamp. `Z` is not accepted by fromisoformat < 3.11."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _emit_output(key: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write("{}={}\n".format(key, value))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=DEFAULT_URL)
+    parser.add_argument(
+        "--expected-version",
+        required=True,
+        help="The release tag that SHOULD be live, e.g. v0.14.1.",
+    )
+    parser.add_argument(
+        "--published-at",
+        required=True,
+        help="ISO-8601 publish time of that release. Lag is measured from here.",
+    )
+    parser.add_argument(
+        "--tolerance-minutes",
+        type=int,
+        default=DEFAULT_TOLERANCE_MINUTES,
+        help="Lag below this is reported and tolerated, not failed.",
+    )
+    parser.add_argument("--timeout", type=int, default=20)
+    parser.add_argument(
+        "--site-json-file",
+        default=None,
+        help="Read the site payload from a local file instead of fetching. "
+        "For testing the comparison logic offline; never used in CI.",
+    )
+    args = parser.parse_args(argv)
+
+    # ---- Read the live site. Any failure here is UNKNOWN, never MISMATCH. ----
+    try:
+        if args.site_json_file:
+            with open(args.site_json_file, encoding="utf-8") as handle:
+                payload = json.load(handle)
+        else:
+            payload = _fetch_live_json(args.url, args.timeout)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        print("verdict=unknown  reason=unreachable  detail={}".format(exc))
+        _emit_output("verdict", "unknown")
+        _emit_output("live_version", "")
+        return EXIT_UNKNOWN
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        print("verdict=unknown  reason=unparseable-json  detail={}".format(exc))
+        _emit_output("verdict", "unknown")
+        _emit_output("live_version", "")
+        return EXIT_UNKNOWN
+
+    live_version = ""
+    if isinstance(payload, dict):
+        latest = payload.get("latest_release")
+        if isinstance(latest, dict):
+            live_version = str(latest.get("version") or "")
+
+    if not live_version:
+        print("verdict=unknown  reason=no-latest_release.version-field")
+        _emit_output("verdict", "unknown")
+        _emit_output("live_version", "")
+        return EXIT_UNKNOWN
+
+    try:
+        published = _parse_iso8601(args.published_at)
+    except ValueError as exc:
+        print("verdict=unknown  reason=unparseable-published-at  detail={}".format(exc))
+        _emit_output("verdict", "unknown")
+        _emit_output("live_version", live_version)
+        return EXIT_UNKNOWN
+
+    # ---- Compare. Tags are compared verbatim; both sides carry the `v`. ----
+    expected = args.expected_version.strip()
+    age_minutes = int((datetime.now(timezone.utc) - published).total_seconds() // 60)
+
+    _emit_output("live_version", live_version)
+    _emit_output("expected_version", expected)
+    _emit_output("age_minutes", str(age_minutes))
+
+    print("live site advertises : {}".format(live_version))
+    print("latest release is    : {}".format(expected))
+    print("release age          : {} min".format(age_minutes))
+    print("tolerance            : {} min".format(args.tolerance_minutes))
+
+    if live_version == expected:
+        print("verdict=in-sync")
+        _emit_output("verdict", "in-sync")
+        return EXIT_OK
+
+    # A release published minutes ago has not propagated yet, and saying so is
+    # not a finding. Only a gap the automatic backstop should already have
+    # closed is worth anyone's attention.
+    if age_minutes <= args.tolerance_minutes:
+        print(
+            "verdict=lagging  (mismatch, but inside the tolerated window -- "
+            "the site's own 6-hourly refresh has not necessarily run yet)"
+        )
+        _emit_output("verdict", "lagging")
+        return EXIT_OK
+
+    print(
+        "verdict=stale  pdoom1.com has advertised {} for {} min after {} "
+        "was published".format(live_version, age_minutes, expected)
+    )
+    _emit_output("verdict", "stale")
+    return EXIT_MISMATCH
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes nothing on its own. Addresses the gap named in PipFoweraker/pdoom1-website#285.

## The gap

Nothing in this estate ever asks "is the live site serving the current release?"

`release-sync-monitor.yml` looks like it asks that. It does not. It reads
`repos/PipFoweraker/pdoom1-website/contents/data/current-game-version.json`
through the GitHub API -- a file in the website **repo**. pdoom1-website#285
records those two diverging in production on the `v0.14.0` cut: the repo held
`v0.14.0` while `pdoom1.com` served `v0.13.2`, and every check in the estate was
green throughout, while the link was already being shared.

**Two different assertions**, and conflating them is the whole bug:

| | Asserts | Checked by |
|---|---|---|
| A | the website **repo** has been updated | `release-sync-monitor.yml` (daily 06:17) |
| B | the **live site** serves that update | this PR (2-hourly) |

B can be false while A is true: the commit landed but the deploy did not run, or
ran and a CDN edge is still handing out the previous object.

Same failure again on 2026-08-07, from the other direction: the pdoom1 seat
asserted for eight hours that the site was stale, on the strength of a single
`curl` taken **before the release was published**. That is why the live read here
carries a cache-buster and a `no-cache` header, and why the check is scheduled
rather than performed by hand at a moment somebody chooses.

## What lands

- `scripts/check_site_release_freshness.py` -- stdlib only, read-only, one GET.
- `.github/workflows/live-site-release-freshness.yml` -- `cron: '43 */2 * * *'`
  plus `workflow_dispatch` (with a `tolerance_minutes` override).
- `docs/TOOLS.md` regenerated -- the pre-commit gate requires it. See the note at
  the bottom; it is not all mine.

Explicit `permissions:` block, `contents: read` + `issues: write`. The alert job
opens or comments on a rolling issue; without `issues: write` it 403s and the
workflow reports green, which is worse than not having it. This repo shipped
exactly that shape until #1177 (`release-reminder.yml` had no permissions block
at all).

There is a `resolve` job that closes the rolling issue when the site catches up.
pdoom1-website#149, #204 and #230 all sat open describing conditions that had
already resolved, because something opened them and nothing closed them.

## The threshold: 480 minutes, not the 10 minutes #285 proposes

#285's closing condition is "within 10 minutes of a release publishing". That is
the right **closing condition for #285** -- it describes how fast a push-driven
pipeline ought to be once someone builds it. It is the wrong **alarm threshold
today**, and shipping it as one would make this workflow useless on arrival.

The mechanism the site currently has is a cron: `auto-update-data.yml` on
pdoom1-website runs `0 */6 * * *` (verified 2026-08-08 by reading that file).
So the honest worst case for a **correctly functioning** estate is ~6h of cron
wait, plus GitHub's scheduled-run delay (routinely 5-20 min under load), plus the
website's deploy job, plus CDN propagation. Call it 6h45m.

An alarm at 10 minutes would therefore fire on **every single release**, be
correct every time, and self-heal within six hours without anyone doing
anything. That is precisely the alarm shape this repo family has already ruled
against -- `board-liveness.yml`, reverting its hourly cadence, records that "a
guard firing about a settled question trains people to stop reading it", and on
its push-retry loop that "a red square that always goes green on its own trains
people to stop reading it".

**480 minutes (8h) is set so that firing means the backstop itself failed.** At
least one full 6-hourly cycle has come and gone without fixing it, with ~75
minutes of headroom over the honest worst case. Nothing automatic will clear it,
so every alert is one a human must act on.

The test a threshold has to pass is not "how soon could we know" but "will the
person who gets this still be reading it in a month".

**When #285 is actually fixed** (release publish drives the update rather than
the clock), this number should drop hard -- to 30 or 60 minutes -- and the
comment in the workflow becomes the record of why it was ever this high.

Cadence follows from the threshold: 2-hourly gives four samples inside an 8h
window, so the first run that legitimately *can* fire does fire within 2h.
Polling every 15 minutes would not detect anything sooner; it would re-ask a
question whose verdict cannot change for hours.

Deliberately **not** triggered on `release: published`: a release published
seconds ago has provably not propagated, so such a run could only ever report
"lagging, tolerated" -- a green tick carrying no information, which is the
category of reassurance that caused #285.

## Mismatch vs "cannot tell"

Exit codes mirror pdoom1-website's `board-liveness.yml`, which established the
convention in this repo family ("we cannot tell" is not the same as "we are
losing scores"):

| exit | meaning | job |
|---|---|---|
| 0 | in sync, or mismatched but inside the tolerated window | green |
| 1 | stale beyond tolerance | **RED**, alert fires |
| 2 | UNKNOWN -- unreachable, unparseable JSON, missing field | green + `::warning::` |

An outage at pdoom1.com tells us nothing about whether the version is right.
Failing on it would train everyone to ignore this job.

## Evidence the guard fails when it should

Run locally against the real live site, 2026-08-08. Eight cases; three must fail,
five must pass. Actual output:

```
--- 1. TRUE CURRENT STATE (must pass) ---
$ python scripts/check_site_release_freshness.py --expected-version v0.14.1 --published-at 2026-08-07T16:08:24Z
live site advertises : v0.14.1
latest release is    : v0.14.1
release age          : 590 min
tolerance            : 480 min
verdict=in-sync
exit=0

--- 2. DELIBERATELY WRONG EXPECTED VERSION, old release (must FAIL, exit 1) ---
$ python scripts/check_site_release_freshness.py --expected-version v9.9.9 --published-at 2026-08-07T16:08:24Z
live site advertises : v0.14.1
latest release is    : v9.9.9
release age          : 590 min
tolerance            : 480 min
verdict=stale  pdoom1.com has advertised v0.14.1 for 590 min after v9.9.9 was published
exit=1

--- 3. SAME MISMATCH, release published 3 min ago (legitimate lag, must pass) ---
$ python scripts/check_site_release_freshness.py --expected-version v9.9.9 --published-at 2026-08-08T01:55:38Z
live site advertises : v0.14.1
latest release is    : v9.9.9
release age          : 3 min
tolerance            : 480 min
verdict=lagging  (mismatch, but inside the tolerated window -- the site's own 6-hourly refresh has not necessarily run yet)
exit=0

--- 3b. SAME MISMATCH, release published 7h ago, just inside tolerance (must pass) ---
$ python scripts/check_site_release_freshness.py --expected-version v9.9.9 --published-at 2026-08-07T18:58:39Z
live site advertises : v0.14.1
latest release is    : v9.9.9
release age          : 420 min
tolerance            : 480 min
verdict=lagging  (mismatch, but inside the tolerated window -- the site's own 6-hourly refresh has not necessarily run yet)
exit=0

--- 3c. SAME MISMATCH, release published 9h ago, past tolerance (must FAIL, exit 1) ---
$ python scripts/check_site_release_freshness.py --expected-version v9.9.9 --published-at 2026-08-07T16:58:40Z
live site advertises : v0.14.1
latest release is    : v9.9.9
release age          : 540 min
tolerance            : 480 min
verdict=stale  pdoom1.com has advertised v0.14.1 for 540 min after v9.9.9 was published
exit=1

--- 4. SITE UNREACHABLE (must be UNKNOWN, exit 2) ---
$ python scripts/check_site_release_freshness.py --url https://pdoom1.invalid-host-does-not-exist/data/version.json --expected-version v0.14.1 --published-at 2026-08-07T16:08:24Z --timeout 5
verdict=unknown  reason=unreachable  detail=<urlopen error [Errno 11001] getaddrinfo failed>
exit=2

--- 5. UNPARSEABLE JSON (must be UNKNOWN, exit 2) ---
$ python scripts/check_site_release_freshness.py --site-json-file /tmp/badjson.json --expected-version v0.14.1 --published-at 2026-08-07T16:08:24Z
verdict=unknown  reason=unparseable-json  detail=Expecting value: line 1 column 1 (char 0)
exit=2

--- 6. WELL-FORMED JSON, NO latest_release.version (must be UNKNOWN, exit 2) ---
$ python scripts/check_site_release_freshness.py --site-json-file /tmp/nofield.json --expected-version v0.14.1 --published-at 2026-08-07T16:08:24Z
verdict=unknown  reason=no-latest_release.version-field
exit=2
```

Case 2 is the one that matters: same live site, same real response, only the
expected version changed, and the guard goes red. Case 3 is the one that stops it
being noise. Cases 4-6 are the ones that stop an outage reading as a lie.

The `GITHUB_OUTPUT` contract the workflow's job outputs depend on, also verified:

```
$ GITHUB_OUTPUT=/tmp/gho.txt python scripts/check_site_release_freshness.py --expected-version v0.14.1 --published-at 2026-08-07T16:08:24Z
exit=0
$ cat /tmp/gho.txt
live_version=v0.14.1
expected_version=v0.14.1
age_minutes=709
verdict=in-sync
```

## What this does NOT prove

It has never fired **in CI**, only locally. The first scheduled run after merge is
the real first test, and the alert and resolve jobs have not executed against the
GitHub API at all -- de-duplication by exact title, and the label set
(`release`, `pdoom-website`, `priority:high`, all verified to exist on this repo),
are argued-for, not observed. If the intent is to see the alarm fire before
trusting it, dispatch it with `tolerance_minutes: 0` shortly after a release and
watch it open the issue, then let the next scheduled run close it.

It also does not fix #285. It measures it. A push-driven update is still the
right fix; this is the instrument that will tell you whether the fix worked, and
it is deliberately calibrated so that it goes quiet once the fix lands rather
than needing to be retired.

## Note on the `docs/TOOLS.md` diff

Regenerating that index (required by the `tools-index-check` pre-commit gate)
does more than add one row. It also removes six entries under
`scripts/lib/scores/` and `scripts/lib/services/`. That directory does not exist
in this checkout, and `git log --diff-filter=D` finds no commit deleting those
files -- so the index was generated at some point in a checkout holding untracked
local files, and has advertised phantom tooling since. Pre-existing drift,
unrelated to this change, corrected here only because this is the first commit
the gate forced to regenerate the file. Two new `tools/runsheet/*.html` files also
appear in the count for the same reason.

---

Do not merge on my say-so. The threshold is the contestable part and I would
rather be argued with about 480 than have it merged unread.

Generated with [Claude Code](https://claude.com/claude-code)
