### PR TITLE
fix(changelog,ci): repair the 14 false claims that are public right now, and stop the dead-end writes (#1165)

### DIFF
--- a/.github/workflows/release-sync-monitor.yml
+++ b/.github/workflows/release-sync-monitor.yml
@@ -2,13 +2,31 @@ name: Release Sync Monitor
 
 # Belt-and-braces LOUD failure detector for the version-sync pipeline.
 #
-# The primary sync path (sync-game-version.yml, driven from enhanced-release.yml
-# via workflow_call) can still silently no-op if someone changes how releases
-# are cut. This job independently compares the latest PUBLISHED game release
-# against what the website currently advertises, and FAILS RED (plus ::error::)
-# when they diverge -- which means the primary path did not run. A red scheduled
-# run is the loud signal; re-fire the sync with:
-#   gh workflow run sync-game-version.yml -f target_version=vX.Y.Z
+# Compares the latest PUBLISHED game release against what the website repo
+# holds, and FAILS RED (plus ::error::) when they diverge. A red scheduled run
+# is the loud signal; the site's own refresh is a 6-hourly cron
+# (pdoom1-website auto-update-data.yml), so re-fire it with:
+#   gh workflow run auto-update-data.yml --repo PipFoweraker/pdoom1-website
+#
+# REPOINTED 2026-08-09. This used to read
+# `pdoom1-website:data/current-game-version.json`, written by our own
+# sync-game-version.yml. That made it a decoy in two ways at once:
+#   1. it was the ONLY reader of that file, so it was really checking "did our
+#      own workflow run", not "is the website in sync";
+#   2. the file lives at the website repo root, OUTSIDE `public/`, and their
+#      deploy rsyncs `public/` only -- so it could read "v0.14.1" while
+#      pdoom1.com served something older, which is exactly what happened on
+#      the v0.14.0 cut (pdoom1-website#285).
+# It now reads `public/data/version.json` -- the file that is actually
+# deployed and actually served, and the same artefact
+# live-site-release-freshness.yml (#1182) fetches over HTTP.
+#
+# TWO ASSERTIONS, still deliberately separate:
+#   A) the website REPO has the update       -- this workflow (via the API)
+#   B) the LIVE SITE serves it               -- live-site-release-freshness.yml
+# Both now name the same artefact, so a divergence between them means
+# "committed but not deployed" rather than "we are comparing two unrelated
+# files", which is what it meant before.
 #
 # Read-only: no writes to any repo. Uses CROSS_REPO_TOKEN only to READ the
 # (possibly private) website file.
@@ -42,26 +60,39 @@ jobs:
             exit 0
           fi
 
-          # What the website currently advertises. Read-only; tolerate a missing
-          # file (warn, do not fail) so a first-time setup does not false-alarm.
+          # What the website will actually DEPLOY. public/data/version.json is
+          # inside public/, which is the only tree deploy-dreamhost.yml rsyncs,
+          # and it is the same file live-site-release-freshness.yml fetches
+          # over HTTP. Read-only; tolerate a missing/unreadable file (warn, do
+          # not fail) rather than false-alarming on an API hiccup.
           WEB_RAW=$(GH_TOKEN="$WEBSITE_TOKEN" gh api \
-            repos/PipFoweraker/pdoom1-website/contents/data/current-game-version.json \
+            repos/PipFoweraker/pdoom1-website/contents/public/data/version.json \
             --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
 
           if [ -z "$WEB_RAW" ]; then
-            echo "::warning::Could not read website current-game-version.json (missing or unreadable); skipping strict check."
+            echo "::warning::Could not read pdoom1-website public/data/version.json (missing or unreadable); skipping strict check."
             exit 0
           fi
 
-          WEB_VERSION=$(printf '%s' "$WEB_RAW" | jq -r '.current_version // empty')
+          # That file stores the tag WITH its leading v ("v0.14.1"); strip it so
+          # both sides are compared in the same shape.
+          WEB_VERSION=$(printf '%s' "$WEB_RAW" | jq -r '.latest_release.version // empty')
+          WEB_VERSION="${WEB_VERSION#v}"
 
-          echo "Latest published release: $LATEST"
-          echo "Website current version:  $WEB_VERSION"
+          if [ -z "$WEB_VERSION" ]; then
+            echo "::warning::public/data/version.json has no .latest_release.version; skipping strict check."
+            exit 0
+          fi
+
+          echo "Latest published release:      $LATEST"
+          echo "Website repo (to be deployed): $WEB_VERSION"
 
           if [ "$WEB_VERSION" = "$LATEST" ]; then
-            echo "IN SYNC: website matches the latest published release."
+            echo "IN SYNC: the website repo holds the latest published release."
+            echo "NOTE: this says the REPO is current, not that pdoom1.com serves it."
+            echo "live-site-release-freshness.yml makes that second assertion."
             exit 0
           fi
 
-          echo "::error::Website version ($WEB_VERSION) does not match latest published release ($LATEST). The version-sync pipeline did not run for this release. Re-fire: gh workflow run sync-game-version.yml -f target_version=v$LATEST"
+          echo "::error::pdoom1-website repo advertises $WEB_VERSION, latest published release is $LATEST. The website has not picked this release up. Its refresh is a 6-hourly cron; re-fire it with: gh workflow run auto-update-data.yml --repo PipFoweraker/pdoom1-website"
           exit 1

--- a/.github/workflows/sync-game-version.yml
+++ b/.github/workflows/sync-game-version.yml
@@ -1,5 +1,40 @@
 name: Sync Game Versions to Website
 
+# WHAT THIS DOES NOW: sends ONE repository_dispatch to pdoom1-website saying a
+# release was published. That is all.
+#
+# WHY IT USED TO DO MORE, AND WHY THAT MORE IS GONE (2026-08-09):
+# it cloned pdoom1-website and committed four artefacts into it. Each was
+# checked, one at a time, against the question nobody had asked in the two
+# years this ran -- "does anything READ what this writes?" -- and the answer
+# was no, four times:
+#
+#   content/game-versions/v<X>/release-notes.md
+#     `content/` sits outside `public/`, and deploy-dreamhost.yml rsyncs
+#     `public/` only (its step "Deploy public/ via rsync"). Written every
+#     release since v0.13.0; served to nobody, ever.
+#   data/versions/v<X>.json
+#     zero references anywhere in pdoom1-website (scripts/, .github/,
+#     netlify/) and, being outside public/, never deployed either.
+#   data/version-history.json
+#     written by a step that ran AFTER the only `git add .`/push step, and
+#     guarded by `git diff --quiet` on a path git did not track. The write
+#     always evaporated. The file does not exist in pdoom1-website today.
+#   data/current-game-version.json
+#     exactly one reader in the world, and it was ours:
+#     release-sync-monitor.yml. That monitor is now repointed at
+#     public/data/version.json -- the file the site actually serves -- so this
+#     write has no reader either.
+#
+# This was never three or four bugs. It was one workflow that had never been
+# checked against "does anything read what this writes?", and every one of its
+# steps printed SUCCESS while the answer was no.
+#
+# NOTE ON THE `edited` TRIGGER: this fires on `release: edited` as well as
+# `published`, which means editing a published release body re-runs this. That
+# is now harmless (one idempotent dispatch); while the file-writing steps
+# existed it meant a body edit silently rewrote website content.
+
 on:
   release:
     types: [published, edited]
@@ -130,322 +165,76 @@ jobs:
 
         echo "game_version=$GAME_VERSION" >> "$GITHUB_OUTPUT"
 
-        # Extract changelog section for this version
-        if [ -f "CHANGELOG.md" ]; then
-          python3 << 'EOF'
-        import os
-        import re
-        import sys
 
-        version = os.environ.get("VERSION_CLEAN", "")
-
-        try:
-            with open('CHANGELOG.md', 'r', encoding='utf-8') as f:
-                content = f.read()
-
-            # Find the section for this version
-            pattern = rf'## \[{re.escape(version)}\].*?\n(.*?)(?=\n## \[|\Z)'
-            match = re.search(pattern, content, re.DOTALL)
-
-            if match:
-                changelog_section = match.group(1).strip()
-                # Write to file for GitHub Actions
-                with open('changelog_section.txt', 'w', encoding='utf-8') as f:
-                    f.write(changelog_section)
-                print(f"Extracted changelog for version {version}")
-            else:
-                with open('changelog_section.txt', 'w', encoding='utf-8') as f:
-                    f.write(f"Release notes for version {version}")
-                print(f"No specific changelog found for version {version}")
-        except Exception as e:
-            print(f"Error extracting changelog: {e}")
-            with open('changelog_section.txt', 'w', encoding='utf-8') as f:
-                f.write(f"Release notes for version {version}")
-        EOF
-        fi
-
-        echo "game_version=$GAME_VERSION" >> "$GITHUB_OUTPUT"
-
-    - name: Create Website Version Data
-      id: website_data
-      env:
-        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
-        RELEASE_NAME: ${{ steps.version_info.outputs.release_name }}
-        RELEASE_DATE: ${{ steps.version_info.outputs.release_date }}
-        RELEASE_URL: ${{ steps.version_info.outputs.release_url }}
-        IS_PRERELEASE: ${{ steps.version_info.outputs.is_prerelease }}
-        VERSION_TAG: ${{ steps.version_info.outputs.version }}
-      run: |
-        # Create version data file for website. Env vars expand as data;
-        # release_name is free text so it is JSON-escaped via jq.
-        cat > website_version_update.json << EOF
-        {
-          "game_version": "$GAME_VERSION",
-          "display_version": "v$GAME_VERSION",
-          "release_name": $(printf '%s' "$RELEASE_NAME" | jq -Rs .),
-          "release_date": "$RELEASE_DATE",
-          "release_url": "$RELEASE_URL",
-          "is_prerelease": $IS_PRERELEASE,
-          "changelog_section": $(cat changelog_section.txt | jq -Rs .),
-          "sync_timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-          "sync_source": "pdoom1-game-release",
-          "assets": {
-            "download_url": "$RELEASE_URL",
-            "source_zip": "https://github.com/PipFoweraker/pdoom1/archive/refs/tags/$VERSION_TAG.zip",
-            "changelog_url": "https://github.com/PipFoweraker/pdoom1/blob/main/CHANGELOG.md"
-          },
-          "requirements": {
-            "python": "3.9+",
-            "os": ["Windows 10+", "Linux", "macOS"],
-            "memory": "512MB",
-            "storage": "100MB"
-          },
-          "compatibility": {
-            "website_features": "full",
-            "data_integration": "ready",
-            "api_version": "1.0.0"
-          }
-        }
-        EOF
-
-        echo "Created website version data:"
-        cat website_version_update.json | jq .
-
-    - name: Update Website Repository
-      env:
-        GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
-        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
-        RELEASE_NAME: ${{ steps.version_info.outputs.release_name }}
-        RELEASE_DATE: ${{ steps.version_info.outputs.release_date }}
-        RELEASE_URL: ${{ steps.version_info.outputs.release_url }}
-        IS_PRERELEASE: ${{ steps.version_info.outputs.is_prerelease }}
-        VERSION_TAG: ${{ steps.version_info.outputs.version }}
-      run: |
-        # Clone website repository
-        git clone https://x-access-token:${GITHUB_TOKEN}@github.com/${WEBSITE_REPO}.git website-repo
-        cd website-repo
-
-        # Configure git
-        git config user.name "Game Version Sync Bot"
-        git config user.email "actions@github.com"
-
-        # Derive status strings once (was inline expression ternaries)
-        if [ "$IS_PRERELEASE" = "true" ]; then
-          RELEASE_STATUS="prerelease"
-          RELEASE_STATUS_LABEL="Pre-release"
-        else
-          RELEASE_STATUS="stable"
-          RELEASE_STATUS_LABEL="Stable Release"
-        fi
-
-        # Create version content directory if it doesn't exist
-        mkdir -p "content/game-versions/v$GAME_VERSION"
-        mkdir -p data/versions
-
-        # Copy version data
-        cp ../website_version_update.json "data/versions/v$GAME_VERSION.json"
-
-        # Create release notes content (env vars expand as data)
-        cat > "content/game-versions/v$GAME_VERSION/release-notes.md" << EOF
-        ---
-        title: "$RELEASE_NAME"
-        version: "$GAME_VERSION"
-        release_date: "$RELEASE_DATE"
-        type: "game-release"
-        status: "$RELEASE_STATUS"
-        download_url: "$RELEASE_URL"
-        ---
-
-        # $RELEASE_NAME
-
-        **Version:** v$GAME_VERSION
-        **Release Date:** $RELEASE_DATE
-        **Status:** $RELEASE_STATUS_LABEL
-
-        ## Download
-
-        - [Download Game]($RELEASE_URL)
-        - [View Source Code](https://github.com/PipFoweraker/pdoom1/tree/$VERSION_TAG)
-        - [Full Changelog](https://github.com/PipFoweraker/pdoom1/blob/main/CHANGELOG.md)
-
-        ## Release Notes
-
-        EOF
-
-        # Append changelog content
-        cat ../changelog_section.txt >> "content/game-versions/v$GAME_VERSION/release-notes.md"
-
-        # Update current version tracking
-        cat > data/current-game-version.json << EOF
-        {
-          "current_version": "$GAME_VERSION",
-          "display_version": "v$GAME_VERSION",
-          "release_date": "$RELEASE_DATE",
-          "release_name": $(printf '%s' "$RELEASE_NAME" | jq -Rs .),
-          "status": "$RELEASE_STATUS",
-          "last_updated": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-        }
-        EOF
-
-        # Commit and push changes
-        git add .
-
-        if git diff --staged --quiet; then
-          echo "No changes to commit"
-        else
-          git commit -m "feat: sync game version v$GAME_VERSION
-
-        - Add release notes for v$GAME_VERSION
-        - Update current version tracking
-        - Sync from pdoom1 repository release
-
-        Automated sync from: $GITHUB_REPOSITORY@$GITHUB_SHA"
-
-          git push origin main
-          echo "SUCCESS Successfully updated website with game version v$GAME_VERSION"
-        fi
-
-    - name: Update Version History
-      env:
-        GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
-        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
-        RELEASE_NAME: ${{ steps.version_info.outputs.release_name }}
-        RELEASE_DATE: ${{ steps.version_info.outputs.release_date }}
-        RELEASE_URL: ${{ steps.version_info.outputs.release_url }}
-        IS_PRERELEASE: ${{ steps.version_info.outputs.is_prerelease }}
-        FORCE_SYNC: ${{ inputs.force_sync }}
-      run: |
-        cd website-repo
-
-        # Update version history JSON (untrusted values read from env as data)
-        python3 << 'EOF'
-        import json
-        import os
-        from datetime import datetime
-
-        version = os.environ.get("GAME_VERSION", "")
-        release_date = os.environ.get("RELEASE_DATE", "")
-        release_name = os.environ.get("RELEASE_NAME", "")
-        is_prerelease = os.environ.get("IS_PRERELEASE", "") == "true"
-
-        # Load existing version history
-        history_file = "data/version-history.json"
-        if os.path.exists(history_file):
-            with open(history_file, 'r') as f:
-                history = json.load(f)
-        else:
-            history = {"versions": [], "last_updated": None}
-
-        # Check if version already exists
-        existing_version = next((v for v in history["versions"] if v["version"] == version), None)
-
-        if existing_version and not os.environ.get("FORCE_SYNC", "") == "true":
-            print(f"Version {version} already exists in history")
-        else:
-            # Add or update version entry
-            version_entry = {
-                "version": version,
-                "display_version": f"v{version}",
-                "release_date": release_date,
-                "release_name": release_name,
-                "status": "prerelease" if is_prerelease else "stable",
-                "type": "minor" if ".0" in version else "patch",
-                "download_url": os.environ.get("RELEASE_URL", ""),
-                "changelog_url": f"/game/releases/v{version}"
-            }
-
-            if existing_version:
-                # Update existing entry
-                index = history["versions"].index(existing_version)
-                history["versions"][index] = version_entry
-                print(f"Updated existing version {version}")
-            else:
-                # Add new entry at the beginning (most recent first)
-                history["versions"].insert(0, version_entry)
-                print(f"Added new version {version}")
-
-            # Update timestamp
-            history["last_updated"] = datetime.utcnow().isoformat() + "Z"
-
-            # Save updated history
-            with open(history_file, 'w') as f:
-                json.dump(history, f, indent=2)
-
-            print(f"Version history updated with {len(history['versions'])} total versions")
-        EOF
-
-        # Commit version history update
-        if ! git diff --quiet data/version-history.json; then
-          git add data/version-history.json
-          git commit -m "update: version history with v$GAME_VERSION"
-          git push origin main
-          echo "SUCCESS Updated version history"
-        fi
-
-    - name: Trigger Website Rebuild
+    - name: Notify the website that a release was published
       env:
         GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
         GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
       run: |
-        # Trigger website rebuild via repository dispatch. Payload is built
-        # with jq so the version string is passed as data, not spliced JSON.
+        set -euo pipefail
+
+        # The ONLY thing this workflow does that anything downstream can act
+        # on. Payload is built with jq so the version string is passed as data,
+        # not spliced JSON.
+        #
+        # HONEST LIMIT, because it is the reason this workflow drifted:
+        # POST /dispatches returns 204 whether or not any workflow in the
+        # target repo subscribes to `game_version_sync`. The sending side
+        # CANNOT tell whether it was heard. As of 2026-08-09 nothing there
+        # subscribes -- `gh api "repos/PipFoweraker/pdoom1-website/actions/
+        # runs?event=repository_dispatch"` returns total_count 0, i.e. no
+        # repository_dispatch run has ever executed on that repo. pdoom1-website
+        # PR #289 (ours, theirs to accept) adds
+        # `repository_dispatch: types: [game_version_sync]` to their
+        # auto-update-data.yml. Until that lands this POST is a no-op, and it
+        # is kept -- rather than deleted -- because it is the mechanism the
+        # accepted design depends on.
+        #
+        # ORDERING HAZARD, recorded rather than fixed here: once #289 lands,
+        # a dispatch arriving mid-asset-upload makes the website publish a
+        # version whose `platforms` are derived from an incomplete asset list.
+        # The sending-side fix (fire only once assets are attached) belongs
+        # with whoever wires the receiver; see #289.
         PAYLOAD=$(jq -n \
           --arg game_version "$GAME_VERSION" \
           --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
           '{event_type: "game_version_sync", client_payload: {game_version: $game_version, sync_source: "pdoom1-release", timestamp: $timestamp}}')
 
-        curl -X POST \
+        STATUS=$(curl -sS -o /dev/null -w '%{http_code}' -X POST \
           -H "Authorization: token ${GITHUB_TOKEN}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/${WEBSITE_REPO}/dispatches \
-          -d "$PAYLOAD"
+          -d "$PAYLOAD")
 
-        echo "SUCCESS Triggered website rebuild"
-
-    - name: Notify Data Repository (Future)
-      env:
-        GITHUB_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
-        GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
-        RELEASE_DATE: ${{ steps.version_info.outputs.release_date }}
-      run: |
-        # Placeholder for future data repository notification
-        echo "=== Data Repository Notification (Future) ==="
-        echo "Game Version: v$GAME_VERSION"
-        echo "Release Date: $RELEASE_DATE"
-        echo "Status: Ready for data batch compatibility validation"
-
-        # Future implementation will:
-        # 1. Notify pdoom-data of new game version
-        # 2. Trigger compatibility validation
-        # 3. Update data batch schemas if needed
-        # 4. Validate existing data batches against new version
-
-        # curl -X POST \
-        #   -H "Authorization: token ${GITHUB_TOKEN}" \
-        #   -H "Accept: application/vnd.github.v3+json" \
-        #   https://api.github.com/repos/${DATA_REPO}/dispatches \
-        #   -d "$(jq -n --arg game_version "$GAME_VERSION" \
-        #     --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
-        #     '{event_type: "game_version_update", client_payload: {game_version: $game_version, compatibility_check: true, timestamp: $timestamp}}')"
+        # A transport/auth failure was previously invisible: the old call
+        # discarded the status code entirely and echoed SUCCESS regardless.
+        if [ "$STATUS" != "204" ]; then
+          echo "::error::repository_dispatch to ${WEBSITE_REPO} returned HTTP $STATUS (expected 204)."
+          exit 1
+        fi
+        echo "Dispatch accepted (HTTP 204). This says the POST was received;"
+        echo "it does NOT say any workflow subscribes to it. See the comment above."
 
     - name: Summary
       env:
         GAME_VERSION: ${{ steps.game_details.outputs.game_version }}
       run: |
-        echo "=== Game Version Sync Complete ==="
-        echo "SUCCESS Game Version: v$GAME_VERSION"
-        echo "SUCCESS Website Repository: Updated with release content"
-        echo "SUCCESS Version History: Updated with new release"
-        echo "SUCCESS Website Rebuild: Triggered"
-        echo "REFRESH Data Integration: Placeholder ready for future implementation"
+        echo "=== Game version sync: what actually happened ==="
+        echo "Game version: v$GAME_VERSION"
+        echo "Sent: repository_dispatch game_version_sync -> ${WEBSITE_REPO}"
         echo ""
-        echo "Website will be updated with:"
-        echo "- Release notes at /game/releases/v$GAME_VERSION"
-        echo "- Updated version badge and current version display"
-        echo "- Version history page with new release"
-        echo "- Download links and compatibility information"
+        echo "This workflow no longer writes files into the website repo."
+        echo "It used to write four things and NONE of them had a reader:"
+        echo "  content/game-versions/v*/release-notes.md -- outside public/,"
+        echo "    and the DreamHost deploy rsyncs public/ only, so it was never"
+        echo "    served to anyone"
+        echo "  data/versions/v*.json                     -- zero readers"
+        echo "  data/version-history.json                 -- written after the"
+        echo "    only commit step, so it was never even committed; the file has"
+        echo "    never existed in that repo"
+        echo "  data/current-game-version.json            -- one reader, and it"
+        echo "    was ours (release-sync-monitor.yml), now repointed at what the"
+        echo "    site actually serves"
         echo ""
-        echo "Next steps:"
-        echo "- Monitor website deployment"
-        echo "- Verify version display is correct"
-        echo "- Test download links and content"
+        echo "Whether pdoom1.com SERVES this release is checked by"
+        echo "live-site-release-freshness.yml, against the live site."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,22 +87,34 @@ Featured league seed rolls to `weekly-2026-w32`.
 
 Every entry below is tied to a commit merged between `v0.13.2` and this release.
 
+**Corrected 2026-08-09.** As first published, this section named 14 issues in
+wording that read as "we delivered this", and all 14 were -- and still are --
+open. The code behind each one is real and merged in this range; the issue it
+belongs to is not finished. Every such citation now says so in the same
+sentence, so you can tell what shipped from what only moved. Nothing about the
+build changed, and no entry was deleted.
+
 ### Added
 - **Pick the music from the pause menu** (#802, #1146) -- track selection while
-  you play, not only in Settings.
+  you play, not only in Settings. The wider music controller is not done:
+  **#802 is still OPEN** for mute/skip and the doom-triggered rotation.
 - **A credits screen you can actually reach** (#1161).
 - **Month review shows what CHANGED**, and SPACE opens it (#1100).
 - **Settings rebuilt as a front card plus an operations board** (#1096, #1103).
 - **One-time "claim a name" prompt before your first upload**, plus a lab-name
   generator (#957, #1063, #1133) -- a public board of identical
-  "Researcher -- AI Safety Lab" rows is one nobody can find themselves on.
+  "Researcher -- AI Safety Lab" rows is one nobody can find themselves on. The
+  prompt appears at upload, not on the first screen (**#1063 is still OPEN**),
+  and your own row is not yet highlighted on the board (**#957 is still OPEN**).
 - **Epoch-aware update check** reads `release_manifest.json`; the manifest now
   carries the ladder epoch and sha256 anchors (#1110).
 
 ### Changed
 - **Historical event deck retimed to one turn = one month**, with a timing dial
-  and the ruled promotions applied (#1111, #1125, #1137). *This is the change
-  that forks the ladder.*
+  and the ruled promotions applied (#1137), against Pip's rulings of 2026-08-04.
+  *This is the change that forks the ladder.* The ruling records stay open
+  because deferred items remain in them (**#1111 is still OPEN**,
+  **#1125 is still OPEN**); the retime itself shipped.
 - **Difficulty lock enforced where the value is CONSUMED**, not on one screen,
   and Alpha Tools now set a sticky unranked flag (#1058, #1060, #1084, #1104).
 - **One table for choice keys, one door per panel** -- keyboard and navigation
@@ -123,29 +135,41 @@ Every entry below is tied to a commit merged between `v0.13.2` and this release.
   (#1083).
 - **The office cat was a magenta checkerboard in every shipped build** -- not one
   flaky JPG (#796, #1080).
-- **The server rack painted over the feed and the staff were oversized** (#793,
-  #1081).
+- **The server rack painted over the feed and the staff were oversized**
+  (#793, #1081). Every staff member still renders as the same character, so
+  **#793 is still OPEN**.
 - **The public build wore a stale, clipped "DEV BUILD" banner** (#1067, #1079).
+  The banner is fixed; CI still does not run `write_build_stamp.py`, so
+  **#1067 is still OPEN**.
 - **A failed global leaderboard fetch is now VISIBLE**, and players are warned
-  about SmartScreen (#1126, #1127).
+  about SmartScreen (#1127). The toggle's own un-press behaviour is unverified
+  in a shipped build, so **#1126 is still OPEN**.
 - **Music was too loud and the wrong track; Graphics Settings was an empty
   header** (#1095).
 - **Percent tie direction pinned**, so doom reads the same on every platform.
 - **Release export filename derives from the preset**, and the Linux alias is
-  published (#1068, #1072, #1099).
+  published (#1099). Neither the site's Linux download button
+  (**#1068 is still OPEN**) nor the hardcoded-output-name issue
+  (**#1072 is still OPEN**) has been confirmed closed against a shipped build.
 - **The backslash dev key returns in release builds** (dev gates split) (#1129).
 
 ### Dev / tooling (no player-visible change)
 - CI exports now route through `build_release.py`'s freshness proof (#1069,
   #1114); the GDScript syntax gate COMPILES every `.gd` rather than only what
   boot reaches (#1082, #1119).
-- New instruments: `find_dead_code.py` (#1117, #1124), an action-taxonomy checker
-  (#798, #1139), a generated `docs/TOOLS.md` (#1123), a generated
-  `decisions/README.md` (#1108).
-- Dead paths retired; what remains is LOUD (#1115, #1118).
+- New instruments: `find_dead_code.py` (#1124), an action-taxonomy checker
+  (#1139), a generated `docs/TOOLS.md` (#1123), a generated
+  `decisions/README.md` (#1108). These are instruments, not fixes: the dead-path
+  sweep they serve is unfinished (**#1117 is still OPEN**) and the taxonomy
+  checker reports the action grouping it was built to measure
+  (**#798 is still OPEN**).
+- Dead paths retired; what remains is LOUD (#1118). The pdoom-data re-sync
+  capability was deleted rather than replaced, so **#1115 is still OPEN**.
 - Art pipeline: promotion map unblocks 605 then all 327 remaining approved assets
-  (#1093, #1107, #1122); 2,713 human verdicts made durable; the 2026-08-07 art
+  (#1107, #1122); 2,713 human verdicts made durable; the 2026-08-07 art
   night fired 652 images (#1158); art-review gallery keyboard repaired (#1162).
+  The review backlog those assets came from is not cleared, so
+  **#1093 is still OPEN**.
 - Issue triage across all 201 open issues plus a 7-fix drive-by batch (#1144),
   and a pre-close mining pass (#1153).
 - ADR-0019 (the pack is a function of declared demand), a phase-critical state

--- a/docs/RELEASE_NOTES_GUARD.md
+++ b/docs/RELEASE_NOTES_GUARD.md
@@ -60,6 +60,15 @@ Consequences worth stating plainly:
 | RN002 | the same version heading appearing twice | warn |
 | RN003 | a cited issue/PR whose state is OPEN | fatal |
 | RN004 | a cited issue/PR that no commit in `<prev tag>..<tag>` mentions | fatal |
+| RN005 | a bullet saying `#N is still OPEN` about an issue that has CLOSED | fatal |
+
+RN005 is the disclosure escape checked in the other direction, added 2026-08-09
+and taken from the non-overlapping half of #1187, whose author identified it.
+Without it the escape rots into decoration: a marker written truthfully in
+August is a false claim to a player in September, in the same file and on the
+same page, and RN003 -- the only reason the wording exists -- would never look
+at it. It became load-bearing immediately, because the `[0.14.0]` correction
+added fourteen such markers in one edit.
 
 RN002 is a warning because `CHANGELOG.md` carries a genuine historical
 duplicate (`[0.7.4]`, twice on 2025-09-16) that predates the guard. Making it

--- a/docs/release-body-v0.14.0-CORRECTED.md
+++ b/docs/release-body-v0.14.0-CORRECTED.md
@@ -1,0 +1,149 @@
+## [0.14.0] - 2026-08-07
+
+Ladder epoch **L3 -> L4** -- this is a FORKING release. The historical event deck
+was retimed to one-turn-one-month and the ruled promotions were applied (#1137),
+which changes which events fire on a given seed, so scores are not comparable
+with L3 boards. L3 entries stay valid and visible under L3; new runs land on L4.
+Featured league seed rolls to `weekly-2026-w32`.
+
+Every entry below is tied to a commit merged between `v0.13.2` and this release.
+
+**Corrected 2026-08-09.** As first published, this section named 14 issues in
+wording that read as "we delivered this", and all 14 were -- and still are --
+open. The code behind each one is real and merged in this range; the issue it
+belongs to is not finished. Every such citation now says so in the same
+sentence, so you can tell what shipped from what only moved. Nothing about the
+build changed, and no entry was deleted.
+
+### Added
+- **Pick the music from the pause menu** (#802, #1146) -- track selection while
+  you play, not only in Settings. The wider music controller is not done:
+  **#802 is still OPEN** for mute/skip and the doom-triggered rotation.
+- **A credits screen you can actually reach** (#1161).
+- **Month review shows what CHANGED**, and SPACE opens it (#1100).
+- **Settings rebuilt as a front card plus an operations board** (#1096, #1103).
+- **One-time "claim a name" prompt before your first upload**, plus a lab-name
+  generator (#957, #1063, #1133) -- a public board of identical
+  "Researcher -- AI Safety Lab" rows is one nobody can find themselves on. The
+  prompt appears at upload, not on the first screen (**#1063 is still OPEN**),
+  and your own row is not yet highlighted on the board (**#957 is still OPEN**).
+- **Epoch-aware update check** reads `release_manifest.json`; the manifest now
+  carries the ladder epoch and sha256 anchors (#1110).
+
+### Changed
+- **Historical event deck retimed to one turn = one month**, with a timing dial
+  and the ruled promotions applied (#1137), against Pip's rulings of 2026-08-04.
+  *This is the change that forks the ladder.* The ruling records stay open
+  because deferred items remain in them (**#1111 is still OPEN**,
+  **#1125 is still OPEN**); the retime itself shipped.
+- **Difficulty lock enforced where the value is CONSUMED**, not on one screen,
+  and Alpha Tools now set a sticky unranked flag (#1058, #1060, #1084, #1104).
+- **One table for choice keys, one door per panel** -- keyboard and navigation
+  unified (#565, #567, #575, #602, #1120).
+- **The last player-facing "AP" is gone**, and one number format is ruled across
+  the UI (#1073, #1087, #1116).
+- **Copy stops teaching a different game** -- the guide, the win condition and
+  the cold open now describe what the game actually does (#1136).
+- **Turn-1 hand fits above the fold; Fundraising is tile 1** (#1130).
+- **The debug event-trigger is deleted, not guarded** (#1134, #1143).
+- **A third-party endpoint and its unreachable fetch path were removed** (#1101,
+  #1105).
+- **Contact addresses redacted from the bundled historical events** (#1106).
+- **The pause menu grows into its text, not into padding** (#1155).
+
+### Fixed
+- **The achievement toast rendered as a giant purple rectangle** in v0.13.2
+  (#1083).
+- **The office cat was a magenta checkerboard in every shipped build** -- not one
+  flaky JPG (#796, #1080).
+- **The server rack painted over the feed and the staff were oversized**
+  (#793, #1081). Every staff member still renders as the same character, so
+  **#793 is still OPEN**.
+- **The public build wore a stale, clipped "DEV BUILD" banner** (#1067, #1079).
+  The banner is fixed; CI still does not run `write_build_stamp.py`, so
+  **#1067 is still OPEN**.
+- **A failed global leaderboard fetch is now VISIBLE**, and players are warned
+  about SmartScreen (#1127). The toggle's own un-press behaviour is unverified
+  in a shipped build, so **#1126 is still OPEN**.
+- **Music was too loud and the wrong track; Graphics Settings was an empty
+  header** (#1095).
+- **Percent tie direction pinned**, so doom reads the same on every platform.
+- **Release export filename derives from the preset**, and the Linux alias is
+  published (#1099). Neither the site's Linux download button
+  (**#1068 is still OPEN**) nor the hardcoded-output-name issue
+  (**#1072 is still OPEN**) has been confirmed closed against a shipped build.
+- **The backslash dev key returns in release builds** (dev gates split) (#1129).
+
+### Dev / tooling (no player-visible change)
+- CI exports now route through `build_release.py`'s freshness proof (#1069,
+  #1114); the GDScript syntax gate COMPILES every `.gd` rather than only what
+  boot reaches (#1082, #1119).
+- New instruments: `find_dead_code.py` (#1124), an action-taxonomy checker
+  (#1139), a generated `docs/TOOLS.md` (#1123), a generated
+  `decisions/README.md` (#1108). These are instruments, not fixes: the dead-path
+  sweep they serve is unfinished (**#1117 is still OPEN**) and the taxonomy
+  checker reports the action grouping it was built to measure
+  (**#798 is still OPEN**).
+- Dead paths retired; what remains is LOUD (#1118). The pdoom-data re-sync
+  capability was deleted rather than replaced, so **#1115 is still OPEN**.
+- Art pipeline: promotion map unblocks 605 then all 327 remaining approved assets
+  (#1107, #1122); 2,713 human verdicts made durable; the 2026-08-07 art
+  night fired 652 images (#1158); art-review gallery keyboard repaired (#1162).
+  The review backlog those assets came from is not cleared, so
+  **#1093 is still OPEN**.
+- Issue triage across all 201 open issues plus a 7-fix drive-by batch (#1144),
+  and a pre-close mining pass (#1153).
+- ADR-0019 (the pack is a function of declared demand), a phase-critical state
+  audit (#1145), and a claims audit of the project's own output (#1160).
+
+## Before you download: your OS will warn you, and that is expected
+
+These builds are **unsigned**. Signing means buying a code-signing certificate
+(Windows) or an Apple Developer identity plus notarization (macOS). P(Doom) is
+an alpha made by one person and has not bought either yet, so every operating
+system reports that it cannot verify who made the program. The warnings mean
+"we cannot check the publisher", not "this is malware".
+
+### Windows -- SmartScreen
+
+You will see a blue **"Windows protected your PC"** box, often naming an
+**unknown / untrusted publisher**. To run the game:
+
+1. Click **More info** (the small link under the message).
+2. Click **Run anyway**.
+
+Also: extract the whole zip to a folder before running `PDoom.exe`. Running it
+from inside the zip viewer hides `PDoom.pck` from it, and the game will not
+start. That is the single most common problem people hit.
+
+### macOS -- Gatekeeper
+
+First launch is blocked. On macOS 15 (Sequoia) and later, double-click the app
+once, dismiss the warning, then go to **System Settings -> Privacy & Security**
+and click **Open Anyway**. On macOS 14 and earlier you can right-click (or
+Control-click) the app and choose **Open**. Full steps are in `HOW-TO-RUN.txt`
+inside the zip.
+
+### Linux
+
+You may need to set the executable bit: `chmod +x PDoom.x86_64`.
+
+### Checking you have the real file
+
+Because the OS cannot vouch for the publisher, verify the source instead:
+
+- **This release page is the only trusted download.** Do not run a P(Doom)
+  binary that reached you any other way.
+- `release_manifest.json`, attached to this release, lists the exact size and
+  **sha256** of every zip. Compare it against your download:
+  - Windows (PowerShell): `Get-FileHash -Algorithm SHA256 .\PDoom-Windows.zip`
+  - macOS / Linux: `shasum -a 256 PDoom-Linux.zip`
+
+A matching hash means the file is byte-for-byte what was published here.
+
+## Build Information
+
+- **Commit:** `7368e2373393badc16f9189209c199732cb4fcec`
+- **Data Hash:** `4b2b31dab682e25ea2338e52fd6e47a55048208a10e3346a751a3a4e869442dc`
+- **Manifest Hash:** `47ef38eb1d5c02d53e17bc95d2d79e5bd605ba197fa21e8f0ae6c867f0f0db93`
+- **Engine:** Godot 4.5.1

--- a/scripts/check_release_notes.py
+++ b/scripts/check_release_notes.py
@@ -21,6 +21,13 @@ RN003  an issue or PR number cited in a release body whose issue is still
 RN004  an issue or PR number cited in a version's release body that cannot be
        tied to any commit message between that version's tag and the previous
        one.  FATAL when a tag range is supplied.
+RN005  a bullet that says `#N is still OPEN` about an issue that has since
+       CLOSED.  FATAL.  The disclosure escape is only worth having if it is
+       checked in both directions: a stale "still open" tells a player that
+       finished work is unfinished, which is the same defect as RN003 pointing
+       the other way. Taken from #1187, whose author identified this; the
+       `[0.14.0]` correction added fourteen of these markers at once, so the
+       rot has somewhere to happen now.
 
 WHAT THIS DOES NOT CHECK (still a human's job -- see docs/RELEASE_NOTES_GUARD.md)
 --------------------------------------------------------------------------------
@@ -404,6 +411,22 @@ def check_body_citations(
                     False,
                     "{}: could not resolve #{} (line {})".format(label, number, line_no),
                     "Treated as unresolved, not as a pass.",
+                )
+            )
+        elif is_disclosed(number, unit):
+            findings.append(
+                Finding(
+                    "RN005",
+                    True,
+                    "{}: says #{} is still OPEN, but it is {}".format(label, number, state),
+                    "line {}: {}\n".format(line_no, unit.strip().splitlines()[0][:100])
+                    + 'Drop the "#{} is still OPEN" clause. '.format(number)
+                    + "A disclosure that has gone stale is its own false claim,\n"
+                    + "in the same file and to the same reader -- it now tells a\n"
+                    + "player that finished work is unfinished. RN003 is the only\n"
+                    + "reason the disclosure wording exists, so the wording has to\n"
+                    + "be checked in BOTH directions or the escape rots into\n"
+                    + "decoration. Taken from the non-overlapping half of #1187.",
                 )
             )
     return findings, numbers

--- a/tests/test_release_notes_guard.py
+++ b/tests/test_release_notes_guard.py
@@ -9,6 +9,7 @@ must go RED on the exact text that reached players. A guard that has never been
 shown to fail is not evidence.
 """
 
+import re
 import sys
 from pathlib import Path
 
@@ -157,3 +158,55 @@ def test_the_real_changelog_has_exactly_one_unreleased_heading():
     """Regression pin for the six-heading corruption (#1165)."""
     findings = guard.check_changelog_structure(guard.CHANGELOG.read_text(encoding="utf-8"))
     assert "RN001" not in codes(findings)
+
+
+# --------------------------------------------------------------------------
+# RN005 -- the disclosure escape checked in the OTHER direction.
+# Taken from the non-overlapping half of #1187. It matters now because the
+# [0.14.0] correction added fourteen `is still OPEN` markers in one edit; every
+# one of them becomes a false claim on the day its issue closes.
+# --------------------------------------------------------------------------
+
+
+def test_rn005_stale_disclosure_is_fatal():
+    body = "- **Music picker** (#1146) -- shipped. **#1146 is still OPEN**.\n"
+    findings, _ = guard.check_body_citations(body, "vX")
+    assert "RN005" in codes(findings)
+
+
+def test_rn005_does_not_fire_on_a_live_disclosure():
+    # #500 is OPEN in the fixture, so the disclosure is true and must pass.
+    body = "- **Research quality** (#500, #1146). **#500 is still OPEN**.\n"
+    findings, _ = guard.check_body_citations(body, "vX")
+    assert codes(findings) == []
+
+
+def test_rn005_is_scoped_to_the_bullet_that_discloses():
+    """A stale marker in one bullet must not condemn a clean neighbour."""
+    body = "- clean (#1146).\n\n- stale (#965). **#965 is still OPEN**.\n"
+    findings, _ = guard.check_body_citations(body, "vX")
+    fatal = [f for f in findings if f.fatal]
+    assert [f.code for f in fatal] == ["RN005"]
+    assert "#965" in fatal[0].message
+
+
+def test_rn005_and_rn003_do_not_both_fire_on_one_citation():
+    """An OPEN issue with no disclosure is RN003 only; RN005 is the inverse."""
+    body = "- undisclosed (#500).\n"
+    findings, _ = guard.check_body_citations(body, "vX")
+    assert codes(findings) == ["RN003"]
+
+
+def test_corrected_0140_section_passes_all_rules_offline():
+    """Regression pin for this PR's own subject.
+
+    The [0.14.0] section is byte-identical to the first 74 lines of the
+    PUBLISHED v0.14.0 body, so a regression here is a regression in player-
+    facing text, not in a repo file.
+    """
+    section = guard.extract_changelog_section("0.14.0", guard.CHANGELOG.read_text(encoding="utf-8"))
+    assert section, "[0.14.0] section must still be extractable"
+    for number in (793, 798, 802, 957, 1063, 1067, 1068, 1072, 1093, 1111, 1115, 1117, 1125, 1126):
+        assert "#{} is still OPEN".format(number) in re.sub(r"[*_`]", "", section).replace(
+            "\n", " "
+        ), "#{} lost its disclosure".format(number)


### PR DESCRIPTION
Follow-on to #1183 (merged), which guards the NEXT bad release body. This
repairs the one that is public right now, and stops a workflow that has been
writing into another repo for months with nothing on the other end.

## 1. `[0.14.0]` announces 14 open issues as delivered

Counted independently rather than inherited -- two lanes had produced counts and
one was corrected. One batched GraphQL query over all 68 numbers cited in the
section (`issueOrPullRequest` aliases, not ~68 sequential REST calls):

**68 cited. 54 closed. 14 OPEN.**

| # | what the section implied | what is actually unfinished |
|---|---|---|
| #802 | music controller shipped | mute/skip and the doom-triggered rotation |
| #957 | own row highlighted on the board | not implemented |
| #1063 | name set on the first screen | prompt appears at upload instead |
| #1111 | ruling delivered | deferred items remain in the ruling |
| #1125 | ruling delivered | deferred items remain in the ruling |
| #793 | office floor fixed | all staff still render as one character |
| #1067 | build stamp fixed | CI still never runs `write_build_stamp.py` |
| #1126 | toggle fixed | un-press behaviour unverified in a shipped build |
| #1068 | Linux download fixed | not confirmed against a shipped build |
| #1072 | preset-derived filename fixed | not confirmed against a shipped build |
| #1117 | dead-path sweep done | sweep unfinished; #1124 is the instrument |
| #798 | action grouping done | #1139 is the checker that measures it |
| #1115 | pdoom-data re-sync retired | capability deleted, not replaced |
| #1093 | art review done | backlog not cleared |

**This section IS the published body.** Verified, not assumed:
`diff <(sed -n '69,142p' CHANGELOG.md) <(gh release view v0.14.0 --json body)`
reports the first 74 lines byte-identical. The GitHub release page is where
pdoom1.com's download button sends people.

Every one of the 14 has a real merged commit in `v0.13.2..v0.14.0`, so **nothing
was deleted**. Each now discloses in the ruled form and says *what* is
unfinished -- the part a player can act on. The corrected section passes
RN001-RN004 **including `--tag v0.14.0`**, so it satisfies #1183's own RN004
rule ("every bullet ties to a commit in range").

### Ruling: `#500 is still OPEN`, not `#500 [open]`

Two PRs for #1165 used different disclosure syntax. Settled on the prose form.
These sections are extracted verbatim into published release bodies and rendered
to players on `/game-changelog/`. A bracket tag reads as machine residue to a
human; a sentence reads as a sentence. The guard parses either, so the tie-break
is the reader, and the reader is a player. **Two conventions on one file is
worse than either**, so there is now one.

### The published body: prepared, NOT applied

`docs/release-body-v0.14.0-CORRECTED.md` is the corrected section plus the
release workflow's download/SmartScreen/Build-Information tail, verbatim. It
passes `check_release_notes.py --body ... --tag v0.14.0`.

Applying it edits outward-facing text under Pip's name, so it stays his:

```
gh release edit v0.14.0 --notes-file docs/release-body-v0.14.0-CORRECTED.md
```

**That command has not been run.**

### One thing #1183's guard does not handle, found by using it

`split_bullets()` treats any line whose stripped form starts with `#` as a new
claim unit -- including a continuation line that begins with a *wrapped
citation*, e.g. `  #1081).`. That orphans a bullet's disclosure from its
citation and reports a FAIL that is not real. Fail-safe direction only (it can
never manufacture a false pass), worked around here by reflowing one bullet.
Not fixed in this PR.

## 2. `sync-game-version.yml` wrote four things and nothing read any of them

Each verified independently before anything was changed:

| written artefact | reader | verification |
|---|---|---|
| `content/game-versions/v*/release-notes.md` | **none** | `content/` is outside `public/`; `deploy-dreamhost.yml` step "Deploy public/ via rsync" rsyncs `public/` only. Written every release since v0.13.0, served to nobody |
| `data/versions/v*.json` | **none** | zero references in pdoom1-website `scripts/`, `.github/`, `netlify/`; also outside `public/` |
| `data/version-history.json` | **none** | written by a step running *after* the only `git add .`/push, guarded by `git diff --quiet` on an untracked path -- the write always evaporated. **The file has never existed in that repo** |
| `data/current-game-version.json` | **one, and it was ours** | `release-sync-monitor.yml`, reading a repo-root file the site never deploys |
| `repository_dispatch game_version_sync` | **none yet** | `gh api "repos/PipFoweraker/pdoom1-website/actions/runs?event=repository_dispatch"` -> `total_count: 0`. No such run has ever executed there, and no workflow there declares that type (the five wired types are `bug-report`, `pdoom1_release`, `pdoom1_docs_update`, `sync-tokens`, `events-updated`, `update-game-status`) |

**This is not three bugs. It is one workflow that has never been checked against
the question "does anything read what this writes?"** -- and every step of it
printed `SUCCESS` while the answer was no. The `Summary` step literally echoed
`SUCCESS Website Repository: Updated with release content` on every run.

### Sequencing, because getting it backwards is the same error class

`release-sync-monitor.yml` is **repointed first**, at
`public/data/version.json -> .latest_release.version` -- the file that is
actually inside the deployed tree, and the same artefact
`live-site-release-freshness.yml` (#1182) fetches over HTTP. Dry-run against
live data before committing: website repo says `v0.14.1`, latest published
release is `v0.14.1`, so it reports IN SYNC correctly today. **Only then** does
the write go.

The two assertions #1182 wanted kept apart stay apart, and now name the same
artefact:
- **A) the website repo has the update** -- `release-sync-monitor.yml`
- **B) the live site serves it** -- `live-site-release-freshness.yml`

A divergence between them now means "committed but not deployed" instead of "we
are comparing two unrelated files", which is what it meant before.

### What is KEPT

The `repository_dispatch`. It has never triggered anything, but pdoom1-website
**PR #289** -- ours, theirs to accept -- adds
`repository_dispatch: types: [game_version_sync]` to their
`auto-update-data.yml`. It is the mechanism the accepted design depends on, so
deleting it would be the wrong direction. It now checks the HTTP status instead
of echoing SUCCESS regardless, with the honest limit written into the file:
**`POST /dispatches` returns 204 whether or not anyone subscribes -- the sending
side cannot tell.** That is precisely why this went unnoticed rather than
failing loudly.

The ordering hazard #289 names (a dispatch arriving mid-asset-upload publishes a
version with an incomplete `platforms` list) is **recorded in the workflow
comment, not fixed here** -- it only becomes reachable once #289 lands.

Also removed: the CHANGELOG extractor inside this workflow. It fed only the
deleted writes, and it is the one that also fires on `release: edited` -- so
until now, editing a published release body silently rewrote website content.

**No changes to the pdoom1-website repo.** PR #289 is theirs.

## Not done

Not touched: `version.txt`, `ladder_version.txt`, any tag, `docs/workshop-2/`,
`check_ladder_bump.py`, `quality-checks.yml`, `scripts/run_godot_tests.py`,
`live-site-release-freshness.yml`.

None of the 14 issues were closed. Several look finished from their commits;
deciding that from a commit message is the guess that produced this defect.

Squash-merge here does not fire closes-keywords -- close #1165 by hand.

Generated with [Claude Code](https://claude.com/claude-code)
