### PR TITLE
fix(ui): make submenu-driven refusals visible -- one door, at the child chokepoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Every action reached through a submenu could fail in complete silence, and
+  hiring is entirely on that path.** Reported from a live playtest, in the
+  player's words: *"I can fail silently if I queue 19 fundraisings and then try
+  to make offers to 2 people. Making offers doesn't show up as a card."*
+  `_on_dynamic_action_pressed` returns at its `is_submenu` branch, which sits
+  ABOVE the attention/affordability guards and their `report_rejection()` calls.
+  #1204 re-armed those guards inside `SubmenuController.on_option_selected`,
+  which covers the six icon-grid panels plus financing -- but the two BESPOKE
+  panels never queue through it. Hiring and travel call the
+  `GameManager.hiring_*` / `GameActions` conference delegates directly and
+  rendered the refusal with a bare `log_message()`, i.e. into WatchScreen's
+  feed, which `ScreenModeController` hides for the whole of PLAN. Eleven
+  child-click buttons across those two panels therefore produced nothing at all
+  when refused: no card, no message, no explanation. **This was a pre-existing
+  gap, not a regression.**
+  Fixed at the chokepoints, not the buttons: one new door,
+  `EventResultPresenter.present_outcome()` (exposed as `MainUI.report_outcome()`),
+  decides what an acceptance and a refusal look like for a backend
+  `{success, message}` verdict, and routes refusals through the SAME
+  `present_error()` the rest of the rejection surface uses -- so they reach the
+  PLAN toast as well as the feed. All six hiring handlers already funnelled
+  through `_hiring_action_result`, so hiring is fixed in one line; travel's
+  three leaf commits report through the same door.
+  The refusal REASON is relayed from the backend verbatim, deliberately: a
+  shadow pre-check in the view is exactly the defect #1204 fixed, and only the
+  backend knows whether a click failed for Attention, money, reputation, desk
+  space or pipeline state.
+  **The guards were NOT hoisted above the `is_submenu` return, and must not be**:
+  the submenu driver is free, the child inside the menu carries the cost, so
+  guarding the driver would refuse to OPEN a menu the player is entitled to
+  browse. A test now pins that ordering.
+  No gameplay change: same conditions, same early returns, same economy, and no
+  phantom queue tiles (#821 -- the door returns the backend's verdict so a call
+  site can gate its follow-up). The cumulative overbook that triggers the repro
+  was already refused correctly by `MonthPlan`; only the presentation was broken.
 - **Contact email addresses were publicly fetchable from the bundled historical
   events, and the changelog said they had been removed.** Both are fixed here.
   `godot/data/historical_events.json` carried **12 addresses naming 26 real

--- a/godot/scripts/ui/event_result_presenter.gd
+++ b/godot/scripts/ui/event_result_presenter.gd
@@ -85,6 +85,46 @@ func present_error(error_msg: String) -> void:
 		host.plan_screen.flash_error(error_msg)
 
 
+# --- Backend verdict for the BESPOKE submenu panels (hiring / travel) ----------------------
+
+func present_outcome(result: Dictionary, verb: String) -> bool:
+	"""ONE door for the {success, message} Dictionaries the bespoke submenu panels get back
+	from their backend delegates. An ACCEPTANCE keeps the cyan feed line those panels already
+	wrote; a REFUSAL goes out through present_error, so it reaches the PLAN toast as well as
+	the feed. Returns result.success, so a call site can gate its follow-up on the backend
+	having actually accepted (#821: the UI tile appears only when the backend accepts).
+
+	Why this exists -- the gap #1204 left open. _on_dynamic_action_pressed returns at its
+	`is_submenu` branch, ABOVE the attention/affordability guards that report through
+	report_rejection(). SubmenuController.on_option_selected re-armed those guards for the six
+	icon-grid panels plus financing, but the two BESPOKE panels never queue through it: hiring
+	and travel call GameManager.hiring_* / GameActions.*_conference_* directly and presented
+	the refusal with a bare log_message(). The feed lives inside WatchScreen, which
+	ScreenModeController hides for the whole of PLAN, so every refused hiring/travel click
+	looked like a dead button. Playtest, verbatim: "I can fail silently if I queue 19
+	fundraisings and then try to make offers to 2 people. Making offers doesn't show up as a
+	card."
+
+	The refusal REASON is relayed from the backend VERBATIM, on purpose. The view must not
+	re-derive it: a shadow pre-check in the view is exactly the defect #1204 fixed, and the
+	backend is the only thing that knows why it said no (a hiring click can be refused for
+	Attention, money, reputation, desk space, or pipeline state). It already answers in house
+	voice and names the number -- "Not enough Attention to make an offer (1 needed)" -- the
+	same shape as the view's own "Not enough Attention: need %d %s hours, have %d".
+
+	This changes NO gameplay: same conditions, same early returns, same economy. Only which
+	surface the refusal lands on."""
+	var accepted := bool(result.get("success", false))
+	var message := String(result.get("message", "")).strip_edges()
+	if accepted:
+		host.log_message("[color=cyan]%s: %s[/color]" % [verb, message])
+		return true
+	# A refusal with no reason is the same dead button by another route -- name the action at
+	# least, so the player knows which click was rejected.
+	present_error(message if message != "" else "%s was refused (no reason given)." % verb)
+	return false
+
+
 # --- Delta formatting helper (was main_ui._format_deltas) ---------------------------------
 
 func _format_deltas(deltas: Dictionary) -> String:

