### PR TITLE
ci(guard): detect a stale Godot class cache -- the failure CI structurally cannot see

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -72,6 +72,19 @@ jobs:
         echo " A silent drift forks the leaderboard board-key, so this gate is FATAL.)"
         python tools/sync_version.py --check
 
+    - name: Stale class-cache guard -- prove the DETECTOR still works
+      run: |
+        echo "CI cannot reproduce the bug this guards: a stale"
+        echo "godot/.godot/global_script_class_cache.cfg only exists in a long-lived working"
+        echo "copy, and CI clones fresh every run, so it always generates a correct cache."
+        echo "What CI CAN prove is that the detector has not decayed into a function that"
+        echo "always returns 0 -- so these tests assert BOTH answers against a synthetic tree"
+        echo "shaped like Godot's own writer output, including the exact 2026-08-13 shape"
+        echo "(cache correct about all 95 other classes, silent about the one #1211 added)."
+        echo "BLOCKING on purpose: the only other CI run of tests/ is"
+        echo "'unittest discover tests || echo INFO', which swallows failures (#640)."
+        python -m unittest tests.test_check_class_cache -v
+
     - name: Ladder Bump Gate -- self-test (prove it can still fail)
       run: |
         echo "Replaying the historical acceptance cases from issue #1178: the gate must go"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,6 +153,26 @@ repos:
         files: '^(docs/.*\.md|docs/calendar/github_snapshot\.json|scripts/generate_commitment_calendar\.py|tools/.*\.py|scripts/.*\.py|[^/]*\.md)$'
         pass_filenames: false
 
+      # Godot class cache vs the class_name declarations (2026-08-13 playtest incident).
+      # NOTE THE STAGE: post-merge / post-checkout, NOT pre-commit. This failure is a
+      # property of a long-lived WORKING COPY, not of a diff -- the machine that authors a
+      # new `class_name` always has a fresh cache, so a commit-time gate would be watching
+      # the one place that is never wrong. It goes stale at `git pull`, which is exactly
+      # when these stages fire.
+      # Warn-only by design: a merge cannot be undone, and a `git pull` should not block for
+      # the minutes a Godot --import takes. The REPAIR happens at launch (`make run`), which
+      # is where the cost is worth paying and where the failure would otherwise bite.
+      # Inert until installed -- this needs, once per checkout:
+      #   pre-commit install --hook-type post-merge --hook-type post-checkout
+      - id: class-cache-check
+        name: Godot class cache matches the class_name declarations
+        entry: python tools/check_class_cache.py
+        language: system
+        stages: [post-merge, post-checkout]
+        always_run: true
+        pass_filenames: false
+        verbose: true
+
       - id: scene-nav-check
         name: Scene navigation routes through SceneTransition
         entry: python tools/check_scene_nav.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,10 @@ runtime -- the old Python bridge is gone). Python exists only for CI/tooling in
 `scripts/` and `tools/`. Windows dev machine; CI is Ubuntu.
 
 ## Run the game
-- `godot --path godot` (or `make run`). On Pip's machine Godot is
+- **`make run`, not a bare `godot --path godot`.** Same launch, plus the
+  stale-class-cache pre-flight (~30ms; see the Tests section). The bare command
+  is what was typed on 2026-08-13 and it launched a silently broken build in
+  front of a first-time playtester. On Pip's machine Godot is
   `C:/Program Files/Godot/Godot_v4.5.1-stable_win64.exe`.
 
 ## Tests -- two tiers, don't conflate them
@@ -41,6 +44,19 @@ runtime -- the old Python bridge is gone). Python exists only for CI/tooling in
   directly, run `godot --headless --path godot --import` first. Running headless
   Godot also floods stderr with SCRIPT ERROR class-cache lines on the first pass --
   expected noise, not a real failure.
+- **STALE cache is the worse half of that trap (2026-08-13, cost a playtest).**
+  Cold = absent, and it fails loudly. **Stale = present, plausible, and wrong
+  about exactly the file someone just added.** `godot/.godot/` is generated,
+  gitignored and PER-CHECKOUT, so a worktree that authors a new `class_name`
+  builds a correct cache and passes 1313 tests while the shared checkout, which
+  only pulled, keeps a cache that predates the file. Every dependent script then
+  hits `Parse Error: Identifier "X" not declared`. **The game still launches** --
+  background art, doom readout, phase stuck on "starting up", no action icons,
+  no upgrades, no commit-month, no music. It reads as "still loading".
+  **CI is structurally blind to this** (it always clones fresh).
+  Guard: `python tools/check_class_cache.py [--repair]`, ~30ms, no Godot launch;
+  `make run` and `make lint` now depend on it. Note `godot --headless --quit`
+  exits **0** through the whole cascade, so "it did not crash" proves nothing.
 - `make test` = fast gate; `make run` = game.
 
 ## `.import` / `.uid` files -- the staging trap

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 GODOT := godot
 PYTHON := python
 
-.PHONY: help run test lint validate clean commit
+.PHONY: help run test lint validate clean commit class-cache
 
 help: ## Show this help message
 	@echo "P(Doom) Development Commands"
@@ -13,7 +13,16 @@ help: ## Show this help message
 	@echo ""
 	@echo "Prerequisites: Godot 4.5.1, Python 3.9+"
 
-run: ## Run the game
+# Pre-flight for anything that LAUNCHES the game (2026-08-13, cost a playtest).
+# godot/.godot/global_script_class_cache.cfg is GENERATED, GITIGNORED and PER-CHECKOUT, so a
+# long-lived working copy can hold a cache that predates a pulled `class_name`. The game then
+# starts, draws, and does nothing -- no crash, no dialog, just a screen that looks like it is
+# still loading. CI cannot catch this (it always clones fresh). ~30ms when clean; only pays
+# for a Godot --import when it is actually stale. See tools/check_class_cache.py.
+class-cache: ## Verify + repair the Godot class cache (stale cache = silently broken game)
+	$(PYTHON) tools/check_class_cache.py --repair
+
+run: class-cache ## Run the game
 	$(GODOT) --path godot
 
 test: ## Run GUT unit tests
@@ -22,7 +31,10 @@ test: ## Run GUT unit tests
 test-ci: ## Run tests in CI mode (exits with status)
 	$(PYTHON) scripts/run_godot_tests.py --quick --ci-mode
 
