### PR TITLE
refactor(attention): one derivation point for monthly capacity, seed in the signature

### DIFF
--- a/godot/scripts/core/capacity.gd
+++ b/godot/scripts/core/capacity.gd
@@ -1,0 +1,191 @@
+extends RefCounted
+class_name Capacity
+## THE single derivation point for the founder's monthly ATTENTION budget.
+##
+## Ruled 2026-08-12 (coordination/DESIGN_2026-08-12_interrupt-resolution-variants.md,
+## sections "AMENDED minutes later" and "AMENDED again"):
+##
+##   The calendar is the world; ATTENTION is the player. The two are different objects
+##   and the gap between them is the fiction -- you cannot attend to everything that
+##   happens. So the budget does NOT track month length. It is 20, always, while gross
+##   balance is being developed.
+##
+## What this file is for, then, given the value is locked: it is the SHAPE the budget
+## will need when sickness / leave / per-difficulty capacity are unlocked later. Every
+## input that future capacity needs is already in the signature -- the seed, the month,
+## and a modifier set -- so unlocking variety is editing THIS function rather than
+## hunting every reference. That is the whole cost of not retrofitting, and it is one
+## parameter (ruling, "THE CONSTRAINT").
+##
+## THE CONSTRAINT, and it is load-bearing:
+##   ANY variability here must derive from the SEED, never from runtime RNG.
+##   This repo's run artifact is an input-replay re-simulated against the same engine
+##   (ADR-0006), and a capacity drawn from an unseeded source would break replay
+##   determinism SILENTLY -- the run still completes and still posts a score. Worse, a
+##   draw taken from `state.rng` would advance the shared stream and fork every recorded
+##   replay even while returning the same number. So:
+##     - the value never touches an rng at all (it is the grant, unconditionally);
+##     - the REASON uses a CHILD RandomNumberGenerator seeded off hash(seed|month), the
+##       same pattern as GameState._init (game_state.gd) and Researcher's hidden-trait
+##       draw (researcher.gd) -- it reads the seed, it never advances the run stream.
+##
+## FLAVOUR SHIPS BEFORE VARIETY. The function returns a value AND a reason, because a
+## cap with no reason reads to a new player as a bug ("a decision with no destination
+## reads as a decision that did not happen", the Jason playtest). While the value is
+## locked at 20, the reason can already vary, so the architecture pays for itself during
+## balance development rather than after it -- and when capacity does start moving, the
+## explanation channel already exists and the player does not read the change as a break.
+##
+## NOTE for whoever unlocks variety: this returns the grant unchanged today. The moment
+## `value` stops equalling `modifiers.grant`, the ladder epoch must bump
+## (`ladder_version.txt`) -- by definition, per the ruling's sequencing step 3.
+
+# The locked budget. Only a fallback: the live number is the Balance dial
+# `attention.per_month`, and difficulty / scenario packs override it via `modifiers.grant`.
+const DEFAULT_GRANT: int = 20
+
+# Modifier-set keys. Today only GRANT is read. Named as constants so the future
+# sickness / leave / difficulty inputs land next to it instead of as loose strings.
+const MOD_GRANT := "grant"
+
+# Month-flavoured explanations for the cap, indexed by CALENDAR month (0 = January).
+# Selected deterministically from seed + month; see reason_for().
+#
+# House rules for anything added here:
+#   1. Start with the month name and a full stop -- reason_for()'s contract, and
+#      test_capacity.gd asserts it.
+#   2. Never name a NUMBER. These sentences must stay true when the value unlocks.
+#   3. ASCII only, no emoji (scripts/check_no_emoji.py is a blocking pre-commit gate).
+#   4. Appending to a pool CHANGES which sentence a given seed reads in a given month.
+#      That is cosmetic today (nothing consumes the reason yet) but it is a visible
+#      diff to a player once the reason is surfaced -- treat pools as append-with-care.
+const MONTH_REASONS: Array = [
+	# January
+	[
+		"January. Half the team is still on leave and the other half is pretending to be back.",
+		"January. Nothing has been signed off since mid-December and the queue knows it.",
+		"January. The building's cooling lost an argument with the heat, and so did everyone in it.",
+	],
+	# February
+	[
+		"February. The shortest month bills you for a full one anyway.",
+		"February. Grant season. Every hour not spent on a form is an hour spent worrying about a form.",
+		"February. Two of the team are at a conference you approved in a more optimistic month.",
+	],
+	# March
+	[
+		"March. End of quarter, so every external party wants a number from you before Friday.",
+		"March. The compliance review landed, and it landed on the calendar.",
+		"March. Term started. Your academic collaborators have gone quiet until it stops.",
+	],
+	# April
+	[
+		"April. A long weekend, then another, then a week where nobody quite restarts.",
+		"April. There is scaffolding on the building and the lift has opinions.",
+		"April. Tax paperwork. It is not research, and it is not optional.",
+	],
+	# May
+	[
+		"May. Submission deadlines everywhere, and none of them are yours.",
+		"May. Two of the team are interviewing elsewhere and being polite about it.",
+		"May. Power was cut for building maintenance on the one day you had blocked out.",
+	],
+	# June
+	[
+		"June. Mid-year reviews. Everyone needs an hour and everyone gets one.",
+		"June. The flu went around the office, then came back for the people it missed.",
+		"June. Financial year end. Finance would like a word, several times.",
+	],
+	# July -- the ruling's worked example.
+	[
+		"July. Two researchers away, the university is shut, nobody answers email.",
+		"July. Peak conference season. The people you need are all in a different timezone.",
+		"July. Half the building is on leave and the other half is covering for them.",
+	],
+	# August
+	[
+		"August. Everyone who did not take July took August.",
+		"August. The new cohort arrived, and onboarding is a full-time job you did not budget.",
+		"August. Reviewing season. Your senior people are reading other people's papers.",
+	],
+	# September
+	[
+		"September. Term restarts, teaching loads land, and your collaborators vanish into lectures.",
+		"September. The board wants a plan for next year, and wants it in a meeting.",
+		"September. A funder visit. Two days of preparation for ninety minutes of nodding.",
+	],
+	# October
+	[
+		"October. Grant renewal season. The forms are longer this year.",
+		"October. Three deadlines collided and the calendar simply gave up.",
+		"October. The office move that was going to take a weekend is taking a fortnight.",
+	],
+	# November
+	[
+		"November. Conference travel, jet lag, and a week of catching up on what broke.",
+		"November. Annual reviews, and the honest conversations they drag along.",
+		"November. The audit arrived early, which is the only way audits ever arrive.",
+	],
+	# December
+	[
+		"December. Everything shuts, and it shuts earlier than anyone admits.",
+		"December. End-of-year reporting eats the fortnight nobody thought to protect.",
+		"December. Half the team has leave they must use or lose, and they are using it.",
+	],
+]
+
+# Namespaces the child RNG so capacity's stream can never collide with another
+# seed-derived feature that happens to key off the same (seed, month) pair.
+const _REASON_SALT := "capacity/reason/v1"
+
+
+static func derive(game_seed: String, month_index: int, modifiers: Dictionary = {}) -> Dictionary:
+	"""The derivation point. Returns {"value": int, "reason": String}.
+
+	`game_seed`   -- the run's seed string (GameState.game_seed_str). IGNORED by `value`
+	                 today, present from the first line so unlocking variety is a body
+	                 edit, not a signature change that ripples to every call site.
+	`month_index` -- ABSOLUTE month ordinal, Clock.month_index() form (year*12 + month-1).
+	                 Absolute rather than 0-based-since-start so the calendar month is
+	                 recoverable (month_index % 12) and July is July in every run.
+	`modifiers`   -- the modifier set. Today: {"grant": int} -- the difficulty / scenario
+	                 grant already held on GameState.attention_per_month. Tomorrow: leave,
+	                 sickness, difficulty capacity bands.
+
+	ZERO BEHAVIOUR CHANGE is the contract: `value` is exactly the grant, for every seed
+	and every month. Nothing here reads an rng."""
+	return {
+		"value": grant_of(modifiers),
+		"reason": reason_for(game_seed, month_index),
+	}
+
+
+static func grant_of(modifiers: Dictionary = {}) -> int:
+	"""The locked budget: the caller's grant, else the Balance dial, else DEFAULT_GRANT.
+
+	This is the ONLY place `value` is decided. When variety unlocks, the leave /
+	sickness / difficulty terms modulate the number returned HERE and nowhere else."""
+	if modifiers.has(MOD_GRANT):
+		return int(modifiers[MOD_GRANT])
+	return Balance.inum("attention.per_month", DEFAULT_GRANT)
+
+
+static func reason_for(game_seed: String, month_index: int) -> String:
+	"""The month-flavoured sentence explaining the cap. SEED-DERIVED and pure: the same
+	(seed, month) reads the same sentence in every run and every replay of that board.
+
+	Determinism, stated so it can be checked rather than trusted:
+	  - the draw uses a CHILD RandomNumberGenerator, seeded off hash(salt|seed|month).
+	    Godot's String hash is a pure function of the characters, so it is stable across
+	    runs and platforms for the same build (same argument as Researcher's
+	    self_report_optimism, which is pinned by unit test).
+	  - it NEVER touches GameState.rng, so calling this cannot advance the run stream and
+	    cannot fork a recorded replay (ADR-0006). test_capacity.gd pins that too.
+	  - the pools are fixed-order literal Arrays, not Dictionary iteration, so the index
+	    draw is order-stable (the ADR-0006 sorted-index rule, satisfied by construction)."""
+	var pool: Array = MONTH_REASONS[posmod(month_index, 12)]
+	if pool.is_empty():
+		return ""
+	var reason_rng := RandomNumberGenerator.new()
+	reason_rng.seed = hash("%s|%s|%d" % [_REASON_SALT, game_seed, month_index])
+	return String(pool[reason_rng.randi() % pool.size()])