--- a/godot/scripts/ui/hiring_panel_controller.gd
+++ b/godot/scripts/ui/hiring_panel_controller.gd
@@ -396,12 +396,18 @@ func _hiring_job_status(candidate_id: String) -> String:
 	return ""
 
 func _hiring_action_result(result: Dictionary, verb: String) -> void:
-	"""Log a hiring delegate's result, refresh the HUD (attention/money changed), and rebuild
-	the pipeline panel in place so new reveal / job state is visible immediately."""
-	var ok := bool(result.get("success", false))
-	var msg := String(result.get("message", ""))
-	var color := "cyan" if ok else "red"
-	host.log_message("[color=%s]%s: %s[/color]" % [color, verb, msg])
+	"""Present a hiring delegate's verdict, refresh the HUD (attention/money changed), and
+	rebuild the pipeline panel in place so new reveal / job state is visible immediately.
+
+	THE CHOKEPOINT: all six hiring child-click handlers (advertise / connections / interview /
+	onboard step / skip mentoring / send offer) land here, so the refusal surface is fixed
+	once instead of six times. It used to render a refusal as a red log_message(), i.e. into
+	WatchScreen's feed, which ScreenModeController hides for the whole of PLAN -- so a hiring
+	click refused for want of Attention produced NOTHING the player could see (playtest: 19
+	queued fundraisings, then two offers, and no card, no message). host.report_outcome routes
+	the same verdict through EventResultPresenter, which raises the PLAN toast as well as the
+	feed line. Same conditions, same early returns, same economy -- only the surface changed."""
+	host.report_outcome(result, verb)
 	host._on_game_state_updated(host.game_manager.get_game_state())
 	_show_hiring_submenu()
 

