### PR TITLE
fix(test-gate): a timed-out run is NO RESULT, not "0 tests, 0 fail (FAIL)" (#1181)

### DIFF
--- a/docs/TESTING_QUALITY_GATES.md
+++ b/docs/TESTING_QUALITY_GATES.md
@@ -353,6 +353,35 @@ python scripts/run_all_godot_tests.py --ci-mode
 python scripts/run_godot_tests.py --smoke-only
 ```
 
+### The wall-clock cap, and the third outcome (#1181 / #1168)
+
+Each GUT invocation is capped. The cap defaults to **900s** -- the value that was
+hardcoded before #1181, so CI is unchanged -- and is now settable:
+
+```bash
+python scripts/run_godot_tests.py --simulation --timeout 3600   # slow/contended box
+PDOOM1_TEST_TIMEOUT=3600 python scripts/run_godot_tests.py --simulation
+python scripts/run_godot_tests.py --simulation --timeout 0      # no cap at all
+```
+
+Raising it is the supported fix on Windows dev boxes, where the simulation tier
+has been measured still making progress at 27m10s while the Ubuntu CI runner
+finishes it in 460-550s.
+
+The runner reports **three** outcomes, not two:
+
+| Outcome | Exit | Means |
+|---|---:|---|
+| PASS | 0 | Measured: tests ran, floor met, no failures |
+| FAIL | 1 | Measured: tests ran and something was wrong |
+| NO RESULT | 2 | **Not measured.** The run was killed or could not start |
+
+A NO RESULT run prints no test counts anywhere (`-` in the summary table, no
+`N tests` in `[TOTALS]`). It used to print `0 tests, 0 fail (FAIL)`, which is
+literally true and completely misleading -- the same class of defect as #640,
+where the gate reported a number that did not come from tests executing.
+**Never quote a suite result from a NO RESULT run.**
+
 ---
 
 ## Coverage Goals

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -58,7 +58,7 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | pre_version_bump.py | -- | Pre-Version Bump Quality Checks for P(Doom) | human (docstring usage) |
 | project_health.py | -- | P(Doom) Project Health Dashboard - BLITZ MODE IMPLEMENTATION | make; ci:enhanced-cicd-pipeline.yml; ci:quality-checks.yml |
 | repo-status.py | -- | P(Doom) Ecosystem Repository Status Dashboard | NONE FOUND |
-| run_godot_tests.py | PROVE | Run Godot GUT (Godot Unit Test) tests from command line. | make; ci:godot-tests.yml; test:test_find_dead_code.py; test:test_generate_tools_index.py |
+| run_godot_tests.py | PROVE | Run Godot GUT (Godot Unit Test) tests from command line. | make; ci:godot-tests.yml; test:test_find_dead_code.py; test:test_generate_tools_index.py; test:test_run_godot_tests_timeout.py |
 | setup-token.py | -- | GitHub Token Setup Helper for VS Code Users | NONE FOUND |
 | sync_website_docs.py | -- | Sync documentation from pdoom1 repo to website export format. | ci:docs-sync.yml |
 | test_before_push.py | -- | Test Before Push - Local Development Workflow | human (docstring usage) |

--- a/scripts/run_godot_tests.py
+++ b/scripts/run_godot_tests.py
@@ -20,6 +20,17 @@ old runner did NOT, each of which is why CI was green while running zero tests:
      skips (parse error, or `extends Node` instead of GutTest) => count mismatch
      => hard failure naming the offending files. Silence is failure.
 
+Three outcomes, not two (#1181 / #1168): PASS / FAIL / NO RESULT. Point 2 above
+says a number that did not come from tests executing must not be trusted; the
+timeout path used to break that rule in the runner's own reporting. A run killed
+by the wall-clock cap produced no JUnit file, so no test count exists for it --
+yet it rendered as `simulation: 0 tests, 0 fail (FAIL)`, character-identical in
+shape to a measured result, and as `| simulation | 0 | 0 | FAIL |` in the CI
+summary table. Now a killed run reports NO RESULT, prints `-` where the counts
+would go, and exits 2 (distinct from 1 = measured failure, 0 = measured pass).
+The cap itself is `--timeout` / `PDOOM1_TEST_TIMEOUT`, default 900s -- the same
+900 that was hardcoded before, so CI's contract is unchanged.
+
 Non-blocking-tier surfacing (#964): the simulation tier is intentionally
 non-blocking in CI (slow, run-simulating). A failure there must still be LOUD,
 not silently green -- format_summary_markdown() emits a "[!] <MODE> TIER RED"
@@ -37,6 +48,11 @@ Usage:
     python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300
     python scripts/run_godot_tests.py --simulation --summary            # print the RED-banner table locally
     python scripts/run_godot_tests.py --simulation --summary-file out.md
+    python scripts/run_godot_tests.py --simulation --timeout 3600  # slow box (#1181)
+    python scripts/run_godot_tests.py --simulation --timeout 0     # no cap at all
+
+Exit codes: 0 = measured pass, 1 = measured failure, 2 = NO RESULT (the run did
+not complete, so no measurement exists -- do not report a suite result from it).
 """
 
 import argparse
@@ -46,6 +62,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -108,6 +125,70 @@ MODE_DIRS = {
     "integration": "res://tests/integration",
     "smoke": "res://tests/smoke",
 }
+
+
+# --- Outcomes (#1181) -------------------------------------------------------
+# Three states, deliberately not two. FAILED means "we measured, and it was
+# bad". NO_RESULT means "we did not measure": there is no count, no verdict, and
+# it must never be renderable in the shape of the former.
+PASSED = "PASS"
+FAILED = "FAIL"
+NO_RESULT = "NO RESULT"
+
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_NO_RESULT = 2
+
+# The wall-clock cap for one GUT invocation. 900 is the value that was hardcoded
+# at scripts/run_godot_tests.py:375 before #1181; it is kept as the default so
+# CI's behaviour is byte-identical unless someone opts out. It is now a
+# parameter because there is no single number right for every machine: the
+# Ubuntu CI runner completes the simulation tier in 460-550s, while Pip's
+# Windows box (concurrent agent lanes, art generation, several Godot instances)
+# was still emitting live GUT progress at 27m10s. A cap that cannot be raised
+# means that machine can never obtain a result from that tier at all.
+DEFAULT_TIMEOUT = 900
+TIMEOUT_ENV_VAR = "PDOOM1_TEST_TIMEOUT"
+
+
+def resolve_timeout(cli_timeout):
+    """Resolve the per-run wall-clock cap.
+
+    Precedence: --timeout, then $PDOOM1_TEST_TIMEOUT, then DEFAULT_TIMEOUT.
+    Returns (seconds_or_None, provenance_string); None means no cap at all
+    (`--timeout 0`). The provenance is printed, because an implicit cap that
+    silently destroys a measurement is the defect being fixed here -- the reader
+    should never have to guess which number was in force.
+    """
+    seconds = DEFAULT_TIMEOUT
+    source = "default"
+    if cli_timeout is not None:
+        seconds, source = cli_timeout, "--timeout"
+    else:
+        raw = os.environ.get(TIMEOUT_ENV_VAR, "").strip()
+        if raw:
+            try:
+                seconds, source = int(raw), f"${TIMEOUT_ENV_VAR}"
+            except ValueError:
+                print(
+                    f"[WARN] {TIMEOUT_ENV_VAR}={raw!r} is not an integer; "
+                    f"falling back to the {DEFAULT_TIMEOUT}s default."
+                )
+    if seconds <= 0:
+        return None, f"{source} (cap DISABLED)"
+    return seconds, source
+
+
+def _no_result(mode, detail):
+    """Build a result row for a run that produced no measurement."""
+    return {
+        "mode": mode,
+        "outcome": NO_RESULT,
+        "tests": None,
+        "failures": None,
+        "failing_tests": [],
+        "detail": detail,
+    }
 
 
 def find_godot():
@@ -327,10 +408,24 @@ def _parse_junit(junit_path):
         return None
 
 
-def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
+def _fail_row(mode, tests=0, failures=0, failing_tests=None):
+    return {
+        "mode": mode,
+        "outcome": FAILED,
+        "tests": tests,
+        "failures": failures,
+        "failing_tests": failing_tests or [],
+        "detail": "",
+    }
+
+
+def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests, timeout=DEFAULT_TIMEOUT):
     """Run one test directory and hard-gate on the JUnit results.
 
-    Returns (ok: bool, tests: int, failures: int, failing_tests: list).
+    Returns a result dict: {mode, outcome, tests, failures, failing_tests,
+    detail}. `outcome` is PASSED / FAILED / NO_RESULT. When outcome is
+    NO_RESULT, `tests` and `failures` are None -- there is deliberately no
+    number to print, because no number was measured.
     """
     disk_files = _disk_test_files(test_dir)
     if disk_files is None:
@@ -338,11 +433,11 @@ def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
         # runner skipped missing dirs, which is exactly how the smoke gate
         # "passed" while pointing at a nonexistent tests/smoke (#629).
         print(f"\n[FAIL] Test directory {test_dir} does not exist -- cannot run '{mode}'.")
-        return (False, 0, 0, [])
+        return _fail_row(mode)
 
     if not disk_files:
         print(f"\n[FAIL] No test_*.gd files found in {test_dir} for '{mode}'.")
-        return (False, 0, 0, [])
+        return _fail_row(mode)
 
     junit_fs = GODOT_PROJECT / f"test-results-{mode}.xml"
     junit_res = f"res://test-results-{mode}.xml"
@@ -366,22 +461,38 @@ def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
     print(f"[CMD] {' '.join(cmd)}\n")
 
     exit_code = None
+    started = time.monotonic()
     try:
         result = subprocess.run(
             cmd,
             cwd=GODOT_PROJECT,
             capture_output=False,
             text=True,
-            timeout=900,
+            timeout=timeout,
             env=ISOLATED_ENV,
         )
         exit_code = result.returncode
     except subprocess.TimeoutExpired:
-        print("\n[FAIL] Tests timed out after 15 minutes!")
-        return (False, 0, 0, [])
+        elapsed = time.monotonic() - started
+        detail = (
+            f"killed by the {timeout}s wall-clock cap after {elapsed:.0f}s, before "
+            "GUT wrote any results. Raise the cap with --timeout N (or "
+            f"{TIMEOUT_ENV_VAR}=N), or --timeout 0 to remove it."
+        )
+        print("\n" + "!" * 68)
+        print(f"[NO RESULT] '{mode}': TIMED OUT after {elapsed:.0f}s (cap {timeout}s).")
+        print("[NO RESULT] No JUnit file was written, so there is NO test count for")
+        print("[NO RESULT] this run: nothing passed and nothing failed. This is NOT a")
+        print("[NO RESULT] green run and NOT a measured failure -- it is an absence of")
+        print("[NO RESULT] measurement. Do not report a suite result from it.")
+        print(f"[NO RESULT] Fix: --timeout N / {TIMEOUT_ENV_VAR}=N (0 removes the cap).")
+        print("!" * 68)
+        return _no_result(mode, detail)
     except Exception as e:
-        print(f"\n[FAIL] Failed to run tests: {e}")
-        return (False, 0, 0, [])
+        detail = f"the Godot process could not be run to completion: {e}"
+        print(f"\n[NO RESULT] '{mode}': failed to run tests -- {e}")
+        print("[NO RESULT] No measurement exists for this run (not a pass, not a failure).")
+        return _no_result(mode, detail)
 
     # --- The gate: trust the JUnit file, not the exit code. ---
     parsed = _parse_junit(junit_fs)
@@ -390,7 +501,7 @@ def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
             f"\n[FAIL] '{mode}': no parseable JUnit results at {junit_fs}. "
             "GUT ran nothing or quit early (missing import pass? bad args?)."
         )
-        return (False, 0, 0, [])
+        return _fail_row(mode)
 
     tests = parsed["tests"]
     failures = parsed["failures"]
@@ -430,12 +541,19 @@ def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
     if exit_code not in (0, None) and ok:
         print(f"\n[WARN] '{mode}': JUnit looked clean but GUT exit code was {exit_code}.")
 
-    status = "PASS" if ok else "FAIL"
+    status = PASSED if ok else FAILED
     print(
         f"\n[{status}] '{mode}': {tests} tests, {failures} failures, "
         f"{len(collected)}/{len(disk_files)} files collected."
     )
-    return (ok, tests, failures, failing_tests)
+    return {
+        "mode": mode,
+        "outcome": status,
+        "tests": tests,
+        "failures": failures,
+        "failing_tests": failing_tests,
+        "detail": "",
+    }
 
 
 # Modes considered "non-blocking" tiers in CI: a failure here does not fail the
@@ -446,32 +564,84 @@ def run_gut_tests(godot_path, mode, test_dir, log_level, min_tests):
 NON_BLOCKING_MODES = {"simulation"}
 
 
+def format_totals_line(rows):
+    """The one-line [TOTALS] verdict.
+
+    A NO_RESULT row prints no counts at all. Before #1181 it printed
+    `0 tests, 0 fail (FAIL)` -- literally true and completely misleading, since
+    "0 fail" describes a run that never happened.
+    """
+    parts = []
+    for r in rows:
+        if r["outcome"] == NO_RESULT:
+            parts.append(f"{r['mode']}: NO RESULT -- run did not complete, no test count exists")
+        else:
+            parts.append(
+                f"{r['mode']}: {r['tests']} tests, {r['failures']} fail "
+                f"({'ok' if r['outcome'] == PASSED else 'FAIL'})"
+            )
+    return "[TOTALS] " + " | ".join(parts)
+
+
+def decide_exit(rows):
+    """0 measured pass / 1 measured failure / 2 no measurement.
+
+    NO_RESULT outranks FAILED: if any tier did not run, the most important thing
+    to tell the caller is that the run cannot be reported on, not that some
+    other tier was red.
+    """
+    if any(r["outcome"] == NO_RESULT for r in rows):
+        return EXIT_NO_RESULT
+    if any(r["outcome"] == FAILED for r in rows):
+        return EXIT_FAILED
+    return EXIT_OK
+
+
 def format_summary_markdown(rows):
     """Build one markdown report shared by GITHUB_STEP_SUMMARY, --summary, and
-    the PR-comment step (issue #964). `rows` is a list of
-    (mode, tests, failures, ok, failing_tests) tuples.
+    the PR-comment step (issue #964). `rows` is a list of result dicts from
+    run_gut_tests().
 
     Non-blocking tiers (currently: simulation) get an unmissable
     '[!] <MODE> TIER RED' banner plus a per-test failure table when they fail,
     since a plain PASS/FAIL row in a wall of green is exactly what went
     unnoticed for 5 main-branch runs before this was added.
+
+    A tier that did NOT COMPLETE gets its own banner and renders its counts as
+    `-`, never as 0 (#1181): the simulation tier is non-blocking in CI, so a
+    timeout there would otherwise appear as a quiet `| simulation | 0 | 0 |`
+    row that a reader would have to already know how to distrust.
     """
     lines = []
 
-    for mode, tests, failures, ok, failing_tests in rows:
-        if not ok and failing_tests and mode in NON_BLOCKING_MODES:
+    for r in rows:
+        if r["outcome"] != NO_RESULT:
+            continue
+        lines.append("")
+        lines.append(f"## [!] {r['mode'].upper()} DID NOT COMPLETE -- NO RESULT")
+        lines.append("")
+        lines.append(
+            f"`{r['mode']}` was {r['detail']} No test count exists for this run: it "
+            "is neither a pass nor a failure. Treat this tier as UNMEASURED and do "
+            "not quote a suite result from it."
+        )
+        lines.append("")
+
+    for r in rows:
+        if r["outcome"] == FAILED and r["failing_tests"] and r["mode"] in NON_BLOCKING_MODES:
             lines.append("")
-            lines.append(f"## [!] {mode.upper()} TIER RED (non-blocking, but real)")
+            lines.append(f"## [!] {r['mode'].upper()} TIER RED (non-blocking, but real)")
             lines.append("")
             lines.append(
-                f"`{mode}` tier: {failures}/{tests} test failures. This tier does "
-                "NOT block merges -- it is surfaced here so it is not silently red. "
-                "See docs/ARCHITECTURE.md / the sim-tier test files for context."
+                f"`{r['mode']}` tier: {r['failures']}/{r['tests']} test failures. This "
+                "tier does NOT block merges -- it is surfaced here so it is not "
+                "silently red. See docs/ARCHITECTURE.md / the sim-tier test files "
+                "for context."
             )
             lines.append("")
             lines.append("| Suite | Test | Failure |")
             lines.append("|---|---|---|")
-            for ft in failing_tests:
+            for ft in r["failing_tests"]:
                 lines.append(f"| {ft['suite']} | {ft['test']} | {ft['message']} |")
             lines.append("")
 
@@ -480,9 +650,14 @@ def format_summary_markdown(rows):
     lines.append("")
     lines.append("| Suite | Tests | Failures | Result |")
     lines.append("|---|---:|---:|---|")
-    for mode, tests, failures, ok, _failing_tests in rows:
-        tier_note = " (non-blocking)" if mode in NON_BLOCKING_MODES else ""
-        lines.append(f"| {mode}{tier_note} | {tests} | {failures} | {'PASS' if ok else 'FAIL'} |")
+    for r in rows:
+        tier_note = " (non-blocking)" if r["mode"] in NON_BLOCKING_MODES else ""
+        if r["outcome"] == NO_RESULT:
+            lines.append(f"| {r['mode']}{tier_note} | - | - | **NO RESULT (did not run)** |")
+        else:
+            lines.append(
+                f"| {r['mode']}{tier_note} | {r['tests']} | {r['failures']} | {r['outcome']} |"
+            )
     lines.append("")
 
     return "\n".join(lines)
@@ -562,6 +737,18 @@ def main():
         dest="no_import",
         help="Skip the headless import pass (only if the class cache is already warm)",
     )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help=(
+            "Wall-clock cap in seconds for EACH GUT run. Default "
+            f"{DEFAULT_TIMEOUT} -- the same value that was hardcoded before "
+            "#1181, so CI behaviour is unchanged. 0 removes the cap entirely. "
+            f"Env fallback: {TIMEOUT_ENV_VAR}. Exceeding the cap is reported as "
+            "NO RESULT (exit 2), never as a test failure."
+        ),
+    )
     parser.add_argument("--verbose", action="store_true", help="Verbose GUT output (log level 3)")
     parser.add_argument(
         "--summary",
@@ -615,14 +802,18 @@ def main():
     else:
         modes = ["quick", "simulation", "integration"]
 
-    all_passed = True
+    timeout, provenance = resolve_timeout(args.timeout)
+    print(
+        "\n[TIMEOUT] Per-run wall-clock cap: "
+        + (f"{timeout}s" if timeout else "DISABLED")
+        + f" (from {provenance})."
+    )
+
     summary_rows = []
     for mode in modes:
-        ok, tests, failures, failing_tests = run_gut_tests(
-            godot_path, mode, MODE_DIRS[mode], log_level, args.min_tests
+        summary_rows.append(
+            run_gut_tests(godot_path, mode, MODE_DIRS[mode], log_level, args.min_tests, timeout)
         )
-        summary_rows.append((mode, tests, failures, ok, failing_tests))
-        all_passed = all_passed and ok
 
     _write_step_summary(summary_rows)
     if args.summary_file:
@@ -631,21 +822,25 @@ def main():
         print("\n" + format_summary_markdown(summary_rows))
 
     print("\n" + "=" * 60)
-    print(
-        "[TOTALS] "
-        + " | ".join(
-            f"{m}: {t} tests, {fl} fail ({'ok' if o else 'FAIL'})"
-            for (m, t, fl, o, _ft) in summary_rows
+    print(format_totals_line(summary_rows))
+
+    incomplete = [r for r in summary_rows if r["outcome"] == NO_RESULT]
+    if incomplete:
+        print(
+            "[NO RESULT] "
+            + ", ".join(r["mode"] for r in incomplete)
+            + " did not run to completion. This is NOT a pass and NOT a test "
+            "failure -- no measurement exists. Do not report a suite result "
+            "from this run."
         )
-    )
-    if all_passed:
-        print("[SUCCESS] All requested suites passed the gate! CHECKED")
-        print("=" * 60)
-        sys.exit(0)
-    else:
+        for r in incomplete:
+            print(f"            {r['mode']}: {r['detail']}")
+    elif any(r["outcome"] == FAILED for r in summary_rows):
         print("[FAILURE] Gate failed (see above).")
-        print("=" * 60)
-        sys.exit(1)
+    else:
+        print("[SUCCESS] All requested suites passed the gate! CHECKED")
+    print("=" * 60)
+    sys.exit(decide_exit(summary_rows))
 
 
 if __name__ == "__main__":

--- a/tests/test_run_godot_tests_timeout.py
+++ b/tests/test_run_godot_tests_timeout.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Unit tests for the run_godot_tests.py wall-clock cap and its reporting (#1181).
+
+The defect these lock down: the cap was hardcoded (`timeout=900`) with no flag,
+and when it tripped the runner returned `(False, 0, 0, [])`, which the reporting
+layer rendered as
+
+    [TOTALS] simulation: 0 tests, 0 fail (FAIL)
+    | simulation (non-blocking) | 0 | 0 | FAIL |
+
+Those zeros were fabricated -- no JUnit file was ever written, so nothing ran,
+nothing passed and nothing failed. Presenting an unmeasured run in the same
+shape as a measured one is the #640 defect (a number that did not come from
+tests executing) reappearing in the runner's own output.
+
+So the assertions here are mostly NEGATIVE: the timeout path must not emit a
+count, must not emit the word FAIL as its verdict, and must exit 2.
+"""
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import run_godot_tests as R  # noqa: E402  (deliberate late import; sys.path just set)
+
+
+class ResolveTimeoutTests(unittest.TestCase):
+    def test_default_is_still_900(self):
+        """Guard the CI contract: #1181 asked for a flag, NOT a new default.
+
+        If this ever needs to change, it changes CI's behaviour for everyone and
+        must be a deliberate, separately-reviewed decision.
+        """
+        self.assertEqual(R.DEFAULT_TIMEOUT, 900)
+        with mock.patch.dict("os.environ", {}, clear=False):
+            R.os.environ.pop(R.TIMEOUT_ENV_VAR, None)
+            seconds, source = R.resolve_timeout(None)
+        self.assertEqual(seconds, 900)
+        self.assertEqual(source, "default")
+
+    def test_cli_flag_wins(self):
+        with mock.patch.dict("os.environ", {R.TIMEOUT_ENV_VAR: "111"}):
+            seconds, source = R.resolve_timeout(3600)
+        self.assertEqual(seconds, 3600)
+        self.assertEqual(source, "--timeout")
+
+    def test_env_var_used_when_no_flag(self):
+        with mock.patch.dict("os.environ", {R.TIMEOUT_ENV_VAR: "2700"}):
+            seconds, source = R.resolve_timeout(None)
+        self.assertEqual(seconds, 2700)
+        self.assertIn(R.TIMEOUT_ENV_VAR, source)
+
+    def test_garbage_env_var_falls_back_to_default(self):
+        with mock.patch.dict("os.environ", {R.TIMEOUT_ENV_VAR: "soon"}):
+            seconds, _source = R.resolve_timeout(None)
+        self.assertEqual(seconds, 900)
+
+    def test_zero_disables_the_cap(self):
+        seconds, source = R.resolve_timeout(0)
+        self.assertIsNone(seconds)
+        self.assertIn("DISABLED", source)
+
+
+class TimeoutOutcomeTests(unittest.TestCase):
+    """Drive the real timeout branch of run_gut_tests()."""
+
+    def _run_with_timeout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / "godot"
+            test_dir = project / "tests" / "unit"
+            test_dir.mkdir(parents=True)
+            (test_dir / "test_example.gd").write_text("extends GutTest\n", encoding="ascii")
+
+            def boom(cmd, *args, **kwargs):
+                raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 5))
+
+            with (
+                mock.patch.object(R, "GODOT_PROJECT", project),
+                mock.patch.object(R.subprocess, "run", boom),
+            ):
+                return R.run_gut_tests(
+                    "godot-never-launched",
+                    "simulation",
+                    "res://tests/unit",
+                    2,
+                    80,
+                    timeout=5,
+                )
+
+    def test_timeout_is_no_result_not_failure(self):
+        row = self._run_with_timeout()
+        self.assertEqual(row["outcome"], R.NO_RESULT)
+        self.assertNotEqual(row["outcome"], R.FAILED)
+        self.assertNotEqual(row["outcome"], R.PASSED)
+
+    def test_timeout_reports_no_counts_at_all(self):
+        """The load-bearing assertion: no fabricated zeros."""
+        row = self._run_with_timeout()
+        self.assertIsNone(row["tests"])
+        self.assertIsNone(row["failures"])
+
+    def test_totals_line_never_says_zero_tests(self):
+        row = self._run_with_timeout()
+        line = R.format_totals_line([row])
+        self.assertIn("NO RESULT", line)
+        self.assertNotIn("0 tests", line)
+        self.assertNotIn("0 fail", line)
+
+    def test_markdown_row_shows_dashes_not_zeros(self):
+        row = self._run_with_timeout()
+        md = R.format_summary_markdown([row])
+        self.assertIn("DID NOT COMPLETE", md)
+        self.assertIn("| - | - |", md)
+        self.assertNotIn("| 0 | 0 |", md)
+
+    def test_exit_code_is_two(self):
+        row = self._run_with_timeout()
+        self.assertEqual(R.decide_exit([row]), R.EXIT_NO_RESULT)
+        self.assertNotEqual(R.EXIT_NO_RESULT, R.EXIT_OK)
+
+
+class DecideExitTests(unittest.TestCase):
+    @staticmethod
+    def _row(outcome):
+        return {
+            "mode": "quick",
+            "outcome": outcome,
+            "tests": 0 if outcome == R.NO_RESULT else 10,
+            "failures": 0,
+            "failing_tests": [],
+            "detail": "",
+        }
+
+    def test_all_pass_is_zero(self):
+        self.assertEqual(R.decide_exit([self._row(R.PASSED)]), 0)
+
+    def test_measured_failure_is_one(self):
+        self.assertEqual(R.decide_exit([self._row(R.PASSED), self._row(R.FAILED)]), 1)
+
+    def test_no_result_outranks_failure(self):
+        rows = [self._row(R.FAILED), self._row(R.NO_RESULT)]
+        self.assertEqual(R.decide_exit(rows), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1181. Partially addresses #1168 (asks 1 and 2; ask 3 is a different defect -- see below).

## What the runner reported at the cap BEFORE this change

`scripts/run_godot_tests.py:375` had `timeout=900` hardcoded, and the timeout branch returned `(False, 0, 0, [])`. Those zeros were then rendered by the reporting layer as if they were measurements.

Reproduced deterministically without launching Godot, by replacing `subprocess.run` with a stub that raises `subprocess.TimeoutExpired` exactly as it would after 900s, so the real timeout branch and the real reporting path execute:

```
[TEST] Running 'quick' tests in res://tests/unit (1 files on disk)

[FAIL] Tests timed out after 15 minutes!

============================================================
[TOTALS] quick: 0 tests, 0 fail (FAIL)
[FAILURE] Gate failed (see above).
============================================================

--- markdown summary CI would render ---

### Godot test results

| Suite | Tests | Failures | Result |
|---|---:|---:|---|
| quick | 0 | 0 | FAIL |

--- process would sys.exit(1) ---
```

**Two findings, one of which corrects the issue title.**

1. It did **not** exit zero and did **not** read as a pass. Exit was 1 and the word was `FAIL`. The issue title's "reports a timeout as `0 tests, 0 fail (FAIL)`" is exactly right; anyone reading it as "looks green" would be wrong, and that is worth stating because it bounds the damage.
2. The real defect is that a run which produced **no measurement** was rendered in the identical shape to one that did. No JUnit file was ever written -- nothing ran, nothing passed, nothing failed -- yet the output asserts `0 tests` and `0 fail`. Both are fabricated. `0 fail` is literally true and completely misleading.

That is #640's defect (the gate reporting a number that did not come from tests executing) reappearing inside the runner written to prevent it, with the sign flipped. It matters most in the CI step summary, where the simulation tier is non-blocking: a timeout there renders as `| simulation (non-blocking) | 0 | 0 | FAIL |`, one quiet row that a reader has to already know how to distrust.

## What changed

- **`--timeout SECONDS`**, env fallback **`PDOOM1_TEST_TIMEOUT`**, `0` removes the cap. Default stays **900** -- the previously-hardcoded value -- so CI's contract is byte-identical. A unit test pins that default so a future change to it has to be deliberate.
- The resolved cap **and its provenance** are printed before each run (`[TIMEOUT] Per-run wall-clock cap: 900s (from default).`). An implicit cap that silently destroys a measurement is the thing being fixed; the reader should never have to guess which number was in force.
- **Three outcomes rather than two**: `PASS` / `FAIL` / `NO RESULT`, exit `0` / `1` / `2`. A `NO RESULT` row carries `tests=None, failures=None`, so there is no number available to print anywhere. `NO RESULT` outranks `FAIL` in the exit code: if a tier did not run, the most important thing to tell the caller is that the run cannot be reported on.
- The `NO RESULT` path also covers "the Godot process could not be run at all". The deliberate hard-failure paths from #629/#590 (missing dir, no test files, unparseable JUnit) are left as `FAIL` -- unchanged.
- 13 unit tests in `tests/test_run_godot_tests_timeout.py`, mostly **negative** assertions: the totals line must not contain `0 tests` or `0 fail`, the markdown must not contain `| 0 | 0 |`, the outcome must not equal `FAIL` or `PASS`.
- Doc section in `docs/TESTING_QUALITY_GATES.md`; `docs/TOOLS.md` regenerated by its own generator.

## Proof: the cap now reports unmistakably, and exits non-zero

Real Godot 4.5.1, this branch, isolated `APPDATA`, `--timeout 5`:

```
[TIMEOUT] Per-run wall-clock cap: 5s (from --timeout).

[TEST] Running 'quick' tests in res://tests/unit (126 files on disk)

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[NO RESULT] 'quick': TIMED OUT after 5s (cap 5s).
[NO RESULT] No JUnit file was written, so there is NO test count for
[NO RESULT] this run: nothing passed and nothing failed. This is NOT a
[NO RESULT] green run and NOT a measured failure -- it is an absence of
[NO RESULT] measurement. Do not report a suite result from it.
[NO RESULT] Fix: --timeout N / PDOOM1_TEST_TIMEOUT=N (0 removes the cap).
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

============================================================
[TOTALS] quick: NO RESULT -- run did not complete, no test count exists
[NO RESULT] quick did not run to completion. This is NOT a pass and NOT a test failure -- no measurement exists. Do not report a suite result from this run.
            quick: killed by the 5s wall-clock cap after 5s, before GUT wrote any results. Raise the cap with --timeout N (or PDOOM1_TEST_TIMEOUT=N), or --timeout 0 to remove it.
============================================================
EXIT=2
```

And the markdown CI would render (via `PDOOM1_TEST_TIMEOUT=4 ... --summary`, which also demonstrates the env var):

```
## [!] QUICK DID NOT COMPLETE -- NO RESULT

`quick` was killed by the 4s wall-clock cap after 4s, before GUT wrote any results. Raise the cap with --timeout N (or PDOOM1_TEST_TIMEOUT=N), or --timeout 0 to remove it. No test count exists for this run: it is neither a pass nor a failure. Treat this tier as UNMEASURED and do not quote a suite result from it.

### Godot test results

| Suite | Tests | Failures | Result |
|---|---:|---:|---|
| quick | - | - | **NO RESULT (did not run)** |
```

## Proof: a normal run still passes

```
$ python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300 --summary

[TIMEOUT] Per-run wall-clock cap: 900s (from default).

[TEST] Running 'quick' tests in res://tests/unit (126 files on disk)

[PASS] 'quick': 1250 tests, 0 failures, 126/126 files collected.

| Suite | Tests | Failures | Result |
|---|---:|---:|---|
| quick | 1250 | 0 | PASS |

============================================================
[TOTALS] quick: 1250 tests, 0 fail (ok)
[SUCCESS] All requested suites passed the gate! CHECKED
============================================================
EXIT=0
```

Python tests: `13 passed`.

## Is #1168 the same root cause?

**Half of it.** #1168 lists three asks. Asks 1 (`--timeout` flag) and 2 (a timeout must report as UNKNOWN / DID NOT RUN, never `0 tests, 0 fail`) are the same two defects as #1181 and are fixed here -- same file, same lines, same code path.

Ask 3 is **not** the same root cause and is not touched: *why* the simulation tier takes >1630s on Windows while Ubuntu CI finishes it in 460-550s. That is a Godot/GUT/test-content performance question (#1168 has a partial diagnosis: 16.2 min wall clock against 7.9s user CPU, so blocked on I/O, and the per-RNG-draw `[VerificationTracker]` print is the suspect -- with the caveat, stated in the issue, that redirecting stdout to a file did not fix it). Nothing in this PR makes that faster. It makes the tier **obtainable** locally by letting the cap be raised, which is the difference between "no result is possible on this machine" and "a result costs 30 minutes".

So: **#1168 should stay open** after this merges, retitled or scoped down to ask 3 alone.

## Deliberately not done

- The default is still 900. Changing it silently alters CI for everyone and belongs in its own reviewed decision.
- No environment-dependent default (e.g. a longer cap when `CI` is unset). Tempting, and it would make the Windows case work with no flag, but it forks behaviour between machines on an implicit signal -- the opposite of what this issue is about.
- No streaming stall-detector. `capture_output=False` already streams GUT's output live, so "slow" and "hung" are separable by watching; making the *runner* able to tell them apart is worth doing, but it belongs with #1168 ask 3 where the measurement is.

## Note for the reviewer: a duplicate lane

There is a second, uncommitted attempt at this same issue in the worktree `C:/Users/Pip/AppData/Local/Temp/claude/wt-1181` on branch `fix/1181-sim-timeout-flag` -- ~420 insertions, no commits, no PR, last modified 06:41 and untouched for 36 minutes when this lane started. Flagging it so it is not reviewed twice or lost silently. Its approach differs in one way worth a decision either way: it makes the local default 2700s for the simulation tier while keeping 900 in CI, gated on the `CI` env var. This PR does not, for the reason under "Deliberately not done".

Generated with [Claude Code](https://claude.com/claude-code)
