### PR TITLE
docs(privacy): PRIVACY_POSTURE.md now says HOW both names reach the public board (and why the doc was not the thing that was wrong)

### DIFF
--- a/docs/PRIVACY_POSTURE.md
+++ b/docs/PRIVACY_POSTURE.md
@@ -22,6 +22,22 @@ leaderboard.
 
 **What:** player name + lab name + score, submitted to the global leaderboard.
 
+**HOW the two names are published (measured, PR #1176, 2026-08-10).** Both names
+are public, and they travel as ONE composed string inside the frozen wire field
+`player_name`, formatted `LAB -- OPERATOR` (e.g. `GRIM -- Pip`). There is no
+separate operator field on the server: an unknown extra key is accepted with
+HTTP 200 and then silently dropped by the API's `$ALLOWED_FIELDS` whitelist, so
+composition is the only route by which a player's own name reaches a public
+board. Consequences worth stating in a privacy document:
+
+- The Operator name is rendered publicly, verbatim, beside the lab name. It is
+  NOT a local-only value.
+- The composed string is fitted CLIENT-SIDE to the board's measured 40-byte
+  budget and marked with `...` when cut, so a long name is published truncated
+  rather than amputated by the server.
+- A run with no Operator name submits the lab alone, byte-identical to the
+  pre-#1176 shape. Legacy rows are never back-filled with a fabricated operator.
+
 **Consent:** EXPLICIT opt-in at the point of first submission -- the first time
 a run reaches score submission, a one-time prompt asks the player to confirm
 (game-over screen, `ConfirmationDialog`). Flipping the Settings toggle counts
@@ -43,7 +59,10 @@ identity-carrying leaves the machine.
 **Code:** `godot/autoload/leaderboard_sync.gd` (`should_submit`,
 `consent_flow_state`), `godot/scripts/ui/game_over_screen.gd` (prompt +
 reminder), `godot/scripts/ui/settings_menu.gd`,
-`godot/autoload/game_config.gd`.
+`godot/autoload/game_config.gd`, and `godot/scripts/leaderboard.gd`
+(`ScoreEntry.to_wire_dict` + `Leaderboard.compose_board_name` -- this is the
+file that decides the exact shape of what leaves the machine, so a change there
+is a change to this posture).
 
 ### Tier 2 -- anonymous telemetry (default ON, honest opt-out)
 


### PR DESCRIPTION
Documentation only. No `.gd`, no behaviour, no test change.

## Read this part first -- the brief I was given was stale, and I did not act on it

I was asked to fix `docs/PRIVACY_POSTURE.md` on the premise that it over-claims:
it says the leaderboard shares *"player name + lab name"* while the code sends
**one** name (`lab_name`, in a field called `player_name`).

**That premise was true until 2026-08-10 and is not true now.** I checked the
code before editing, and the finding is the reverse of the brief:

- `godot/scripts/leaderboard.gd:196`, inside `ScoreEntry.to_wire_dict()`:
  ```gdscript
  body["player_name"] = Leaderboard.compose_board_name(lab_name, operator_name)
  ```
- `Leaderboard.compose_board_name` (`godot/scripts/leaderboard.gd:32`) emits
  `LAB -- OPERATOR`.

So **both** names go to the public board. `PRIVACY_POSTURE.md:23` is correct in
substance, and "fixing" it to say one name would have made a privacy SSOT wrong
in the one direction a privacy statement must never be wrong in -- understating
what is published. **I did not make that edit.** The code is right; the doc was
not wrong, it was *incomplete*.

The thing that landed this is PR #1176's second commit,
[`18180379`](https://github.com/PipFoweraker/pdoom1/commit/18180379f6288c746bfe720eb3355567f74e5c30).
The stale account survives in three other places on `main` -- #1176's own merged
body and two comments in `game_over_screen.gd` -- and that is filed separately
and urgently as **#1206**. This PR does not touch those.

## What this PR actually changes

`PRIVACY_POSTURE.md` opens by declaring itself the canonical statement of *"what
the shipped game sends, under what consent, and why"*, with an explicit
anti-policy-rot instruction (Pip, 2026-07-26) to keep it current. Measured
against that bar, Tier 1 has two gaps:

**1. It says the two names are shared, and stops.** It never says they are not
two fields. They are composed into ONE public string in the frozen wire key
`player_name`, because the server has no operator field -- an unknown extra key
is accepted with HTTP 200 and then dropped by `$ALLOWED_FIELDS` (measured
2026-08-10 against the deployed API). Three consequences a privacy reader needs
and could not previously get from this file:

- the Operator name is rendered publicly, verbatim, beside the lab -- it is
  **not** a local-only value;
- the composed string is fitted **client-side** to a measured 40-byte budget and
  marked `...` when cut, so a long name is published truncated;
- a run with no Operator name submits the lab alone, byte-identical to the
  pre-#1176 shape, and legacy rows are never back-filled.

**2. The Tier 1 "Code:" list omitted the one file that decides the wire shape.**
It named `leaderboard_sync.gd`, `game_over_screen.gd`, `settings_menu.gd` and
`game_config.gd` -- consent and plumbing -- but not `godot/scripts/leaderboard.gd`,
which is where `to_wire_dict` and `compose_board_name` live. An SSOT whose code
pointers skip the file that composes the published string cannot be checked
against reality by the next reader. Added, with a note that a change there is a
change to this posture.

## Verify

```
sed -n '20,45p' docs/PRIVACY_POSTURE.md
sed -n '183,199p' godot/scripts/leaderboard.gd
```

## Checks

Full pre-commit suite green (ASCII/no-emoji enforcement, line endings, standards
gate). No test run: nothing under `godot/` is touched.

---

Generated with [Claude Code](https://claude.com/claude-code)

---

Ladder-Impact: none -- documentation only, no file under `godot/` touched.
