### PR TITLE
ci(ladder): arm the board-key guard -- drop '|| true', add a written ack (#1178)

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -66,17 +66,27 @@ jobs:
         echo " A silent drift forks the leaderboard board-key, so this gate is FATAL.)"
         python tools/sync_version.py --check
 
-    - name: Ladder Bump Heuristic (advisory)
+    - name: Ladder Bump Check (blocking, ack-able)
       if: github.event_name == 'pull_request'
       env:
-        # SECURITY: branch name is user-influenced -- pass via env, not inline
+        # SECURITY: all three are user-influenced -- pass via env, never inline in run
         BASE_REF: ${{ github.base_ref }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+        PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
       run: |
-        echo "Build-vs-ladder split: warn when gameplay-surface files changed without a"
-        echo "ladder_version.txt bump (or vice versa). Advisory smell detector, never blocks;"
-        echo "reviewer acks against the spec Section 3.3 checklist."
+        echo "Build-vs-ladder split: fail when gameplay-surface files changed without a"
+        echo "ladder_version.txt bump (or vice versa) AND nobody acked it in writing."
+        echo "(Board key is (seed, ladder_version). A silent ladder move writes scores to a"
+        echo " board built under different rules -- issue #1178. This step ran with '|| true'"
+        echo " until 2026-08-09, so it could not fail; it missed the #1137 bump for 31 hours.)"
+        echo "Ack by putting 'ladder-ack: <reason>' in the PR body, or applying 'ladder-ack'."
         git fetch origin "$BASE_REF" --depth=1
-        python tools/check_ladder_bump.py --base "origin/$BASE_REF" || true
+        case ",$PR_LABELS," in
+          *,ladder-ack,*) LADDER_ACK="ladder-ack: the 'ladder-ack' label is applied to this PR" ;;
+          *)              LADDER_ACK="$PR_BODY" ;;
+        esac
+        export LADDER_ACK
+        python tools/check_ladder_bump.py --base "origin/$BASE_REF" --strict
 
     - name: Web Export System Check
       run: |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -74,7 +74,7 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | archive_masters.py | -- | Sync the local art-masters cache to off-site object storage (DreamObjects). | tool:slim_repo.py |
 | build_release.py | PROVE | build_release.py -- export a P(Doom) build FROM A VERIFIED-CLEAN STATE. | ci:enhanced-release.yml; test:test_build_all_platforms.py; test:test_build_release_paths.py; tool:build_all_platforms.py; tool:find_dead_code.py |
 | capture_cinematic.py | -- | Cinematic capture harness for P(Doom)1 -- deterministic scene footage -> mp4/gif. | test:test_find_dead_code.py; tool:find_dead_code.py |