--- a/godot/scripts/ui/main_ui.gd
+++ b/godot/scripts/ui/main_ui.gd
@@ -1452,6 +1452,20 @@ func report_rejection(message: String) -> void:
 	PLAN toast is a plain Label, so BBCode passed in here would be shown literally."""
 	event_result_presenter.present_error(message)
 
+func report_outcome(result: Dictionary, verb: String) -> bool:
+	"""Report a BACKEND VERDICT ({success, message}) through the same door as report_rejection.
+
+	The bespoke submenu panels (hiring, travel) do not queue through PlanController -- they
+	call the GameManager.hiring_* / GameActions conference delegates and get a result
+	Dictionary back. They used to render it with a bare log_message(), which is the
+	PLAN-hidden feed, so a refused hiring/travel click said nothing at all. This is the one
+	place that decides what an acceptance and a refusal look like for those panels; the call
+	sites just hand it the verdict.
+
+	Returns result.success so a call site can gate its follow-up on the backend accepting
+	(#821: no UI tile unless it did). See EventResultPresenter.present_outcome."""
+	return event_result_presenter.present_outcome(result, verb)
+
 func _notification(what: int) -> void:
 	# P0 rage-quit friction: intercept the window-manager close during a run and route to the
 	# Main Menu instead of quitting to desktop. Quit-to-desktop stays available from the pause
@@ -1678,6 +1692,15 @@ func _on_dynamic_action_pressed(action_id: String, action_name: String):
 		# built from config; hiring/travel delegate back to the bespoke builders here).
 		# #602 P1: the click path and the hotkey path share ONE door (_open_submenu), which
 		# also tags the panel with its id + aligns it to the clicked button (#510).
+		#
+		# THIS RETURN IS DELIBERATELY ABOVE THE COST GUARDS BELOW -- do not "fix" that by
+		# hoisting them. The submenu DRIVER is free; the CHILD inside the menu carries the
+		# cost, so guarding here would refuse to OPEN a menu the player is entitled to browse.
+		# The child-side refusals are reported at each panel family's own chokepoint:
+		#   grid + financing -> SubmenuController.on_option_selected  (report_rejection)
+		#   hiring           -> HiringPanelController._hiring_action_result -> report_outcome
+		#   travel           -> TravelPanelController leaf commits          -> report_outcome
+		# Every one of those ends at EventResultPresenter.present_error, so PLAN sees them.
 		_open_submenu(action_id)
 		return
 

--- a/godot/scripts/ui/travel_panel_controller.gd
+++ b/godot/scripts/ui/travel_panel_controller.gd
@@ -292,9 +292,11 @@ func _on_travel_option_selected(action_id: String, action_name: String, dialog: 
 	host.active_dialog = null
 	host.active_dialog_buttons = []
 
-	# Handle stub action
+	# Handle stub action. A click that can never land is the same silent-failure class as a
+	# refused one: during PLAN the old bare log_message() went into the hidden feed, so the
+	# button read as broken rather than as not-built-yet. report_rejection reaches the toast.
 	if action_id == "send_delegation":
-		host.log_message("[color=yellow][Issue #411] Delegation system coming soon![/color]")
+		host.report_rejection("Delegation is not built yet (issue #411) - nothing was queued.")
 		return
 
 	# For submit_paper and attend_conference, show dedicated dialogs
@@ -421,6 +423,10 @@ func _on_conference_trip_committed(conf_id: String, dialog: Control) -> void:
 
 	var trip: Dictionary = host.game_manager.attend_conference_trip(conf_id)
 	if not bool(trip.get("success", false)):
+		# NOT host.report_outcome: GameManager.attend_conference_trip already emits
+		# error_occurred on a refusal, which is the SAME door (present_error -> feed + PLAN
+		# toast). Reporting again here would raise the toast twice for one click. This line is
+		# the feed record only, which is why it is safe as a bare log_message.
 		host.log_message("[color=yellow]%s[/color]" % String(trip.get("message", "Cannot attend.")))
 		return
 
@@ -532,7 +538,10 @@ func _show_paper_submission_dialog():
 			lead.researcher_name = researchers[0].get("researcher_name", "Anonymous")
 			lead.skill_level = researchers[0].get("skill_level", 3)
 		var result = GameActions.submit_paper_to_conference(host.game_manager.state, conf_id, topic, research_amount, lead)
-		host.log_message("[color=cyan]%s[/color]" % result.get("message", "Paper submitted"))
+		# The delegate refuses on research OR on Attention ("Not enough Attention (1 operating
+		# hour required)"), and this used to report EVERY verdict as a cyan success line into
+		# the PLAN-hidden feed -- so a refused submission read as an accepted one that vanished.
+		host.report_outcome(result, "Paper")
 		dialog.queue_free()
 		host.active_dialog = null
 	)
@@ -645,10 +654,9 @@ func _show_conference_attendance_dialog():
 		# TODO: Multi-stage booking with traveler/class selection
 		var traveler = host.game_manager.state.researchers[0] if host.game_manager.state.researchers.size() > 0 else null
 		var result = GameActions.attend_conference_action(host.game_manager.state, conf_id, "economy", traveler)
-		if result.get("success", false):
-			host.log_message("[color=lime]%s[/color]" % result.get("message", "Attended conference"))
-		else:
-			host.log_message("[color=red]%s[/color]" % result.get("message", "Failed to attend"))
+		# Same door as hiring: the refusal ("Cannot afford: $X + 2 operating hours required")
+		# reached only the PLAN-hidden feed before, so an unaffordable trip was a dead button.
+		host.report_outcome(result, "Conference")
 		dialog.queue_free()
 		host.active_dialog = null
 	)

--- a/godot/tests/unit/test_plan_rejection_visibility.gd
+++ b/godot/tests/unit/test_plan_rejection_visibility.gd
@@ -286,12 +286,14 @@ func test_a_refused_hiring_child_click_reaches_the_player_not_the_hidden_feed():
 	assert_eq(host.rejections.size(), 1,
 		"the refused offer is reported through the PLAN-visible door, not swallowed")
 	assert_true(String(host.rejections[0]).contains("Not enough Attention"),
-		"the message says WHY it was refused, got: %s" % host.rejections)
+		"the message says WHY it was refused, got: %s" % [host.rejections])
 	assert_true(String(host.rejections[0]).contains("1 needed"),
-		"and names the shortfall, got: %s" % host.rejections)
+		"and names the shortfall, got: %s" % [host.rejections])
+	# NOTE the wrapping array: `"%s" % some_array` spreads the array as the argument LIST, so an
+	# empty one raises "not enough arguments for format string" -- on the passing path.
 	assert_eq(host.feed_lines_containing("Not enough Attention").size(), 0,
 		"the panel no longer writes the refusal straight into the PLAN-hidden feed: %s"
-			% host.feed_lines_containing("Not enough Attention"))
+			% [host.feed_lines_containing("Not enough Attention")])
 
 
 func test_an_accepted_hiring_child_click_still_confirms_through_the_same_door():
@@ -347,7 +349,7 @@ func test_a_travel_click_that_cannot_do_anything_says_so():
 	assert_eq(host.rejections.size(), 1,
 		"a click that cannot land is refused where the player can see it")
 	assert_true(String(host.rejections[0]).contains("411"),
-		"the refusal still carries the tracking issue, got: %s" % host.rejections)
+		"the refusal still carries the tracking issue, got: %s" % [host.rejections])
 
 
 # --- The one backend-result door -------------------------------------------------------------

