### PR TITLE
fix(ui): every response window now advertises the Attention it charges (the stray cat is 25 events)

### DIFF
--- a/godot/scripts/core/window_resolver.gd
+++ b/godot/scripts/core/window_resolver.gd
@@ -242,6 +242,51 @@ static func strip_attention(event: Dictionary) -> Dictionary:
 	return clone
 
 
+## Display-only keys stamped onto the dialog's copy of a window by present_for_dialog().
+## They exist so the PRESENTER never has to re-derive resolution policy -- see that function.
+const DISPLAY_ATTENTION_KEY := "_display_window_attention"
+const DISPLAY_FREE_OPTION_KEY := "_display_free_option_id"
+
+
+static func present_for_dialog(event: Dictionary) -> Dictionary:
+	"""The copy of a window the event_dialog should present: Attention stripped from the
+	options (strip_attention's job) AND the window's own Attention price stamped back on as
+	DISPLAY metadata.
+
+	Why the stamp exists at all. strip_attention's docstring already promised that "the
+	dialog's affordability display matches what resolution will actually charge" -- but it
+	only ever did the erasing half. The window levies attention_cost(event) of its own, and
+	nothing put that number anywhere the player could see it, so every popup with a priced
+	option read as cheaper than it was and the free-out read " (Free)". Playtest 2026-08-10,
+	Pip, on the stray cat: "Adopting the cat also costs attention, which is not advertised on
+	the screen." That is not a cat bug -- stray_cat carries no `window` block, so it takes
+	DEFAULT_ATTENTION_COST, exactly like every other un-annotated legacy popup.
+
+	Stamping rather than letting the presenter compute it is deliberate. The dialog is handed
+	events from SIX emit sites; only the two window paths strip, and a stripped event is
+	indistinguishable from an un-stripped one whose options simply never declared Attention.
+	The presenter therefore CANNOT tell from the dict alone whether a window charge is coming.
+	Stamping at the one seam that knows makes the un-stamped paths (plan-phase legacy events,
+	the synthetic month review) silently correct: no key, no claim.
+
+	DISPLAY_FREE_OPTION_KEY mirrors resolve_chosen_option's free-out test verbatim -- the
+	option that resolves as IGNORE pays no Attention, and on stray_cat that is `shoo_away`
+	(it is the first option with an empty costs dict). Deriving it here rather than in the UI
+	is what stops the label and the charge from drifting apart.
+
+	Windows carrying `option_verbs` (#789 hiring accept-prompts) stamp ZERO: their option TEXT
+	already names the price and the payment source ("Set them up now (2 Att from reserve)"),
+	so a generic suffix would print the number twice."""
+	var clone := strip_attention(event)
+	var cfg := window_config(event)
+	if cfg.has("option_verbs"):
+		clone[DISPLAY_ATTENTION_KEY] = 0
+	else:
+		clone[DISPLAY_ATTENTION_KEY] = attention_cost(event)
+	clone[DISPLAY_FREE_OPTION_KEY] = "" if EventTiers.is_unignorable(event) else ignore_option_id(event)
+	return clone
+
+
 static func _merge_option(result: Dictionary, opt_result: Dictionary) -> void:
 	if opt_result.get("message", "") != "":
 		result["message"] = opt_result["message"]

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -683,7 +683,7 @@ func surface_pending_events() -> void:
 		return
 	turn_phase_changed.emit("turn_start")
 	for event in state.pending_events:
-		event_triggered.emit(WindowResolver.strip_attention(event))
+		event_triggered.emit(WindowResolver.present_for_dialog(event))
 
 
 func end_month():
@@ -774,8 +774,10 @@ func _run_month_playback() -> void:
 				turn_phase_changed.emit("turn_start")
 				for w in month_controller.window_queue:
 					# AP pre-stripped so the dialog's cost display matches what window