-| check_ladder_bump.py | OBSERVE | Heuristic guard: did this diff need a ladder_version bump (or get one it didn't need)? | ci:quality-checks.yml; tool:sync_version.py |
+| check_ladder_bump.py | PROVE | Heuristic guard: did this diff need a ladder_version bump (or get one it didn't need)? | ci:quality-checks.yml; test:test_check_ladder_bump.py; tool:sync_version.py |
 | check_scene_nav.py | PROVE | check_scene_nav.py -- enforce the single-scene-navigation-chokepoint invariant. | pre-commit; ci:quality-checks.yml; tool:enforce_standards.py |
 | cleanup-duplicate-issues.py | -- | Cleanup script for duplicate GitHub issues created by sync tool failure. | NONE FOUND |
 | collect_ui_evolution.py | -- | UI evolution capture collector for P(Doom). | human (docstring usage) |
@@ -210,4 +210,4 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 
 25 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/SUNDAY-postmortem-2026-08-07.html`, `tools/runsheet/chronicle-2026-08-06_07.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
 
-Total: 113 active tools (9 GENERATE, 6 OBSERVE, 5 PROVE, 1 SWEEP, 92 undeclared); 11 in UNKNOWN; 6 archived.
+Total: 113 active tools (9 GENERATE, 5 OBSERVE, 6 PROVE, 1 SWEEP, 92 undeclared); 11 in UNKNOWN; 6 archived.

--- a/docs/rituals/gate_2_the_freeze.md
+++ b/docs/rituals/gate_2_the_freeze.md
@@ -37,9 +37,13 @@ announced in the day-log", which records *that* a freeze happened but not
 *what* was frozen. Without a SHA, "no new law crossed this line" has no
 line. Every later gate should be able to name its base commit.
 
-Check 5 is advisory by design: `check_ladder_bump.py` is a smell detector,
-not a proof (its own docstring says so). Acking a warning is a legitimate
-outcome; ignoring one silently is not.
+Check 5 is judgement over a smell detector: `check_ladder_bump.py` is not a
+proof (its own docstring says so). Acking a warning is a legitimate outcome;
+ignoring one silently is not -- and since #1178 that second half is machine-
+enforced. CI runs the checker with `--strict` and WITHOUT `|| true`, so an
+unacked warning now fails the PR; the ack is a `ladder-ack: <reason>` line in
+the PR body (or the `ladder-ack` label). At this gate, run it without `--strict`
+and record the ack in the day-log as before.
 
 ## The incantation
 

--- a/tests/test_check_ladder_bump.py
+++ b/tests/test_check_ladder_bump.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/check_ladder_bump.py -- the board-key bump guard (issue #1178).
+
+What these lock down:
+
+- **The guard can actually fail.** Until 2026-08-09 this check ran in CI as
+  ``python tools/check_ladder_bump.py --base ... || true`` AND with its own
+  default of exit-0-on-warning, so it was disarmed twice over. These tests
+  assert the exit codes directly, so a future re-disarming shows up as a red
+  test rather than as a green CI job that checks nothing.
+- Ack parsing: a ``ladder-ack:`` line with a substantive reason turns a strict
+  failure green; a token-length reason does not.
+- The gameplay-surface allowlist, including the ``.md`` exclusion added because
+  the real #1137 run named ``godot/data/events/overrides/README.md`` as
+  gameplay surface (prose in the .pck cannot move a score).
+"""
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import check_ladder_bump as clb  # noqa: E402
+
+
+def git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True, text=True)
+
+
+def write(root: Path, rel: str, text: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class FakeRepo:
+    """A throwaway git repo with a base commit, so changed_files() has real input."""
+
+    def __init__(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        git(self.root, "init", "-q", "-b", "main")
+        git(self.root, "config", "user.email", "test@example.invalid")
+        git(self.root, "config", "user.name", "test")
+        write(self.root, "README.md", "base\n")
+        write(self.root, "ladder_version.txt", "4\n")
+        git(self.root, "add", "README.md", "ladder_version.txt")
+        git(self.root, "commit", "-qm", "base")
+        self.base = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def commit(self, files: dict, message: str = "change") -> None:
+        for rel, text in files.items():
+            write(self.root, rel, text)
+        git(self.root, "add", *files.keys())
+        git(self.root, "commit", "-qm", message)
+
+    def close(self) -> None:
+        self._tmp.cleanup()
+
+
+class LadderBumpGuardTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo = FakeRepo()
+        patcher = mock.patch.object(clb, "REPO_ROOT", self.repo.root)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self.repo.close)
+
+    def run_main(self, *argv: str, env: dict | None = None) -> int:
+        with mock.patch.object(
+            sys, "argv", ["check_ladder_bump.py", "--base", self.repo.base, *argv]
+        ):
+            with mock.patch.dict("os.environ", env or {}, clear=False):
+                return clb.main()
+
+    # -- the case the guard exists for: gameplay change, no bump ------------
+
+    def test_gameplay_without_bump_is_advisory_green_without_strict(self):
+        """Documents the pre-#1178 behaviour: warning, exit 0. Not a bug -- a default."""
+        self.repo.commit({"godot/data/events/balancing/rarity_curves.json": "{}\n"})
+        self.assertEqual(self.run_main(), 0)
+
+    def test_gameplay_without_bump_fails_under_strict(self):
+        """The load-bearing assertion: this guard CAN go red."""
+        self.repo.commit({"godot/data/events/balancing/rarity_curves.json": "{}\n"})
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": ""}), 1)
+
+    def test_core_script_change_without_bump_fails_under_strict(self):
+        self.repo.commit({"godot/scripts/core/doom_system.gd": "extends Node\n"})
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": ""}), 1)
+
+    # -- the reverse direction: bump with nothing to justify it -------------
+
+    def test_bump_without_gameplay_change_fails_under_strict(self):
+        self.repo.commit({"ladder_version.txt": "5\n"})
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": ""}), 1)
+
+    # -- the legitimate quiet cases: must stay green ------------------------
+
+    def test_consistent_bump_passes(self):
+        self.repo.commit(
+            {
+                "godot/scripts/core/doom_system.gd": "extends Node\n",
+                "ladder_version.txt": "5\n",
+            }
+        )
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": ""}), 0)
+
+    def test_cosmetic_only_diff_passes(self):
+        self.repo.commit({"godot/scripts/ui/main_ui.gd": "extends Control\n"})
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": ""}), 0)
+
+    def test_tests_and_godot_metadata_are_not_gameplay_surface(self):
+        self.repo.commit(
+            {
+                "godot/tests/unit/test_thing.gd": "extends GutTest\n",
+                "godot/data/events/thing.json.uid": "uid://abc\n",
+            }
+        )
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": ""}), 0)
+
+    def test_markdown_under_data_is_not_gameplay_surface(self):
+        """The real #1137 false positive: a README under godot/data/ flagged as gameplay."""
+        self.assertFalse(clb.is_gameplay_surface("godot/data/events/overrides/README.md"))
+        self.repo.commit({"godot/data/events/overrides/README.md": "docs\n"})
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": ""}), 0)
+
+    def test_patch_notes_are_not_gameplay_surface(self):
+        """Release copy under godot/data/ changes every release; it cannot move a score."""
+        self.assertFalse(clb.is_gameplay_surface("godot/data/patch_notes.json"))
+        self.repo.commit({"godot/data/patch_notes.json": '{"versions": []}\n'})
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": ""}), 0)
+
+    # -- the ack escape hatch ----------------------------------------------
+
+    def test_written_ack_turns_a_strict_failure_green(self):
+        self.repo.commit({"godot/data/events/balancing/rarity_curves.json": "{}\n"})
+        ack = "please explain\n\nladder-ack: comment-only retune, no score can move\n"
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": ack}), 0)
+
+    def test_token_ack_reason_is_not_an_ack(self):
+        self.repo.commit({"godot/data/events/balancing/rarity_curves.json": "{}\n"})
+        self.assertEqual(self.run_main("--strict", env={"LADDER_ACK": "ladder-ack: y"}), 1)
+
+    def test_ack_env_name_is_configurable(self):
+        self.repo.commit({"godot/data/events/balancing/rarity_curves.json": "{}\n"})
+        env = {"LADDER_ACK": "", "OTHER_ACK": "ladder-ack: reviewed against 3.3 checklist"}
+        self.assertEqual(self.run_main("--strict", "--ack-env", "OTHER_ACK", env=env), 0)
+
+    def test_find_ack_parsing(self):
+        self.assertIsNone(clb.find_ack(""))
+        self.assertIsNone(clb.find_ack("no ack here at all"))
+        self.assertIsNone(clb.find_ack("ladder-ack:"))
+        self.assertIsNone(clb.find_ack("this mentions ladder-ack: inline but ends"))
+        self.assertEqual(clb.find_ack("LADDER-ACK: cosmetic only"), "cosmetic only")
+        self.assertEqual(clb.find_ack("  ladder-ack:  spaced reason  "), "spaced reason")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_ladder_bump.py
+++ b/tools/check_ladder_bump.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Heuristic guard: did this diff need a ladder_version bump (or get one it didn't need)?
 
-Layer: OBSERVE -- warn-only smell detector; CI runs it non-blocking (|| true)
+Layer: PROVE -- under --strict this fails the build unless a human acks in writing
 
 Part of the build-vs-ladder version split
 (docs/game-design/BUILD_VS_LADDER_VERSION_SPLIT.md, Section 4.2). The dangerous
@@ -14,27 +14,45 @@ This is a SMELL DETECTOR, not a proof: a comment-only edit inside
 ``godot/scripts/core/`` is a false positive, and an RNG-stream refactor hidden
 in a file outside the allowlist is a false negative (the golden-replay
 determinism backstop in the slow test tier is the stronger signal for that).
-Warnings are meant to be acked by a reviewer against the Section 3.3 checklist,
-not to hard-block.
+So a warning is not "you must bump" -- it is "a human must say, in writing,
+which of the two it is". ``--strict`` enforces exactly that: warnings fail the
+build UNLESS the ack text (see ``--ack-env``) carries a ``ladder-ack:`` line.
+
+Why the ack instead of a plain hard-fail (issue #1178): the ladder legitimately
+moves ONCE PER EPOCH, not once per PR (L1..L4 across hundreds of PRs), so
+"gameplay files changed and the ladder did not move" is the NORMAL case. A bare
+hard-fail would go red on nearly every gameplay PR and be switched off again --
+which is how this check spent its whole life behind ``|| true``.
 
 Usage::
 
     python tools/check_ladder_bump.py                  # diff vs origin/main, warn only
     python tools/check_ladder_bump.py --base <ref>     # explicit base ref
-    python tools/check_ladder_bump.py --strict         # exit 1 on any warning (CI gate)
+    python tools/check_ladder_bump.py --strict         # exit 1 on unacked warnings (CI gate)
+    LADDER_ACK="ladder-ack: cosmetic copy fix" python tools/check_ladder_bump.py --strict
 
-Default exit code is 0 even with warnings (advisory); ``--strict`` turns
-warnings into a failing exit for pipelines that want an explicit ack step.
+Default exit code is 0 even with warnings (advisory, for local and gate-ritual
+use); ``--strict`` is what CI runs, and CI runs it WITHOUT ``|| true``.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
+import re
 import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LADDER_FILE = "ladder_version.txt"
+
+# A reviewer's written ack, looked for in the --ack-env text (in CI: the PR body,
+# or a synthesised line when the `ladder-ack` label is applied). The reason is
+# mandatory and must be substantive -- "ladder-ack: y" is not a decision record.
+ACK_PATTERN = re.compile(
+    r"^[^\S\n]*ladder-ack[^\S\n]*:[^\S\n]*(\S.*?)[^\S\n]*$", re.IGNORECASE | re.MULTILINE
+)
+ACK_MIN_REASON_CHARS = 8
 
 # Gameplay surface (spec Section 4.2): paths where a change plausibly alters
 # scores, trajectories, seeds, or RNG streams on a fixed seed -- i.e. the
@@ -50,11 +68,20 @@ EXCLUDE_PREFIXES = (
     "godot/scripts/dev/",
 )
 # Godot metadata churn, never gameplay: .uid = stable resource IDs, .import = import
-# metadata (both tracked on purpose, see CLAUDE.md).
+# metadata (both tracked on purpose, see CLAUDE.md). ".md" is prose that ships in
+# the .pck but cannot move a score -- it was a real false positive: the #1137 run
+# named godot/data/events/overrides/README.md as gameplay surface.
 EXCLUDE_SUFFIXES = (
     ".uid",
     ".import",
+    ".md",
 )
+# Exact paths under a gameplay prefix that are prose, not rules. Kept as an explicit
+# short list rather than a pattern, so adding one is a decision someone made.
+# patch_notes.json is release copy read only by godot/scripts/ui/whats_new_modal.gd;
+# it changes on EVERY release, so leaving it in made the strict gate demand an ack
+# on every release PR -- the exact noise that got '|| true' added in the first place.
+EXCLUDE_PATHS = ("godot/data/patch_notes.json",)
 
 
 def _git_diff_names(spec: list[str]) -> str:
@@ -87,6 +114,8 @@ def changed_files(base: str) -> list[str]:
 
 def is_gameplay_surface(path: str) -> bool:
     p = path.replace("\\", "/")
+    if p in EXCLUDE_PATHS:
+        return False
     if any(p.startswith(x) for x in EXCLUDE_PREFIXES):
         return False
     if any(p.endswith(x) for x in EXCLUDE_SUFFIXES):
@@ -94,6 +123,19 @@ def is_gameplay_surface(path: str) -> bool:
     if any(p.startswith(x) for x in GAMEPLAY_PREFIXES):
         return True
     return any(p.endswith("/" + name) or p == name for name in GAMEPLAY_BASENAMES)
+
+
+def find_ack(text: str) -> str | None:
+    """The reviewer's written ack reason, or None if the text carries no usable ack.
+
+    A ``ladder-ack:`` line with a too-short reason is deliberately NOT an ack --
+    the point of the mechanism is that someone had to state which case this is.
+    """
+    for match in ACK_PATTERN.finditer(text or ""):
+        reason = match.group(1).strip()
+        if len(reason) >= ACK_MIN_REASON_CHARS:
+            return reason
+    return None
 
 
 def main() -> int:
@@ -106,7 +148,15 @@ def main() -> int:
     parser.add_argument(
         "--strict",
         action="store_true",
-        help="exit 1 on any warning (default: advisory, exit 0)",
+        help="exit 1 on any warning that carries no written ack (this is what CI runs)",
+    )
+    parser.add_argument(
+        "--ack-env",
+        default="LADDER_ACK",
+        help=(
+            "name of the environment variable searched for a 'ladder-ack: <reason>' "
+            "line (default: LADDER_ACK). Only consulted under --strict."
+        ),
     )
     args = parser.parse_args()
 
@@ -143,11 +193,30 @@ def main() -> int:
 
     for w in warnings:
         print(f"[check_ladder_bump] WARNING: {w}")
-    if args.strict:
-        print("[check_ladder_bump] --strict: treating warnings as failure")
-        return 1
-    print("[check_ladder_bump] advisory mode: not failing the build. Reviewer must ack.")
-    return 0
+
+    if not args.strict:
+        print("[check_ladder_bump] advisory mode (no --strict): not failing. Reviewer must ack.")
+        return 0
+
+    ack = find_ack(os.environ.get(args.ack_env, ""))
+    if ack:
+        print(f"[check_ladder_bump] ACKED by reviewer via {args.ack_env}: {ack}")
+        print("[check_ladder_bump] --strict: warning(s) acked in writing, passing.")
+        return 0
+
+    print(
+        "[check_ladder_bump] --strict: FAILING. The warning above is not a demand to bump --\n"
+        "  it is a demand that a human state, in writing, which case this is.\n"
+        "  To ack, do EITHER:\n"
+        "    - add a line to the PR body:  ladder-ack: <reason, at least "
+        f"{ACK_MIN_REASON_CHARS} chars>\n"
+        "    - or apply the 'ladder-ack' label to the PR,\n"
+        "  then re-run this job. Decide against the Section 3.3 checklist in\n"
+        "  docs/game-design/BUILD_VS_LADDER_VERSION_SPLIT.md. If the diff CAN change a\n"
+        "  score/trajectory/seed/RNG stream on a fixed seed, bump ladder_version.txt and\n"
+        "  run: python tools/sync_version.py"
+    )
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1178.

## The neutered invocation, confirmed

`.github/workflows/quality-checks.yml:79` (on `origin/main` at `1ddb033d`):

```yaml
python tools/check_ladder_bump.py --base "origin/$BASE_REF" || true
```

It was disarmed **twice**, not once. `|| true` swallows a non-zero exit, and
`tools/check_ladder_bump.py` *also* returns 0 on a warning by default
(`--strict` was never passed). Either alone would have made the step green.

## Before: proof it swallows a real failure

Run against **#1137** (`8791ba47`), the known offender -- it retimed the
historical event deck and edited `rarity_curves.json`, and its missing ladder
bump stood for 31 hours. A detached worktree at `8791ba47`, base `8791ba47^`,
running the code exactly as `main` has it:

```
$ bash -c 'python tools/check_ladder_bump.py --base 8791ba47^ || true; echo "wrapper exit=$?"'
[check_ladder_bump] WARNING: gameplay-surface files changed but ladder_version.txt was NOT bumped.
  ...
  Gameplay-surface files in this diff:
    - godot/data/events/balancing/rarity_curves.json
    - godot/data/events/overrides/README.md
    - godot/data/events/overrides/promotion_pass_2026_08.json

[check_ladder_bump] advisory mode: not failing the build. Reviewer must ack.
wrapper exit=0
```

Isolating the two layers:

```
$ bash -c 'python tools/check_ladder_bump.py --base 8791ba47^; echo "script exit=$?"'
... [same warning] ...
script exit=0

$ bash -c 'python tools/check_ladder_bump.py --base 8791ba47^ --strict >/dev/null; echo "strict exit=$?"'
strict exit=1
$ bash -c 'python tools/check_ladder_bump.py --base 8791ba47^ --strict >/dev/null || true; echo "strict+|| true wrapper exit=$?"'
strict+|| true wrapper exit=0
```

So: the script *can* fail, `--strict` makes it fail, and `|| true` un-fails it.

**Unflattering correction to the record.** The `v0.14.0` tag message (in
`public/releases/releases.json`) says the guard missed #1137 because
`GAMEPLAY_PREFIXES` excludes `godot/autoload/`, where the retime lives. The run
above shows that is not what happened: #1137 also touched
`godot/data/events/**`, which **is** in the allowlist, and the checker named
those files. The allowlist worked. The double-disarm is the whole reason nobody
saw it. The `godot/autoload/` gap is real but was not the cause here, and it is
out of scope for this PR.

## After: the same scenario, now failing

Same worktree, same range, with this branch's checker and the invocation CI now
uses (`--strict`, no `|| true`):

```
$ bash -c 'LADDER_ACK="" python tools/check_ladder_bump.py --base 8791ba47^ --strict; echo "CI step exit=$?"'
[check_ladder_bump] WARNING: gameplay-surface files changed but ladder_version.txt was NOT bumped.
  ...
  Gameplay-surface files in this diff:
    - godot/data/events/balancing/rarity_curves.json
    - godot/data/events/overrides/promotion_pass_2026_08.json

[check_ladder_bump] --strict: FAILING. The warning above is not a demand to bump --
  it is a demand that a human state, in writing, which case this is.
  To ack, do EITHER:
    - add a line to the PR body:  ladder-ack: <reason, at least 8 chars>
    - or apply the 'ladder-ack' label to the PR,
  then re-run this job. ...
CI step exit=1
```

Acked, it goes green -- and the reason is printed into the job log, so the
decision is recoverable later:

```
$ LADDER_ACK="ladder-ack: retimes the historical deck, forking to L4 in the release cut" \
  python tools/check_ladder_bump.py --base 8791ba47^ --strict
[check_ladder_bump] ACKED by reviewer via LADDER_ACK: retimes the historical deck, forking to L4 in the release cut
[check_ladder_bump] --strict: warning(s) acked in writing, passing.
CI step exit=0
```

And the clean case stays clean -- the `v0.14.0..HEAD` range (the `v0.14.1`
patch, which must NOT move the ladder):

```
$ LADDER_ACK="" python tools/check_ladder_bump.py --base v0.14.0 --strict
[check_ladder_bump] OK: 0 gameplay-surface file(s) changed, ladder_version.txt not bumped -- consistent.
CI step exit=0
```

## Why `|| true` was there -- determined, not guessed

`git log -S'|| true' -- .github/workflows/quality-checks.yml` returns exactly one
commit: **`e0963ca9`**, the commit that *introduced* the checker. It was born
disarmed, with the step named "Ladder Bump Heuristic (advisory)" and the inline
echo "Advisory smell detector, never blocks; reviewer acks against the spec
Section 3.3 checklist." It was **not** added later to suppress observed noise.

So the design intent was already right --
`BUILD_VS_LADDER_VERSION_SPLIT.md` 4.2 asks for "a WARNING **requiring an
explicit ack**". The ack half was never mechanised. `|| true` stood in for a
mechanism that did not exist.

## Why not simply delete `|| true`

Because the ladder moves **once per epoch, not once per PR** (L1..L4 across
hundreds of PRs). "Gameplay files changed and the ladder did not move" is the
*normal, correct* state of almost every gameplay PR. A bare hard-fail would go
red constantly and be switched back off within a week -- reproducing the
original failure with extra steps.

So this PR builds the missing ack:

- CI runs `--strict` and **no** `|| true`.
- A warning fails **unless** the PR body has a `ladder-ack: <reason>` line
  (reason >= 8 chars, so `ladder-ack: y` is not an ack) **or** the `ladder-ack`
  label is applied.
- The ack reason is echoed into the job log.
- PR body and labels are passed via `env:`, never interpolated inline -- matching
  the existing `BASE_REF` SECURITY comment.

## Two real false positives fixed, so the strict gate is not noisy

Removing `|| true` only holds if the check is not crying wolf. Two came out of
the runs above:

1. `*.md` under `godot/data/` -- the #1137 run flagged
   `godot/data/events/overrides/README.md` as gameplay surface. Prose in the
   `.pck` cannot move a score.
2. `godot/data/patch_notes.json` -- release copy read only by
   `godot/scripts/ui/whats_new_modal.gd`. It changes on **every** release, so
   leaving it in would demand an ack on every release PR. Kept as an explicit
   one-entry `EXCLUDE_PATHS` list rather than a pattern, so adding to it is a
   decision someone made.

I did **not** widen `GAMEPLAY_PREFIXES` to include `godot/autoload/` in this PR.
It is a genuine gap (`event_service.gd` lives there) but it is a separate change
with its own false-positive surface, and #1178 is about the guard being armed.

## Tests

New `tests/test_check_ladder_bump.py`, 13 tests, all passing:

```
$ python -m pytest tests/test_check_ladder_bump.py -q
.............                                                            [100%]
13 passed in 3.90s
```

The load-bearing ones assert the **exit codes**, so a future re-disarming shows
up as a red test rather than as a green job that checks nothing:
`test_gameplay_without_bump_fails_under_strict`,
`test_bump_without_gameplay_change_fails_under_strict`,
`test_token_ack_reason_is_not_an_ack`.

Pre-existing, unrelated: `tests/test_ascii_compliance.py` fails on
`docs/AGENT_EFFICIENCY_AUDIT.md` (non-ASCII at position 144) on `main` as well.
Not touched here.

`docs/TOOLS.md` regenerated (`check_ladder_bump.py` moves OBSERVE -> PROVE, and
picks up its new test as a discovered caller). No Godot code changed, so the
Godot fast gate is untouched by this diff.

## Note: other guards wearing the same clothes (NOT changed here)

`grep -n "|| true\|continue-on-error\|exit 0" .github/workflows/*.yml`. Reported
so it is written down, deliberately out of scope for #1178:

| Location | What it does | Read |
|---|---|---|
| `godot-tests.yml:37` | `godot --headless --path godot --import \|\| true` | Probably fine -- the import pass floods stderr by design (CLAUDE.md); the real gate is the test run after it. Worth a second look. |
| `data-validation.yml:59` | `validate_historical_data.py --verbose > report.txt 2>&1 \|\| true` | **Same shape as #1178.** A validator whose exit code is discarded into a report file. Highest-value follow-up on this list. |
| `docs-sync.yml:42` | `continue-on-error: true` | Sync step; low stakes. |
| `enhanced-release.yml:50, :434` | `continue-on-error: true` | On the RELEASE path. Worth reading -- release-path softness is what this repo keeps getting bitten by. |
| `godot-tests.yml:186, :272` | `continue-on-error: true` | Both annotated with a reason (artifact upload / PR-comment API hiccup), and `:126` explicitly notes it does NOT use `continue-on-error` for the gate itself. This is the pattern the others should copy. |
| `live-site-release-freshness.yml:104,153,158`; `release-sync-monitor.yml:42,49,53,63`; `sync-documentation.yml:64` | bare `exit 0` | Early-outs on "nothing to check" branches; need reading one by one to tell a legitimate skip from a swallowed failure. Not audited here. |

Filing these as a note, not a PR. If they want chasing, they want their own
issue -- `data-validation.yml:59` first.

Godot fast gate: not run, no `.gd`/`godot/**` files in this diff.

Generated with [Claude Code](https://claude.com/claude-code)
