### PR TITLE
fix(ui): make the first screen legible to a first-time player

### DIFF
--- a/godot/scenes/main.tscn
+++ b/godot/scenes/main.tscn
@@ -268,8 +268,8 @@ layout_mode = 2
 layout_mode = 2
 text = "Buy time -- survival is the score | Lose: P(Doom) = 100%"
 horizontal_alignment = 1
-theme_override_font_sizes/font_size = 10
-theme_override_colors/font_color = Color(0.6, 0.7, 0.6, 0.8)
+theme_override_font_sizes/font_size = 16
+theme_override_colors/font_color = Color(0.7, 0.85, 0.7, 1)
 tooltip_text = "P(Doom) = Probability of catastrophic AI outcome.
 There is no victory condition. Your score is the number of months you survive.
 The run ends when doom reaches 100%, or when your reputation collapses to zero."
@@ -310,7 +310,7 @@ theme_override_constants/separation = 8
 
 [node name="QueueHint" type="Label" parent="TabManager/MainUI/ContentArea/InstrumentColumn/QueuePanel/QueueContainer"]
 layout_mode = 2
-text = "No actions queued..."
+text = "No actions queued yet -- click an action to add it here."
 modulate = Color(0.5, 0.5, 0.5, 1)
 
 [node name="WatchScreen" parent="TabManager/MainUI/ContentArea" instance=ExtResource("14_watch_screen")]
@@ -335,7 +335,7 @@ theme_override_constants/margin_bottom = 5
 [node name="InfoLabel" type="RichTextLabel" parent="TabManager/MainUI/InfoBar/MarginContainer"]
 layout_mode = 2
 bbcode_enabled = true
-text = "[color=gray]Hover over actions to see details...
+text = "[color=gray]Click an action to add it to this month's plan. Hover an action to see what it costs.
  [/color]"
 fit_content = true
 scroll_active = false
@@ -372,7 +372,7 @@ theme_override_font_sizes/font_size = 12
 layout_mode = 2
 size_flags_horizontal = 3
 text = "COMMIT THE MONTH >"
-tooltip_text = "Commit the queued plan and advance the month. Warns if you have unspent Attention."
+tooltip_text = "Commit the queued plan and advance the month."
 disabled = true
 theme_override_font_sizes/font_size = 16
 theme_override_colors/font_color = Color(0.118, 0.765, 0.702, 1)
@@ -389,7 +389,7 @@ theme_override_font_sizes/font_size = 12
 layout_mode = 2
 size_flags_horizontal = 3
 bbcode_enabled = true
-text = "[color=white]Phase: Not Started[/color]"
+text = "[color=white]Phase: Starting up...[/color]"
 fit_content = true
 scroll_active = false
 

--- a/godot/scenes/ui/plan_screen.tscn
+++ b/godot/scenes/ui/plan_screen.tscn
@@ -10,10 +10,11 @@ script = ExtResource("1_plan")
 
 [node name="GettingStartedHint" type="Label" parent="."]
 layout_mode = 2
-text = "TIP: Hire safety researchers to reduce P(Doom)"
+text = "Each month: click actions below to plan them, then COMMIT THE MONTH to play it out."
 horizontal_alignment = 1