-					# resolution actually charges (Attention, not AP).
-					event_triggered.emit(WindowResolver.strip_attention(w))
+					# resolution actually charges (Attention, not AP) -- and the window's
+					# OWN Attention price stamped on for display, which the strip alone
+					# never disclosed (playtest 2026-08-10, the stray cat).
+					event_triggered.emit(WindowResolver.present_for_dialog(w))
 				return  # playback resumes via resolve_event once answered
 			"month_open":
 				_finish_month_playback()

--- a/godot/scripts/ui/event_dialog.gd
+++ b/godot/scripts/ui/event_dialog.gd
@@ -83,6 +83,56 @@ static func format_cost_summary(costs: Dictionary) -> String:
 	return " (%s)" % ", ".join(parts)
 
 
+static func window_attention_for_option(event: Dictionary, option: Dictionary) -> int:
+	"""Founder Attention this window will charge for THIS option, for display. 0 when nothing
+	is owed -- and 0 is also the honest answer whenever we cannot prove otherwise.
+
+	A window levies an Attention price that lives on the EVENT, not on the option's costs
+	(WindowResolver.attention_cost). The presenter is handed events from six emit sites and
+	only the two window paths carry it, so this reads the display stamp that
+	WindowResolver.present_for_dialog() leaves rather than re-deriving resolution policy --
+	an un-stamped event (plan-phase legacy popup, the synthetic month review) claims nothing.
+
+	Two options pay nothing and must not be surcharged: the free-out that resolves as IGNORE
+	(stamped by the resolver), and an option whose own costs still carry `attention` -- that
+	is an UN-stripped legacy event whose declared cost format_cost_summary already prints, so
+	adding to it would bill the player twice on the label for one charge."""
+	var cost := int(event.get(WindowResolver.DISPLAY_ATTENTION_KEY, 0))
+	if cost <= 0:
+		return 0
+	var costs = option.get("costs", {})
+	if costs is Dictionary and costs.has("attention"):
+		return 0
+	if String(option.get("id", "")) == String(event.get(WindowResolver.DISPLAY_FREE_OPTION_KEY, "")):
+		return 0
+	return cost
+
+
+static func costs_with_window_attention(event: Dictionary, option: Dictionary) -> Dictionary:
+	"""The option's costs as the player should SEE them: its own declared costs plus the
+	window's Attention price folded in. One merged dict feeds both the button face and the
+	tooltip, so the two can never disagree.
+
+	Money-then-Attention ordering is preserved by appending: format_cost_summary iterates
+	costs.keys() in insertion order, and core_events.json's header pins that order as load-
+	bearing for the cost-summary label.
+
+	NOT used for the affordability grey-out, deliberately. Window Attention is paid
+	reserve-FIRST (WindowResolver.resolve_chosen_option -> pay_from_reserve, falling back to
+	cannibalizing planned work), and the dialog's affordability loop reads state.attention,
+	which is get_available_attention() = total - spent - RESERVED. After a month commits,
+	GameManager reserves the whole remainder, so available is 0 while the reserve is full --
+	gating on it would grey out every window button in the game."""
+	var merged: Dictionary = {}
+	var costs = option.get("costs", {})
+	if costs is Dictionary:
+		merged = costs.duplicate()
+	var att := window_attention_for_option(event, option)
+	if att > 0:
+		merged["attention"] = att
+	return merged
+
+
 ## Teal of the bottom bar's END TURN button (scenes/main.tscn:378). The month loop's two
 ## forward doors must look like siblings -- see is_navigation_popup below.
 const PRIMARY_TEAL := Color(0.118, 0.765, 0.702, 1.0)
@@ -238,6 +288,11 @@ func _show_next_event() -> void:
 		var choice_id = option.get("id", "")
 		var choice_text = option.get("text", "")
 		var costs = option.get("costs", {})