-lint: ## Check GDScript syntax
+# `--quit` alone is NOT a syntax check on a stale cache: measured 2026-08-13, it emitted 30
+# `Identifier "Capacity" not declared` parse errors plus 17 depended-script compile failures
+# and still EXITED 0. The class-cache prerequisite is what makes this target honest.
+lint: class-cache ## Check GDScript syntax
 	$(GODOT) --headless --path godot --quit
 
 validate: ## Validate historical data files

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -76,6 +76,7 @@ Declared with a `Layer:` line in a tool's module docstring; `--` = undeclared.
 | archive_masters.py | -- | Sync the local art-masters cache to off-site object storage (DreamObjects). | tool:slim_repo.py |
 | build_release.py | PROVE | build_release.py -- export a P(Doom) build FROM A VERIFIED-CLEAN STATE. | ci:enhanced-release.yml; test:test_build_all_platforms.py; test:test_build_release_paths.py; tool:build_all_platforms.py; tool:find_dead_code.py |
 | capture_cinematic.py | -- | Cinematic capture harness for P(Doom)1 -- deterministic scene footage -> mp4/gif. | test:test_find_dead_code.py; tool:find_dead_code.py |
+| check_class_cache.py | PROVE | check_class_cache.py -- catch a STALE global script class cache before it eats a playtest. | pre-commit; make; test:test_check_class_cache.py |
 | check_ladder_bump.py | PROVE | Guard: did this diff need a ladder_version bump (or get one it did not need)? | ci:quality-checks.yml; test:test_check_ladder_bump.py; test:test_check_self_merge_eligibility.py; tool:sync_version.py |
 | check_scene_nav.py | PROVE | check_scene_nav.py -- enforce the single-scene-navigation-chokepoint invariant. | pre-commit; ci:quality-checks.yml; tool:enforce_standards.py |
 | check_self_merge_eligibility.py | PROVE | Guard: does this PR actually qualify for the self-merge class it claims? | ci:self-merge-eligibility.yml; test:test_check_self_merge_eligibility.py |
@@ -203,6 +204,7 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 - `tools/art_review/scan_text_leak.py` -- docstring mentions CI; no workflow calls it
 - `tools/assets/build_share_set.py` -- docstring mentions CI; no workflow calls it
 - `tools/capture_cinematic.py` -- docstring mentions CI; no workflow calls it
+- `tools/check_class_cache.py` -- docstring mentions CI; no workflow calls it
 - `tools/commit.py` -- docstring mentions pre-commit; no pre-commit hook calls it
 - `tools/find_dead_code.py` -- docstring mentions pre-commit; no pre-commit hook calls it
 - `tools/find_dead_code.py` -- docstring mentions CI; no workflow calls it
@@ -223,4 +225,4 @@ DISCUSSING CI); the rest are the hollow-runner shape -- read them.
 
 27 `.html` tool(s) under `tools/` (browser-opened, no docstring to parse): `tools/art_review/doom_overlay_preview.html`, `tools/art_review/hero_gallery_template.html`, `tools/art_review/icon_pass_2026-07-21.html`, `tools/art_review/icon_pass_verdicts_2026-07-21.html`, `tools/art_review/palette.html`, `tools/art_review/palette_swatches.html`, `tools/art_review/scene_wave2_2026-07-21.html`, `tools/art_review/style_review.html`, `tools/assets/review_generated.html`, `tools/music/commission_sheets.html`, `tools/music/jukebox.html`, `tools/music/listening_room.html`, `tools/music/stem_board.html`, `tools/runsheet/CEREMONY-ALL-GATES-2026-07-31.html`, `tools/runsheet/SUNDAY-postmortem-2026-08-07.html`, `tools/runsheet/chronicle-2026-08-06_07.html`, `tools/runsheet/commitments-2026-08.html`, `tools/runsheet/copy-review-2026-08-09.html`, `tools/runsheet/fri-2026-07-31-EVENING-1620.html`, `tools/runsheet/fri-2026-07-31-GATES-1700.html`, `tools/runsheet/fri-2026-07-31-TO-MIDNIGHT-1733.html`, `tools/runsheet/fri-2026-07-31-league-day.html`, `tools/runsheet/playtest_card.html`, `tools/runsheet/wed-thu-2026-07-29.html`, `tools/social_composer.html`, `tools/ui_comparison.html`, `tools/ui_mockup/wireframe.html`.
 
-Total: 123 active tools (10 GENERATE, 5 OBSERVE, 7 PROVE, 1 SWEEP, 100 undeclared); 11 in UNKNOWN; 6 archived.
+Total: 124 active tools (10 GENERATE, 5 OBSERVE, 8 PROVE, 1 SWEEP, 100 undeclared); 11 in UNKNOWN; 6 archived.

--- a/docs/calendar/COMMITMENTS_INDEX.md
+++ b/docs/calendar/COMMITMENTS_INDEX.md
@@ -13,7 +13,7 @@ Horizon: **2026-08-09** (the prose scan reports dates at or after this; roll it
 forward deliberately in `COMMITMENTS.md`, never automatically -- a clock-reading
 generator goes stale overnight and trains people to ignore the check).
 
-**48 declared, 4 release-train, 38 UNPARSED, 0 malformed.**
+**48 declared, 4 release-train, 40 UNPARSED, 0 malformed.**
 
 ## Declared commitments
 
@@ -117,10 +117,13 @@ keeps appearing. There is deliberately no silent ignore list.
 | 2026-08-11 | `tools/assets/backfill_provenance.py` | 30 | ORIGIN VOCABULARY -- five values, ruled by Pip 2026-08-11 |
 | 2026-08-11 | `tools/assets/check_provenance.py` | 4 | Ruled by Pip 2026-08-11: the six unattributable assets are KEPT and recorded as |
 | 2026-08-11 | `tools/assets/check_provenance.py` | 151 | "_why": "Pinned unknown set. Ruled by Pip 2026-08-11: keep the " |