--- a/godot/tests/unit/test_plan_rejection_visibility.gd
+++ b/godot/tests/unit/test_plan_rejection_visibility.gd
@@ -15,10 +15,39 @@ extends GutTest
 ## reports those refusals through MainUI.report_rejection() -> present_error().
 ##
 ## Presentation only: these tests assert on the FEEDBACK, never on queue/attention state.
+##
+## SECOND PASS (fix/submenu-rejection-visibility). #1204 fixed the DIRECT-click path and gave
+## SubmenuController.on_option_selected the same two guards, which covers the six icon-grid
+## panels plus financing. It did not cover the SUBMENU-DRIVEN path as a whole:
+## _on_dynamic_action_pressed returns at its `is_submenu` branch ABOVE those guards, and the two
+## BESPOKE panels (hiring, travel) never queue through on_option_selected -- they call the
+## GameManager.hiring_* / GameActions conference delegates directly and presented the backend's
+## refusal with a bare log_message(), i.e. straight back into the PLAN-hidden feed.
+##
+## Playtest repro, verbatim: "I can fail silently if I queue 19 fundraisings and then try to make
+## offers to 2 people. Making offers doesn't show up as a card."
+##
+## The guards must NOT move above the `is_submenu` return: opening a menu is free, the CHILD
+## inside it carries the cost, so guarding the driver would refuse to open a menu the player is
+## entitled to browse. The refusal belongs at child selection -- at the chokepoint each panel
+## family already funnels through.
 
 const PLAN_SCENE := "res://scenes/ui/plan_screen.tscn"
 const MAIN_UI_SRC := "res://scripts/ui/main_ui.gd"
 const SUBMENU_SRC := "res://scripts/ui/submenu_controller.gd"
+const HIRING_SRC := "res://scripts/ui/hiring_panel_controller.gd"
+const TRAVEL_SRC := "res://scripts/ui/travel_panel_controller.gd"
+
+# Every child-click handler in the hiring panel. All six must reach the ONE chokepoint, which is
+# why the refusal surface is fixed in one place rather than six.
+const HIRING_CHILD_CLICK_HANDLERS := [
+	"_on_hiring_advertise_pressed",
+	"_on_hiring_connections_pressed",
+	"_on_hiring_interview_pressed",
+	"_on_hiring_onboard_pressed",
+	"_on_hiring_skip_mentoring_pressed",
+	"_on_hiring_send_offer_pressed",
+]
 
 
 class StubHost extends RefCounted:
@@ -30,6 +59,56 @@ class StubHost extends RefCounted:
 
 	func log_message(text: String, channel: String = "normal") -> void:
 		logged.append({"text": text, "channel": channel})
+
+
+class StubGameManager extends RefCounted:
+	## The bespoke panels touch game_manager only for the post-action HUD refresh and the panel
+	## rebuild. A null `state` makes _show_hiring_submenu() return at its own first guard, so the
+	## chokepoint can be exercised without booting a run.
+	var state = null
+
+	func get_game_state() -> Dictionary:
+		return {}
+
+
+class StubPanelHost extends StubHost:
+	## Stand-in for MainUI as the BESPOKE panels see it: the feed, the rejection door, the
+	## backend-result door, and the two dialog slots. Records which surface each refusal reached,
+	## so a test can tell "the player was told" from "it went into the hidden feed".
+	var rejections: Array = []
+	var outcomes: Array = []
+	var game_manager = StubGameManager.new()
+	var active_dialog = null
+	var active_dialog_buttons: Array = []
+
+	func report_rejection(message: String) -> void:
+		rejections.append(message)
+
+	func report_outcome(result: Dictionary, verb: String) -> bool:
+		outcomes.append({"result": result, "verb": verb})
+		var ok := bool(result.get("success", false))
+		if not ok:
+			rejections.append(String(result.get("message", "")))
+		return ok
+
+	func _on_game_state_updated(_state) -> void:
+		pass
+
+	func feed_lines_containing(needle: String) -> Array:
+		var hits: Array = []
+		for entry in logged:
+			if String(entry["text"]).contains(needle):
+				hits.append(entry["text"])
+		return hits
+
+
+func _function_body(src: String, func_name: String) -> String:
+	"""Source of one top-level function, from its `func` line to the next one."""
+	var at: int = src.find("func %s" % func_name)
+	if at < 0:
+		return ""
+	var nxt: int = src.find("\nfunc ", at + 1)
+	return src.substr(at, (nxt - at) if nxt > at else -1)
 
 
 func _plan_screen() -> PlanScreen:
@@ -156,10 +235,208 @@ func test_submenu_rejections_route_through_report_rejection():
 func test_report_rejection_messages_are_plain_text():
 	# present_error applies the feed colour itself and the PLAN toast is a plain Label, so a
 	# BBCode tag passed in here would be printed literally to the player as "[color=red]...".