+		# What the player is SHOWN: the option's own costs plus the window's Attention price,
+		# which is charged by WindowResolver and appears in no option's costs dict. `costs`
+		# stays raw below -- see costs_with_window_attention on why the grey-out must not use
+		# this (window Attention is paid reserve-first; the affordability pool is not).
+		var shown_costs := costs_with_window_attention(event, option)
 
 		var btn = Button.new()
 		btn.focus_mode = Control.FOCUS_NONE  # Don't grab focus - let MainUI handle keys
@@ -251,7 +306,7 @@ func _show_next_event() -> void:
 			btn.add_theme_color_override("font_color", PRIMARY_TEAL)
 			btn.add_theme_color_override("font_hover_color", Color(1, 1, 1, 1))
 		else:
-			btn.text = "%s%s%s" % [DialogKeys.prefix_for(button_index), choice_text, format_cost_summary(costs)]
+			btn.text = "%s%s%s" % [DialogKeys.prefix_for(button_index), choice_text, format_cost_summary(shown_costs)]
 			btn.custom_minimum_size = Vector2(500, 45)
 
 		# Add button border for better definition
@@ -317,10 +372,10 @@ func _show_next_event() -> void:
 		# player-facing tooltip. Both now route through the GameConfig
 		# number-format policy (docs/NUMBER_FORMATS.md).
 		var tooltip = ""
-		if not costs.is_empty():
+		if not shown_costs.is_empty():
 			tooltip += "Costs:\n"
-			for resource in costs.keys():
-				tooltip += "  %s\n" % GameConfig.format_resource(str(resource), costs[resource])
+			for resource in shown_costs.keys():
+				tooltip += "  %s\n" % GameConfig.format_resource(str(resource), shown_costs[resource])
 
 		var effects = option.get("effects", {})
 		if not effects.is_empty():

--- a/godot/tests/unit/test_cost_display.gd
+++ b/godot/tests/unit/test_cost_display.gd
@@ -121,3 +121,147 @@ func test_costs_affordable_free_option_always_affordable():
 	var ui = _main_ui_script.new()
 	assert_true(ui._costs_affordable({}, {}), "a free option is always affordable regardless of state")
 	ui.free()