-theme_override_font_sizes/font_size = 10
-theme_override_colors/font_color = Color(0.5, 0.8, 0.5, 0.9)
+autowrap_mode = 3
+theme_override_font_sizes/font_size = 14
+theme_override_colors/font_color = Color(0.7, 0.85, 0.7, 1)
 
 [node name="ActionsScroll" type="ScrollContainer" parent="."]
 layout_mode = 2

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -810,7 +810,11 @@ func _finish_month_playback() -> void:
 	var review := {
 		"id": MONTH_REVIEW_EVENT_ID,
 		"name": "Month Review -- %s" % label,
-		"description": "%s\n\nQueue this month's actions, then End Turn to play the month out." % body,
+		# Name the control the player can actually see. "End Turn" is the internal name for this
+		# commit (end_month() below, the EndTurnButton node); the BUTTON is labelled
+		# "COMMIT THE MONTH >". This popup is the most-repeated instruction in the game -- once a
+		# month, every month -- so it was also the most-repeated wrong one.
+		"description": "%s\n\nQueue this month's actions, then press COMMIT THE MONTH to play the month out." % body,
 		"type": "popup",
 		"options": [
 			{"id": "begin_planning", "text": "Begin planning %s" % label, "costs": {}, "effects": {}}

--- a/godot/scripts/ui/action_bar_renderer.gd
+++ b/godot/scripts/ui/action_bar_renderer.gd
@@ -213,6 +213,25 @@ func _render_flat(categories: Dictionary, category_order: Array, category_colors
 			icon_stack.add_child(icon_button)
 
 
+## The hover tooltip for one action tile/row. PLAIN TEXT ONLY -- Godot tooltips render BBCode
+## literally, so the info bar's markup (main_ui._on_action_hover) must not be reused here.
+##
+## Why it carries the description. The hand is 13 uncaptioned pictograms, and the tooltip used to
+## repeat only the tile's own name -- which tells a player nothing they cannot already see. Two
+## external playtests in a week landed on the same wall: 2026-08-05, "2 of 2 external players
+## could not find Fundraising" (see the FUNDING LEADS note in render()); 2026-08-10, Jason, asked
+## whether it was apparent what he was meant to do -- "Not yet." The description already rides in
+## the action dictionary, so this is a free caption.
+func _tooltip_for(action_name: String, action: Dictionary, is_coming_soon: bool) -> String:
+	var tip := action_name
+	var description := String(action.get("description", "")).strip_edges()
+	if description != "":
+		tip += "\n" + description
+	if is_coming_soon:
+		tip += COMING_SOON_TOOLTIP_SUFFIX
+	return tip
+
+
 ## VARIANT PLUG POINT: builds ONE classic icon tile. A display variant overrides this to restyle
 ## the tile without touching _render_flat's grouping/affordability logic. Verbatim from the
 ## pre-carve inline build.
@@ -280,8 +299,7 @@ func _build_action_tile(action: Dictionary, category_key, category_colors: Dicti
 		var button_color = category_colors.get(category_key, Color(1.0, 1.0, 1.0))
 		icon_button.modulate = Color(0.9, 0.9, 0.9).lerp(button_color, 0.4)
 
-	# Simple tooltip for accessibility
-	icon_button.tooltip_text = (action_name + COMING_SOON_TOOLTIP_SUFFIX) if is_coming_soon else action_name
+	icon_button.tooltip_text = _tooltip_for(action_name, action, is_coming_soon)
 
 	# Tag with action_id so submenus can align to the button that opened them (#510)
 	icon_button.set_meta("action_id", action_id)
@@ -396,7 +414,7 @@ func _build_action_row(action: Dictionary, accent: Color, current_state: Diction
 		row.modulate = Color(0.4, 0.4, 0.4)
 	else:
 		row.modulate = Color(0.9, 0.9, 0.9).lerp(accent, 0.4)
-	row.tooltip_text = (action_name + COMING_SOON_TOOLTIP_SUFFIX) if is_coming_soon else action_name
+	row.tooltip_text = _tooltip_for(action_name, action, is_coming_soon)
 	row.pressed.connect(func(): host._on_dynamic_action_pressed(action_id, action_name))
 	row.mouse_entered.connect(func(): host._on_action_hover(action, can_afford, missing_resources))
 	row.mouse_exited.connect(func(): host._on_action_unhover())

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -2161,8 +2161,13 @@ func _on_action_hover(action: Dictionary, can_afford: bool, missing_resources: A
 	_highlight_resources(action_costs)
 
 func _on_action_unhover():
-	"""Reset info bar when mouse leaves action - maintain 2-line format to prevent flicker (issue #450)"""
-	info_label.text = "[color=gray]Hover over actions to see details...\n [/color]"
+	"""Reset info bar when mouse leaves action - maintain 2-line format to prevent flicker (issue #450)
+
+	The resting copy INSTRUCTS (playtest 2026-08-10, Jason: "Is it at all apparent what you're
+	meant to do?" / "Not yet."). This strip is full-width prime real estate and spends most of
+	the turn idle, so it names the core verb instead of describing itself. Must keep the
+	trailing "\\n " -- that is the #450 two-line height lock."""
+	info_label.text = "[color=gray]Click an action to add it to this month's plan. Hover an action to see what it costs.\n [/color]"
 	# Reset resource highlights
 	_reset_resource_highlights()
 

--- a/godot/tests/integration/test_ui_stability.gd
+++ b/godot/tests/integration/test_ui_stability.gd
@@ -61,7 +61,7 @@ func test_infobar_maintains_height():
 	info_bar.add_child(label)
 
 	# Set single-line text (unhovered)
-	label.text = "[color=gray]Hover over actions to see details...\n [/color]"
+	label.text = "[color=gray]Click an action to add it to this month's plan. Hover an action to see what it costs.\n [/color]"
 	assert_true(label.text.contains("\n"), "Unhover text should maintain 2-line format")
 
 	# Set multi-line text (hovered)
@@ -75,7 +75,7 @@ func test_infobar_maintains_height():
 
 func test_info_label_unhover_text_format():
 	# Test that unhover text maintains 2-line format
-	var unhover_text = "[color=gray]Hover over actions to see details...\n [/color]"
+	var unhover_text = "[color=gray]Click an action to add it to this month's plan. Hover an action to see what it costs.\n [/color]"
 
 	# Count newlines
 	var newline_count = unhover_text.count("\n")

--- a/godot/tests/unit/test_boot_produces_live_run.gd
+++ b/godot/tests/unit/test_boot_produces_live_run.gd
@@ -12,8 +12,9 @@ extends GutTest
 ##
 ## The hole this file closes is the third mode, and it is the one that matches Pip's report
 ## most literally: **the run boots but the view never receives it.** Every existing boot test
-## asserts on GameManager only. A UI left rendering main.tscn's baked chrome -- "Phase: Not
-## Started", "58.5%", "Money: $0", "Week 1 | Mon Jul 3, 2017 | Day 1/5" -- is indistinguishable
+## asserts on GameManager only. A UI left rendering main.tscn's baked chrome -- "Phase:
+## Starting up..." (was "Phase: Not Started" when #1023 was filed), "58.5%", "Money: $0",
+## "Week 1 | Mon Jul 3, 2017 | Day 1/5" -- is indistinguishable
 ## from a healthy boot to all 990 of them. That was measured too: severing the state->view
 ## handler produced exactly ONE failure in the whole suite, this file's placeholder test.
 ##
@@ -49,7 +50,7 @@ const BOOT_FRAME_BUDGET := 60  # _ready awaits 1 frame then _boot_game; 60 is sl
 # InstrumentColumn/CoreZone/RightZones/NumericDoomZone/NumericDoomLabel.
 const PLACEHOLDER_TURN := "Week 1 |"
 const PLACEHOLDER_MONEY := "Money: $0"
-const PLACEHOLDER_PHASE := "Not Started"
+const PLACEHOLDER_PHASE := "Starting up"
 const PLACEHOLDER_DOOM := "58.5%"
 
 var _prev_pending_load_path: String = ""


### PR DESCRIPTION
**DO NOT MERGE -- player-facing copy is Pip's.** This is a copy review, laid out as copy.

Playtest 2026-08-10, Jason, 27 minutes (`coordination/PLAYTEST_2026-08-10_jason.md`):

> Pip: *"Is this at all apparent what you're meant to do?"*
> Jason: **"Not yet."**

Item 4 of the same transcript, noticed independently by both of them: *"I should probably just make all the icons and stuff a bit bigger"* / *"I was noticing some readability problems as well."*

This PR is the copy-and-constants half of the answer. Six strings, two font sizes, one colour, one autowrap flag. No relayout, no new features, no gameplay change.

---

## The strings, before and after

### 1. The only objective sentence on the play screen

`godot/scenes/main.tscn` (ExplanationLabel). The words were already right; nobody could read them.

| | |
|---|---|
| **Text** | unchanged: `Buy time -- survival is the score \| Lose: P(Doom) = 100%` |
| **Before** | `font_size = 10`, `font_color = Color(0.6, 0.7, 0.6, 0.8)` |
| **After** | `font_size = 16`, `font_color = Color(0.7, 0.85, 0.7, 1)` |

### 2. Action tooltips

`godot/scripts/ui/action_bar_renderer.gd`. The hand is 13 uncaptioned pictograms and the tooltip repeated the tile's own name -- the one thing hovering cannot tell you.

**Before** (both the icon tile at `:284` and the grouped row at `:399`):

```gdscript
icon_button.tooltip_text = (action_name + COMING_SOON_TOOLTIP_SUFFIX) if is_coming_soon else action_name
```

**After** -- one shared `_tooltip_for()` helper for both call sites, appending the `description` that was already riding unused in the action dictionary:

```
Fundraising
Choose funding strategy - different risk/reward options
```
```
Work Your Connections
SOURCE: spend a favor (reputation) + Attention for one fast, pre-vetted lead. Success
scales with your standing; the favor is spent whether or not it lands.
```

Plain text, no BBCode -- Godot tooltips render markup literally, so `main_ui._on_action_hover`'s formatting cannot be reused here. The `-- COMING SOON (...)` suffix still lands last.

This file already recorded the cost of the old tooltip, at `:147`: *"playtest 2026-08-05: 2 of 2 external players could not find Fundraising"*.

### 3. Three strings that described the UI instead of instructing the player

**3a. The full-width info strip** -- prime real estate, idle for most of the turn. `main.tscn:338` and `main_ui.gd:2165` (the unhover reset restores it, so both had to change or the new copy would vanish on the first hover).

| | |
|---|---|
| **Before** | `Hover over actions to see details...` |
| **After** | `Click an action to add it to this month's plan. Hover an action to see what it costs.` |

**3b. The empty action queue** -- `main.tscn:313`.

| | |
|---|---|
| **Before** | `No actions queued...` |
| **After** | `No actions queued yet -- click an action to add it here.` |

**3c. The bottom bar on a game that has already started** -- `main.tscn:392`, the scene-baked phase label.

| | |
|---|---|
| **Before** | `[color=white]Phase: Not Started[/color]` |
| **After** | `[color=white]Phase: Starting up...[/color]` |

### 4. The Month Review popup named a button that does not exist

`godot/scripts/game_manager.gd:813`. Fires once a month, every month -- the most-repeated instruction in the game, and it was the most-repeated wrong one. `End Turn` is the internal name (`end_turn()`, the `EndTurnButton` node); the on-screen button reads `COMMIT THE MONTH >`.

| | |
|---|---|
| **Before** | `Queue this month's actions, then End Turn to play the month out.` |
| **After** | `Queue this month's actions, then press COMMIT THE MONTH to play the month out.` |

### 5. A tooltip promising a feature that does not exist

`main.tscn:375`, the commit button. `main_ui._on_end_turn_button_pressed` (`:986-1046`) warns on doom band, reputation, money and technical debt. There is no unspent-Attention warning. Sentence deleted rather than a feature invented to justify it.

| | |
|---|---|
| **Before** | `Commit the queued plan and advance the month. Warns if you have unspent Attention.` |
| **After** | `Commit the queued plan and advance the month.` |

### 6. The Plan screen hint was a strategy tip, and it contradicted the cold open

`godot/scenes/ui/plan_screen.tscn:13`. A turn-loop explanation belongs here. The old text told the player to hire; the cold open hands them a **Scouting** choice on its way out (`GameConfig.first_lever_hint_text`, `main_ui.gd:1538`). Two different first moves, from the same game, thirty seconds apart.

| | |
|---|---|
| **Before** | `TIP: Hire safety researchers to reduce P(Doom)` at `font_size = 10`, `Color(0.5, 0.8, 0.5, 0.9)` |
| **After** | `Each month: click actions below to plan them, then COMMIT THE MONTH to play it out.` at `font_size = 14`, `Color(0.7, 0.85, 0.7, 1)`, plus `autowrap_mode = 3` |

The `autowrap_mode` is not cosmetic: without it this label sets a hard minimum width on the whole left column, and the cold-open advisor line that overwrites it at runtime is longer still.

---

## Tests

Two test files carried their own copies of literals this PR changes, and were updated with them:

- `test_boot_produces_live_run.gd` -- `PLACEHOLDER_PHASE` `"Not Started"` -> `"Starting up"`. Its own comment says *"Keep in sync with main.tscn"*, and its negative control asserts the baked string **is** on screen before boot; a drifted constant would quietly weaken that guard.
- `test_ui_stability.gd` -- two mirrors of the info-bar resting string (issue #450's two-line height lock, which the new copy preserves: the trailing `\n ` is still there).

## No reflow -- measured, not assumed

The concern with raising a font inside a fixed three-column layout is that a label's minimum width propagates up and squeezes its neighbours. Booted `main.tscn` at a 1920 logical viewport, before and after:

| | before | after |
|---|---|---|
| PlanScreen width | 957px | **957px** |
| InstrumentColumn width | 958px | **958px** |
| ContentArea *minimum* width | 591px | 672px |
| ExplanationLabel min width | 267px | 427px (fits RightZones' 479px) |
| PlanHint min width | 226px | 1px (autowrap) |

Actual column widths are identical. The minimum grows but stays far below any shipping window, and the whole screen still fits inside 1080px of height (bottom bar at y=1049).

Verified on a real turn-1 render at 1920x1080, not headless layout numbers alone.

## Explicitly not touched

Noted and left, per scope:

- **Action tile size** -- resizing the 70px tiles reflows the whole left panel. That is issue **#1043**, a deliberate separate job.
- **The Liability Ledger's prominence** -- still the most visually dominant element on turn 1, and still empty on turn 1.
- **The Plan screen layout.**
- **The Staff Roster block** (`Staff Roster` / `No staff hired`) is still tiny on the turn-1 render -- same class of problem as #1 above, not on the brief's list.
- **Action tooltips do not show costs**, only name + description. The `costs` dictionary is right there and `main_ui._on_action_hover` already formats all three; adding it is a one-line follow-up if wanted.

## Gate

```
python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300
-> [TOTALS] quick: 1250 tests, 0 fail (ok)
-> [SUCCESS] All requested suites passed the gate! CHECKED    (exit 0)
```

`pre-commit run --files <the 7 changed files>`: all hooks pass, including the blocking `no-emoji` gate. `tools/check_ladder_bump.py`: OK.

Ladder-Impact: none -- presentation only. Six UI strings, two font sizes, one colour and one autowrap flag. No action costs, effects, RNG draws, turn ordering or scoring touched; `game_manager.gd`'s only change is the wording inside a popup description string.

---

Also worth knowing, from doing this on the Debian laptop: `scripts/run_godot_tests.py` **cannot find Godot on this machine**. `_isolated_env()` overrides `HOME`, and `~/.local/bin/godot` is a shell wrapper that resolves the binary through `$HOME` -- so the probe execs a path inside the test sandbox and dies with `exit 127`, reported as `Could not find Godot executable!`. Fixable in one line by making that wrapper use an absolute path; filed here rather than changed, since it is a machine config file and not repo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