-	for path in [MAIN_UI_SRC, SUBMENU_SRC]:
+	for path in [MAIN_UI_SRC, SUBMENU_SRC, HIRING_SRC, TRAVEL_SRC]:
 		var src: String = FileAccess.get_file_as_string(path)
 		for line in src.split("\n"):
 			if not String(line).contains("report_rejection(\""):
 				continue
 			assert_false(String(line).contains("[color="),
 				"%s: report_rejection takes plain text, not BBCode -- %s" % [path, line.strip_edges()])
+
+
+# --- The SUBMENU-DRIVEN child paths (fix/submenu-rejection-visibility) ----------------------
+#
+# What #1204 left uncovered. Four panel families hang off the `is_submenu` early return:
+#   1. the six icon-grid panels  -> SubmenuController.on_option_selected   (COVERED by #1204)
+#   2. financing (list layout)   -> SubmenuController.on_option_selected   (COVERED by #1204)
+#   3. hiring (6 child clicks)   -> HiringPanelController._hiring_action_result
+#   4. travel (4 child clicks)   -> TravelPanelController leaf commits
+# 3 and 4 presented the backend's refusal with a bare log_message(). These pin the fix at the
+# chokepoints, not at the eleven individual buttons.
+
+
+func test_the_submenu_branch_still_returns_above_the_affordability_guards():
+	# Pins the SHAPE of the defect, so the fix cannot be "undone" by hoisting the guards. The
+	# submenu DRIVER is free; the CHILD inside the menu carries the cost. Guarding the driver
+	# would refuse to OPEN a menu the player is entitled to browse -- a worse bug than the one
+	# being fixed. The early return must stay exactly where it is.
+	var src: String = FileAccess.get_file_as_string(MAIN_UI_SRC)
+	var branch: int = src.find("if action.get(\"is_submenu\", false):")
+	var guard: int = src.find("report_rejection(\"Not enough Attention: need %d %s hours, have %d\"")
+	assert_true(branch > -1, "the submenu branch is still the first thing the click handler does")
+	assert_true(guard > -1, "the Attention guard is still there")
+	assert_true(branch < guard,
+		"opening a submenu still returns BEFORE the cost guards -- browsing a menu stays free")
+
+
+func test_a_refused_hiring_child_click_reaches_the_player_not_the_hidden_feed():
+	# THE REPRO, at the chokepoint it flows through. Playtest, in the player's own words:
+	# "I can fail silently if I queue 19 fundraisings and then try to make offers to 2 people.
+	# Making offers doesn't show up as a card."
+	# 19 fundraisings exhaust the month plan, so MonthPlan.spend_attention(1) refuses the offer
+	# and HiringPipeline hands back {success: false, message: "Not enough Attention ..."}. Every
+	# hiring child click lands in _hiring_action_result, which used to render that with a bare
+	# log_message() -- into WatchScreen's feed, which ScreenModeController hides for all of PLAN.
+	var host := StubPanelHost.new()
+	var panel := HiringPanelController.new(host)
+
+	panel._hiring_action_result(
+		{"success": false, "message": "Not enough Attention to make an offer (1 needed)"}, "Offer")
+
+	assert_eq(host.rejections.size(), 1,
+		"the refused offer is reported through the PLAN-visible door, not swallowed")
+	assert_true(String(host.rejections[0]).contains("Not enough Attention"),
+		"the message says WHY it was refused, got: %s" % host.rejections)
+	assert_true(String(host.rejections[0]).contains("1 needed"),
+		"and names the shortfall, got: %s" % host.rejections)
+	assert_eq(host.feed_lines_containing("Not enough Attention").size(), 0,
+		"the panel no longer writes the refusal straight into the PLAN-hidden feed: %s"
+			% host.feed_lines_containing("Not enough Attention"))
+
+
+func test_an_accepted_hiring_child_click_still_confirms_through_the_same_door():
+	# The other half of "same conditions, same early returns": an accepted action must still
+	# confirm, and must NOT be reported as a rejection.
+	var host := StubPanelHost.new()
+	var panel := HiringPanelController.new(host)
+
+	panel._hiring_action_result({"success": true, "message": "Interview scheduled with Ada."}, "Interview")
+
+	assert_eq(host.rejections.size(), 0, "an accepted action raises no rejection")
+	assert_eq(host.outcomes.size(), 1, "the acceptance goes out the same one door")
+	assert_true(bool(host.outcomes[0]["result"].get("success", false)),
+		"the door is handed the backend's verdict verbatim")
+
+
+func test_hiring_refusals_are_fixed_at_one_chokepoint_not_six_buttons():
+	# A fix applied in six places rots in five. All six hiring child-click handlers must keep
+	# funnelling through _hiring_action_result, and that one function must be what reports.
+	var src: String = FileAccess.get_file_as_string(HIRING_SRC)
+	for handler in HIRING_CHILD_CLICK_HANDLERS:
+		var body: String = _function_body(src, handler)
+		assert_ne(body, "", "%s exists" % handler)
+		assert_true(body.contains("_hiring_action_result("),
+			"%s reports through the single chokepoint, not its own presentation" % handler)
+	assert_true(_function_body(src, "_hiring_action_result").contains("host.report_outcome("),
+		"the chokepoint routes the backend verdict through the host's one result door")
+
+
+func test_travel_child_clicks_report_through_the_same_one_door():
+	# Travel's leaves each call a different GameActions delegate, so they cannot share a
+	# chokepoint of their own -- they share the HOST's door instead, so the decision about what
+	# a refusal looks like still lives in exactly one place.
+	var src: String = FileAccess.get_file_as_string(TRAVEL_SRC)
+	assert_true(src.contains("host.report_outcome("),
+		"travel's backend results go out the same door as hiring's")
+	assert_false(src.contains("log_message(\"[color=red]%s[/color]\" % result.get(\"message\", \"Failed to attend\"))"),
+		"the failed-conference refusal is no longer feed-only")
+	assert_false(src.contains("host.log_message(\"[color=cyan]%s[/color]\" % result.get(\"message\", \"Paper submitted\"))"),
+		"a refused paper submission no longer reports itself as a cyan success line")
+
+
+func test_a_travel_click_that_cannot_do_anything_says_so():
+	# The delegation option is a stub: clicking it can never queue anything. That is the same
+	# silent-failure class -- during PLAN its "coming soon" line went into the hidden feed, so
+	# the button read as broken rather than unimplemented.
+	var host := StubPanelHost.new()
+	var panel := TravelPanelController.new(host)
+	var dialog := Control.new()   # orphan on purpose: the handler queue_free()s it
+
+	panel._on_travel_option_selected("send_delegation", "Send Delegation", dialog)
+
+	assert_eq(host.rejections.size(), 1,
+		"a click that cannot land is refused where the player can see it")
+	assert_true(String(host.rejections[0]).contains("411"),
+		"the refusal still carries the tracking issue, got: %s" % host.rejections)
+
+
+# --- The one backend-result door -------------------------------------------------------------
+
+
+func test_present_outcome_is_the_one_door_for_a_backend_verdict():
+	var plan := _plan_screen()
+	await get_tree().process_frame
+	var host := StubHost.new()
+	host.plan_screen = plan
+	# Deliberately untyped: while the door is missing this must fail as an ASSERTION, not as a
+	# parse error that would take the whole file (and its RED evidence) down with it.
+	var presenter = EventResultPresenter.new(host)
+	assert_true(presenter.has_method("present_outcome"),
+		"EventResultPresenter owns the one backend-result door")
+	if not presenter.has_method("present_outcome"):
+		return
+
+	var accepted: bool = presenter.present_outcome(
+		{"success": false, "message": "Not enough Attention to interview (2 needed)"}, "Interview")
+
+	assert_false(accepted,
+		"a refusal reports false so the call site can skip its follow-up -- no phantom tile (#821)")
+	var toast := _find_error_toast(plan)
+	assert_true(toast.visible, "the refusal is raised on the PLAN screen, where the player clicked")
+	assert_true(toast.text.contains("Not enough Attention to interview (2 needed)"),
+		"the toast says WHY, got: %s" % toast.text)
+	assert_eq(host.logged.size(), 1, "and it is recorded in the feed exactly once")
+
+
+func test_present_outcome_confirms_an_acceptance_without_raising_a_rejection():
+	var plan := _plan_screen()
+	await get_tree().process_frame
+	var host := StubHost.new()
+	host.plan_screen = plan
+	var presenter = EventResultPresenter.new(host)
+	if not presenter.has_method("present_outcome"):
+		assert_true(false, "EventResultPresenter owns the one backend-result door")
+		return
+
+	var accepted: bool = presenter.present_outcome({"success": true, "message": "Offer sent to Ada."}, "Offer")
+
+	assert_true(accepted, "an accepted result reports true")
+	assert_eq(host.logged.size(), 1, "the acceptance is one plain feed line")
+	assert_true(String(host.logged[0]["text"]).contains("Offer sent to Ada."),
+		"carrying the backend's own wording, got: %s" % host.logged[0]["text"])
+	assert_false(_find_error_toast(plan).visible, "an acceptance raises no PLAN error toast")
+
+
+func test_present_outcome_never_refuses_in_silence():
+	# A backend that refuses with no message must still produce something the player can see:
+	# a blank toast is the same dead button by another route.
+	var plan := _plan_screen()
+	await get_tree().process_frame
+	var host := StubHost.new()
+	host.plan_screen = plan
+	var presenter = EventResultPresenter.new(host)
+	if not presenter.has_method("present_outcome"):
+		assert_true(false, "EventResultPresenter owns the one backend-result door")
+		return
+
+	presenter.present_outcome({"success": false}, "Offer")
+
+	var toast := _find_error_toast(plan)
+	assert_true(toast.visible, "a message-less refusal still raises the toast")
+	assert_true(toast.text.contains("Offer"), "and names what was refused, got: %s" % toast.text)
+
+
+func test_main_ui_exposes_the_outcome_door_the_bespoke_panels_report_through():
+	var src: String = FileAccess.get_file_as_string(MAIN_UI_SRC)
+	assert_true(src.contains("func report_outcome"),
+		"MainUI keeps the backend-result door next to report_rejection")
+
+
+# --- The economy is untouched: the backend still refuses on exactly the same condition -------
+
+
+func test_the_cumulative_queue_is_what_refuses_the_offer_not_the_offers_own_cost():
+	# The actual repro is a CUMULATIVE overbook: one offer costs 1 Attention and the player can
+	# afford one offer in isolation -- it is the 19 already-queued fundraisings that leave no
+	# Attention behind them. MonthPlan.available() nets out what is already committed, so the
+	# refusal is real and belongs to the backend. This test exists so the presentation fix can
+	# never be "corrected" into a view-side pre-check that re-derives the rule and drifts.
+	var plan := MonthPlan.new()
+	plan.begin_month(3, 1)
+
+	assert_true(plan.can_queue(1), "with the month untouched, a 1-Attention offer fits")
+	assert_true(plan.spend_attention(3), "the player commits the whole month elsewhere")
+	assert_eq(plan.available(), 0, "nothing is left behind the committed plan")
+	assert_false(plan.can_queue(1), "so the 1-Attention offer no longer fits -- cumulatively")
+	assert_false(plan.spend_attention(1), "and the spend is refused, charging nothing")
+	assert_eq(plan.available(), 0, "a refused spend leaves the plan exactly as it was")


