### PR TITLE
ci(release): block a release body that announces an open issue as delivered (#1165)

### DIFF
--- a/.github/workflows/enhanced-release.yml
+++ b/.github/workflows/enhanced-release.yml
@@ -353,6 +353,25 @@ jobs:
           echo "- **Manifest Hash:** \`${{ needs.create-release-manifest.outputs.manifest_hash }}\`" >> release_notes.txt
           echo "- **Engine:** Godot 4.5.1" >> release_notes.txt
 
+      # The release BODY is what reaches players -- pdoom1.com's /game-changelog/
+      # renders release bodies live from the releases API, with no human in
+      # between. v0.13.2 shipped a body announcing the Research Quality System as
+      # delivered while #500 was open. A pre-commit hook on CHANGELOG.md would not
+      # have caught it: the body is assembled HERE, at release time, by the sed
+      # above, and the sed's start pattern is not even anchored to a heading.
+      # So the gate checks release_notes.txt itself -- the exact bytes about to be
+      # published -- and it must sit between assembly and publication. Blocking:
+      # a false delivery claim fails the release rather than reaching readers.
+      # Issue #1165.
+      - name: Guard the release body against false delivery claims
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.inputs.version || github.ref_name }}
+        run: |
+          python scripts/check_release_notes.py \
+            --body release_notes.txt \
+            --tag "$RELEASE_TAG"
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/pre-release-checks.yml
+++ b/.github/workflows/pre-release-checks.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          # Full history + tags: the #1165 guard ties each cited issue to a
+          # commit in <previous tag>..<this tag>, which a shallow clone cannot see.
+          fetch-depth: 0
 
       # Note: unit tests run on PRs via godot-tests.yml (GUT). Pre-release focuses
       # on release-readiness (changelog, version, clean tree). The former pygame-era
@@ -30,6 +34,26 @@ jobs:
             echo "Please update CHANGELOG.md before releasing!"
             exit 1
           fi
+        shell: bash
+
+      # Early, cheap half of the #1165 guard: structural corruption in
+      # CHANGELOG.md, plus the citations in this version's section. Fails here
+      # rather than 20 minutes later in enhanced-release.yml, after the builds.
+      # The authoritative gate is still the release-body check in
+      # enhanced-release.yml -- this one runs against the FILE, that one runs
+      # against the bytes that get published.
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Release notes guard (structure + citations)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          python scripts/check_release_notes.py --changelog-structure
+          python scripts/check_release_notes.py --version "$TAG_VERSION"
         shell: bash
 
       - name: Check version in project.godot

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,6 +149,18 @@ repos:
       # pattern as the DQ index. Scoped to the feed itself, so it only fires when someone
       # touches those files -- a full-tree gate would block every commit after a tag until
       # the index was regenerated.
+      # Cheapest third of the #1165 guard: structural corruption only (duplicate
+      # [Unreleased] headings), offline, no gh call, no network. The checks that
+      # actually matter -- open-issue citations and commit ties -- run at RELEASE
+      # time in enhanced-release.yml, because the false claim reaches players
+      # through the release body, not through this file.
+      - id: changelog-structure-check
+        name: CHANGELOG.md has exactly one [Unreleased] heading
+        entry: python scripts/check_release_notes.py --changelog-structure --offline
+        language: system
+        files: '^CHANGELOG\.md$'
+        pass_filenames: false
+
       - id: release-index-check
         name: release feed index matches the git tags
         entry: python scripts/generate_release_metadata.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to P(Doom): Bureaucracy Strategy Game will be documented in 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+> **Note on the "Archived draft" sections below (2026-08-09, issue #1165).**
+> This file carried SIX `## [Unreleased]` headings. Five were accumulator
+> residue: past releases that shipped without clearing the section, leaving
+> stale work filed under a heading that claims it never shipped. They are
+> retitled here, keeping their original titles and dates verbatim, so that
+> exactly one `[Unreleased]` heading remains -- the one at the top, which is
+> the live accumulator. Which release actually shipped each block was NOT
+> established; the file's ordering is unreliable in that stretch (the
+> 2025-09-19 block sits below `[0.7.1] - 2025-09-15`), so no version is
+> claimed. `scripts/check_release_notes.py --changelog-structure` now blocks
+> a second `[Unreleased]` heading from appearing again.
 
 ## [Unreleased]
 
@@ -586,7 +597,7 @@ nine doom streams, visible rivals, and the leaderboard going live -- see
 - **README**: Modernized with alpha testing features and screenshots
 - **Dependencies**: numpy>=2.3.3 now required for audio functionality
 
-## [Unreleased] - 'Input System Architecture Overhaul'
+## [Archived draft A] - 'Input System Architecture Overhaul'
 
 ### Added - Phase 2 Architecture
 - **[TARGET] InputEventManager System** - Extracted complete keyboard event processing from main.py monolith (500+ lines)
@@ -664,7 +675,7 @@ nine doom streams, visible rivals, and the leaderboard going live -- see
 - **Settings Flow** - Stable initialization sequence for consistent game startup
 - **Core Game Loop** - Validated deterministic behavior across all major systems
 
-## [Unreleased] - 2025-09-17 - 'RNG Architecture Discovery Release'
+## [Archived draft: 2025-09-17] - 'RNG Architecture Discovery Release'
 
 ### Major Discovery: RNG System Already Complete
 #### Analysis
@@ -925,7 +936,7 @@ nine doom streams, visible rivals, and the leaderboard going live -- see
   - Reusable components reduce code duplication across menu systems
   - Clear separation of concerns: layout, rendering, state management
 
-## [Unreleased] - 2025-09-19 - 'Bug Sweep Session: Critical Stability Fixes'
+## [Archived draft: 2025-09-19] - 'Bug Sweep Session: Critical Stability Fixes'
 ### Fixed
 - **CRITICAL DEBUG CONSOLE CRASH**: Fixed fatal access violation in debug console rendering
   - **Root Cause**: Font objects were not initialized before being used in draw methods