+
+
+# --- The window's OWN Attention price reaches the button face (playtest 2026-08-10) --------
+#
+# A response window charges WindowResolver.attention_cost(event) -- a price that lives on the
+# EVENT and appears in no option's costs dict. strip_attention() then erased any declared
+# Attention before the dialog ever saw the event, so the founder currency was spent with the
+# label saying "($500)" or, on the free-out, "(Free)". Pip, on the stray cat: "Adopting the
+# cat also costs attention, which is not advertised on the screen."
+#
+# These lock the disclosure, not the price. Nothing here asserts a cost VALUE that gameplay
+# owns -- they compare the label against WindowResolver's own accessors, so a rebalance moves
+# both together and only a DIVERGENCE fails.
+
+func _event_by_id(event_id: String) -> Dictionary:
+	GameEvents.reload_definitions()
+	for event in GameEvents.get_all_events():
+		if String(event.get("id", "")) == event_id:
+			return event
+	return {}
+
+func _option_by_id(event: Dictionary, option_id: String) -> Dictionary:
+	for option in event.get("options", []):
+		if option is Dictionary and String(option.get("id", "")) == option_id:
+			return option
+	return {}
+
+func test_stray_cat_priced_options_advertise_the_window_attention():
+	# The reported bug, pinned on the exact event. Adopting and feeding are HANDLEs, so they
+	# draw the window's Attention on top of their money -- and must say so on the face.
+	var cat := _event_by_id("stray_cat")
+	assert_false(cat.is_empty(), "stray_cat event still exists in the event data")
+	var shown := WindowResolver.present_for_dialog(cat)
+	for option_id in ["adopt_cat", "feed_and_release"]:
+		var option := _option_by_id(shown, option_id)
+		assert_false(option.is_empty(), "stray_cat still has option %s" % option_id)
+		var text := EventDialog.format_cost_summary(
+			EventDialog.costs_with_window_attention(shown, option))
+		assert_string_contains(text, "Attention",
+			"%s spends founder Attention and must advertise it on the button face" % option_id)
+
+func test_stray_cat_free_out_is_not_surcharged():
+	# shoo_away resolves as IGNORE (WindowResolver.ignore_option_id picks the first option with
+	# an empty costs dict), which draws NO Attention. Labelling it would be the opposite lie.
+	var cat := _event_by_id("stray_cat")
+	var shown := WindowResolver.present_for_dialog(cat)
+	assert_eq(WindowResolver.ignore_option_id(cat), "shoo_away",
+		"shoo_away is the auto-detected free-out; the label below depends on that")
+	var option := _option_by_id(shown, "shoo_away")
+	assert_eq(EventDialog.window_attention_for_option(shown, option), 0,
+		"the IGNORE option pays no Attention, so it must not be surcharged on the face")
+
+func test_free_out_label_tracks_the_resolver_not_a_hardcoded_id():
+	# Anti-drift: the option the LABEL treats as free must be the same one RESOLUTION treats as
+	# free, for every window-tier popup -- not a name the UI happens to recognise.
+	GameEvents.reload_definitions()
+	var checked := 0
+	for event in GameEvents.get_all_events():
+		if not EventTiers.is_window(event) or EventTiers.is_unignorable(event):
+			continue
+		var shown := WindowResolver.present_for_dialog(event)
+		var free_id := WindowResolver.ignore_option_id(event)
+		if free_id == "":
+			continue
+		var option := _option_by_id(shown, free_id)
+		if option.is_empty():
+			continue
+		checked += 1
+		assert_eq(EventDialog.window_attention_for_option(shown, option), 0,
+			"%s/%s resolves as IGNORE (no Attention drawn) but the face would surcharge it" % [
+				event.get("id", "?"), free_id])
+	assert_gt(checked, 0, "the sweep must actually have inspected some windows")
+
+func test_every_charging_window_option_now_shows_attention():
+	# The class, not the instance. Every non-free option of every window-tier popup draws
+	# attention_cost(event); before this lock, all of them rendered money-only or " (Free)".
+	GameEvents.reload_definitions()
+	var silent: Array[String] = []
+	var checked := 0
+	for event in GameEvents.get_all_events():
+		if not EventTiers.is_window(event):
+			continue
+		var shown := WindowResolver.present_for_dialog(event)
+		if WindowResolver.attention_cost(event) <= 0:
+			continue
+		for option in shown.get("options", []):
+			if not (option is Dictionary):
+				continue
+			if EventDialog.window_attention_for_option(shown, option) <= 0:
+				continue  # the free-out, covered by its own test above
+			checked += 1
+			var text := EventDialog.format_cost_summary(
+				EventDialog.costs_with_window_attention(shown, option))
+			if not text.contains("Attention"):
+				silent.append("%s/%s -> %s" % [event.get("id", "?"), option.get("id", "?"), text])
+	assert_gt(checked, 0, "the sweep must actually have inspected some charging options")
+	assert_eq(silent.size(), 0,
+		"these window options draw founder Attention without saying so: %s" % [silent])
+
+func test_unstamped_events_claim_nothing():
+	# The negative control, and the reason the price is STAMPED rather than recomputed in the
+	# UI. Plan-phase legacy popups and the synthetic month review reach the dialog WITHOUT
+	# going through present_for_dialog; their options are un-stripped and self-describing, so
+	# an un-stamped event must add no surcharge at all.
+	var raw := {"id": "unstamped", "type": "popup", "options": [
+		{"id": "act", "text": "Act", "costs": {"money": 100}},
+	]}
+	var option := _option_by_id(raw, "act")
+	assert_eq(EventDialog.window_attention_for_option(raw, option), 0,
+		"no display stamp means no claim -- the UI must not re-derive resolution policy")
+	assert_eq(EventDialog.costs_with_window_attention(raw, option), {"money": 100},
+		"an un-stamped option's shown costs are exactly its declared costs")
+
+func test_declared_attention_is_not_billed_twice_on_the_label():
+	# An option whose own costs still carry `attention` is an UN-stripped legacy event.
+	# format_cost_summary already prints that number; adding the window price on top would
+	# show one charge as two.
+	var event := {"id": "legacy", "type": "popup",
+		WindowResolver.DISPLAY_ATTENTION_KEY: 1,
+		WindowResolver.DISPLAY_FREE_OPTION_KEY: "",
+		"options": [{"id": "act", "text": "Act", "costs": {"attention": 2}}]}
+	var option := _option_by_id(event, "act")
+	assert_eq(EventDialog.window_attention_for_option(event, option), 0,
+		"a declared Attention cost is already on the face; do not add the window price to it")
+
+func test_option_verbs_windows_are_not_double_labelled():
+	# #789 hiring accept-prompts write the price INTO the option text ("Set them up now
+	# (2 Att from reserve)"), so present_for_dialog stamps zero and the generic suffix stays
+	# out of the way.
+	var event := {"id": "hiring_onboard", "type": "popup",
+		"window": {"attention_cost": 2, "option_verbs": {"provision_reserve": "handle_reserve"}},
+		"options": [{"id": "provision_reserve", "text": "Set them up now (2 Att from reserve)"}]}
+	var shown := WindowResolver.present_for_dialog(event)
+	var option := _option_by_id(shown, "provision_reserve")
+	assert_eq(EventDialog.window_attention_for_option(shown, option), 0,
+		"an option whose text already names the price must not also get the generic suffix")
+
+func test_month_review_door_is_still_free_and_prefix_free():
+	# B2/B3 guard: is_navigation_popup reads the RAW option costs, so folding the window price
+	# into the display must not turn the month-review door back into a priced decision.
+	var review := {"id": "month_review", "type": "popup",
+		"options": [{"id": "begin", "text": "Begin planning August 2017", "costs": {}}]}
+	assert_true(EventDialog.is_navigation_popup(review),
+		"the month review is a door, not a decision -- no price tag, no letter prefix")


