### PR TITLE
docs(comments): four in-tree comments still say the Operator name stays local -- it is published

### DIFF
--- a/godot/scripts/leaderboard.gd
+++ b/godot/scripts/leaderboard.gd
@@ -134,7 +134,7 @@ class ScoreEntry:
 	# labs over several months is a feature, which a single conflated field
 	# would destroy permanently.
 	var lab_name: String  # The org the player runs. What the frozen wire key `player_name` has always carried.
-	var operator_name: String  # The human (GameConfig.player_name, "Operator:" in the prompt). Local-only so far.
+	var operator_name: String  # The human (GameConfig.player_name, "Operator:" in the prompt). PUBLISHED: composed into `player_name` by to_wire_dict() as `LAB -- OPERATOR` (:196).
 	var date: String  # ISO timestamp
 	var level_reached: int  # Final turn number (== score; kept for back-compat)
 	var game_mode: String  # Game version, e.g. "v0.11.0"

--- a/godot/scripts/ui/game_over_screen.gd
+++ b/godot/scripts/ui/game_over_screen.gd
@@ -29,9 +29,13 @@ static func _hex(c: Color) -> String:
 	return c.to_html(false)
 
 # What the identity prompt is allowed to promise. The prompt collects an
-# Operator name AND a Lab name; the remote board's frozen contract carries one
-# string, and it is the lab. Until the server takes both (coordination item),
-# the prompt says which one goes public rather than implying both do.
+# Operator name AND a Lab name, and BOTH are published: the remote board's
+# frozen contract carries one string, and `ScoreEntry.to_wire_dict()` composes
+# both names into it as `LAB -- OPERATOR` (see `Leaderboard.compose_board_name`,
+# godot/scripts/leaderboard.gd:32 and :196). A separate `operator_name` key is
+# not sent because the server drops unknown keys via $ALLOWED_FIELDS (measured
+# 2026-08-10) -- that is a wire-shape detail, NOT a limit on what goes public.
+# So the prompt must say both names go public, and it does.
 const IDENTITY_PROMPT_BOARD_NOTE := "The global board shows both, as 'Lab -- Operator'. One Operator can run many labs, and lab names collide, so the Operator name is what tells two identical labs apart. Long names are shortened with '...' to fit the board."
 
 @onready var panel_container = $CenterContainer/PanelContainer
@@ -350,8 +354,9 @@ func _persist_and_submit_score(final_state: Dictionary, game_seed: String) -> vo
 	# BOTH identity values (Pip's ruling 2026-08-08). Until this, only the lab
 	# was passed -- into a field then named `player_name` -- so #1133 could
 	# collect an Operator name that no code path ever carried anywhere. A player