@@ -1292,7 +1303,7 @@ nine doom streams, visible rivals, and the leaderboard going live -- see
 - **Event Handling Priority**: Resolved conflicts between tutorial overlays and core game controls
 - **Modal Dialog Behavior**: Improved popup and dialog interaction handling
 
-## [Unreleased]
+## [Archived draft B]
 ### Added
 - **[ACHIEVE] Achievements & Enhanced Endgame System (Issue #195)**: Comprehensive achievement tracking and victory conditions beyond binary win/lose
   - 24 achievements across 8 categories: Survival, Workforce, Research, Financial, Safety, Reputation, Competitive, Rare
@@ -1462,7 +1473,7 @@ nine doom streams, visible rivals, and the leaderboard going live -- see
 - **Spacing & Layout**: Consistent margins and alignment across all resource displays
 - **Screenshot Functionality**: Alt+Tab and screen capture tools now work properly
 
-## [Unreleased]
+## [Archived draft C]
 ### Added
 - **[SETTINGS] Enhanced Settings System**: Comprehensive settings and configuration architecture
   - **Custom Seed Management**: Fixed critical 'Launch with Custom Seed' crash, added seed validation and normalization

--- a/docs/RELEASE_NOTES_GUARD.md
+++ b/docs/RELEASE_NOTES_GUARD.md
@@ -1,0 +1,134 @@
+# Release notes guard
+
+`scripts/check_release_notes.py`, issue #1165.
+
+## Why this exists
+
+v0.13.2's published release body announced the Research Quality System as
+delivered. `#500` was open then and is open now. The same body announced the
+scenario/mod hook system 7.5 months after that work closed. pdoom1.com's
+`/game-changelog/` renders release bodies live from the GitHub releases API, so
+a false sentence reached readers with no human in between. Found by the
+`pdoom1-website` seat on 2026-08-07 (`coordination#35`).
+
+Two mechanisms produced it, both verified:
+
+1. `CHANGELOG.md` carried **six** `## [Unreleased]` headings, three of them
+   dated 2025-09. At least five past releases failed to clear the accumulator
+   and nobody noticed, because the failure is silent and the output is
+   plausible.
+2. Misfiled sections. The `[0.13.2]` section carried `#500`/`#483` content that
+   merged in `v0.11.0..v0.12.0` (`30f3c6d5`, `6eb20174`). Relocated to a
+   reconstructed `[0.12.0]` on 2026-08-08.
+
+## The propagation path -- established, not assumed
+
+The path is narrower than it looks. Two extractors exist and only one of them
+builds the thing players read:
+
+| Where | Code | What it feeds |
+| --- | --- | --- |
+| `.github/workflows/enhanced-release.yml`, `create-github-release` job, step "Extract changelog" | `sed -n "/\[$VERSION_NUM\]/,/^## /p" CHANGELOG.md \| head -n -1 > release_notes.txt` | `release_notes.txt` -> `softprops/action-gh-release` `body_path` -> **the published release body** -> releases API -> `pdoom1.com/game-changelog/` |
+| `scripts/generate_release_metadata.py`, `extract_changelog_for_version()` | anchors on `## [<version>]`, breaks at the next `## ` | `public/releases/*.json` feed, `scripts/generate_release_manifest.py` `highlights` field |
+
+Consequences worth stating plainly:
+
+- **A pre-commit hook on `CHANGELOG.md` could not have caught v0.13.2.** The
+  body is assembled at release time from whatever the file says then.
+- `extract_changelog_for_version()` matches only `## [<version>]` and breaks at
+  the next `## `, so a misfiled `[0.13.2]` section could **not** leak into a
+  `0.14.1` manifest. Cross-version leakage through the manifest was a decoy.
+- The workflow's `sed`, by contrast, has a start pattern that is **not anchored
+  to a heading**: `/\[0.13.2\]/` matches the string anywhere, including in
+  prose. The guard sidesteps this entirely by checking `release_notes.txt`
+  itself rather than re-deriving the section -- it checks the bytes that get
+  published, whatever produced them.
+
+## Where the checks run
+
+| Gate | Runs | Checks | Blocking |
+| --- | --- | --- | --- |
+| pre-commit `changelog-structure-check` | on `CHANGELOG.md` commits | RN001, RN002. Offline. | yes (RN001) |
+| `pre-release-checks.yml` | on `v*.*.*` tag push | RN001, RN002 + RN003/RN004 on the CHANGELOG section | yes |
+| `enhanced-release.yml`, before `action-gh-release` | on `v*.*.*` tag push | RN003, RN004 on `release_notes.txt` | **yes -- this is the one that stops a bad body being published** |
+
+## What is checked mechanically
+
+| ID | Rule | Severity |
+| --- | --- | --- |
+| RN001 | more than one `## [Unreleased]` heading | fatal |
+| RN002 | the same version heading appearing twice | warn |
+| RN003 | a cited issue/PR whose state is OPEN | fatal |
+| RN004 | a cited issue/PR that no commit in `<prev tag>..<tag>` mentions | fatal |
+
+RN002 is a warning because `CHANGELOG.md` carries a genuine historical
+duplicate (`[0.7.4]`, twice on 2025-09-16) that predates the guard. Making it
+fatal would have meant rewriting history to land the guard.
+
+RN003 resolves state through one batched `gh api graphql` call per 50 numbers,
+using `issueOrPullRequest` rather than `gh issue view`, because the changelog
+mixes issue and PR references and `gh issue view` on a PR number is a
+coincidence, not a lookup. An unresolvable number is reported as a warning --
+never silently treated as a pass.
+
+## What is NOT checked -- still a human's job
+
+Be clear about this, because "every bullet ties to a merged commit" was enforced
+by hand on 2026-08-08, twice, at real cost, and the guard replaces only part of
+that labour.
+
+- **Prose accuracy.** `#1173` being closed and in range says the work happened.
+  It says nothing about whether "it opens on global now" is true. Only running
+  the build settles that.
+- **Uncited bullets.** RN003 and RN004 bind to `#N`. A bullet that cites nothing
+  passes silently. The mitigation is a convention, not a check: cite the issue.
+- **Correct version filing.** RN004 is a **lower bound, not a proof**. Run
+  against v0.13.2 it caught the misfiled `#500` and did **not** catch the
+  misfiled `#483`, because an unrelated commit in that range
+  (`fix(league): scenario runs are UNRANKED ... (#1060)`) happened to mention
+  `#483` in its body. A coincidental mention satisfies the tie.
+- **Scope creep inside a bullet.** A bullet may cite a closed, in-range issue
+  and then describe more than that issue delivered.
+
+## The disclosure escape
+
+Describing shipped code that belongs to an unfinished feature is legitimate.
+Announcing that feature as delivered is not. So RN003 permits a citation of an
+OPEN issue when the same bullet says so in exactly these words:
+
+```
+#500 is still OPEN
+```
+
+Markdown emphasis is stripped and whitespace collapsed before matching (the
+existing disclosure in `[0.12.0]` is bold and line-wrapped), but the wording
+itself must be exact. The escape is scoped to the bullet making the claim, so
+one disclosed bullet cannot launder its neighbours.
+
+## Proving it fails
+
+A guard that has never been shown to fail is not evidence.
+
+```
+$ python scripts/check_release_notes.py --release v0.13.2
+[FAIL] RN003: published release v0.13.2: cites #791 but that issue is OPEN
+[FAIL] RN003: published release v0.13.2: cites #811 but that issue is OPEN
+[FAIL] RN003: published release v0.13.2: cites #500 but that issue is OPEN
+[FAIL] RN003: published release v0.13.2: cites #500 but that issue is OPEN
+[FAIL] RN004: published release v0.13.2: cites #500, which no commit in v0.13.1..v0.13.2 mentions
+...
+RELEASE NOTES CHECK FAILED: 8 fatal, 0 warning
+
+$ python scripts/check_release_notes.py --release v0.14.1
+[OK] release notes check passed (0 warning(s))
+```
+
+`tests/test_release_notes_guard.py` pins both directions offline, with issue
+states stubbed to their real values.
+
+## Outstanding
+
+The **published v0.13.2 release body is still wrong** and is still being served
+by `pdoom1.com/game-changelog/`. Correcting a published body is Pip's call;
+`pdoom1-website` has asked him. This guard prevents the next one, it does not
+repair that one.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -32,6 +32,7 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | branch_manager.py | -- | Automated Branch Management System for P(Doom) | human (docstring usage) |
 | build_all_platforms.py | -- | Build P(Doom) for all platforms (Windows, Linux, macOS). | ci:enhanced-release.yml; test:test_build_all_platforms.py; tool:generate_release_metadata.py |
 | check_no_emoji.py | PROVE | Blocking no-emoji / ASCII enforcement for the Godot tree (issue #744). | pre-commit |
+| check_release_notes.py | -- | Guard against a release note that announces something we did not ship. | pre-commit; ci:enhanced-release.yml; ci:pre-release-checks.yml; test:test_release_notes_guard.py |
 | check_site_release_freshness.py | -- | Is pdoom1.com advertising the release we actually published? | ci:live-site-release-freshness.yml |
 | check_style_guide.py | -- | Style Guide Enforcement Check | pre-commit |
 | ci_health_integration.py | -- | CI/CD Health Integration - GitHub Actions Integration | ci:enhanced-cicd-pipeline.yml; ci:quality-checks.yml |
@@ -210,4 +211,4 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 
 25 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/SUNDAY-postmortem-2026-08-07.html`, `tools/runsheet/chronicle-2026-08-06_07.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
 
-Total: 113 active tools (9 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 92 undeclared); 11 in UNKNOWN; 6 archived.
+Total: 114 active tools (9 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 93 undeclared); 11 in UNKNOWN; 6 archived.

--- a/scripts/check_release_notes.py
+++ b/scripts/check_release_notes.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Guard against a release note that announces something we did not ship.
+
+Issue #1165. This already reached players: v0.13.2's published release body
+announced the Research Quality System as delivered while `#500` was -- and at
+the time of writing still is -- OPEN. pdoom1.com's /game-changelog/ renders
+release bodies live from the GitHub releases API, so there is no human between
+a wrong sentence and a reader.
+
+WHAT THIS CHECKS (mechanical, no judgement involved)
+----------------------------------------------------
+RN001  more than one `## [Unreleased]` heading in CHANGELOG.md.  FATAL.
+       Unambiguous corruption: at least five past releases failed to clear the
+       accumulator and nobody noticed, because the failure is silent and the
+       output stays plausible.
+RN002  the same version heading appearing twice in CHANGELOG.md.  WARN.
+       Warn, not fatal, because the file carries genuine historical duplicates
+       (`[0.7.4]` twice, 2025-09-16) that predate this guard.
+RN003  an issue or PR number cited in a release body whose issue is still
+       OPEN.  FATAL.  This is the one that actually bit.
+RN004  an issue or PR number cited in a version's release body that cannot be
+       tied to any commit message between that version's tag and the previous
+       one.  FATAL when a tag range is supplied.
+
+WHAT THIS DOES NOT CHECK (still a human's job -- see docs/RELEASE_NOTES_GUARD.md)
+--------------------------------------------------------------------------------
+- whether a bullet's PROSE is true. `#1173` being closed and in-range says the
+  work happened; it says nothing about whether "it opens on global now" is
+  accurate. Only playing the build settles that.
+- a bullet that cites no issue number at all. RN003/RN004 have nothing to bind
+  to, so an uncited claim passes silently. Cite your issues.
+- whether a bullet is filed under the RIGHT version. RN004 is a lower bound,
+  not a proof: it was run against v0.13.2 and did NOT catch the misfiled
+  `#483`, because an unrelated commit in that range happened to mention `#483`
+  in its body. A coincidental mention satisfies the tie.
+
+DISCLOSURE ESCAPE
+-----------------
+A citation of an OPEN issue is permitted if the same bullet says so in exactly
+these words: `#<N> is still OPEN`. That phrasing already exists in the
+`[0.12.0]` section, written by hand on 2026-08-08. It is deliberately narrow
+and greppable: describing shipped code that belongs to an unfinished feature is
+legitimate; announcing that feature as delivered is not.
+
+USAGE
+-----
+  # offline structural check (pre-commit)
+  python scripts/check_release_notes.py --changelog-structure
+
+  # the release gate: check the exact bytes about to become the release body
+  python scripts/check_release_notes.py --body release_notes.txt --tag v0.14.1
+
+  # audit an already-published release (read-only; never edits it)
+  python scripts/check_release_notes.py --release v0.13.2
+
+  # check what CHANGELOG.md would produce for a version
+  python scripts/check_release_notes.py --version 0.14.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+# A citation is `#` immediately followed by digits, not preceded by a word
+# character or another `#`. The negative lookbehind is what keeps `#### Added`
+# out (no digit follows anyway) and, more importantly, what keeps the guard off
+# `~500 art files` and `$500k` -- neither carries a `#`, and both sit in the
+# v0.13.2 body next to the real `#500` defect.
+CITATION_RE = re.compile(r"(?<![\w#])#(\d+)\b")
+
+# Issue numbers below this are pre-history and not reliably resolvable; the
+# repo's real numbering starts well above it. Nothing in a modern release body
+# should cite one.
+MIN_PLAUSIBLE_ISSUE = 1
+
+UNRELEASED_HEADING_RE = re.compile(r"^##\s+\[Unreleased\]", re.MULTILINE)
+VERSION_HEADING_RE = re.compile(r"^##\s+\[([^\]]+)\]", re.MULTILINE)
+FENCE_RE = re.compile(r"^\s*```")
+
+# Everything the release workflow appends AFTER the changelog excerpt. Those
+# sections are machine-generated boilerplate (SmartScreen notice, build hashes)
+# and make no delivery claims, so they are excluded from citation checks.
+APPENDED_SECTION_RE = re.compile(r"^##\s+Build Information\s*$", re.MULTILINE)
+
+
+class Finding:
+    def __init__(self, code: str, fatal: bool, message: str, detail: str = ""):
+        self.code = code
+        self.fatal = fatal
+        self.message = message
+        self.detail = detail
+
+    def render(self) -> str:
+        tag = "FAIL" if self.fatal else "WARN"
+        out = "[{}] {}: {}".format(tag, self.code, self.message)
+        if self.detail:
+            out += "\n" + "\n".join("         " + line for line in self.detail.splitlines())
+        return out
+
+
+# --------------------------------------------------------------------------
+# text handling
+# --------------------------------------------------------------------------
+
+
+def strip_code_fences(text: str) -> str:
+    """Blank out fenced code blocks so a `#123` in a sample never trips RN003."""
+    out = []
+    in_fence = False
+    for line in text.splitlines():
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append("")
+            continue
+        out.append("" if in_fence else line)
+    return "\n".join(out)
+
+
+def strip_appended_boilerplate(text: str) -> str:
+    match = APPENDED_SECTION_RE.search(text)
+    return text[: match.start()] if match else text
+
+
+def split_bullets(text: str) -> List[Tuple[int, str]]:
+    """Group a release body into (line_number, text) claim units.
+
+    A "claim unit" is a top-level `- ` bullet plus its continuation lines, or a
+    standalone paragraph. Grouping matters because the disclosure escape
+    (`#N is still OPEN`) is scoped to the bullet making the claim, not the whole
+    document -- one disclosed bullet must not launder every other citation.
+    """
+    units: List[Tuple[int, List[str]]] = []
+    for idx, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        starts_unit = stripped.startswith(("- ", "* ", "#")) or (
+            stripped and not line.startswith((" ", "\t")) and not units
+        )
+        if starts_unit or not units:
+            units.append((idx, [line]))
+        elif not stripped:
+            units.append((idx + 1, []))
+        else:
+            units[-1][1].append(line)
+    return [(ln, "\n".join(body)) for ln, body in units if body]
+
+
+def citations_in(text: str) -> List[Tuple[int, int, str]]:
+    """Return (issue_number, line_number, bullet_text) for every citation.
+
+    Deduplicated per (number, bullet): a bullet that cites `#500` and then says
+    `#500 is still OPEN` is one claim, not two, and reporting it twice made the
+    first draft of this guard emit duplicate findings.
+    """
+    found = []
+    seen = set()
+    for line_no, unit in split_bullets(text):
+        for match in CITATION_RE.finditer(unit):
+            number = int(match.group(1))
+            key = (number, line_no)
+            if number >= MIN_PLAUSIBLE_ISSUE and key not in seen:
+                seen.add(key)
+                found.append((number, line_no, unit))
+    return found
+
+
+def is_disclosed(number: int, unit: str) -> bool:
+    """Does this bullet declare the issue open, in the agreed words?
+
+    Normalised before matching, because the disclosure that already exists in
+    the `[0.12.0]` section is written `**#500 is still\\nOPEN**` -- bold, and
+    wrapped across a line by the 80-column house style. A literal substring
+    match missed it, which would have failed the one section a human had
+    already got right. Markdown emphasis is stripped and whitespace collapsed;
+    the wording itself still has to be exact.
+    """
+    flat = re.sub(r"[*_`]", "", unit)
+    flat = re.sub(r"\s+", " ", flat)
+    return "#{} is still OPEN".format(number) in flat
+
+
+# --------------------------------------------------------------------------
+# sources of release-body text
+# --------------------------------------------------------------------------
+
+
+def extract_changelog_section(version: str, changelog_text: str) -> str:
+    """Mirror the release workflow's extraction, on the tight `## [` anchor.
+
+    Two extractors exist in this repo and they are NOT the same:
+      * `generate_release_metadata.extract_changelog_for_version()` anchors on
+        `## [<version>]` and breaks at the next `## `.
+      * `.github/workflows/enhanced-release.yml` -- the one that actually builds
+        the published body -- runs
+        `sed -n "/\\[$VERSION_NUM\\]/,/^## /p" | head -n -1`, whose start
+        pattern is NOT anchored to a heading, so a mere in-prose mention of
+        `[0.13.2]` earlier in the file would start the range in the wrong place.
+    This function uses the tight anchor. The workflow gate does not rely on it:
+    it checks `release_notes.txt` itself, which is the sed output, so the loose
+    pattern is covered by checking the bytes rather than by re-deriving them.
+    """
+    version_num = version.lstrip("v")
+    lines = changelog_text.split("\n")
+    inside = False
+    collected: List[str] = []
+    for line in lines:
+        if line.startswith("## [{}]".format(version_num)) or line.startswith(
+            "## {}".format(version_num)
+        ):
+            inside = True
+            continue
+        if inside and line.startswith("## "):
+            break
+        if inside:
+            collected.append(line)
+    return "\n".join(collected).strip()
+
+
+def fetch_published_body(tag: str) -> str:
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--json", "body", "-q", ".body"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            "could not read published release {}: {}".format(tag, result.stderr.strip())
+        )
+    return result.stdout
+
+
+# --------------------------------------------------------------------------
+# github state resolution
+# --------------------------------------------------------------------------
+
+
+def resolve_states(numbers: Sequence[int]) -> Dict[int, str]:
+    """Batch-resolve issue/PR states via one GraphQL call per 50 numbers.
+
+    `issueOrPullRequest` is used rather than `gh issue view` because the
+    CHANGELOG mixes issue and PR references freely and `gh issue view` on a PR
+    number is a silent coincidence, not a lookup. States returned: OPEN,
+    CLOSED, MERGED. Anything unresolvable comes back as UNKNOWN and is reported
+    as a warning, never as a pass.
+    """
+    states: Dict[int, str] = {}
+    unique = sorted(set(numbers))
+    for start in range(0, len(unique), 50):
+        chunk = unique[start : start + 50]
+        fields = "\n".join(
+            "n{n}: issueOrPullRequest(number: {n}) {{ "
+            "... on Issue {{ state }} ... on PullRequest {{ state }} }}".format(n=n)
+            for n in chunk
+        )
+        query = 'query {{ repository(owner: "PipFoweraker", name: "pdoom1") {{ {} }} }}'.format(
+            fields
+        )
+        result = subprocess.run(
+            ["gh", "api", "graphql", "-f", "query=" + query],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            # A partial GraphQL response still carries data alongside errors.
+            try:
+                payload = json.loads(result.stdout)
+            except (ValueError, TypeError):
+                for n in chunk:
+                    states[n] = "UNKNOWN"
+                continue
+        else:
+            payload = json.loads(result.stdout)
+        repo = (payload.get("data") or {}).get("repository") or {}
+        for n in chunk:
+            node = repo.get("n{}".format(n))
+            states[n] = (node or {}).get("state", "UNKNOWN") if node else "UNKNOWN"
+    return states
+
+
+def commit_referenced_numbers(tag: str, prev_tag: str) -> set:
+    """Numbers mentioned anywhere in commit messages in `prev_tag..tag`.
+
+    Full message bodies (`%B`), not subjects: squash-merge subjects carry the PR
+    number while the issue number lives in the body's `Closes #N`. Measured on
+    v0.13.1..v0.13.2 -- subjects alone tie 20 of the section's 22 citations,
+    full bodies tie 21, and the one that stays untied is `#500`, the real
+    defect.
+    """
+    result = subprocess.run(
+        ["git", "log", "--format=%B", "{}..{}".format(prev_tag, tag)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            "could not read commits {}..{}: {}".format(prev_tag, tag, result.stderr.strip())
+        )
+    return {int(m.group(1)) for m in CITATION_RE.finditer(result.stdout)}
+
+
+def previous_tag(tag: str) -> Optional[str]:
+    result = subprocess.run(
+        ["git", "tag", "--sort=v:refname"], cwd=REPO_ROOT, capture_output=True, text=True
+    )
+    tags = [t for t in result.stdout.split() if t]
+    if tag not in tags:
+        return None
+    index = tags.index(tag)
+    return tags[index - 1] if index > 0 else None
+
+
+# --------------------------------------------------------------------------
+# checks
+# --------------------------------------------------------------------------
+
+
+def check_changelog_structure(changelog_text: str) -> List[Finding]:
+    findings: List[Finding] = []
+    lines = changelog_text.split("\n")
+
+    unreleased_lines = [
+        i for i, line in enumerate(lines, start=1) if line.startswith("## [Unreleased]")
+    ]
+    if len(unreleased_lines) > 1:
+        findings.append(
+            Finding(
+                "RN001",
+                True,
+                "CHANGELOG.md has {} [Unreleased] headings; exactly one is allowed".format(
+                    len(unreleased_lines)
+                ),
+                "lines: {}\n".format(", ".join(str(n) for n in unreleased_lines))
+                + "Each extra heading is a past release that failed to clear the\n"
+                + "accumulator. Retitle each historical one to the version that\n"
+                + "actually shipped it, or fold it into that version's section.",
+            )
+        )
+
+    seen: Dict[str, List[int]] = {}
+    for i, line in enumerate(lines, start=1):
+        match = re.match(r"^##\s+\[([^\]]+)\]", line)
+        if match:
+            key = match.group(1).lstrip("v")
+            if key.lower() in ("unreleased", "previous"):
+                continue
+            seen.setdefault(key, []).append(i)
+    for version, at_lines in sorted(seen.items()):
+        if len(at_lines) > 1:
+            findings.append(
+                Finding(
+                    "RN002",
+                    False,
+                    "version [{}] has {} headings".format(version, len(at_lines)),
+                    "lines: {}".format(", ".join(str(n) for n in at_lines)),
+                )
+            )
+    return findings
+
+
+def check_body_citations(
+    body: str, label: str, offline: bool = False
+) -> Tuple[List[Finding], List[int]]:
+    body = strip_appended_boilerplate(strip_code_fences(body))
+    cites = citations_in(body)
+    numbers = [n for n, _, _ in cites]
+    if offline or not numbers:
+        return [], numbers
+
+    states = resolve_states(numbers)
+    findings: List[Finding] = []
+    for number, line_no, unit in cites:
+        state = states.get(number, "UNKNOWN")
+        if state == "OPEN":
+            if is_disclosed(number, unit):
+                continue
+            findings.append(
+                Finding(
+                    "RN003",
+                    True,
+                    "{}: cites #{} but that issue is OPEN".format(label, number),
+                    "line {}: {}\n".format(line_no, unit.strip().splitlines()[0][:100])
+                    + "A release body reaches pdoom1.com /game-changelog/ with no\n"
+                    + "human in between. Either the work shipped and the issue should\n"
+                    + "be closed, or the bullet is wrong. If the bullet describes\n"
+                    + "shipped code belonging to an unfinished feature, say so with\n"
+                    + 'the exact words "#{} is still OPEN".'.format(number),
+                )
+            )
+        elif state == "UNKNOWN":
+            findings.append(
+                Finding(
+                    "RN003",
+                    False,
+                    "{}: could not resolve #{} (line {})".format(label, number, line_no),
+                    "Treated as unresolved, not as a pass.",
+                )
+            )
+    return findings, numbers
+
+
+def check_commit_ties(numbers: Iterable[int], tag: str, prev_tag: str, label: str) -> List[Finding]:
+    in_range = commit_referenced_numbers(tag, prev_tag)
+    findings = []
+    for number in sorted(set(numbers)):
+        if number not in in_range:
+            findings.append(
+                Finding(
+                    "RN004",
+                    True,
+                    "{}: cites #{}, which no commit in {}..{} mentions".format(
+                        label, number, prev_tag, tag
+                    ),
+                    "Either the claim belongs to a different release section, or\n"
+                    "the work is not in this build. This is a LOWER BOUND: a\n"
+                    "coincidental mention in an unrelated commit body satisfies\n"
+                    "the tie, so a clean RN004 is not proof of correct filing.",
+                )
+            )
+    return findings
+
+
+# --------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--changelog-structure", action="store_true", help="RN001/RN002 only")
+    parser.add_argument("--body", help="path to the assembled release body to check")
+    parser.add_argument("--release", help="check an already-published release by tag (read-only)")
+    parser.add_argument("--version", help="check what CHANGELOG.md yields for this version")
+    parser.add_argument("--tag", help="tag this body belongs to, enables RN004")
+    parser.add_argument("--prev-tag", help="override the auto-detected previous tag")
+    parser.add_argument(
+        "--offline", action="store_true", help="skip RN003/RN004 (no gh, no network)"
+    )
+    parser.add_argument("filenames", nargs="*", help="ignored (pre-commit passes filenames)")
+    args = parser.parse_args(argv)
+
+    findings: List[Finding] = []
+    checked_something = False
+
+    if args.changelog_structure or not (args.body or args.release or args.version):
+        findings.extend(check_changelog_structure(CHANGELOG.read_text(encoding="utf-8")))
+        checked_something = True
+
+    body = None
+    label = ""
+    if args.body:
+        body = Path(args.body).read_text(encoding="utf-8")
+        label = args.body
+    elif args.release:
+        body = fetch_published_body(args.release)
+        label = "published release {}".format(args.release)
+    elif args.version:
+        body = extract_changelog_section(args.version, CHANGELOG.read_text(encoding="utf-8"))
+        label = "CHANGELOG section [{}]".format(args.version.lstrip("v"))
+        if not body:
+            findings.append(
+                Finding("RN000", True, "no CHANGELOG section found for {}".format(args.version))
+            )
+
+    if body:
+        checked_something = True
+        cite_findings, numbers = check_body_citations(body, label, offline=args.offline)
+        findings.extend(cite_findings)
+
+        tag = (
+            args.tag or args.release or (("v" + args.version.lstrip("v")) if args.version else None)
+        )
+        if tag and not args.offline:
+            prev = args.prev_tag or previous_tag(tag)
+            if prev:
+                findings.extend(check_commit_ties(numbers, tag, prev, label))
+            else:
+                findings.append(
+                    Finding(
+                        "RN004",
+                        False,
+                        "no previous tag for {}; commit-tie check skipped".format(tag),
+                    )
+                )
+
+    fatal = [f for f in findings if f.fatal]
+    for finding in findings:
+        print(finding.render())
+
+    if not checked_something:
+        print("[FAIL] nothing was checked -- refusing to report a pass")
+        return 2
+
+    if fatal:
+        print("")
+        print(
+            "RELEASE NOTES CHECK FAILED: {} fatal, {} warning".format(
+                len(fatal), len(findings) - len(fatal)
+            )
+        )
+        return 1
+
+    print("[OK] release notes check passed ({} warning(s))".format(len(findings)))
+    print("     Mechanical only. Prose accuracy and uncited claims remain manual --")
+    print("     see docs/RELEASE_NOTES_GUARD.md.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_release_notes_guard.py
+++ b/tests/test_release_notes_guard.py
@@ -1,0 +1,159 @@
+"""Tests for scripts/check_release_notes.py (issue #1165).
+
+These are OFFLINE. Issue states are stubbed so the suite does not depend on
+GitHub -- but the stub values are the real ones, read from the live API on
+2026-08-09: #500 OPEN, #483 CLOSED, #1173/#1175/#1179 CLOSED.
+
+The load-bearing test is `test_red_against_the_real_v0132_defect`: the guard
+must go RED on the exact text that reached players. A guard that has never been
+shown to fail is not evidence.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import check_release_notes as guard  # noqa: E402
+
+# Verbatim from the published v0.13.2 release body (`gh release view v0.13.2`).
+# Trimmed to the lines that matter; wording untouched.
+V0132_EXCERPT = """\
+#### Dev / data (no visible gameplay change yet)
+- ~500 art files (worker round 2, cat west-walk variants, prop re-base, tier-6
+  diagonals) made durable from the day's generation runs (#965, #966).
+
+#### Added
+- **Research Quality System** (#500): Rushed / Standard / Thorough quality toggle for research
+- **Scenario/Mod Hook System** (#483): Custom scenarios without code changes
+    - **Bootstrap Mode**: Extra resources for learning ($500k, 200 compute)
+"""
+
+# Verbatim from the published v0.14.1 release body, hand-checked and clean.
+V0141_EXCERPT = """\
+### Fixed
+- **The leaderboard screen opened on LOCAL** and only fetched the global board if
+  you pressed a toggle (#1173). It opens on global now.
+
+### Added
+- **In-game patch notes cover 0.12.0 onwards** (#1175), ending three releases
+  where the What's New screen said nothing about what changed.
+"""
+
+# Verbatim from CHANGELOG.md [0.12.0], written by hand on 2026-08-08. Cites an
+# OPEN issue and discloses it, so it must pass.
+DISCLOSED_EXCERPT = """\
+### Added
+- Research quality: a Rushed / Standard / Thorough toggle that trades speed
+  against risk, feeding the hidden risk pool (#500). Wired into the plan screen
+  via `main_ui.gd`, with `research_quality_selector.gd` as the control. **#500 is
+  still OPEN** -- this describes what the shipped code does, not a finished
+  feature.
+"""
+
+REAL_STATES = {
+    500: "OPEN",
+    483: "CLOSED",
+    791: "OPEN",
+    811: "OPEN",
+    965: "CLOSED",
+    966: "CLOSED",
+    1173: "CLOSED",
+    1175: "CLOSED",
+    1179: "CLOSED",
+}
+
+
+@pytest.fixture(autouse=True)
+def stub_github(monkeypatch):
+    monkeypatch.setattr(
+        guard, "resolve_states", lambda numbers: {n: REAL_STATES.get(n, "CLOSED") for n in numbers}
+    )
+
+
+def codes(findings):
+    return sorted(f.code for f in findings if f.fatal)
+
+
+def test_red_against_the_real_v0132_defect():
+    findings, numbers = guard.check_body_citations(V0132_EXCERPT, "v0.13.2")
+    fatal = [f for f in findings if f.fatal]
+    assert fatal, "guard must go RED on the body that actually reached players"
+    assert all("#500" in f.message for f in fatal)
+    assert 500 in numbers
+
+
+def test_green_against_hand_checked_v0141():
+    findings, numbers = guard.check_body_citations(V0141_EXCERPT, "v0.14.1")
+    assert [f for f in findings if f.fatal] == []
+    assert set(numbers) == {1173, 1175}
+
+
+def test_prose_numbers_are_not_citations():
+    """`~500 art files` and `$500k` sit next to the real #500 in the same body.
+
+    If the citation regex caught either, the guard would cry wolf on every
+    release and get switched off.
+    """
+    numbers = [n for n, _, _ in guard.citations_in(V0132_EXCERPT)]
+    assert numbers.count(500) == 1
+
+
+def test_markdown_headings_are_not_citations():
+    assert guard.citations_in("#### Added\n### Fixed\n## [0.14.1]") == []
+
+
+def test_disclosed_open_issue_passes():
+    findings, _ = guard.check_body_citations(DISCLOSED_EXCERPT, "[0.12.0]")
+    assert [f for f in findings if f.fatal] == []
+
+
+def test_disclosure_does_not_launder_a_neighbouring_bullet():
+    body = DISCLOSED_EXCERPT + "- Something else entirely (#500).\n"
+    findings, _ = guard.check_body_citations(body, "mixed")
+    assert len([f for f in findings if f.fatal]) == 1
+
+
+def test_code_fences_are_ignored():
+    body = "```\ngh issue view #500\n```\n"
+    findings, numbers = guard.check_body_citations(body, "fenced")
+    assert numbers == []
+    assert findings == []
+
+
+def test_unknown_state_is_not_a_pass(monkeypatch):
+    monkeypatch.setattr(guard, "resolve_states", lambda numbers: {n: "UNKNOWN" for n in numbers})
+    findings, _ = guard.check_body_citations(V0141_EXCERPT, "unknown")
+    assert findings, "an unresolvable citation must be reported, not silently passed"
+
+
+def test_rn001_catches_multiple_unreleased_headings():
+    text = "# Changelog\n\n## [Unreleased]\n\n- a\n\n## [Unreleased] - 2025-09-17\n\n- b\n"
+    findings = guard.check_changelog_structure(text)
+    assert "RN001" in codes(findings)
+
+
+def test_rn001_passes_on_a_single_unreleased_heading():
+    text = "# Changelog\n\n## [Unreleased]\n\n## [0.14.1] - 2026-08-08\n\n- a\n"
+    assert codes(guard.check_changelog_structure(text)) == []
+
+
+def test_rn002_duplicate_version_is_warn_only():
+    text = "## [0.7.4] - x\n- a\n## [0.7.4] - y\n- b\n"
+    findings = guard.check_changelog_structure(text)
+    assert codes(findings) == []
+    assert any(f.code == "RN002" for f in findings)
+
+
+def test_extraction_stops_at_the_next_version_heading():
+    text = "## [0.14.1]\n- in\n\n## [0.14.0]\n- out\n"
+    section = guard.extract_changelog_section("0.14.1", text)
+    assert "- in" in section and "- out" not in section
+
+
+def test_the_real_changelog_has_exactly_one_unreleased_heading():
+    """Regression pin for the six-heading corruption (#1165)."""
+    findings = guard.check_changelog_structure(guard.CHANGELOG.read_text(encoding="utf-8"))
+    assert "RN001" not in codes(findings)


### PR DESCRIPTION
Closes #1165.

v0.13.2's published release body announced the Research Quality System as delivered. `#500` was open then and is open now. pdoom1.com's `/game-changelog/` renders release bodies live from the releases API, so it reached readers with no human in between. Found by `pdoom1-website` on 2026-08-07 (`coordination#35`).

## The propagation path -- established, not assumed

Two extractors exist and only one builds what players read.

| Where | Code | Feeds |
| --- | --- | --- |
| `enhanced-release.yml`, `create-github-release`, step "Extract changelog" | `sed -n "/\[$VERSION_NUM\]/,/^## /p" CHANGELOG.md \| head -n -1 > release_notes.txt` | `body_path` -> **the published release body** -> releases API -> `pdoom1.com/game-changelog/` |
| `generate_release_metadata.extract_changelog_for_version()` | anchors on `## [<version>]`, breaks at next `## ` | `public/releases/*.json`, manifest `highlights` |

Consequences, stated because they change where the guard goes:

- **A pre-commit hook could not have caught v0.13.2.** The body is assembled at release time from whatever the file says then.
- `extract_changelog_for_version()` breaks at the next `## `, so a misfiled `[0.13.2]` section could **not** leak into a `0.14.1` manifest. Cross-version leakage through the manifest was a decoy -- confirmed, not designed around.
- The workflow's `sed` start pattern is **not anchored to a heading**, so `/\[0.13.2\]/` would match in prose. The guard sidesteps this by checking `release_notes.txt` itself rather than re-deriving the section: **the exact bytes about to be published, whatever produced them.**

## Where it runs

| Gate | Trigger | Checks | Blocking |
| --- | --- | --- | --- |
| pre-commit `changelog-structure-check` | `CHANGELOG.md` commits | RN001, RN002 (offline) | yes |
| `pre-release-checks.yml` | `v*.*.*` tag push | RN001/2 + RN003/4 on the section | yes |
| `enhanced-release.yml`, **between assembly and `action-gh-release`** | `v*.*.*` tag push | RN003, RN004 on `release_notes.txt` | **yes -- this is the one that stops a bad body publishing** |

## Mechanical vs manual

Caught mechanically:

| ID | Rule | Severity |
| --- | --- | --- |
| RN001 | more than one `## [Unreleased]` heading | fatal |
| RN002 | the same version heading twice | warn (`[0.7.4]` is genuine history) |
| RN003 | a cited issue/PR whose state is OPEN | fatal |
| RN004 | a cited issue/PR no commit in `<prev tag>..<tag>` mentions | fatal |

**Still manual** -- "every bullet ties to a merged commit" was enforced by hand twice on Friday and this replaces only part of that:

- **Prose accuracy.** `#1173` closed and in range says the work happened, not that "it opens on global now" is true.
- **Uncited bullets.** RN003/RN004 bind to `#N`; a bullet citing nothing passes silently.
- **Correct version filing.** RN004 is a **lower bound, not a proof**. Against v0.13.2 it caught the misfiled `#500` and did **not** catch the misfiled `#483`, because an unrelated commit in that range (`... scenario runs are UNRANKED ... (#1060)`) happens to mention `#483` in its body. A coincidental mention satisfies the tie.

Full accounting: `docs/RELEASE_NOTES_GUARD.md`.

## Disclosure escape

Describing shipped code belonging to an unfinished feature is legitimate; announcing that feature as delivered is not. RN003 permits an OPEN citation when the same bullet says, in exactly these words, `#500 is still OPEN` -- the phrasing already hand-written in `[0.12.0]`. Scoped to the bullet, so one disclosure cannot launder its neighbours.

## Red first, then green

```
$ python scripts/check_release_notes.py --release v0.13.2
[FAIL] RN003: published release v0.13.2: cites #791 but that issue is OPEN
[FAIL] RN003: published release v0.13.2: cites #811 but that issue is OPEN
[FAIL] RN003: published release v0.13.2: cites #500 but that issue is OPEN
[FAIL] RN003: published release v0.13.2: cites #500 but that issue is OPEN
[FAIL] RN004: published release v0.13.2: cites #500, which no commit in v0.13.1..v0.13.2 mentions
[FAIL] RN004: published release v0.13.2: cites #527, ...
[FAIL] RN004: published release v0.13.2: cites #530, ...
[FAIL] RN004: published release v0.13.2: cites #535, ...

RELEASE NOTES CHECK FAILED: 8 fatal, 0 warning     (exit 1)

$ python scripts/check_release_notes.py --release v0.14.1
[OK] release notes check passed (0 warning(s))     (exit 0)
```

`#791` and `#811` are **not false positives** -- both are genuinely OPEN and both are announced as delivered in the same v0.13.2 body. Same defect class, two more instances, found by running the guard rather than by reading the body.

## The six headings: still there, now fixed separately

They were still present at `origin/main` -- lines 7, 589, 667, 928, 1295, 1465. The second commit retitles the five stale ones to `[Archived draft ...]`, titles and dates verbatim, content untouched, **no version claimed** (which release shipped each block was not established, and file order is unreliable there -- the 2025-09-19 block sits below `[0.7.1] - 2025-09-15`).

Kept as a separate commit so the guard is reviewable against the broken state: at commit 1 the regression pin fails; at commit 2 all 13 tests pass.

## Two bugs found in the guard by testing it

Not by reading it: the disclosure escape missed the existing `**#500 is still\nOPEN**` (bold, line-wrapped), and a bullet citing the same number twice reported twice. Both fixed before commit.

## Outstanding -- not actioned here

**The published v0.13.2 body is still wrong** and `pdoom1.com/game-changelog/` is still serving it. Correcting a published body is Pip's call and `pdoom1-website` has asked him; deliberately not pre-empted. This guard prevents the next one; it does not repair that one.

`#791` and `#811` being open while announced as shipped is a second outstanding item on the same body.

No touches to `version.txt`, `ladder_version.txt`, any tag, `check_ladder_bump.py`, `quality-checks.yml`, or `scripts/run_godot_tests.py`.

Generated with [Claude Code](https://claude.com/claude-code)