+| 2026-08-13 | `CLAUDE.md` | 14 | is what was typed on 2026-08-13 and it launched a silently broken build in |
+| 2026-08-13 | `CLAUDE.md` | 47 | - **STALE cache is the worse half of that trap (2026-08-13, cost a playtest).** |
 | 2026-08-13 | `coordination#32` | 0 | Asset provenance is UNMET, not at-risk: the Manifund obligation has no capture mechanism in pdoom1 -- blocking party pdoom1, return date 2026-08-13 |
 | 2026-08-13 | `coordination#35` | 0 | Pip is out this evening through Rektango -- last synchronous window today. Post your asks ranked, or say you have none |
 | 2026-08-13 | `docs/CLAIM_AUDIT_2026-08-06.md` | 500 | audit against pdoom1's output for the week of 2026-08-13 finds a WRONG rate at or |
 | 2026-08-13 | `docs/POSTMORTEM_2026-08-07_CAPTURE.md` | 754 | \| P3 \| Every published measurement command ships a control line proving it can return the other answer \| Re-run the claim audit on the week of **2026- |
+| 2026-08-13 | `tools/check_class_cache.py` | 6 | WHY (2026-08-13, cost a first-time playtester's session): |
 | 2026-08-15 | `pdoom1#1092` | 0 | art(sweep): events name physical things the office never shows -- install a security system, no cameras appear; sweep events for asset refs, then bulk |
 | 2026-08-16 | `docs/workshop-2/position.md` | 547 | **On 2026-08-16**, ask for three run IDs -- one per guard -- each showing the |
 | 2026-08-16 | `docs/workshop-2/position.md` | 647 | 2026-08-16. |

--- a/docs/calendar/pdoom1-commitments.ics
+++ b/docs/calendar/pdoom1-commitments.ics
@@ -650,6 +650,28 @@ DESCRIPTION:needs a declaration -- CLAIM_AUDIT_2026-08-06.md (unparsed) --
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
+UID:b8d46314dfce5289@commitments.pdoom1
+DTSTAMP:20260813T000000Z
+DTSTART;VALUE=DATE:20260813
+DTEND;VALUE=DATE:20260814
+SUMMARY:[UNPARSED] needs a declaration -- CLAUDE.md
+DESCRIPTION:Owner: unowned. Kind: unparsed. Source: CLAUDE.md:14. 2 line(s
+ ) in CLAUDE.md mention this date and no COMMITMENT: declaration accounts 
+ for it. Either add a declaration or the date is incidental. First line: i
+ s what was typed on 2026-08-13 and it launched a silently broken build in
+  -- Generated from tracked sources by scripts/generate_commitment_calenda
+ r.py\; regenerate to update.
+CATEGORIES:UNPARSED
+TRANSP:TRANSPARENT
+SEQUENCE:0
+STATUS:CONFIRMED
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT8H
+DESCRIPTION:needs a declaration -- CLAUDE.md (unparsed) -- unowned
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
 UID:7cd15c5536c4a8d0@commitments.pdoom1
 DTSTAMP:20260813T000000Z
 DTSTART;VALUE=DATE:20260813
@@ -672,6 +694,29 @@ ACTION:DISPLAY
 TRIGGER:PT8H
 DESCRIPTION:needs a declaration -- POSTMORTEM_2026-08-07_CAPTURE.md (unpar
  sed) -- unowned
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+UID:22febdc8638a9de1@commitments.pdoom1
+DTSTAMP:20260813T000000Z
+DTSTART;VALUE=DATE:20260813
+DTEND;VALUE=DATE:20260814
+SUMMARY:[UNPARSED] needs a declaration -- check_class_cache.py
+DESCRIPTION:Owner: unowned. Kind: unparsed. Source: tools/check_class_cach
+ e.py:6. 1 line(s) in tools/check_class_cache.py mention this date and no 
+ COMMITMENT: declaration accounts for it. Either add a declaration or the 
+ date is incidental. First line: WHY (2026-08-13\, cost a first-time playt
+ ester's session): -- Generated from tracked sources by scripts/generate_c
+ ommitment_calendar.py\; regenerate to update.
+CATEGORIES:UNPARSED
+TRANSP:TRANSPARENT
+SEQUENCE:0
+STATUS:CONFIRMED
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:PT8H
+DESCRIPTION:needs a declaration -- check_class_cache.py (unparsed) -- unow
+ ned
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT

--- a/tests/test_check_class_cache.py
+++ b/tests/test_check_class_cache.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/check_class_cache.py -- the stale-class-cache guard.
+
+WHY THESE EXIST AT ALL, given that the bug they guard is invisible to CI:
+
+    The guard's subject -- a stale `godot/.godot/global_script_class_cache.cfg` -- cannot
+    occur in CI, because CI clones fresh and therefore always generates a correct cache.
+    So CI cannot test the CONDITION. What it can and must test is the DETECTOR: that
+    check_class_cache.py still goes red on a cache that does not describe its checkout.
+
+    This is the #640 lesson applied to a new gate: a check nobody has watched fail is not
+    known to work. The real RED run happened on the incident's own shape (Capacity removed
+    from a real generated cache, 30 parse errors reproduced). These tests pin that shape as
+    a fixture so the detector cannot silently degrade to a function that always returns 0.
+
+The fixtures are byte-shaped like Godot's own writer output (see the real file: a single
+`list=[{...}, {...}]` with `&"..."` StringName markers), so a change to that format breaks
+these tests loudly instead of turning the guard into a no-op.
+"""
+
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import check_class_cache as ccc  # noqa: E402
+
+
+def cache_text(entries: list[tuple[str, str]]) -> str:
+    """Render entries as Godot writes them: one list=[...] of dicts, StringName-marked."""
+    records = []
+    for name, path in entries:
+        records.append(
+            textwrap.dedent(
+                f"""\
+                {{
+                "base": &"RefCounted",
+                "class": &"{name}",
+                "icon": "",
+                "is_abstract": false,
+                "is_tool": false,
+                "language": &"GDScript",
+                "path": "{path}"
+                }}"""
+            )
+        )
+    return "list=[" + ", ".join(records) + "]\n"
+
+
+class FakeTree:
+    """A minimal godot/ tree: .gd sources plus an optional .godot cache."""
+
+    def __init__(self, root: Path):
+        self.root = root
+        (root / "scripts" / "core").mkdir(parents=True, exist_ok=True)
+
+    def add_script(self, rel: str, body: str) -> None:
+        path = self.root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    def write_cache(self, entries: list[tuple[str, str]]) -> None:
+        cache = self.root / ccc.CACHE_REL
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        cache.write_text(cache_text(entries), encoding="utf-8")
+
+
+class ScanSourceTests(unittest.TestCase):
+    def setUp(self):
+        self._dir = Path(__file__).resolve().parent / "_tmp_ccc_scan"
+        self._cleanup()
+        self._dir.mkdir(parents=True)
+        self.tree = FakeTree(self._dir)
+        self.patch = mock.patch.object(ccc, "GODOT_ROOT", self._dir)
+        self.patch.start()
+
+    def tearDown(self):
+        self.patch.stop()
+        self._cleanup()
+
+    def _cleanup(self):
+        import shutil
+
+        if self._dir.exists():
+            shutil.rmtree(self._dir)
+
+    def test_finds_declaration_and_maps_to_res_path(self):
+        self.tree.add_script(
+            "scripts/core/capacity.gd", "extends RefCounted\nclass_name Capacity\n\nvar x = 1\n"
+        )
+        found = ccc.scan_source(self._dir)
+        self.assertEqual(found, {"Capacity": "res://scripts/core/capacity.gd"})
+
+    def test_class_name_with_inline_extends(self):
+        self.tree.add_script("scripts/core/a.gd", "class_name Alpha extends Node\n")
+        self.assertEqual(ccc.scan_source(self._dir), {"Alpha": "res://scripts/core/a.gd"})
+
+    def test_commented_out_declaration_is_not_a_declaration(self):
+        self.tree.add_script("scripts/core/b.gd", "# class_name Ghost\nextends Node\n")
+        self.assertEqual(ccc.scan_source(self._dir), {})
+
+    def test_declaration_quoted_in_a_docstring_is_not_a_declaration(self):
+        self.tree.add_script(
+            "scripts/core/c.gd",
+            '"""\nDo not write class_name Ghost here.\n"""\nextends Node\n',
+        )
+        self.assertEqual(ccc.scan_source(self._dir), {})
+
+    def test_inner_class_keyword_is_not_class_name(self):
+        self.tree.add_script("scripts/core/d.gd", "extends Node\n\nclass Inner:\n\tvar y = 2\n")
+        self.assertEqual(ccc.scan_source(self._dir), {})
+
+    def test_generated_godot_dir_is_not_source(self):
+        gen = self._dir / ".godot" / "junk.gd"
+        gen.parent.mkdir(parents=True, exist_ok=True)
+        gen.write_text("class_name Generated\n", encoding="utf-8")
+        self.assertEqual(ccc.scan_source(self._dir), {})
+
+
+class ParseCacheTests(unittest.TestCase):
+    def setUp(self):
+        self._dir = Path(__file__).resolve().parent / "_tmp_ccc_cache"
+        self._cleanup()
+        self._dir.mkdir(parents=True)
+        self.tree = FakeTree(self._dir)
+
+    def tearDown(self):
+        self._cleanup()
+
+    def _cleanup(self):
+        import shutil
+
+        if self._dir.exists():
+            shutil.rmtree(self._dir)
+
+    def test_parses_godot_writer_format(self):
+        self.tree.write_cache(
+            [
+                ("ActionBarRenderer", "res://scripts/ui/action_bar_renderer.gd"),
+                ("Capacity", "res://scripts/core/capacity.gd"),
+            ]
+        )
+        parsed = ccc.parse_cache(self._dir / ccc.CACHE_REL)
+        self.assertEqual(
+            parsed,
+            {
+                "ActionBarRenderer": "res://scripts/ui/action_bar_renderer.gd",
+                "Capacity": "res://scripts/core/capacity.gd",
+            },
+        )
+
+    def test_absent_cache_is_none_not_empty(self):
+        # None (cold, never generated) and {} (generated but empty) are different worlds;
+        # conflating them would hide a truncated cache.
+        self.assertIsNone(ccc.parse_cache(self._dir / ccc.CACHE_REL))
+
+    def test_real_cache_in_this_checkout_parses(self):
+        # Format-drift canary against the actual engine output, when it is present.
+        real = ccc.GODOT_ROOT / ccc.CACHE_REL
+        if not real.exists():
+            self.skipTest("no generated cache in this checkout (fresh clone)")
+        parsed = ccc.parse_cache(real)
+        self.assertGreater(len(parsed), 50, "real cache parsed to implausibly few entries")
+        for name, path in parsed.items():
+            self.assertTrue(path.startswith("res://"), f"{name} -> {path}")
+
+
+class CompareTests(unittest.TestCase):
+    """The classification rules. These are what the guard's verdict reduces to."""
+
+    def test_agreement_is_not_stale(self):
+        both = {"Capacity": "res://scripts/core/capacity.gd"}
+        findings = ccc.compare(both, dict(both))
+        self.assertFalse(ccc.is_stale(findings))
+
+    def test_missing_is_the_1211_shape(self):
+        # Declared in source, absent from cache: the cache predates the file.
+        declared = {
+            "Capacity": "res://scripts/core/capacity.gd",
+            "TurnManager": "res://scripts/core/turn_manager.gd",
+        }
+        cached = {"TurnManager": "res://scripts/core/turn_manager.gd"}
+        findings = ccc.compare(declared, cached)
+        self.assertTrue(ccc.is_stale(findings))
+        self.assertEqual(findings["missing"], [("Capacity", "res://scripts/core/capacity.gd")])
+        self.assertEqual(findings["moved"], [])
+        self.assertEqual(findings["orphaned"], [])
+
+    def test_moved_detects_a_rename_the_cache_did_not_see(self):
+        declared = {"Capacity": "res://scripts/core/capacity.gd"}
+        cached = {"Capacity": "res://scripts/core/old_capacity.gd"}
+        findings = ccc.compare(declared, cached)
+        self.assertTrue(ccc.is_stale(findings))
+        self.assertEqual(
+            findings["moved"],
+            [("Capacity", "res://scripts/core/capacity.gd", "res://scripts/core/old_capacity.gd")],
+        )
+
+    def test_orphaned_detects_a_deletion_the_cache_did_not_see(self):
+        findings = ccc.compare({}, {"Deleted": "res://scripts/core/gone.gd"})
+        self.assertTrue(ccc.is_stale(findings))
+        self.assertEqual(findings["orphaned"], [("Deleted", "res://scripts/core/gone.gd")])
+
+    def test_cold_cache_reports_every_class_missing(self):
+        declared = {"A": "res://a.gd", "B": "res://b.gd"}
+        findings = ccc.compare(declared, {})
+        self.assertEqual(len(findings["missing"]), 2)
+
+
+class EndToEndTests(unittest.TestCase):
+    """The guard must be capable of returning BOTH answers against a real-shaped tree.
+
+    CLAUDE.md's relay rule: "a published command must be shown capable of returning the
+    other answer." These two tests are that demonstration, in CI, forever.
+    """
+
+    def setUp(self):
+        self._dir = Path(__file__).resolve().parent / "_tmp_ccc_e2e"
+        self._cleanup()
+        self._dir.mkdir(parents=True)
+        self.tree = FakeTree(self._dir)
+        self.tree.add_script(
+            "scripts/core/capacity.gd", "extends RefCounted\nclass_name Capacity\n"
+        )
+        self.tree.add_script(
+            "scripts/core/turn_manager.gd", "extends RefCounted\nclass_name TurnManager\n"
+        )
+        self.patch = mock.patch.object(ccc, "GODOT_ROOT", self._dir)
+        self.patch.start()
+
+    def tearDown(self):
+        self.patch.stop()
+        self._cleanup()
+
+    def _cleanup(self):
+        import shutil
+
+        if self._dir.exists():
+            shutil.rmtree(self._dir)
+
+    def test_green_when_cache_agrees(self):
+        self.tree.write_cache(
+            [
+                ("Capacity", "res://scripts/core/capacity.gd"),
+                ("TurnManager", "res://scripts/core/turn_manager.gd"),
+            ]
+        )
+        self.assertEqual(ccc.main(["--quiet"]), 0)
+
+    def test_red_on_the_incident_shape(self):
+        # The 2026-08-13 cache: correct about everything except the file #1211 added.
+        self.tree.write_cache([("TurnManager", "res://scripts/core/turn_manager.gd")])
+        self.assertEqual(ccc.main([]), 1)
+
+    def test_repair_without_a_godot_binary_exits_2_not_0(self):
+        # A missing engine must never be reported as a clean cache.
+        self.tree.write_cache([("TurnManager", "res://scripts/core/turn_manager.gd")])
+        with mock.patch.object(ccc, "find_godot", return_value=None):
+            self.assertEqual(ccc.main(["--repair"]), 2)
+
+    def test_repair_reports_failure_when_import_does_not_fix_it(self):
+        self.tree.write_cache([("TurnManager", "res://scripts/core/turn_manager.gd")])
+        with (
+            mock.patch.object(ccc, "find_godot", return_value="/fake/godot"),
+            mock.patch.object(ccc, "run_import", return_value=0) as fake_import,
+        ):
+            self.assertEqual(ccc.main(["--repair"]), 1)
+        fake_import.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_class_cache.py
+++ b/tools/check_class_cache.py
@@ -169,10 +169,7 @@ def compare(declared: dict[str, str], cached: dict[str, str]) -> dict[str, list]
 
 
 def is_stale(findings: dict[str, list]) -> bool:
-    # TEMPORARY -- deliberate decay, to record the RED run required by estate rule 5g.
-    # This is the exact way a guard rots: it keeps running, keeps printing, keeps exiting 0.
-    # Reverted in the next commit.
-    return False
+    return any(findings.values())
 
 
 def report(findings: dict[str, list], cache_path: Path) -> None:

--- a/tools/check_class_cache.py
+++ b/tools/check_class_cache.py
@@ -169,7 +169,10 @@ def compare(declared: dict[str, str], cached: dict[str, str]) -> dict[str, list]
 
 
 def is_stale(findings: dict[str, list]) -> bool:
-    return any(findings.values())
+    # TEMPORARY -- deliberate decay, to record the RED run required by estate rule 5g.
+    # This is the exact way a guard rots: it keeps running, keeps printing, keeps exiting 0.
+    # Reverted in the next commit.
+    return False
 
 
 def report(findings: dict[str, list], cache_path: Path) -> None:

--- a/tools/check_class_cache.py
+++ b/tools/check_class_cache.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""check_class_cache.py -- catch a STALE global script class cache before it eats a playtest.
+
+Layer: PROVE -- and deliberately NOT a CI gate. See "WHY CI CANNOT CATCH THIS".
+
+WHY (2026-08-13, cost a first-time playtester's session):
+    #1211 added `godot/scripts/core/capacity.gd` declaring `class_name Capacity`.
+    Godot resolves every `class_name` through `godot/.godot/global_script_class_cache.cfg`,
+    which is GENERATED, GITIGNORED and PER-CHECKOUT. The agent that wrote #1211 worked in a
+    separate worktree, which built its own fresh cache; 1313 tests passed there. The shared
+    checkout's cache predated the new file, so after pulling `main` every script that
+    referenced `Capacity` died with:
+
+        Parse Error: Identifier "Capacity" not declared in the current scope.
+        Compile Error: Failed to compile depended scripts
+
+    cascading through the autoloads.
+
+    THE SYMPTOM WAS NOT AN ERROR. No crash, no dialog, no red text. The window opened, the
+    background art drew, the doom readout said 58.5%, the phase label said "starting up", and
+    the research-quality selector (rushed / standard / thorough) still worked. Dead: every
+    action icon, every upgrade, commit-month, the music, and game initialisation itself --
+    the phase never advanced past "starting up". Pip, at the machine, narrating
+    (capture 2026-08-13_214820__db1ee7a2):
+
+        "all my icons have disappeared. And all my upgrades have disappeared, and I can't
+         commit the month, and the music track seems not to be working, and also, there's no
+         active game, so I don't think the game's actually initialized"
+
+    It looks exactly like a game that has not finished loading. Anyone would wait. Diagnosis
+    took a headless run to surface the parse errors that the windowed run swallowed.
+
+    Fix was `godot --headless --path godot --import`. Mechanical, unambiguous, ~seconds.
+
+WHY CI CANNOT CATCH THIS:
+    CI clones fresh every run, so it ALWAYS generates a correct cache. Only a long-lived
+    working copy can hold a stale one. Every check that starts clean is structurally blind to
+    this class of failure -- which is most of them. That is why this tool is wired into the
+    LAUNCH path (`make run`), not into a workflow. What CI can and does prove is that this
+    checker itself still works: tests/test_check_class_cache.py.
+
+    Note the difference from the already-known COLD-cache trap in CLAUDE.md ("GUT quits(0) if
+    the class cache is cold"). Cold = absent, and it fails loudly and immediately. STALE =
+    present, plausible, mostly correct, and it fails silently. Stale is the worse half.
+
+WHAT IT CHECKS (pure Python, no Godot launch, ~50ms):
+    The set of `class_name X` declarations in godot/**/*.gd must match, name AND path, the
+    entries in godot/.godot/global_script_class_cache.cfg. Three ways that breaks:
+
+      MISSING  -- declared in source, absent from cache. A new class the cache never saw.
+                  This is the #1211 shape and the one that kills a playtest.
+      MOVED    -- in both, but the cache points at a different path (a rename or a move).
+      ORPHANED -- in the cache, no longer declared anywhere in source (a delete or a rename's
+                  other half). Godot tolerates this better, but it means the same thing:
+                  the cache does not describe this checkout.
+
+USAGE:
+    python tools/check_class_cache.py             # report; exit 0 clean, 1 stale
+    python tools/check_class_cache.py --repair    # if stale, run --import and re-check
+    python tools/check_class_cache.py --quiet     # print only on failure (for wrappers)
+
+    --repair is the recommended mode for anything that launches the game. The repair is
+    mechanical and there is no judgement call to make, so refusing to launch would just be
+    a slower way of arriving at the same command. Auto-repair converts a silent, mystifying
+    failure into a named, self-healing one -- which is the whole value here, because the
+    failure mode is a screen that looks like it is still loading.
+
+EXIT CODES:
+    0  cache agrees with source (or --repair made it agree)
+    1  cache is stale (or --repair could not fix it)
+    2  could not run the check at all (no godot/ tree, Godot binary missing for --repair)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GODOT_ROOT = REPO_ROOT / "godot"
+CACHE_REL = Path(".godot") / "global_script_class_cache.cfg"
+
+REPAIR_ARGS = ["--headless", "--path", "godot", "--import"]
+REPAIR_HINT = "godot --headless --path godot --import"
+
+# `class_name Foo` / `class_name Foo extends Bar`, at the start of a line. GDScript only
+# permits it at top level, but leading whitespace is tolerated here so a stray indent shows up
+# as a finding rather than vanishing from the scan.
+CLASS_NAME_RE = re.compile(r"^[ \t]*class_name[ \t]+([A-Za-z_][A-Za-z0-9_]*)")
+
+# One cache record: "class": &"Foo", ... "path": "res://a/b.gd". Key order is stable in
+# Godot's writer (alphabetical), so class always precedes path within a record, but the regex
+# is anchored on the pair rather than on record boundaries to survive a reordering.
+CACHE_ENTRY_RE = re.compile(
+    r'"class"\s*:\s*&?"([^"]+)".*?"path"\s*:\s*&?"([^"]+)"',
+    re.DOTALL,
+)
+
+TRIPLE_QUOTES = ('"""', "'''")
+
+
+def _code_part(line: str) -> str:
+    """Strip a trailing '#' comment so a commented-out declaration is not counted."""
+    hashpos = line.find("#")
+    return line if hashpos == -1 else line[:hashpos]
+
+
+def res_path(path: Path, godot_root: Path) -> str:
+    """godot/scripts/core/capacity.gd -> res://scripts/core/capacity.gd"""
+    return "res://" + path.resolve().relative_to(godot_root.resolve()).as_posix()
+
+
+def scan_source(godot_root: Path | None = None) -> dict[str, str]:
+    """Map every `class_name` declared under godot/**/*.gd to its res:// path.
+
+    Skips docstring blocks so prose that quotes a declaration is not mistaken for one.
+
+    The root is resolved at CALL time, not bound as a default, so tests can point the
+    scanner at a synthetic tree.
+    """
+    godot_root = GODOT_ROOT if godot_root is None else godot_root
+    declared: dict[str, str] = {}
+    for gd in sorted(godot_root.rglob("*.gd")):
+        # .godot/ is the generated dir itself; anything in there is not source.
+        if ".godot" in gd.parts:
+            continue
+        try:
+            text = gd.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "class_name" not in text:
+            continue
+        in_docstring = False
+        for raw in text.splitlines():
+            delims = sum(raw.count(q) for q in TRIPLE_QUOTES)
+            was_in_docstring = in_docstring
+            if delims % 2 == 1:
+                in_docstring = not in_docstring
+            if was_in_docstring:
+                continue
+            match = CLASS_NAME_RE.match(_code_part(raw))
+            if match:
+                declared[match.group(1)] = res_path(gd, godot_root)
+                break  # one class_name per file; the rest of the file cannot add another
+    return declared
+
+
+def parse_cache(cache_path: Path) -> dict[str, str] | None:
+    """Map class name -> res:// path from the cache. None if the cache does not exist."""
+    if not cache_path.exists():
+        return None
+    text = cache_path.read_text(encoding="utf-8", errors="replace")
+    return {name: path for name, path in CACHE_ENTRY_RE.findall(text)}
+
+
+def compare(declared: dict[str, str], cached: dict[str, str]) -> dict[str, list]:
+    """Findings, by kind. Empty lists everywhere = the cache describes this checkout."""
+    missing = sorted((n, p) for n, p in declared.items() if n not in cached)
+    orphaned = sorted((n, p) for n, p in cached.items() if n not in declared)
+    moved = sorted(
+        (n, declared[n], cached[n]) for n in declared if n in cached and declared[n] != cached[n]
+    )
+    return {"missing": missing, "orphaned": orphaned, "moved": moved}
+
+
+def is_stale(findings: dict[str, list]) -> bool:
+    return any(findings.values())
+
+
+def report(findings: dict[str, list], cache_path: Path) -> None:
+    print("STALE CLASS CACHE -- this checkout will run the WRONG code, silently.")
+    print(f"  cache: {cache_path}")
+    print()
+    if findings["missing"]:
+        print(
+            f"  {len(findings['missing'])} class_name(s) declared in source but NOT in the cache."
+        )
+        print("  Every script referencing one of these will fail to parse, and the failure")
+        print("  will look like a game that is still loading -- no crash, no dialog.")
+        for name, path in findings["missing"]:
+            print(f"    MISSING   {name:<32} {path}")
+        print()
+    if findings["moved"]:
+        print(f"  {len(findings['moved'])} class(es) the cache points at the wrong file:")
+        for name, src, cache in findings["moved"]:
+            print(f"    MOVED     {name:<32} source={src}")
+            print(f"    {'':<42}cache ={cache}")
+        print()
+    if findings["orphaned"]:
+        print(f"  {len(findings['orphaned'])} cache entry(ies) with no declaration left in source:")
+        for name, path in findings["orphaned"]:
+            print(f"    ORPHANED  {name:<32} {path}")
+        print()
+    print(f"  FIX:  {REPAIR_HINT}")
+    print("        (or re-run this with --repair, which does exactly that)")
+
+
+def find_godot() -> str | None:
+    return os.environ.get("GODOT_BIN") or shutil.which("godot")
+
+
+def run_import(godot_bin: str, quiet: bool) -> int:
+    """Rebuild the cache. Godot's first import pass floods stderr with the very
+    class-cache SCRIPT ERRORs we are repairing -- expected noise, not a failure
+    (CLAUDE.md, "Fresh worktree gotcha")."""
+    if not quiet:
+        print(f"  repairing: {godot_bin} {' '.join(REPAIR_ARGS)}")
+        print("  (SCRIPT ERROR class-cache lines during this pass are expected noise)")
+    proc = subprocess.run(
+        [godot_bin, *REPAIR_ARGS],
+        cwd=REPO_ROOT,
+        capture_output=quiet,
+        text=True,
+    )
+    return proc.returncode
+
+
+def check(godot_root: Path | None = None) -> tuple[dict[str, list], dict[str, str]]:
+    godot_root = GODOT_ROOT if godot_root is None else godot_root
+    declared = scan_source(godot_root)
+    cached = parse_cache(godot_root / CACHE_REL)
+    if cached is None:
+        # A cold cache (no .godot at all) is the loud, already-known failure; report it as
+        # every class missing so the same --repair path fixes it.
+        cached = {}
+    return compare(declared, cached), declared
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--repair",
+        action="store_true",
+        help="if stale, run the Godot --import pass and re-check",
+    )
+    ap.add_argument("--quiet", action="store_true", help="print nothing unless something is wrong")
+    args = ap.parse_args(argv)
+
+    if not GODOT_ROOT.is_dir():
+        print(f"ERROR: no godot/ tree at {GODOT_ROOT}", file=sys.stderr)
+        return 2
+
+    cache_path = GODOT_ROOT / CACHE_REL
+    findings, declared = check()
+
+    if not is_stale(findings):
+        if not args.quiet:
+            print(f"class cache OK -- {len(declared)} class_name declaration(s) all resolve.")
+        return 0
+
+    report(findings, cache_path)
+
+    if not args.repair:
+        return 1
+
+    godot_bin = find_godot()
+    if not godot_bin:
+        print()
+        print("ERROR: --repair asked for, but no Godot binary found on PATH or in $GODOT_BIN.")
+        print(f"       Run this yourself, from {REPO_ROOT}:  {REPAIR_HINT}")
+        return 2
+
+    print()
+    rc = run_import(godot_bin, args.quiet)
+
+    findings, declared = check()
+    if is_stale(findings):
+        print()
+        print(f"REPAIR FAILED -- cache still stale after --import (godot exit {rc}).")
+        report(findings, cache_path)
+        return 1
+
+    print()
+    print(f"repaired -- {len(declared)} class_name declaration(s) now resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Closes #1215. Guard only -- **the incident itself is already fixed** (`godot --headless --path godot --import`, confirmed working). This builds the thing that would have caught it.

**Not for the release cut.** Tooling and docs only; nothing under `godot/` changes and no game code is touched. `Ladder-Impact: none -- tooling and docs only, no file under godot/ changed.`

## What broke

`godot/.godot/global_script_class_cache.cfg` is **generated, gitignored and per-checkout**. `#1211` added `class_name Capacity` from a separate worktree, which built its own fresh cache and passed 1313 tests. The shared checkout only pulled, so its cache predated the file. Every dependent script failed to parse -- and the game still launched, drew the background art and the doom readout, and then did nothing, in front of a first-time playtester. Full symptom record and the verbatim capture are in #1215.

## Why this cannot be a CI gate

CI clones fresh every run, so it always generates a correct cache. **Only a long-lived working copy can hold a stale one.** The guard therefore lives on the launch path. CI's only job here is to prove the *detector* still works.

## The check

`tools/check_class_cache.py` -- pure Python, no Godot launch, **~30ms over 364 `.gd` files**. Every `class_name X` in `godot/**/*.gd` must match, name and path, an entry in the cache. Reports `MISSING` / `MOVED` / `ORPHANED`.

## RED runs (observed, per estate 5g)

RED-RUN: https://github.com/PipFoweraker/pdoom1/actions/runs/31768503202 -- hardwired `is_stale()` to return False, the exact way a guard rots; the CI detector-self-test went red on `test_red_on_the_incident_shape` (`FAILED (failures=6)`). Reverted in `f0308415`.

That run proves the **CI step** is load-bearing. The run below proves the **detector** catches the real condition -- both are needed, because CI can never produce a stale cache itself.

### The real condition, locally

On a scratch worktree at `origin/main`, with a real generated cache, removing the single `Capacity` record -- i.e. reconstructing the 2026-08-13 cache exactly: correct about all 95 other classes, silent about the one that mattered.

**1. Baseline GREEN**
```
$ python3 tools/check_class_cache.py
class cache OK -- 96 class_name declaration(s) all resolve.        # exit 0
```

**2. Stale it, and the check goes RED**
```
$ python3 stale_it.py godot/.godot/global_script_class_cache.cfg Capacity
removed 1 record for Capacity from .../global_script_class_cache.cfg

$ python3 tools/check_class_cache.py
STALE CLASS CACHE -- this checkout will run the WRONG code, silently.
  1 class_name(s) declared in source but NOT in the cache.
    MISSING   Capacity                         res://scripts/core/capacity.gd
  FIX:  godot --headless --path godot --import                     # exit 1
```

**3. The staled cache reproduces the real failure** -- so the check is not detecting a synthetic condition:
```
$ godot-iso cacheguard godot --headless --path godot --quit
  30  x  Parse Error: Identifier "Capacity" not declared in the current scope.
  17  x  Compile Error: Failed to compile depended scripts.
  godot exit = 0          <-- NOTE
```
Dead scripts included `game_manager.gd`, `game_state.gd`, `month_controller.gd`, `turn_manager.gd` (no active game, phase stuck on *starting up*, cannot commit the month), `actions.gd` and `upgrades.gd` (no icons, no upgrades), plus 3 autoloads. That maps 1:1 onto what the playtester saw.

**That `exit 0` is the finding that changed the wiring.** `godot --headless --path godot --quit` is `make lint`, and it was green through the whole cascade. So `make lint` now depends on the class-cache target too.

**4. Repair, and it goes GREEN**
```
$ godot-iso cacheguard python3 tools/check_class_cache.py --repair
STALE CLASS CACHE -- ...
    MISSING   Capacity                         res://scripts/core/capacity.gd
  repairing: godot --headless --path godot --import
repaired -- 96 class_name declaration(s) now resolve.              # exit 0

$ godot-iso cacheguard godot --headless --path godot --quit
  0  x  Parse Error ...
  0  x  Compile Error ...
```

`tests/test_check_class_cache.py` (18 tests, all green) pins this as a fixture so the detector cannot decay into a function that always returns 0.

## Where it is wired

| Where | Mode | Why |
| --- | --- | --- |
| `make run` | auto-repair | The launch path. Where the failure bites. |
| `make lint` | auto-repair | Makes an existing gate honest -- see the `exit 0` above. |
| pre-commit `post-merge` / `post-checkout` | warn only | The exact moment a working copy goes stale: `git pull`. |
| `quality-checks.yml` | blocking unit tests | Proves the detector, since CI cannot produce the condition. |
| `CLAUDE.md` | doc | "Run the game" now says `make run`, not bare `godot --path godot`. |

**Auto-repair over refusal**, chosen deliberately. The fix is mechanical with no judgement call, so refusing to launch is just a slower path to the same command. The stronger reason: the failure looks like a game that is still loading, so a warning behind a plausible-looking window is not a guard. Auto-repair turns a silent, mystifying failure into a named, self-healing one.

**Not a pre-commit hook**, also deliberately. The machine that authors a new `class_name` always has a fresh cache; a commit-time gate watches the one place that is never wrong.

## Two things needing Pip's call

**1. `godot-iso` was not the playtest path.** The brief suggested wiring the guard there. Reading `~/.local/bin/godot-iso` first, it says in its own header:

> `# DO NOT use this for playtesting -- a real playtest SHOULD write to the real profile, or the score does not count and the league board never sees it.`

So a guard there would **not** have caught this incident. It is still worth having as a second layer for agent lanes and headless runs, and the proposed diff is below -- but the wiring that actually covers the incident is `make run`.

**2. `~/.local/bin/godot-iso` is outside the repo. I did NOT edit it.** Proposed diff, inserted after the mtime snapshot so the existing isolation guarantee is unaffected, with the repair running **inside** `XDG_DATA_HOME` so an auto-import cannot touch the real profile:

```diff
@@ -45,6 +45,32 @@
 # snapshot the real profile's mtimes so we can PROVE it was not written to
 before=$(find "$REAL" -type f -printf '%T@ %p\n' 2>/dev/null | sort | sha256sum)

+# --- stale class-cache pre-flight (2026-08-13 incident; see tools/check_class_cache.py) ---
+# godot/.godot/global_script_class_cache.cfg is generated, gitignored and PER-CHECKOUT. A
+# long-lived working copy can hold one that predates a pulled `class_name`, and then every
+# dependent script fails to parse while Godot still EXITS 0. Measured on the incident's own
+# shape: 30 parse errors, 17 depended-script compile failures, exit status 0. So a run under
+# this wrapper can report a clean isolation proof over a build that is silently not the code.
+#
+# Deliberately INSIDE the isolation: the repair is a Godot --import, so it runs with
+# XDG_DATA_HOME pointed at the sandbox like everything else. The mtime digest above is
+# already taken, so the existing "real profile untouched" guarantee still covers it.
+#
+# Non-fatal by design: this wrapper's job is isolation, not correctness gating. If the repair
+# cannot happen (no Godot, no checkout) it says so and runs the command anyway.
+if [ -f tools/check_class_cache.py ]; then
+    set +e
+    XDG_DATA_HOME="$SANDBOX" python3 tools/check_class_cache.py --repair --quiet
+    cache_rc=$?
+    set -e
+    if [ $cache_rc -ne 0 ]; then
+        echo "godot-iso: *** class cache is STALE and could not be repaired ***" >&2
+        echo "godot-iso: this run may execute code whose class_names do not resolve." >&2
+        echo "godot-iso: fix with: godot --headless --path godot --import" >&2
+        echo >&2
+    fi
+fi
+
 set +e
 XDG_DATA_HOME="$SANDBOX" "$@"
 rc=$?
```

The proposed version was **run from the scratchpad, not installed**, against a deliberately staled cache. It detected, repaired, ran the command, and the existing guarantee still held:

```
godot-iso: lane 'cacheguard'
STALE CLASS CACHE -- ...
    MISSING   Capacity                         res://scripts/core/capacity.gd
repaired -- 96 class_name declaration(s) now resolve.
4.5.1.stable.official.f62fdbde1
godot-iso: real profile untouched (verified by mtime digest)     <-- non-regression
```

To install: `cp /tmp/claude-1000/-home-pip/d2a42750-061c-4dbf-851b-b445da5210dc/scratchpad/godot-iso.proposed /home/pip/.local/bin/godot-iso`

**One more thing that is inert until installed:** the `post-merge` / `post-checkout` hook needs, once per checkout:
`pre-commit install --hook-type post-merge --hook-type post-checkout`

## Verification

```
python3 -m unittest tests.test_check_class_cache      # Ran 18 tests -- OK
python3 tools/check_class_cache.py                    # exit 0, 96 declarations resolve
pre-commit validate-config .pre-commit-config.yaml    # CONFIG OK  (pre-commit 4.2.0)
make class-cache                                      # exit 0
bash -n godot-iso.proposed                            # syntax OK
```

Also regenerated, because their `--check` hooks gate the commit and the new dated prose feeds them: `docs/TOOLS.md`, `docs/calendar/`.

Not touched: `art_generated/`, `art_prompts/`, `tools/art_review/`. No `.import` / `.uid` churn was staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
