### PR TITLE
chore(league): roll the featured seed to weekly-2026-w33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+**Featured league seed rolls to `weekly-2026-w33`.** Board key becomes
+`(weekly-2026-w33, L4)`.
+
+**The ladder does NOT move.** 14 August is the second Friday of the month, so
+this is a weekly Seed, not an Epoch -- `RELEASE_NOMENCLATURE.md` puts the Epoch
+on the first Friday, and the next one is v0.15 on 4 September. `ladder_version.txt`
+stays `4`.
+
+Scores posted on `(weekly-2026-w32, L4)` are untouched and remain valid on that
+board. Each seed is its own board; rolling the seed opens a new one rather than
+retiring the old.
+
+Rolled at Pip's call per `docs/rituals/gate_5_seed_blessing.md`, which requires the
+const to be **merged and inside the cut before** Gate 5 -- blessing a seed without
+editing the const makes the blessed and posted boards diverge silently, and looks
+correct from both ends.
+
 ## [0.14.1] - 2026-08-08
 
 **The board key does NOT move.** Ladder stays **L4**, featured seed stays

--- a/godot/autoload/game_config.gd
+++ b/godot/autoload/game_config.gd
@@ -540,7 +540,7 @@ func increment_games_played() -> void:
 ## league seed -- the metabolic cycle rotates it at Pip's call ("manual for now",
 ## see docs/RELEASE_AND_LEAGUE_CYCLE.html). To rotate the league, edit this const
 ## (or clear it to fall back to the calendar-week auto-seed below).
-const FEATURED_SEED_OVERRIDE: String = "weekly-2026-w32"
+const FEATURED_SEED_OVERRIDE: String = "weekly-2026-w33"
 
 ## Get weekly challenge seed (the featured/default league seed).
 func get_weekly_seed() -> String:


### PR DESCRIPTION
**Rolled at Pip's call, 2026-08-13 ~12:55.** This must merge and be inside tomorrow's cut **before** Gate 5, not during it.

## What changed

| | before | after |
|---|---|---|
| `FEATURED_SEED_OVERRIDE` (`game_config.gd:543`) | `weekly-2026-w32` | **`weekly-2026-w33`** |
| `ladder_version.txt` | `4` | `4` — **unchanged** |
| `version.txt` | `0.14.1` | `0.14.1` — unchanged |
| Board key | `(weekly-2026-w32, L4)` | `(weekly-2026-w33, L4)` |

Plus a `[Unreleased]` CHANGELOG entry recording the roll.

## The ladder does not move, and that is deliberate

**14 August is the second Friday of the month.** `RELEASE_NOMENCLATURE.md` puts the Epoch on the **first** Friday, so tomorrow is a weekly **Seed**, not an Epoch. No minor bump, no ladder bump. The next Epoch is v0.15 on **4 September**.

Scores already posted on `(weekly-2026-w32, L4)` are untouched and remain valid on that board. Each seed is its own board — rolling opens a new one rather than retiring the old.

## Why it has to clear tonight's freeze

`docs/rituals/gate_5_seed_blessing.md` is explicit, and the reason is good:

> *Blessing a seed without editing it makes the blessed and posted boards diverge -- silently, and in a way that looks completely fine from both ends.* … *Changing it is a code change, not a ceremony action -- so it must be done, merged and re-cut BEFORE this gate, not during it.*

The const is compiled into the build. If it lands after the cut, there is no proven build.

## Only one live site was touched

`grep` finds twelve other mentions of `weekly-2026-w32` in the tree — CHANGELOG history, postmortems, the cutover playbook, workshop-2 position notes. **All are historical records of what w32 was and are deliberately unedited.** `docs/RELEASE_PLATFORMS.md:26-28` makes the point itself: *"a dated sheet quoting them will always be a release behind"*, and directs the reader to the const.

## Verification

Ran the ritual's own mechanical checks from the gate sheet:

- `FEATURED_SEED_OVERRIDE` reads `weekly-2026-w33`
- `get_weekly_seed()` returns the const directly when non-empty (`:547-548`), so the roll reaches the wire rather than only the config
- `get_board_version()` -> `"L" + LADDER_VERSION` (`:745-746`), unchanged
- `ladder_version.txt` = `4`
- `python3 tools/sync_version.py --check` -> *all targets in sync with version.txt=0.14.1, ladder_version.txt=4*
- `run_godot_tests.py --quick --ci-mode --min-tests 300` -> **1313 tests, 0 failures, 130/130 files** — byte-identical to the pre-change baseline on `ea197205`
- All pre-commit hooks green, including the commitment-calendar guard and the single-`[Unreleased]`-heading check

## Not addressed here, and it is the real risk

`weekly-league-reset.yml` runs `0 14 * * 4` = **Friday 00:00 Hobart, roughly sixteen hours before the 16:15 tag**. Two website files still carry stale ladder data (`public/data/ladder-epochs.json`, `public/data/integration-health.json`), so when it fires it can stamp a `v0.14.1` + `L3` record that has never existed. `check-blessing-consistency.py` sees this and is advisory only, so CI stays green while it happens. **That is a `pdoom1-website` fix and is not in scope for this PR.**

Generated with [Claude Code](https://claude.com/claude-code)