### PR DESCRIPTION
Fixes #1219.

**Do not merge yet** -- a release tag may happen this afternoon and this may or may not make it.
Flagged for Pip's call.

## The bug

`_on_dynamic_action_pressed()` returns at its `is_submenu` branch, which sits **above** the
attention/affordability guards and the `report_rejection()` calls that make a refusal visible.
#1204 re-armed those guards inside `SubmenuController.on_option_selected()`, covering the six
icon-grid panels plus financing -- but the two BESPOKE panels never queue through it. Hiring and
travel call the `GameManager.hiring_*` / `GameActions` conference delegates directly and rendered
the backend's refusal with a bare `log_message()`, i.e. into `WatchScreen`'s feed, which
`ScreenModeController` hides for the whole of PLAN.

Playtest repro, verbatim:

> I can fail silently if I queue 19 fundraisings and then try to make offers to 2 people. Making
> offers doesn't show up as a card.

Pre-existing gap, not a regression.

## How many child-click paths, and where the check went

Eleven child-click buttons hang off the `is_submenu` early return, in four panel families
reaching the commit through three chokepoints:

| # | family | child clicks | chokepoint | before this PR |
|---|--------|--------------|------------|----------------|
| 1 | six icon-grid panels | per-option buttons | `SubmenuController.on_option_selected` | covered by #1204 |
| 2 | financing (list layout) | per-option buttons | `SubmenuController.on_option_selected` | covered by #1204 |
| 3 | hiring | 6 (advertise / connections / interview / onboard step / skip mentoring / send offer) | `HiringPanelController._hiring_action_result` | **silent** |
| 4 | travel | 4 (delegation stub / submit paper / attend conference / conference trip) | 4 separate leaf commits | **silent**, except the trip |