--- a/godot/scripts/core/capacity.gd.uid
+++ b/godot/scripts/core/capacity.gd.uid
@@ -1,0 +1,1 @@
+uid://nltcel0vnhlv

--- a/godot/scripts/core/game_state.gd
+++ b/godot/scripts/core/game_state.gd
@@ -78,6 +78,13 @@ var player_frontier: float:
 # ATTENTION, granted per PLAN MONTH and held by month_plan (MonthPlan), typed 2-way into
 # planning vs operating hours. `attention_per_month` is the grant size -- difficulty scales
 # THIS now (it used to scale max_action_points).
+#
+# 2026-08-12 ruling: this field is an INPUT to the budget, not the budget. Do NOT read it
+# to open a month -- call `capacity_for_month()` (-> Capacity.derive), which is the single
+# derivation point. Difficulty, scenario packs and save/load still WRITE here: this is the
+# grant modifier they set, and the derivation reads it back out as `modifiers.grant`. The
+# two numbers are identical today by contract, and the point of the indirection is that the
+# day they stop being identical, exactly one function changes.
 var attention_per_month: int = 20
 var stationery: float = 100.0  # Office supplies, depletes with staff usage
 
@@ -324,7 +331,11 @@ func reset():
 	# L1/ADR-0009: fresh month plan, opened with the first month's Attention grant. The plan
 	# month ordinal is derived from the calendar (turn 0 -> ordinal 0).
 	month_plan = MonthPlan.new()
