### PR TITLE
fix(ui): PLAN-time rejections reach the player instead of a hidden feed

### DIFF
--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -815,7 +815,10 @@ func _boot_game():
 		# sibling of #979) exists to catch callers that DON'T declare that intent.
 		if game_manager.load_saved_game(load_path, true):
 			return
-		log_message("[color=red]Load failed -- starting a new game instead.[/color]")
+		# The boot lands in PLAN, so a bare feed line here was invisible: the player asked for
+		# a save, silently got a fresh run, and had nothing on screen saying so. Same door as
+		# the other PLAN-time refusals (see report_rejection).
+		report_rejection("Load failed -- starting a new game instead.")
 	log_message("[color=cyan]Initializing game...[/color]")
 	# #617 debt: was hardcoded "test-seed" -- every boot ran the SAME timeline and
 	# GameConfig.game_seed was ignored. Empty arg -> GameManager falls back to
@@ -1431,6 +1434,24 @@ func _on_error_occurred(error_msg: String):
 	# EventResultPresenter now.
 	event_result_presenter.present_error(error_msg)
 
+func report_rejection(message: String) -> void:
+	"""Refuse a player action THROUGH THE SAME DOOR the backend's error_occurred uses.
+
+	Why this exists: the feed (log_message -> watch_screen.message_log) lives inside
+	WatchScreen, which ScreenModeController hides for the whole of PLAN. Most of the view's
+	rejections fire while PLAN is on screen, so a bare log_message() wrote them into a hidden
+	node and the player saw nothing happen at all -- the click just did not land.
+
+	EventResultPresenter.present_error() already solved this for rejections raised by the
+	BACKEND (it writes the feed line AND flashes plan_screen's toast). The view's own
+	pre-checks shadowed that fix: they `return` before game_manager.select_action() can emit
+	error_occurred, so the toast never fired for exactly the messages its comment names.
+	Routing them here restores one presentation door for both paths.
+
+	`message` must be PLAIN TEXT -- present_error applies the feed colour itself, and the
+	PLAN toast is a plain Label, so BBCode passed in here would be shown literally."""
+	event_result_presenter.present_error(message)
+
 func _notification(what: int) -> void:
 	# P0 rage-quit friction: intercept the window-manager close during a run and route to the
 	# Main Menu instead of quitting to desktop. Quit-to-desktop stays available from the pause
@@ -1660,7 +1681,13 @@ func _on_dynamic_action_pressed(action_id: String, action_name: String):
 		_open_submenu(action_id)
 		return
 
-	# Check if action can be afforded before adding to UI queue (#456)
+	# Check if action can be afforded before adding to UI queue (#456).
+	# These two branches are the game's highest-volume rejection: they fire on every
+	# unaffordable click, during PLAN, which is where the player spends most of the run.
+	# They report through report_rejection() (feed line + PLAN toast), NOT log_message()
+	# alone -- the feed is inside WatchScreen and is hidden for the whole of PLAN, so the
+	# old bare log_message() left an unaffordable click looking like a dead button. The
+	# guards themselves are UNCHANGED: same conditions, same early return, same gameplay.
 	var action_def = _get_action_by_id(action_id)
 	var attention_cost: int = GameActions.attention_cost(action_def)
 	var hour_type: String = GameActions.hour_type(action_def)
@@ -1668,12 +1695,12 @@ func _on_dynamic_action_pressed(action_id: String, action_name: String):
 	var available_hours = game_manager.state.get_available_hours(hour_type)
 
 	if available_attention < attention_cost or available_hours < attention_cost:
-		log_message("[color=red]Not enough Attention: need %d %s hours, have %d[/color]" % [
+		report_rejection("Not enough Attention: need %d %s hours, have %d" % [
 			attention_cost, hour_type, mini(available_hours, available_attention)])
 		return
 
 	if not game_manager.state.can_afford(action_def.get("costs", {})):
-		log_message("[color=red]Cannot afford action: %s[/color]" % action_name)
+		report_rejection("Cannot afford action: %s" % action_name)
 		return
 
 	# Track queued action -- #821: only add the UI tile when the backend accepts
@@ -2224,9 +2251,11 @@ func _on_pass_button_pressed():
 	var action_id = pass_action.get("id", GameActions.PASS_ACTION_ID)
 	var action_name = pass_action.get("name", "Do Nothing")
 
-	# Check if we're in action selection phase
+	# Check if we're in action selection phase. The Do Nothing button lives in PlanScreen's
+	# command zone, so both refusals below are PLAN-time -- report_rejection, not the
+	# WATCH-only feed (see report_rejection's docstring).
 	if current_turn_phase.to_upper() != "ACTION_SELECTION":
-		log_message("[color=red]Cannot pass - not in action selection phase[/color]")
+		report_rejection("Cannot pass - not in action selection phase")
 		return
 
 	# Check Attention availability (pass costs 0 but still verify game state)
@@ -2234,7 +2263,7 @@ func _on_pass_button_pressed():
 	var ap_cost: int = GameActions.attention_cost(pass_action)
 
 	if available_ap < ap_cost:
-		log_message("[color=red]Not enough Attention: need %d, have %d[/color]" % [ap_cost, available_ap])
+		report_rejection("Not enough Attention: need %d, have %d" % [ap_cost, available_ap])
 		return
 
 	log_message("[color=gray]%s - skipping this action[/color]" % action_name)

--- a/godot/scripts/ui/submenu_controller.gd
+++ b/godot/scripts/ui/submenu_controller.gd
@@ -142,12 +142,17 @@ func on_option_selected(action_id: String, action_name: String, dialog: Control,
 	var hour_type: String = GameActions.hour_type(action_def)
 	var available_hours: int = host.game_manager.state.get_available_hours(hour_type)
 	var available_attention: int = host.game_manager.state.get_available_attention()
+	# Submenus are opened from the PLAN screen, so these two refusals are PLAN-time: they go
+	# through host.report_rejection() (feed line + PLAN toast), not the WATCH-only feed, which
+	# ScreenModeController hides for the whole of PLAN. Same guards, same early return -- only
+	# the presentation door changed. Plain text: present_error colours the feed line itself and
+	# the PLAN toast is a plain Label.
 	if available_attention < attention_cost or available_hours < attention_cost:
-		host.log_message("[color=red]Not enough Attention: need %d %s hours, have %d[/color]" % [
+		host.report_rejection("Not enough Attention: need %d %s hours, have %d" % [
 			attention_cost, hour_type, mini(available_hours, available_attention)])
 		return
 	if not host.game_manager.state.can_afford(action_def.get("costs", {})):
-		host.log_message("[color=red]Cannot afford: %s[/color]" % action_name)
+		host.report_rejection("Cannot afford: %s" % action_name)
 		return
 	host.log_message("[color=cyan]%s: %s[/color]" % [log_label, action_name])
 	if plan_controller.select_action(action_id):

--- a/godot/tests/unit/test_plan_rejection_visibility.gd
+++ b/godot/tests/unit/test_plan_rejection_visibility.gd
@@ -1,0 +1,165 @@
+extends GutTest
+## Locks the PLAN-time rejection surface: an action the player CANNOT afford must produce
+## something the player can actually see.
+##
+## The defect this pins (fix/plan-phase-messages-reach-the-player): log_message() writes into
+## watch_screen.message_log, and ScreenModeController registers WatchScreen as watch-only and
+## sets visible = false on it for the whole of PLAN. The game opens in PLAN and stays there
+## until COMMIT THE MONTH, so a rejection reported with a bare log_message() went into a hidden
+## node -- an unaffordable click looked like a dead button.
+##
+## EventResultPresenter.present_error() already writes BOTH the feed line and PlanScreen's
+## toast, and its header names "Not enough Attention" / "Cannot afford ..." as the case it
+## fixed. But the view's own affordability pre-checks returned BEFORE GameManager could emit
+## error_occurred, so that fix never fired for the clicks that trigger it most. The view now
+## reports those refusals through MainUI.report_rejection() -> present_error().
+##
+## Presentation only: these tests assert on the FEEDBACK, never on queue/attention state.
+
+const PLAN_SCENE := "res://scenes/ui/plan_screen.tscn"
+const MAIN_UI_SRC := "res://scripts/ui/main_ui.gd"
+const SUBMENU_SRC := "res://scripts/ui/submenu_controller.gd"
+
+
+class StubHost extends RefCounted:
+	## Minimal stand-in for MainUI: EventResultPresenter takes an untyped host and only needs
+	## log_message() + plan_screen, so the presenter can be exercised without booting the
+	## 3k-line view or a GameManager.
+	var logged: Array = []
+	var plan_screen: Node = null
+
+	func log_message(text: String, channel: String = "normal") -> void:
+		logged.append({"text": text, "channel": channel})
+
+
+func _plan_screen() -> PlanScreen:
+	var scene: PackedScene = load(PLAN_SCENE)
+	assert_not_null(scene, "plan_screen.tscn should load")
+	var node: PlanScreen = scene.instantiate()
+	add_child_autofree(node)
+	return node
+
+
+func _find_error_toast(plan: Node) -> Label:
+	for child in plan.get_children():
+		if child is Label and child.name == "PlanErrorToast":
+			return child
+	return null
+
+
+# --- The PLAN surface itself ----------------------------------------------------------------
+
+func test_plan_screen_exposes_the_error_toast_surface():
+	# The whole fix depends on this method existing on the PLAN screen; pin it so a later
+	# refactor of PlanScreen cannot quietly remove the only PLAN-visible rejection surface.
+	var plan := _plan_screen()
+	await get_tree().process_frame
+	assert_true(plan.has_method("flash_error"), "PlanScreen exposes flash_error()")
+
+
+func test_flash_error_makes_a_visible_plain_text_toast():
+	var plan := _plan_screen()
+	await get_tree().process_frame
+	var toast := _find_error_toast(plan)
+	assert_not_null(toast, "PlanScreen builds a PlanErrorToast label")
+	assert_false(toast.visible, "the toast starts hidden")
+
+	plan.flash_error("Cannot afford action: Hire Researcher")
+	assert_true(toast.visible, "flash_error shows the toast on the PLAN screen")
+	assert_true(toast.text.contains("Cannot afford action: Hire Researcher"),
+		"the toast carries the rejection text, got: %s" % toast.text)
+	assert_true(toast.text.begins_with("[!]"), "house-style ASCII chrome, got: %s" % toast.text)
+
+
+func test_flash_error_ignores_an_empty_message():
+	var plan := _plan_screen()
+	await get_tree().process_frame
+	var toast := _find_error_toast(plan)
+	plan.flash_error("")
+	assert_false(toast.visible, "an empty rejection does not raise an empty toast")
+
+
+# --- The one presentation door -----------------------------------------------------------
+
+func test_present_error_reaches_both_the_feed_and_the_plan_toast():
+	# present_error is the door BOTH the backend (error_occurred) and the view's own
+	# pre-checks now use, so a rejection is recorded in the feed AND surfaced where the
+	# player is acting.
+	var plan := _plan_screen()
+	await get_tree().process_frame
+	var host := StubHost.new()
+	host.plan_screen = plan
+	var presenter := EventResultPresenter.new(host)
+
+	presenter.present_error("Not enough Attention: need 2 operating hours, have 1")
+
+	assert_eq(host.logged.size(), 1, "the rejection is recorded in the feed model")
+	assert_true(String(host.logged[0]["text"]).contains("Not enough Attention: need 2 operating hours, have 1"),
+		"the feed line carries the message")
+	var toast := _find_error_toast(plan)
+	assert_true(toast.visible, "the same call raises the PLAN toast the player can see")
+	assert_true(toast.text.contains("Not enough Attention: need 2 operating hours, have 1"),
+		"the toast carries the message, got: %s" % toast.text)
+
+
+func test_present_error_survives_a_missing_plan_screen():
+	# A rejection raised before/without a PLAN screen must still reach the feed, not crash.
+	var host := StubHost.new()
+	host.plan_screen = null
+	var presenter := EventResultPresenter.new(host)
+	presenter.present_error("Cannot afford action: Buy Compute")
+	assert_eq(host.logged.size(), 1, "the feed line is written even with no PLAN screen")
+
+
+# --- The call sites: no PLAN-time rejection may go out through log_message alone -------------
+
+func test_main_ui_declares_report_rejection():
+	var src: String = FileAccess.get_file_as_string(MAIN_UI_SRC)
+	assert_true(src.contains("func report_rejection"),
+		"MainUI keeps the single rejection door the view + SubmenuController report through")
+
+
+func test_affordability_rejections_route_through_report_rejection():
+	# The two sharpest cases: _on_dynamic_action_pressed's own pre-check, which returns before
+	# GameManager can emit error_occurred. These MUST NOT go back to a bare log_message().
+	var src: String = FileAccess.get_file_as_string(MAIN_UI_SRC)
+	assert_true(src.contains("report_rejection(\"Not enough Attention: need %d %s hours, have %d\""),
+		"the Attention rejection reports through report_rejection")
+	assert_true(src.contains("report_rejection(\"Cannot afford action: %s\" % action_name)"),
+		"the affordability rejection reports through report_rejection")
+	assert_false(src.contains("log_message(\"[color=red]Cannot afford action:"),
+		"the affordability rejection no longer writes only into the PLAN-hidden feed")
+	assert_false(src.contains("log_message(\"[color=red]Not enough Attention:"),
+		"no Attention rejection writes only into the PLAN-hidden feed")
+
+
+func test_pass_button_rejections_route_through_report_rejection():
+	# The Do Nothing button lives in PlanScreen's command zone, so its refusals are PLAN-time too.
+	var src: String = FileAccess.get_file_as_string(MAIN_UI_SRC)
+	assert_true(src.contains("report_rejection(\"Cannot pass - not in action selection phase\")"),
+		"the wrong-phase pass refusal reports through report_rejection")
+	assert_false(src.contains("log_message(\"[color=red]Cannot pass"),
+		"the wrong-phase pass refusal is not feed-only")
+
+
+func test_submenu_rejections_route_through_report_rejection():
+	# Submenus are opened from PLAN, so their two refusals are the same defect class.
+	var src: String = FileAccess.get_file_as_string(SUBMENU_SRC)
+	assert_true(src.contains("host.report_rejection(\"Not enough Attention: need %d %s hours, have %d\""),
+		"the submenu Attention rejection reports through the host's rejection door")
+	assert_true(src.contains("host.report_rejection(\"Cannot afford: %s\" % action_name)"),
+		"the submenu affordability rejection reports through the host's rejection door")
+	assert_false(src.contains("log_message(\"[color=red]"),
+		"SubmenuController raises no PLAN-time rejection into the hidden feed alone")
+
+
+func test_report_rejection_messages_are_plain_text():
+	# present_error applies the feed colour itself and the PLAN toast is a plain Label, so a
+	# BBCode tag passed in here would be printed literally to the player as "[color=red]...".
+	for path in [MAIN_UI_SRC, SUBMENU_SRC]:
+		var src: String = FileAccess.get_file_as_string(path)
+		for line in src.split("\n"):
+			if not String(line).contains("report_rejection(\""):
+				continue
+			assert_false(String(line).contains("[color="),
+				"%s: report_rejection takes plain text, not BBCode -- %s" % [path, line.strip_edges()])

--- a/godot/tests/unit/test_plan_rejection_visibility.gd.uid
+++ b/godot/tests/unit/test_plan_rejection_visibility.gd.uid
@@ -1,0 +1,1 @@
+uid://bwo1l6sjxv5yd


### PR DESCRIPTION
# The defect: a click that does nothing

Click an action you cannot afford, in the phase you spend most of the game in, and
**nothing happens on screen at all**. No message, no toast, no shake. The button looks
broken.

## The mechanism (hidden node, not a missing message)

The message is written. It is written into a node the player cannot see.

1. `main_ui.log_message()` appends to `watch_screen.message_log`
   (`watch_screen.gd:12` -- the feed lives inside `WatchScreen`).
2. `_setup_plan_watch_scaffold()` registers that whole subtree as watch-only:
   `screen_mode.register_watch_only(watch_screen)` (`main_ui.gd:403`).
3. `ScreenModeController.set_mode()` sets `visible = false` on every watch-only node
   whenever the mode is PLAN (`screen_mode.gd:160-162`).
4. The game opens in PLAN (`main_ui.gd:420`) and returns to PLAN on every
   `action_selection` phase (`main_ui.gd:1410`). PLAN ends only at COMMIT THE MONTH.

So a `log_message()` during PLAN goes into a hidden `RichTextLabel`. It is not lost --
it is still in `_feed_lines` and the player will scroll past it in WATCH later -- but it
is not feedback, because it arrives after the moment it was about.

**26 of the 33 `log_message()` call sites in `main_ui.gd` fire during PLAN.** Full
classification below.

## Why the existing mitigation missed the worst two

A PLAN-side toast already exists: `plan_screen.flash_error()` (`plan_screen.gd:46-61`),
reached from `EventResultPresenter.present_error()` (`event_result_presenter.gd:84-85`),
driven by `GameManager.error_occurred`. Its comment (`event_result_presenter.gd:80-83`)
names `"Not enough Attention"` / `"Cannot afford ..."` as precisely the case it fixed.

That fix landed on the **backend** path. `_on_dynamic_action_pressed` runs its **own**
affordability pre-check and `return`s at `main_ui.gd:1671` / `:1676` **before**
`game_manager.select_action()` can emit `error_occurred`. The UI path shadows the fix,
so the toast never fires for the clicks that trigger it most often.

## The change

One new door, `MainUI.report_rejection(msg)`, which calls the existing
`EventResultPresenter.present_error()` -- the same function the backend rejection path
already uses. It writes the feed line **and** flashes the PLAN toast. No new mechanism.

Rerouted call sites (7):

| File | Function | Message |
|---|---|---|
| `main_ui.gd` | `_on_dynamic_action_pressed` | `Not enough Attention: need %d %s hours, have %d` |
| `main_ui.gd` | `_on_dynamic_action_pressed` | `Cannot afford action: %s` |
| `main_ui.gd` | `_on_pass_button_pressed` | `Cannot pass - not in action selection phase` |
| `main_ui.gd` | `_on_pass_button_pressed` | `Not enough Attention: need %d, have %d` |
| `main_ui.gd` | `_boot_game` | `Load failed -- starting a new game instead.` |
| `submenu_controller.gd` | `on_option_selected` | `Not enough Attention: need %d %s hours, have %d` |
| `submenu_controller.gd` | `on_option_selected` | `Cannot afford: %s` |

`submenu_controller.gd` carried a byte-identical copy of the same shadowing pre-check
(`:145-151`), so it had the same defect; it is fixed the same way.

Messages are passed as **plain text**: `present_error` applies the feed colour itself, and
the PLAN toast is a plain `Label`, so an inherited `[color=red]` would be printed to the
player literally.

## What the player now sees on an unaffordable click

An amber-red toast at the top of the PLAN screen, under the attention gauge, for 4
seconds -- `[!] Cannot afford action: Hire Researcher` -- plus the same line in the feed
for when they next look at it. Before: nothing.

## Presentation only

Every guard keeps its condition and its early `return`. No queue mutation, attention
spend, RNG draw, turn ordering or scoring changed. The pre-checks were deliberately
**not** deleted in favour of letting the backend emit: that would have changed control
flow and error strings, which is a gameplay-surface risk this PR declines to take.

`Ladder-Impact: none -- presentation only. Only godot/scripts/ui/ and godot/tests/ are
touched (both cosmetic prefixes); check_ladder_bump reports 0 gameplay-surface files.`

## Call-site classification (all 33)

**PLAN (26)** -- these fired into a hidden node:
`357`, `358` boot lines; `743` keyboard shortcut; `811`, `818`, `819` boot/load;
`941` conference return; `946` reserve; `971` clear queue; `981` remove queued;
`994`, `1030`, `1031`, `1034` end-turn/warnings; `1057`, `1061` commit plan;
`1614` purchase upgrade; `1647` selecting action; **`1671`, `1676` affordability
rejections**; `1934` strategic unlock; `2065`, `2069` queue display; `2229` pass wrong
phase; `2237` pass attention; `2240` pass skip.

**WATCH (3)**: `1268`, `1270` game over / victory; `232` event-dialog lines (mid-month
response windows).

**Both / mode-independent (4)**: `1419` `Turn Phase: X` (PLAN for `action_selection`,
WATCH for `turn_start`/`turn_end`); `271` ledger screen (reachable in both);
`771`, `1773` dev hotkeys.

## The 19 PLAN sites deliberately left alone

Not every hidden line is a defect, and adding a toast per line would be noise:

- **Commit path** (`994`, `1030`, `1031`, `1034`, `1057`, `1061`): each is immediately
  followed by `screen_mode.enter_watch()`, so the feed becomes visible within the same
  interaction and the player reads them. (`1030`'s danger warnings say "Press Space/Enter
  again to confirm" but no double-confirm exists -- the code says so at `main_ui.gd:1032`.
  That is a gameplay-flow gap, not a presentation one, and is out of scope here.)
- **Queue confirmations** (`1647` `Selecting action`, `981` `Removed`, `971` `Action queue
  cleared`, `2065`/`2069` queue contents): each already has a visible consequence that
  stays on screen in PLAN -- the queue tiles in the shared `InstrumentPanel` (registered to
  neither mode, `main_ui.gd:401-403`) and the PLAN reserve gauge. A toast would duplicate
  a signal the player is already getting.
- **Fanfare-backed** (`1934`): `FanfarePopup` parents to `get_tree().root` and is visible
  in both modes.
- **Dev/debug** (`771`, `1773`): debug-build gated.

So no non-error notice surface was added, and `NotificationManager` was not pulled in --
the only genuinely silent failures were the rejections, and `flash_error` already covers
those.

## Tests

New `godot/tests/unit/test_plan_rejection_visibility.gd` (10 tests):

- `PlanScreen.flash_error` raises a visible, plain-text, `[!]`-prefixed toast; ignores empty.
- `EventResultPresenter.present_error` reaches **both** the feed and the toast, and
  survives a null `plan_screen`.
- Source guards pinning each rejection to `report_rejection` and asserting no rejection
  message carries BBCode.

**Shown capable of returning the other answer**: reverting one call site
(`report_rejection("Cannot afford action: %s"...)` back to `log_message`) fails the suite
-- `1260 tests, 1 failures`, exit 1.

Fast gate on the tree that merges:

```
python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300
[PASS] 'quick': 1260 tests, 0 failures, 127/127 files collected
```

DO NOT MERGE without a look -- this is player-facing.

Ladder-Impact: none -- presentation only; no gameplay-surface file changed.

Generated with [Claude Code](https://claude.com/claude-code)