The travel *trip* leaf was already visible -- `GameManager.attend_conference_trip` emits
`error_occurred`, which is the same door. It is deliberately left alone and commented, because
routing it through the new door too would raise the toast twice for one click.

**The check went to child selection, at the chokepoints -- not above the early return.** The
submenu driver is free; the child inside the menu carries the cost. Hoisting the guards would
refuse to *open* a menu the player is entitled to browse, which is a worse bug than this one.
`test_the_submenu_branch_still_returns_above_the_affordability_guards` now pins that ordering so
it cannot be "fixed" by a later reader.

Because all six hiring handlers already funnelled through `_hiring_action_result`, hiring needed
**one line**. Travel's leaves cannot share a chokepoint of their own (each calls a different
delegate), so they share the **host's** door -- the decision about what a refusal looks like
still lives in exactly one place.

## The one door

```gdscript
EventResultPresenter.present_outcome(result, verb) -> bool   # exposed as MainUI.report_outcome
```

Acceptance keeps the cyan feed line the panels already wrote; refusal goes out through the same
`present_error()` as every other rejection, so it reaches the PLAN toast **and** the feed. It
returns `result.success`, so a call site can gate its follow-up on the backend having actually
accepted (#821 -- no phantom tiles). A refusal with no message still names the action rather than
raising a blank toast.

**The refusal reason is relayed from the backend verbatim, on purpose.** A shadow pre-check in
the view is exactly the defect #1204 fixed, and only the backend knows whether a click failed for
Attention, money, reputation, desk space or pipeline state. It already answers in house voice
with the number -- `"Not enough Attention to make an offer (1 needed)"` -- the same shape as the
view's own `"Not enough Attention: need %d %s hours, have %d"`.

## The two cases called out in the brief

* **Cumulative queue** (the actual repro): `MonthPlan.available()` nets out what is already
  committed, so 19 queued fundraisings are what refuse the 1-Attention offer, not the offer's own
  cost. Already correct in the backend, and it charges nothing for a refused spend.
  `test_the_cumulative_queue_is_what_refuses_the_offer_not_the_offers_own_cost` pins this, so the
  presentation fix can never be "corrected" into a view-side re-derivation of the rule that then
  drifts.
* **Already-queued action becomes unaffordable**: the submenu buttons disable off a snapshot, so
  a button can look live and still be refused. That refusal now reports, whatever its reason.

## No gameplay change

Same conditions, same early returns, same economy. `tools/check_ladder_bump.py` reports
**0 gameplay-surface files changed**. Ladder-Impact: none -- UI presentation only.

## RED before green (TESTING_STRATEGY.md)

`python3 scripts/run_godot_tests.py --quick --ci-mode --min-tests 300`

| stage | result |
|-------|--------|
| baseline, `origin/main` | **1313 tests, 0 failures** |
| tests only, production code untouched (commit `968b5c0d`) | **1324 tests, 9 failures** |
| with the fix (commit `d9756da5`) | **1324 tests, 0 failures** |

The nine RED failures, from the JUnit XML of that run:

```
test_a_refused_hiring_child_click_reaches_the_player_not_the_hidden_feed
    [0] expected to equal [1]:  the refused offer is reported through the PLAN-visible door, not swallowed
test_an_accepted_hiring_child_click_still_confirms_through_the_same_door
    [0] expected to equal [1]:  the acceptance goes out the same one door
test_hiring_refusals_are_fixed_at_one_chokepoint_not_six_buttons
    the chokepoint routes the backend verdict through the host's one result door
test_travel_child_clicks_report_through_the_same_one_door
    travel's backend results go out the same door as hiring's
test_a_travel_click_that_cannot_do_anything_says_so
    [0] expected to equal [1]:  a click that cannot land is refused where the player can see it
test_present_outcome_is_the_one_door_for_a_backend_verdict
    EventResultPresenter owns the one backend-result door
test_present_outcome_confirms_an_acceptance_without_raising_a_rejection
    EventResultPresenter owns the one backend-result door
test_present_outcome_never_refuses_in_silence
    EventResultPresenter owns the one backend-result door
test_main_ui_exposes_the_outcome_door_the_bespoke_panels_report_through
    MainUI keeps the backend-result door next to report_rejection
```

Two of the eleven new tests pass on unmodified `main`, deliberately: the one pinning that the
`is_submenu` return stays above the guards, and the one pinning that `MonthPlan` already refuses
the cumulative overbook correctly. They are there to stop the fix being taken in the wrong
direction, not to go red.

The simulation tier was not run: this touches `godot/scripts/ui/` only, no
simulation/economy/replay code (CLAUDE.md).

## One unrelated commit, and why it is here

`176d2fec` regenerates `docs/calendar/`. It is **not** part of the fix -- it is carried because
it **blocks** it. The pre-commit `commitment-calendar-check` hook fails on any commit touching a
scanned file, and it already fails on a clean checkout of `origin/main`:

```
$ git worktree add --detach <tmp> origin/main
$ python3 scripts/generate_commitment_calendar.py --check
Commitment calendar is STALE: docs/calendar/pdoom1-commitments.ics, docs/calendar/COMMITMENTS_INDEX.md
  computed: 48 declared + 4 release-train + 38 UNPARSED = 90 events; 0 malformed
  MISSING from the committed index: | 2026-08-10 | `docs/PRIVACY_POSTURE.md` | 25 |
```

The missing line is a dated claim added by #1207 whose regeneration did not ship with it. Counts
are identical before and after (48 + 4 + 38 = 90, 0 malformed), so nothing is added or dropped.
Produced by `python3 scripts/generate_commitment_calendar.py`, no hand edits. Drop the commit if
you would rather it landed separately -- the rest of the branch does not depend on it, though
the CHANGELOG entry cannot be committed without it.

## Notes

* Worktree: `/home/pip/Repos/pdoom1-submenu`. The shared checkout was not touched (playtest
  running in it), and nothing under `art_generated/`, `art_prompts/` or `tools/art_review/` was
  modified.
* Linux userdata isolation confirmed empirically this run: `run_godot_tests.py` sandboxes
  `XDG_DATA_HOME`/`HOME`/`APPDATA`, `test_runner_supplied_a_sandbox` passed, and the real profile
  at `~/.local/share/godot/app_userdata/P(Doom)/` was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