### PR DESCRIPTION
Playtest 2026-08-10, Pip, on the stray cat: *"Adopting the cat also costs
attention, which is not advertised on the screen. Feeding it and shooing it away
also cost attention which is not on the screen."*

Two of those three are true, and the cause is not in the cat.

## What is actually happening

A **response window** levies `WindowResolver.attention_cost(event)` -- a price
that lives on the EVENT, not in any option's `costs` dict. `stray_cat` carries no
`window` block, so it takes `DEFAULT_ATTENTION_COST` (1). And
`EventTiers.tier_of()` classifies **any `"type": "popup"` with options** as a
window, so this is the whole popup surface: **25 events, 75 options** in
`core_events.json`, every one of them charging a founder hour the label never
mentioned.

`#1205` did the action bar. The event dialog is a different surface and the sweep
never reached it -- exactly the class the brief predicted.

Per-option, verified against the resolver rather than assumed:

| option | label before | actually charged |
|---|---|---|
| `adopt_cat` | ` ($500)` | $500 **+ 1 Attention** |
| `feed_and_release` | ` ($100)` | $100 **+ 1 Attention** |
| `shoo_away` | ` (Free)` | **nothing** -- correct |

`shoo_away` escapes because `ignore_option_id()` auto-picks the first option with
an empty `costs` dict, and that option resolves as IGNORE, which draws no
Attention. So the reported "all three" is two. Worth saying plainly: the free-out
is free *by auto-detection*, not by declaration -- give `shoo_away` a cost, or
give the event a `window.ignore_option`, and all three become HANDLEs at 1
Attention each.

## The half-kept promise

`strip_attention()`'s own docstring already said the point was that *"the dialog's
affordability display matches what resolution will actually charge"*. It only ever
did the erasing half -- it removed a declared Attention cost and never disclosed
the window's own. This PR writes the other half.