-	month_plan.begin_month(attention_per_month, 0)
+	# Ordinal 0 is the run's START month by definition, so the derivation is asked about
+	# turn 0's calendar month, not `turn` (reset() zeroes `turn` further down, and a
+	# restart would otherwise ask about the month the previous run died in).
+	var start_capacity: Dictionary = capacity_for_month(Clock.month_index(0, start_year, start_month, start_day))
+	month_plan.begin_month(int(start_capacity["value"]), 0)
 	hiring = HiringPipeline.new()  # Phase B: fresh pipeline per game (created BEFORE candidates
 	                               # are populated so add_candidate can stamp their ids)
 	cause_log.clear()      # EE-8: fresh attribution trail per game
@@ -1127,6 +1138,26 @@ func add_upgrade(upgrade_id: String):
 		# Handle special upgrade effects
 		if upgrade_id == "cat_adoption":
 			has_cat = true
+
+# --- Founder Attention capacity (2026-08-12 ruling: ONE derivation point) ------------
+func current_month_index() -> int:
+	"""Absolute month ordinal (Clock.month_index form) for the turn the run is on. The
+	argument capacity_for_month() wants; also the month-boundary counter MonthController
+	already uses, so both sides agree on what 'this month' means."""
+	return Clock.month_index(turn, start_year, start_month, start_day)
+
+func capacity_for_month(month_index: int) -> Dictionary:
+	"""THE derivation point for this run's monthly Attention budget: {value, reason}.
+
+	Every site that opens a plan month goes through here rather than reading
+	`attention_per_month` directly (GameState.reset, MonthController._open_plan_month,
+	GameManager._set_attention_grant). The seed is passed from the first line even though
+	`value` ignores it -- see capacity.gd for why that is the whole point.
+
+	Zero behaviour change today: `value` is exactly `attention_per_month`, for every seed
+	and every month. Only the `reason` varies, and it varies by seed+month, never by an
+	rng draw off the run stream."""
+	return Capacity.derive(game_seed_str, month_index, {Capacity.MOD_GRANT: attention_per_month})
 
 # --- Founder Attention accessors (T2: the AP reserve system is gone; these read the plan) ---
 func get_available_attention() -> int:

--- a/godot/scripts/core/month_controller.gd
+++ b/godot/scripts/core/month_controller.gd
@@ -392,7 +392,11 @@ func _open_plan_month(mi: int) -> void:
 	current_month_index = mi
 	windows_surfaced_this_month = 0
 	var ordinal := Clock.month_ordinal_since_start(state.turn, state.start_year, state.start_month, state.start_day)
-	state.month_plan.begin_month(state.attention_per_month, ordinal)
+	# 2026-08-12 ruling: the budget comes from the ONE derivation point, never from
+	# `state.attention_per_month` directly. `mi` is already the absolute month index the
+	# derivation wants. Identical number today; one function to edit when it stops being.
+	var capacity: Dictionary = state.capacity_for_month(mi)
+	state.month_plan.begin_month(int(capacity["value"]), ordinal)
 	# Office rent (#791): the predictable monthly cash sink, on the payroll rail (a direct
 	# deduction, not a compounding ledger payable -- see office.gd's rail decision). No-op
 	# for an unsigned run, so a bedroom-only game is economically unchanged.

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -1153,7 +1153,16 @@ func _set_attention_grant(per_month: int) -> void:
 	which is why a plain re-begin is safe here and would not be mid-month."""
 	state.attention_per_month = per_month
 	if state.month_plan != null:
-		state.month_plan.begin_month(per_month, state.month_plan.month_ordinal)
+		# `per_month` is the MODIFIER we just stored, not the budget. Re-open through the
+		# derivation point so difficulty/scenario grants pass through the same one function
+		# as everything else (2026-08-12 ruling). Same number today, by contract.
+		# Month index from the plan's own ordinal, not from `turn`: this restates the month
+		# the plan is currently on, which at setup time is month 0 and would be the same
+		# either way, but stays correct if it is ever called later.
+		var mi: int = Clock.month_index(0, state.start_year, state.start_month, state.start_day) \
+			+ state.month_plan.month_ordinal
+		var capacity: Dictionary = state.capacity_for_month(mi)
+		state.month_plan.begin_month(int(capacity["value"]), state.month_plan.month_ordinal)
 
 func _apply_scenario_overrides():
 	"""Apply scenario pack overrides to game state (Issue #483)"""

--- a/godot/tests/unit/test_capacity.gd
+++ b/godot/tests/unit/test_capacity.gd
@@ -1,0 +1,191 @@
+extends GutTest
+## Unit tests for Capacity -- the single derivation point for the monthly Attention budget.
+##
+## These exist to pin the two promises the 2026-08-12 ruling makes, both of which fail
+## SILENTLY if broken:
+##   1. ZERO BEHAVIOUR CHANGE while balance is being developed -- the value is the grant,
+##      for every seed and every month. If this ever goes red, the ladder epoch must bump.
+##   2. ANY variability is SEED-derived, never runtime RNG -- deriving must not advance
+##      GameState.rng, or every recorded input-replay forks (ADR-0006).
+
+const SEEDS := ["alpha", "bravo", "charlie", "2017-opening", "", "a much longer seed string"]
+
+# 2017-01 through 2036-12 in Clock.month_index form (year * 12 + month - 1): twenty years,
+# comfortably longer than any run the ladder will see.
+const FIRST_MONTH := 2017 * 12
+const LAST_MONTH := 2036 * 12 + 11
+
+
+# --- Promise 1: the value is locked -------------------------------------------------
+
+func test_balance_dial_is_still_twenty():
+	# The ruling's number, pinned at its source. If someone retunes the dial this test is
+	# the first thing that says so.
+	assert_eq(Balance.inum("attention.per_month", 20), 20, "Balance attention.per_month is the ruling's 20")
+
+
+func test_value_is_the_grant_for_every_seed_and_every_month():
+	var grant: int = 20
+	var mismatches: int = 0
+	for game_seed in SEEDS:
+		for mi in range(FIRST_MONTH, LAST_MONTH + 1):
+			var got: Dictionary = Capacity.derive(game_seed, mi, {Capacity.MOD_GRANT: grant})
+			if int(got["value"]) != grant:
+				mismatches += 1
+	assert_eq(mismatches, 0, "value == grant for all %d seed/month pairs" % (SEEDS.size() * (LAST_MONTH - FIRST_MONTH + 1)))
+
+
+func test_value_falls_back_to_the_balance_dial_without_a_modifier():
+	var got: Dictionary = Capacity.derive("alpha", FIRST_MONTH)
+	assert_eq(int(got["value"]), Balance.inum("attention.per_month", 20), "no modifier set -> the Balance grant")
+
+
+func test_value_honours_the_difficulty_and_scenario_grants():
+	# Difficulty (easy 24 / standard 20 / hard 16) and scenario packs (sandbox 40) already
+	# move the grant today. The derivation must pass them through untouched -- this is the
+	# half of "zero behaviour change" that a hardcoded 20 would have quietly broken.
+	for grant in [16, 20, 24, 40, 0]:
+		var got: Dictionary = Capacity.derive("alpha", FIRST_MONTH + 6, {Capacity.MOD_GRANT: grant})
+		assert_eq(int(got["value"]), grant, "grant %d passes through the derivation unchanged" % grant)
+
+
+func test_derive_returns_both_fields():
+	var got: Dictionary = Capacity.derive("alpha", FIRST_MONTH, {Capacity.MOD_GRANT: 20})
+	assert_true(got.has("value"), "derive returns a value")
+	assert_true(got.has("reason"), "derive returns a reason")
+	assert_true(got["value"] is int, "value is an int")
+	assert_true(got["reason"] is String, "reason is a String")
+
+
+# --- Promise 2: seed-derived, never runtime RNG -------------------------------------
+
+func test_reason_is_stable_for_the_same_seed_and_month():
+	# Two runs on one board key must read the same sentence in the same month.
+	for game_seed in SEEDS:
+		for mi in [FIRST_MONTH, FIRST_MONTH + 6, FIRST_MONTH + 77, LAST_MONTH]:
+			var first: String = Capacity.reason_for(game_seed, mi)
+			for _repeat in range(5):
+				assert_eq(Capacity.reason_for(game_seed, mi), first,
+					"reason stable for seed '%s' month %d" % [game_seed, mi])
+
+
+func test_deriving_does_not_advance_the_run_rng():
+	# The failure this guards is the nastiest one available: a run that still completes and
+	# still posts a score, from a stream that no longer matches its replay.
+	var state := GameState.new("determinism_seed")
+	var seed_before: int = state.rng.seed
+	var state_before: int = state.rng.state
+	for mi in range(FIRST_MONTH, FIRST_MONTH + 120):
+		var _ignored: Dictionary = state.capacity_for_month(mi)
+	assert_eq(state.rng.seed, seed_before, "capacity_for_month leaves rng.seed untouched")
+	assert_eq(state.rng.state, state_before, "capacity_for_month leaves rng.state untouched")
+
+
+func test_two_states_on_one_seed_read_the_same_reasons():
+	var a := GameState.new("board_key_seed")
+	var b := GameState.new("board_key_seed")
+	for mi in range(FIRST_MONTH, FIRST_MONTH + 60):
+		assert_eq(str(a.capacity_for_month(mi)["reason"]), str(b.capacity_for_month(mi)["reason"]),
+			"same seed, same month, same sentence (month %d)" % mi)
+
+
+func test_reasons_differ_across_seeds_somewhere():
+	# Not every seed/month pair must differ (the pools are small), but the selection must
+	# actually READ the seed. If this goes green with a constant reason, the salt is dead.
+	var differing: int = 0
+	for mi in range(FIRST_MONTH, FIRST_MONTH + 60):
+		if Capacity.reason_for("alpha", mi) != Capacity.reason_for("bravo", mi):
+			differing += 1
+	assert_true(differing > 0, "the reason varies by seed (%d of 60 months differ)" % differing)
+
+
+func test_reasons_differ_across_months_within_a_seed():
+	var seen := {}
+	for mi in range(FIRST_MONTH, FIRST_MONTH + 24):
+		seen[Capacity.reason_for("alpha", mi)] = true
+	assert_true(seen.size() > 1, "the reason varies by month (%d distinct over 24 months)" % seen.size())
+
+
+# --- The reason itself ----------------------------------------------------------------
+
+func test_every_calendar_month_has_a_reason_pool():
+	assert_eq(Capacity.MONTH_REASONS.size(), 12, "one pool per calendar month")
+	for m in range(12):
+		var pool: Array = Capacity.MONTH_REASONS[m]
+		assert_true(pool.size() > 0, "%s pool is not empty" % Clock.MONTH_NAMES[m])
+
+
+func test_reason_names_its_calendar_month():
+	# The contract reason_for() documents: the sentence opens with the month it explains,
+	# so July reads as July in every run regardless of which run-year it falls in.
+	for mi in range(FIRST_MONTH, FIRST_MONTH + 36):
+		var month_name: String = Clock.MONTH_NAMES[posmod(mi, 12)]
+		var reason: String = Capacity.reason_for("alpha", mi)
+		assert_true(reason.begins_with(month_name + "."),
+			"month %d reason opens with '%s.' -- got '%s'" % [mi, month_name, reason])
+
+
+func test_july_reads_as_july_and_the_ruling_sentence_is_in_the_pool():
+	assert_true(Capacity.MONTH_REASONS[6].has("July. Two researchers away, the university is shut, nobody answers email."),
+		"the ruling's worked example is one of July's reasons")
+
+
+func test_reason_is_never_empty_over_a_long_run():
+	var empties: int = 0
+	for mi in range(FIRST_MONTH, LAST_MONTH + 1):
+		if Capacity.reason_for("alpha", mi).length() == 0:
+			empties += 1
+	assert_eq(empties, 0, "every month of a 20-year run has a reason")
+
+
+func test_reason_pools_are_ascii_only():
+	# scripts/check_no_emoji.py is a blocking pre-commit gate on godot/**/*.gd. This is the
+	# same rule asserted at runtime so a bad paste is caught by the suite too.
+	var offenders: Array = []
+	for m in range(12):
+		for reason in Capacity.MONTH_REASONS[m]:
+			var text := String(reason)
+			for i in range(text.length()):
+				if text.unicode_at(i) >= 128:
+					offenders.append(text)
+					break
+	assert_eq(offenders.size(), 0, "ASCII only -- non-ASCII in: %s" % str(offenders))
+
+
+func test_reason_pools_never_name_a_number():
+	# The sentences must stay true when the value unlocks, so they explain the month, not
+	# the size of the budget.
+	for m in range(12):
+		for reason in Capacity.MONTH_REASONS[m]:
+			var digits: int = 0
+			for i in range(String(reason).length()):
+				var c: int = String(reason).unicode_at(i)
+				if c >= 48 and c <= 57:
+					digits += 1
+			assert_eq(digits, 0, "no digits in '%s'" % reason)
+
+
+# --- Wiring: the call sites really do read the derivation -----------------------------
+
+func test_game_state_opens_its_first_month_from_the_derivation():
+	var state := GameState.new("boot_seed")
+	var expected: Dictionary = state.capacity_for_month(
+		Clock.month_index(0, state.start_year, state.start_month, state.start_day))
+	assert_eq(state.month_plan.attention_total, int(expected["value"]),
+		"reset() opened month 0 with the derived value")
+	assert_eq(state.month_plan.attention_total, state.attention_per_month,
+		"and it equals the stored grant -- zero behaviour change")
+
+
+func test_capacity_for_month_reads_the_stored_grant_as_its_modifier():
+	var state := GameState.new("modifier_seed")
+	state.attention_per_month = 16
+	assert_eq(int(state.capacity_for_month(FIRST_MONTH)["value"]), 16,
+		"the field is the modifier the derivation reads back out")
+
+
+func test_current_month_index_matches_the_clock():
+	var state := GameState.new("clock_seed")
+	assert_eq(state.current_month_index(),
+		Clock.month_index(state.turn, state.start_year, state.start_month, state.start_day),
+		"current_month_index is Clock.month_index for the current turn")

--- a/godot/tests/unit/test_capacity.gd.uid
+++ b/godot/tests/unit/test_capacity.gd.uid
@@ -1,0 +1,1 @@
+uid://d4hjttbtdsxnd


### PR DESCRIPTION
Implements the 2026-08-12 ruling in
`coordination/DESIGN_2026-08-12_interrupt-resolution-variants.md` -- sections
**"AMENDED minutes later -- architect for variety, lock the value"** and
**"AMENDED again -- the cap carries its own reason"**. Refactor only. It opens design
space and ships nothing new to the player.

## What changed

New `godot/scripts/core/capacity.gd`:

```
Capacity.derive(game_seed: String, month_index: int, modifiers: Dictionary)
    -> {"value": int, "reason": String}
```

reached through a thin `GameState.capacity_for_month(month_index)` that supplies the run's
seed and the stored grant. The three sites that OPEN a plan month now read the derivation
instead of `state.attention_per_month`:

| Site | What it opens |
|---|---|
| `GameState.reset()` | month 0 |
| `MonthController._open_plan_month()` | every later month |
| `GameManager._set_attention_grant()` | the difficulty / scenario re-open |

`attention_per_month` is **kept, and kept meaning what it meant**: the grant MODIFIER that
difficulty (easy 24 / standard 20 / hard 16), scenario packs (sandbox 40) and save/load
already write. The derivation reads it back out as `modifiers.grant`. This was the one real
surprise in the task -- see "What surprised me" below.

Also added: `GameState.current_month_index()` (the `Clock.month_index` for the current
turn, which is the argument the derivation wants), and 36 month-flavoured reason strings
(12 calendar months x 3).

## Behaviour is unchanged, and here is how that was verified

The value path never reads an rng and never reads the month or the seed. `Capacity.grant_of`
returns `modifiers.grant` unmodified, so the number handed to `MonthPlan.begin_month` is
byte-identical to the number that was handed to it before, for every seed and every month.

Measured, on this branch:

- **Fast gate** -- `python scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`:
  **1313 tests, 0 failures, 130/130 files collected, 15s.**
- **Baseline on `origin/main`, same command, same machine, run BEFORE any edit:**
  **1294 tests, 0 failures, 129/129 files, 12.6s.** There were **no pre-existing failures**
  to distinguish from mine. The +19 tests and +1 file are `test_capacity.gd`.
- **Simulation tier** (full-run / replay / determinism) --
  `python scripts/run_godot_tests.py --simulation --ci-mode`:
  **107 tests, 0 failures, 8/8 files, 135s.** Run because this touches the month-open path;
  it is the tier that would catch a forked replay.
- I did **not** run the integration or smoke tiers, and I did **not** launch the game.

`test_capacity.gd` pins the promise directly rather than by implication:

- `value == grant` across **1440 seed/month pairs** (6 seeds x 240 months, 2017-2036).
- the grant passes through unchanged for 16 / 20 / 24 / 40 / 0, so difficulty and the
  sandbox scenario are covered explicitly.
- `GameState` boots with `month_plan.attention_total == attention_per_month`.

## Seed-determinism guarantee

**Any variability here is SEED-derived. Nothing draws from runtime RNG, and nothing draws
from the run's RNG.**

The value never touches an rng at all. The reason uses a **child**
`RandomNumberGenerator` seeded off `hash("capacity/reason/v1|<seed>|<month_index>")` -- the
same pattern as `GameState._init` (`game_state.gd`) and `Researcher`'s hidden-trait draw
(`researcher.gd`), which is the repo's existing facility for a deterministic keyed draw. It
is a pure function of (seed, month), so:

- two runs on one board key read the same sentence in the same month;
- `state.rng` is **never** touched, so the recorded input-replay stream is unchanged and no
  existing replay forks (ADR-0006);
- the reason pools are fixed-order literal `Array`s, not `Dictionary` iteration, so the
  index draw is order-stable by construction.

`test_capacity.gd::test_deriving_does_not_advance_the_run_rng` asserts `rng.seed` and
`rng.state` are identical before and after 120 derivations. That test is the tripwire for
the failure mode the ruling names as the hardest to notice -- a run that still completes
and still posts a score from a stream that no longer matches its replay.

`month_index` is deliberately the **absolute** `Clock.month_index` form (`year*12 + month-1`)
rather than the 0-based-since-start ordinal, so the calendar month is recoverable and July
is July in every run, in every start year.

## Call-site count

`grep -rn attention_per_month` on `origin/main` returns **42 lines across 15 files**. They
sum to 42 exactly as listed, and most of them are not budget reads:

| Category | Lines | Routed? |
|---|---|---|
| **Budget reads** -- decide what a plan month opens with | **2** | **Yes, both.** `game_state.gd:327`, `month_controller.gd:395` |
| Display / serialisation reads of the field | 6 | No -- see below |
| Writes -- set the grant modifier the derivation consumes | 3 | No, by design: `game_state.gd:315` (Balance), `game_manager.gd:1154` (difficulty/scenario), `game_state.gd:1518` (save restore) |
| `Balance.inum("difficulty.*.attention_per_month")` lookups | 3 | N/A -- balance keys, the input side |
| Scenario-JSON key names in `_apply_scenario_overrides` | 2 | N/A |
| The field declaration `game_state.gd:81` | 1 | Comment rewritten to say it is the modifier, not the budget |
| Comments | 2 | Rewritten |
| `MonthPlan.begin_month`'s parameter of the same name | 5 | N/A -- a local parameter, not the field |
| Tests | 13 | Unchanged -- they assert the grant, which still holds |
| Docs + data JSON | 5 | N/A |
| **Total** | **42** | |

**A `grep` alone would have missed one of the three call sites.** There are **3** sites that
open a plan month, and only **2** of them appear in that 42:
`GameManager._set_attention_grant` (`game_manager.gd:1156`) called
`begin_month(per_month, ...)` with a **local parameter**, so the field's name is not on the
line. All three are routed; the count of budget-determining call sites is **3 of 3**.

The 6 display/serialisation reads left alone, and why:
`game_state.gd:1451` (to_dict must save the MODIFIER, not the derived value, or a
difficulty grant is lost on reload); `game_manager.gd:1204` (a scenario `print`);
`main_ui.gd:1204` (the tooltip -- the deliberate follow-up below);
`tools/dev_tool.gd:125`, `tools/dev_tool_v2.gd:111` and `:112`.

## Follow-up, deliberately NOT done here

**The reason is not surfaced anywhere.** Nothing in the UI reads it today. The obvious cheap
place is the Attention tooltip at `godot/scripts/ui/main_ui.gd:1203-1207`, which already
explains the grant in prose and would take the sentence with no layout work. It was left
alone on purpose: wiring it needs a new key on `GameState.to_dict()` (which is both the UI
snapshot and the save dict, so it wants its own look at save round-trip stability), and
scope discipline beat completeness today.

Two smaller things also left alone:

- `godot/tools/dev_tool.gd` and `dev_tool_v2.gd` both call `GameState.initialize()` and read
  `GameState.seed`. **Neither exists on `GameState` any more** -- those tools are already
  stale against the current API, so routing their `attention_per_month` print would have
  been churn in code that cannot run. Worth its own issue.
- No ladder bump. Declared in the commit as `Ladder-Impact: none`, and
  `python tools/check_ladder_bump.py` passes on the committed tree.

## What surprised me

**`attention_per_month` is not a bare constant, and a literal reading of the brief would
have broken the game.** The ruling describes it as "a bare constant read directly at every
call site", and `game_state.gd:81` does say `= 20`. But that line is only the field's
declaration default: `reset()` immediately overwrites it from the Balance dial
`attention.per_month`, `GameManager._apply_difficulty_modifiers` overwrites it again per
difficulty (24 / 20 / 16), and scenario packs override it a third time (`sandbox.json` sets
40). A `capacity()` that returned a hardcoded 20 would have silently deleted the difficulty
axis and the sandbox scenario -- a behaviour change of exactly the kind the ruling forbids,
arriving through the door marked "zero behaviour change".

So the modifier set is not speculative future-proofing here. It is load-bearing on day one:
the grant is already variable, it is just not variable *by seed or by month* yet. That is
also why the field is kept rather than replaced -- it is the modifier, and the derivation
consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