-	# who typed their name saw it nowhere. The operator reaches the LOCAL board
-	# now; the remote wire still carries the lab alone (see ScoreEntry.to_wire_dict).
+	# who typed their name saw it nowhere. The operator now reaches BOTH the local
+	# board and the PUBLIC one: ScoreEntry.to_wire_dict() composes it into the
+	# frozen `player_name` field as `LAB -- OPERATOR` (leaderboard.gd:196).
 	var entry = Leaderboard.ScoreEntry.new(
 		final_turns,
 		GameConfig.lab_name,

--- a/godot/tests/unit/test_leaderboard_identity_fields.gd
+++ b/godot/tests/unit/test_leaderboard_identity_fields.gd
@@ -429,8 +429,10 @@ func test_game_over_screen_submits_the_operator_name_too():
 
 
 func test_identity_prompt_is_honest_about_what_reaches_the_board():
-	# The prompt collects "Operator:" and "Lab:". Until the wire carries both,
-	# a prompt that implies both appear publicly is lying to the player.
+	# The prompt collects "Operator:" and "Lab:". The wire carries BOTH, composed
+	# as `LAB -- OPERATOR` into the frozen `player_name` field (leaderboard.gd:196),
+	# so a prompt that implies only the lab appears publicly is lying to the player
+	# -- and lying in the direction a privacy statement must never be wrong in.
 	var src := _read(GAME_OVER_SRC)
 	assert_true(src.contains("IDENTITY_PROMPT_BOARD_NOTE"),
 		"the identity prompt must state which of the two values the board shows today")


### PR DESCRIPTION
Comment-only. No `.gd` behaviour, no test assertion, no string a player reads.
Found during an outbound-claims accuracy sweep across the trio ahead of tomorrow's release.

## The fact

`ScoreEntry.to_wire_dict()` composes **both** identity values into the frozen
`player_name` field as `LAB -- OPERATOR`:

```gdscript
# godot/scripts/leaderboard.gd:196
body["player_name"] = Leaderboard.compose_board_name(lab_name, operator_name)
```

`compose_board_name` is at `godot/scripts/leaderboard.gd:32`. The Operator name
-- the human -- is published on the public board.

## What was wrong

Four comments on `main` still describe the pre-#1176 world in which the wire
carried the lab alone. **#1206 names two of them. Two more turned up while
verifying those two**, and they are the same untruth in the same subsystem.

| file:line | said | reality |
|---|---|---|
| `godot/scripts/ui/game_over_screen.gd:31-34` | "the remote board's frozen contract carries one string, and it is the lab... the prompt says which one goes public rather than implying both do" | `leaderboard.gd:196`. Also contradicted the constant on the very next line, which says the board shows both. |
| `godot/scripts/ui/game_over_screen.gd:353-354` | "the remote wire still carries the lab alone (see ScoreEntry.to_wire_dict)" | `to_wire_dict` composes both. |
| **`godot/scripts/leaderboard.gd:137`** (not in #1206) | `operator_name` ... "Local-only so far." | The field *declaration* -- the first comment a reader of this class hits. |
| **`godot/tests/unit/test_leaderboard_identity_fields.gd:432-433`** (not in #1206) | "Until the wire carries both, a prompt that implies both appear publicly is lying to the player." | The guard that exists to keep the prompt honest was itself prefaced on the stale premise. |

## The distinction the old comments were reaching for

It is real, and it was stated wrongly. `operator_name` is not sent as its own
**key**, because the deployed server accepts unknown keys with HTTP 200 and then
drops them via `$ALLOWED_FIELDS` (measured 2026-08-10, recorded in
`to_wire_dict`'s own docstring). That is a **wire-shape** detail, not a limit on
what becomes public. Each rewritten comment now says both halves, so the next
reader cannot collapse "not its own key" into "not published" the way these four
did.

## Why bother with comments

This is the direction a privacy claim must never be wrong in: the in-tree record
told a future reader that a human's typed name stays on their machine. It is
published in plain text beside a lab name. The false version had already
propagated four times inside one subsystem, which is what a claim does when it
is left in place.

## Verify

```
grep -n "compose_board_name" godot/scripts/leaderboard.gd
sed -n '183,199p' godot/scripts/leaderboard.gd
git diff main...chore/claims-sweep-2026-08-13
```

## Checks

- `scripts/check_no_emoji.py` -- OK (godot .gd/.json pure ASCII, .tscn emoji-free)
- `tools/check_ladder_bump.py` -- OK (`Ladder-Impact: none` declared and accepted)
- Changed files verified ASCII-only and LF-only by hand.
- **No Godot test run.** The change is comment-only: no executable line moved, and
  the one guard that reads this source (`test_identity_prompt_is_honest_about_what_reaches_the_board`)
  asserts on the *value* of `IDENTITY_PROMPT_BOARD_NOTE` via
  `get_script_constant_map()`, not on surrounding comment text. CI is the first
  real run.
- Pre-commit hooks were bypassed deliberately for the commit itself: CLAUDE.md
  records that agent commits with hooks running alongside other tool activity
  abort *and discard working-tree edits*. The gates were then run manually, above.

Does **not** close #1206 -- that issue also asks for the #1176 body correction,
which is not mine to make.

---

Generated with [Claude Code](https://claude.com/claude-code)