`WindowResolver.present_for_dialog()` is now what the two window emit sites hand
the presenter: `strip_attention()` plus the price stamped back on as display
metadata.

**Why stamp instead of recomputing in the UI.** The dialog is fed from **six**
`event_triggered` emit sites and only two of them strip. A stripped event is
indistinguishable from an un-stripped one whose options simply never declared
Attention, so the presenter *cannot* tell from the dict alone that a charge is
coming. Stamping at the one seam that knows makes every un-stamped path -- the
plan-phase legacy popups, the synthetic month review -- silently correct: no key,
no claim. There is a negative-control test for exactly that.

## Three options are deliberately NOT surcharged

Each for a reason that was checked, not assumed:

- **The free-out.** The resolver stamps *which* option resolves as IGNORE, so the
  label cannot drift from the charge. Mirroring `resolve_chosen_option`'s test
  verbatim is the whole point -- a hardcoded `"shoo_away"` in the UI would be the
  next bug.
- **An option whose own costs still carry `attention`** -- an un-stripped legacy
  event whose cost `format_cost_summary` already prints. Adding on top would show
  one charge as two.
- **`#789` hiring accept-prompts** (`window.option_verbs`), whose option text
  already names the price *and* the payment source: "Set them up now (2 Att from
  reserve)".

## Display only -- and the grey-out is left alone on purpose

The affordability grey-out is **not** wired to the new number. Window Attention is
paid **reserve-first**, and the dialog's affordability loop reads
`state.attention` = `get_available_attention()` = `total - spent - RESERVED`.
After a month commits, `GameManager` reserves the entire remainder
(`game_manager.gd:730`), so `available` is 0 while the reserve is full -- gating
on it would grey out **every window button in the game**. The number is now shown;
the engine stays the authority on whether it can be paid.

No cost was changed. Balance is Pip's.

## Tests

Eight, in `test_cost_display.gd` -- where the 2026-07-24 cost sweep already lives.
They lock the **disclosure, not the price**: each compares the label against
`WindowResolver`'s own accessors, so a rebalance moves both together and only a
*divergence* fails. Two are class-wide sweeps over every window-tier popup rather
than assertions about the cat.

**Negative control, run rather than asserted.** Stamping `0` instead of
`attention_cost(event)`:

```
1321 tests, 2 failures
  test_stray_cat_priced_options_advertise_the_window_attention
  test_every_charging_window_option_now_shows_attention
```

Restored:

```
python3 scripts/run_godot_tests.py --quick --ci-mode --min-tests 300
[TOTALS] quick: 1321 tests, 0 fail (ok)   130/130 files, exit 0
```

Baseline 1313 + these 8 = 1321.

## Found and NOT fixed here

Neither is display-only, so neither belongs in this PR. Both are in the
consolidated issue with the rest of the audit:

- **The conference trip tile renders "Free"** while the trip consumes *all*
  remaining Attention -- and re-charges at every month boundary crossed while
  away. `travel.json` sets `costs: {}` deliberately (`_seam` comment); the commit
  button is honest but non-numeric, the upstream tile is a flat lie.
- **Five hiring action-bar entries print "No costs"** for actions that spend 1-3
  Attention through the pipeline. Putting those numbers in the `costs` dicts would
  **double-charge**, because `game_manager` debits declared Attention at queue
  time. Needs a display channel, not a data edit.

`Ladder-Impact: none` -- presentation only. `present_for_dialog()` is additive and
used by nobody but the two dialog emit sites; `strip_attention()`,
`attention_cost()` and every payment path are untouched. The two extra keys ride
on the dialog's copy only, and the round trip back through
`resolve_current_window_option()` reads `event.id` and nothing else.

Stayed out of `_on_dynamic_action_pressed()`, `main_ui.gd` and
`submenu_controller.gd` entirely -- concurrent lanes.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
