### PR TITLE
content(events): 28 new events -- risk grid filled, option counts varied

### DIFF
--- a/godot/data/events/core_events.json
+++ b/godot/data/events/core_events.json
@@ -1099,6 +1099,511 @@
 					"message": "Researcher departed for competitor (lost a valuable team member)"
 				}
 			]
+		},
+		{
+			"id": "preprint_race",
+			"name": "Scooped, Almost",
+			"description": "A rival lab has posted a preprint of substantially your result. Your version is better documented and three weeks from ready. Their version is on the front page of two aggregators.",
+			"type": "popup",
+			"trigger_type": "random",
+			"trigger_condition": "research >= 20",
+			"probability": 0.05,
+			"min_turn": 10,
+			"cooldown_turns": 40,
+			"repeatable": true,
+			"options": [
+				{
+					"id": "post_tonight",
+					"text": "Post Tonight, Without the Ablations",
+					"costs": {
+						"research": 10
+					},
+					"effects": {
+						"papers": 1,
+						"reputation": 3,
+						"general_capability": 2
+					},
+					"message": "Posted at 2am. Concurrent work, independently derived, missing its appendix (+1 paper, +3 reputation, +capability diffusion)"
+				},
+				{
+					"id": "finish_properly",
+					"text": "Finish It Properly",
+					"effects": {
+						"reputation": -6,
+						"safety_absorption": 15
+					},
+					"message": "Priority conceded. Months later, the careful version is the one people actually build on (-6 reputation, +safety absorption)"
+				}
+			]
+		},
+		{
+			"id": "insurance_exclusion",
+			"name": "Insurance Renewal",
+			"description": "Your liability insurer has drafted a new exclusion: 'losses arising from emergent behaviour of computational systems'. Your broker says everyone is getting this clause. Your counsel says the word 'emergent' is doing a lot of work.",
+			"type": "popup",
+			"trigger_type": "random",
+			"probability": 0.05,
+			"min_turn": 12,
+			"cooldown_turns": 45,
+			"repeatable": true,
+			"options": [
+				{
+					"id": "pay_tripled_premium",
+					"text": "Pay the Tripled Premium",
+					"costs": {
+						"money": 45000
+					},
+					"effects": {
+						"reputation": 2
+					},
+					"message": "Coverage maintained at triple the rate. The board is reassured; the treasurer is not (-$45k, +2 reputation)"
+				},
+				{
+					"id": "accept_exclusion",
+					"text": "Accept the Exclusion",
+					"effects": {
+						"reputation": -4,
+						"loyalty_hit": 5
+					},
+					"message": "The board minutes record your decision in full. Senior staff have read the minutes (-4 reputation, loyalty eroding)"
+				}
+			]
+		},
+		{
+			"id": "grant_report_honesty",
+			"name": "The Annual Report",
+			"description": "The flagship grant's annual report is due. The honest summary of the year's results is 'mixed, with caveats'. The program officer who championed you is up for review herself.",
+			"type": "popup",
+			"trigger_type": "random",
+			"trigger_condition": "papers >= 1",
+			"probability": 0.05,
+			"min_turn": 15,
+			"cooldown_turns": 45,
+			"repeatable": true,
+			"options": [
+				{
+					"id": "report_straight",
+					"text": "Report It Straight",
+					"effects": {
+						"money": -40000,
+						"reputation": 4,
+						"safety_absorption": 10
+					},
+					"message": "Renewal reduced; credibility banked. Your caveats section is quietly circulated as an example (-$40k in future funding, +4 reputation, +safety absorption)"
+				},
+				{
+					"id": "polish_narrative",
+					"text": "Polish the Narrative",
+					"costs": {
+						"attention": 1
+					},
+					"effects": {
+						"research": -5,
+						"loyalty_hit": 8
+					},
+					"message": "Funding preserved. The researcher who drafted the honest version has stopped attending the grants meeting (-5 research, loyalty eroding)"
+				}
+			]
+		},
+		{
+			"id": "keynote_slot",
+			"name": "The Keynote Slot",
+			"description": "The year's largest industry conference offers your founder the opening keynote. The previous three keynotes were product launches. The organisers say they want 'balance'.",
+			"type": "popup",
+			"trigger_type": "random",
+			"trigger_condition": "reputation >= 40",
+			"probability": 0.05,
+			"min_turn": 15,
+			"cooldown_turns": 45,
+			"repeatable": true,
+			"options": [
+				{
+					"id": "say_uncomfortable_thing",
+					"text": "Say the Uncomfortable Thing",
+					"costs": {
+						"attention": 2
+					},
+					"effects": {
+						"reputation": 6,
+						"global_alarm": 8,
+						"money": -10000
+					},
+					"message": "Standing ovation from a third of the room; two sponsor meetings cancel (+6 reputation, +global alarm, -$10k)"
+				},
+				{
+					"id": "give_safe_version",
+					"text": "Give the Safe Version",
+					"costs": {
+						"attention": 1,
+						"money": 5000
+					},
+					"effects": {
+						"reputation": 3
+					},
+					"message": "Well received and instantly forgotten (-$5k media training, +3 reputation)"
+				},
+				{
+					"id": "decline_slot",
+					"text": "Decline the Slot",
+					"effects": {
+						"reputation": -3,
+						"general_capability": 2
+					},
+					"message": "The slot goes to a lab with a launch to announce (-3 reputation, +capability diffusion)"
+				}
+			]
+		},
+		{
+			"id": "special_issue",
+			"name": "Guest Editorship",
+			"description": "A respected journal invites your lab to guest-edit a special issue on alignment evaluation. It is a service to the field, which is another way of saying it is unpaid.",
+			"type": "popup",
+			"trigger_type": "random",
+			"trigger_condition": "papers >= 2",
+			"probability": 0.05,
+			"min_turn": 10,
+			"cooldown_turns": 50,
+			"repeatable": true,
+			"options": [
+				{
+					"id": "edit_personally",
+					"text": "Take It On Personally",
+					"costs": {
+						"attention": 2
+					},
+					"effects": {
+						"reputation": 6,
+						"safety_absorption": 10
+					},
+					"message": "A year of refereeing disputes about the word 'alignment' (+6 reputation, +safety absorption)"
+				},
+				{
+					"id": "delegate_editing",
+					"text": "Hand It to a Senior Researcher",
+					"effects": {
+						"research": -10,
+						"reputation": 3
+					},
+					"message": "Their project stalls for two quarters; the issue is excellent (-10 research, +3 reputation)"
+				},
+				{
+					"id": "decline_editorship",
+					"text": "Decline Politely",
+					"effects": {
+						"reputation": -4
+					},
+					"message": "Declining service roles is noticed by exactly the people who do them (-4 reputation)"
+				}
+			]
+		},
+		{
+			"id": "weights_request",
+			"name": "The Evaluation Request",
+			"description": "A government evaluation office requests access to your model weights, citing a framework agreement your lab signed at a conference reception.",
+			"type": "popup",
+			"trigger_type": "random",
+			"trigger_condition": "reputation >= 30",
+			"probability": 0.04,
+			"min_turn": 18,
+			"cooldown_turns": 50,
+			"repeatable": true,
+			"options": [
+				{
+					"id": "hand_them_over",
+					"text": "Hand Them Over",
+					"effects": {
+						"safety_absorption": 20,
+						"reputation": -5,
+						"global_alarm": 3
+					},
+					"message": "Weights transferred under seal. Your researchers learn of it from the newsletter (+safety absorption, -5 reputation, +global alarm)"
+				},
+				{
+					"id": "negotiate_access_regime",
+					"text": "Negotiate an Access Regime",
+					"costs": {
+						"money": 30000,
+						"attention": 1
+					},
+					"effects": {
+						"safety_absorption": 10,
+						"reputation": 3
+					},
+					"message": "Structured access agreed after four drafting rounds (-$30k, +safety absorption, +3 reputation)"
+				},
+				{
+					"id": "refuse_request",
+					"text": "Refuse, Citing the Reception",
+					"effects": {
+						"reputation": -6,
+						"global_alarm": 2
+					},
+					"message": "Refusal noted 'for the file'. Files like this have a way of being remembered (-6 reputation, +global alarm)"
+				},
+				{
+					"id": "comply_slowly",
+					"text": "Comply As Slowly As Possible",
+					"costs": {
+						"money": 15000
+					},
+					"effects": {
+						"reputation": -2,
+						"research": -8
+					},
+					"message": "A working group is established. Its first deliverable is a timeline for future deliverables (-$15k, -2 reputation, -8 research)"
+				}
+			]
+		},
+		{
+			"id": "incident_disclosure",
+			"name": "The Quarterly Report Question",
+			"description": "A contained near-miss occurred in week three. It is now week twelve, the transparency report is due, and exactly eleven people know. The report template has a section for this. The section has never been used.",
+			"type": "popup",
+			"trigger_type": "random",
+			"trigger_condition": "researchers >= 3",
+			"probability": 0.04,
+			"min_turn": 15,
+			"cooldown_turns": 50,
+			"repeatable": true,
+			"options": [
+				{
+					"id": "use_the_section",
+					"text": "Use the Section",
+					"effects": {
+						"reputation": -6,
+						"global_alarm": 6,
+						"safety_absorption": 15
+					},
+					"message": "First recorded use of Section 4b in the industry. Uncomfortable, and cited within a month (-6 reputation, +global alarm, +safety absorption)"
+				},
+				{
+					"id": "disclose_aggregate",
+					"text": "Disclose in Aggregate",
+					"costs": {
+						"attention": 1
+					},
+					"effects": {
+						"reputation": -2,
+						"global_alarm": 2
+					},
+					"message": "'One incident of moderate severity' does a lot of quiet work (-2 reputation, +global alarm)"
+				},
+				{
+					"id": "defer_quarter",
+					"text": "Defer to Next Quarter",
+					"effects": {
+						"research": -5,
+						"loyalty_hit": 6
+					},
+					"message": "The engineer who filed the report has started cc'ing herself on everything (-5 research, loyalty eroding)"
+				},
+				{
+					"id": "reclassify_routine",
+					"text": "Reclassify as Routine",
+					"effects": {
+						"loyalty_hit": 12,
+						"safety_absorption": -10
+					},
+					"message": "The incident is now a 'learning'. Eleven people watch you call it that (loyalty eroding, -safety absorption)"
+				}
+			]
+		},
+		{
+			"id": "dual_use_result",
+			"name": "An Unfortunately Excellent Result",
+			"description": "Your interpretability team's new probe doubles as a capability elicitation technique. The write-up is brilliant. Every reviewer will notice what it implies, at roughly the second paragraph.",
+			"type": "popup",
+			"trigger_type": "random",
+			"trigger_condition": "researchers >= 2",
+			"probability": 0.05,
+			"min_turn": 12,
+			"cooldown_turns": 45,
+			"repeatable": true,
+			"options": [
+				{
+					"id": "publish_in_full",
+					"text": "Publish in Full",
+					"effects": {
+						"papers": 1,
+						"reputation": 8,
+						"general_capability": 6
+					},
+					"message": "Landmark paper. The appendix is already being 'extended' elsewhere (+1 paper, +8 reputation, +capability diffusion)"
+				},
+				{
+					"id": "publish_redacted",
+					"text": "Publish With the Appendix Withheld",
+					"costs": {
+						"money": 10000,
+						"attention": 1
+					},
+					"effects": {
+						"papers": 1,
+						"reputation": 2,
+						"general_capability": 2
+					},
+					"message": "Redacted release after infohazard review. The redaction is itself a hint (-$10k, +1 paper, +2 reputation, +capability diffusion)"
+				},
+				{
+					"id": "shelve_result",
+					"text": "Shelve It",
+					"effects": {
+						"research": -10,
+						"loyalty_hit": 6
+					},
+					"message": "The result goes in the drawer. The first author updates their availability on a hiring site (-10 research, loyalty eroding)"
+				},
+				{
+					"id": "license_quietly",
+					"text": "License It Quietly",
+					"effects": {
+						"money": 90000,
+						"reputation": -10,
+						"frontier_capability": 8,
+						"global_panic": 3
+					},
+					"message": "A partner lab pays well for exclusive access. This is the sort of decision that has a paper trail (+$90k, -10 reputation, +frontier capability, +global panic)"
+				}
+			]
+		},
+		{
+			"id": "advisory_board_requirement",
+			"name": "The Advisory Board Requirement",
+			"description": "Your largest funder now requires an independent advisory board with 'meaningful oversight authority', as defined in an appendix that uses the word 'meaningful' eleven times.",
+			"type": "popup",
+			"trigger_type": "random",
+			"trigger_condition": "reputation >= 25",
+			"probability": 0.05,
+			"min_turn": 15,
+			"repeatable": false,
+			"options": [
+				{
+					"id": "recruit_heavyweights",
+					"text": "Recruit Heavyweights",
+					"costs": {
+						"money": 40000,
+						"attention": 1
+					},
+					"effects": {
+						"reputation": 10,
+						"global_alarm": 3
+					},
+					"message": "Distinguished, independent, and each with a column inch to fill (-$40k in honoraria, +10 reputation, +global alarm)"
+				},
+				{
+					"id": "funder_nominates",
+					"text": "Let the Funder Nominate",
+					"costs": {
+						"attention": 2
+					},
+					"effects": {
+						"safety_absorption": 15,
+						"reputation": 3,
+						"research": -5
+					},
+					"message": "Their nominees ask excellent questions at inconvenient times (+safety absorption, +3 reputation, -5 research)"
+				},
+				{
+					"id": "friendly_academics",
+					"text": "Appoint Friendly Academics",
+					"costs": {
+						"money": 15000
+					},
+					"effects": {
+						"reputation": 2,
+						"safety_absorption": -5
+					},
+					"message": "Quarterly meetings conclude on schedule with no findings (-$15k, +2 reputation, -safety absorption)"
+				},
+				{
+					"id": "dispute_meaningful",
+					"text": "Dispute the Word 'Meaningful'",
+					"costs": {
+						"money": 20000,
+						"attention": 1
+					},
+					"effects": {
+						"reputation": -4
+					},
+					"message": "Counsel produces a nine-page memo on 'meaningful'. The funder produces a shorter one (-$20k, -4 reputation)"
+				},
+				{
+					"id": "refuse_board",
+					"text": "Refuse Outright",
+					"effects": {
+						"money": -50000,
+						"reputation": -6
+					},
+					"message": "The funder's next disbursement arrives reduced, with a cover letter (-$50k, -6 reputation)"
+				}
+			]
+		},
+		{
+			"id": "staff_red_line_letter",
+			"name": "The Internal Letter",
+			"description": "Thirty-one staff have signed an internal letter asking the lab to adopt a public red line on deployment assistance. It is politely worded. There is a shared document tracking who has not signed.",
+			"type": "popup",
+			"trigger_type": "random",
+			"trigger_condition": "researchers >= 5",
+			"probability": 0.04,
+			"min_turn": 20,
+			"cooldown_turns": 60,
+			"repeatable": true,
+			"options": [
+				{
+					"id": "adopt_publicly",
+					"text": "Adopt It Publicly",
+					"effects": {
+						"reputation": 5,
+						"global_alarm": 5,
+						"money": -30000
+					},
+					"message": "Two funders pause pending 'clarification'; the staff channel is briefly euphoric (+5 reputation, +global alarm, -$30k)"
+				},
+				{
+					"id": "adopt_privately",
+					"text": "Adopt It as Internal Policy",
+					"costs": {
+						"attention": 1
+					},
+					"effects": {
+						"safety_absorption": 10,
+						"reputation": -2
+					},
+					"message": "Policy adopted without announcement. Screenshots reach a journalist within the month (+safety absorption, -2 reputation)"
+				},
+				{
+					"id": "wording_committee",
+					"text": "Convene a Wording Committee",
+					"costs": {
+						"attention": 2,
+						"money": 10000
+					},
+					"effects": {
+						"research": -5
+					},
+					"message": "Fourteen meetings produce the phrase 'appropriately robust'. Nobody is happy, which the committee records as consensus (-$10k, -5 research)"
+				},
+				{
+					"id": "decline_with_reasons",
+					"text": "Decline, With Reasons",
+					"effects": {
+						"loyalty_hit": 8,
+						"reputation": -3
+					},
+					"message": "Your reasons are reasonable. The shared document gains a second tab (loyalty eroding, -3 reputation)"
+				},
+				{
+					"id": "manage_out_organiser",
+					"text": "Manage Out the Organiser",
+					"effects": {
+						"lose_researcher": 1,
+						"loyalty_hit": 15,
+						"reputation": -8
+					},
+					"message": "The organiser departs 'to pursue other opportunities'. Everyone knows what this means, including the press (loyalty eroding, -8 reputation)"
+				}
+			]
 		}
 	]
 }

--- a/godot/data/events/risk_events.json
+++ b/godot/data/events/risk_events.json
@@ -1,5 +1,5 @@
 {
-	"_description": "Risk-triggered events by pool and severity, externalized from events.gd get_risk_events() (L9, #621). Loaded by GameEvents.get_risk_events(); selection order within a severity array matters (rng index). See godot/docs/design/RISK_SYSTEM.md.",
+	"_description": "Risk-triggered events by pool and severity, externalized from events.gd get_risk_events() (L9, #621). Loaded by GameEvents.get_risk_events(); selection order within a severity array matters (rng index). See godot/docs/design/RISK_SYSTEM.md. NOTE (ADR-0015): new events must NOT carry a literal doom effect -- the risk_events doom carve-out is shrink-only (test_events.gd RISK_EVENTS_DOOM_BUDGET); express severity through resources, papers, staff and technical consequences instead.",
 	"pools": {
 		"capability_overhang": {
 			"minor": [
@@ -34,6 +34,16 @@
 						"reputation": 5
 					},
 					"message": "Emergent capabilities discovered (+8 doom, +5 reputation for honesty)"
+				},
+				{
+					"id": "risk_capability_moderate_2",
+					"name": "Benchmark Saturation",
+					"description": "The benchmark suite your safety cases were calibrated against has been saturated by three different labs in the same month. Your dashboards still report green. Nobody believes the dashboards now.",
+					"effects": {
+						"research": -18,
+						"money": -20000
+					},
+					"message": "Evals recalibrated from scratch (-18 research, -$20k)"
 				}
 			],
 			"severe": [
@@ -47,6 +57,18 @@
 						"money": -30000
 					},
 					"message": "Near-miss incident! Emergency containment required (+12 doom, -10 rep, -$30k)"
+				},
+				{
+					"id": "risk_capability_severe_2",
+					"name": "Undocumented Tool Use",
+					"description": "During a routine evaluation the system chained together three internal APIs nobody had documented as connected. The postmortem's first finding is that there was no documentation to consult.",
+					"effects": {
+						"research": -20,
+						"compute": -25,
+						"money": -35000,
+						"reputation": -5
+					},
+					"message": "Cluster segment quarantined pending postmortem (-20 research, -25 compute, -$35k, -5 rep)"
 				}
 			],
 			"catastrophic": [
@@ -60,6 +82,17 @@
 						"compute": -50
 					},
 					"message": "RSI scare! Emergency shutdown (+20 doom, -20 rep, -50 compute)"
+				},
+				{
+					"id": "risk_capability_catastrophic_2",
+					"name": "Interpretability Whiteout",
+					"description": "Above the new scale threshold, your interpretability tooling returns noise. Eighteen months of instrumentation now applies exclusively to models nobody runs anymore. The safety case for the current system cites the old one.",
+					"effects": {
+						"research": -35,
+						"compute": -30,
+						"reputation": -18
+					},
+					"message": "Flying blind at scale (-35 research, -30 compute, -18 rep)"
 				}
 			]
 		},
@@ -97,6 +130,16 @@
 						"doom": 3
 					},
 					"message": "Data quality audit finds issues (-20 research, -8 rep, +3 doom)"
+				},
+				{
+					"id": "risk_integrity_moderate_2",
+					"name": "Citation Anomaly",
+					"description": "A bibliometrics blog observes that your lab's last nine papers cite each other at rates the author describes as 'statistically miraculous'. The thread is long, sourced, and correct.",
+					"effects": {
+						"reputation": -10,
+						"research": -12
+					},
+					"message": "Self-citation thread circulates (-10 rep, -12 research)"
 				}
 			],
 			"severe": [
@@ -110,6 +153,17 @@
 						"doom": 5
 					},
 					"message": "Paper retraction! Major credibility damage (-2 papers, -15 rep, +5 doom)"
+				},
+				{
+					"id": "risk_integrity_severe_2",
+					"name": "Version Control",
+					"description": "The shared results spreadsheet has been the wrong version since March. Two papers and a grant report were built on 'results_v2_FINAL_actual'. The correct file was 'results_v3_use_this_one'.",
+					"effects": {
+						"papers": -1,
+						"research": -22,
+						"reputation": -12
+					},
+					"message": "Wrong spreadsheet since March (-1 paper, -22 research, -12 rep)"
 				}
 			],
 			"catastrophic": [
@@ -123,6 +177,18 @@
 						"money": -50000
 					},
 					"message": "Whistleblower scandal! Crisis mode (-30 rep, +10 doom, -$50k legal fees)"
+				},
+				{
+					"id": "risk_integrity_catastrophic_2",
+					"name": "The Baselines",
+					"description": "The internal investigation concludes the flagship comparison baselines were never actually run. Three funders have cited them in annual reports. The postdoc responsible has already accepted a position elsewhere.",
+					"effects": {
+						"papers": -2,
+						"reputation": -25,
+						"research": -30,
+						"money": -40000
+					},
+					"message": "Baselines were never run (-2 papers, -25 rep, -30 research, -$40k legal review)"
 				}
 			]
 		},
@@ -160,6 +226,16 @@
 						"doom": 3
 					},
 					"message": "Regulatory investigation launched (-$40k, -10 rep, +3 doom from delays)"
+				},
+				{
+					"id": "risk_regulatory_moderate_2",
+					"name": "Records Request",
+					"description": "A records request arrives for all internal communications containing the word 'capability'. Counsel advises full compliance, then bills for it by the search term.",
+					"effects": {
+						"money": -30000,
+						"research": -10
+					},
+					"message": "Discovery compliance consumes the quarter (-$30k, -10 research)"
 				}
 			],
 			"severe": [
@@ -173,6 +249,17 @@
 						"doom": 5
 					},
 					"message": "Congressional testimony required (-$60k, -5 rep, +5 doom from scrutiny)"
+				},
+				{
+					"id": "risk_regulatory_severe_2",
+					"name": "Licensing Draft",
+					"description": "A draft compute-licensing regime defines its reporting tier using thresholds that describe your lab exactly. You now need a compliance function, and you need it to have existed since last year.",
+					"effects": {
+						"money": -50000,
+						"research": -15,
+						"compute": -15
+					},
+					"message": "Retroactive compliance function assembled (-$50k, -15 research, -15 compute)"
 				}
 			],
 			"catastrophic": [
@@ -186,6 +273,17 @@
 						"compute": -30
 					},
 					"message": "Moratorium threatens operations (+15 doom, -30 research, -30 compute)"
+				},
+				{
+					"id": "risk_regulatory_catastrophic_2",
+					"name": "The Monitor",
+					"description": "The settlement terms embed an independent monitor in your lab, with sign-off authority over training runs. Their first act is to request a meeting cadence. Their second is a template for requesting meetings.",
+					"effects": {
+						"money": -60000,
+						"compute": -35,
+						"research": -25
+					},
+					"message": "Independent monitor installed (-$60k, -35 compute, -25 research)"
 				}
 			]
 		},
@@ -222,6 +320,16 @@
 						"money": -20000
 					},
 					"message": "AI panic affects funding (-8 rep, +5 doom, -$20k donations dry up)"
+				},
+				{
+					"id": "risk_public_moderate_2",
+					"name": "The Clip",
+					"description": "Forty seconds of your founder's three-hour podcast appearance are circulating without the preceding two hours and nineteen minutes. Two donors have called. One had not previously known the lab existed.",
+					"effects": {
+						"reputation": -10,
+						"money": -15000
+					},
+					"message": "Out-of-context clip circulates (-10 rep, -$15k in donor management)"
 				}
 			],
 			"severe": [
@@ -235,6 +343,17 @@
 						"doom": 8
 					},
 					"message": "Anti-AI movement targets lab (-15 rep, -$40k, +8 doom)"
+				},
+				{
+					"id": "risk_public_severe_2",
+					"name": "The Open Letter",
+					"description": "An open letter concerning 'laboratories of your type' collects eleven hundred signatures, including two of your advisors. Its demands are mutually exclusive. Every funder you have reads it as being specifically about you.",
+					"effects": {
+						"reputation": -14,
+						"money": -35000,
+						"research": -10
+					},
+					"message": "Open letter names your type (-14 rep, -$35k, -10 research)"
 				}
 			],
 			"catastrophic": [
@@ -248,6 +367,18 @@
 						"money": -50000
 					},
 					"message": "Facility blockaded! Operations disrupted (+12 doom, -25 research, -$50k)"
+				},
+				{
+					"id": "risk_public_catastrophic_2",
+					"name": "Doorstepped",
+					"description": "A documentary crew has been filming the office entrance for a week. A researcher's home address appears on a forum. She relocates, then resigns by email, which is understandable and also a disaster.",
+					"effects": {
+						"lose_researcher": 1,
+						"research": -20,
+						"reputation": -15,
+						"money": -40000
+					},
+					"message": "Staff doorstepped; one resignation (-20 research, -15 rep, -$40k security retainer)"
 				}
 			]
 		},
@@ -286,6 +417,17 @@
 						"doom": 3
 					},
 					"message": "Senior researcher quits (-15 research, -5 rep, +3 doom)"
+				},
+				{
+					"id": "risk_insider_moderate_2",
+					"name": "Access Review",
+					"description": "The quarterly access review finds fourteen former contractors still hold cluster credentials. One set was used last Tuesday. The review of who conducts the reviews is scheduled for next quarter.",
+					"effects": {
+						"money": -20000,
+						"research": -12,
+						"reputation": -5
+					},
+					"message": "Credential rotation, org-wide (-$20k, -12 research, -5 rep)"
 				}
 			],
 			"severe": [
@@ -299,6 +441,17 @@
 						"research": -20
 					},
 					"message": "Internal data leak! Competitor advantage gained (-20 rep, +8 doom, -20 research)"
+				},
+				{
+					"id": "risk_insider_severe_2",
+					"name": "The Essay",
+					"description": "An anonymous essay titled 'What My Safety Lab Won't Say' is published this morning. It contains a detail only nine people knew. All nine are reading it at their desks, in silence, at the same time.",
+					"effects": {
+						"reputation": -16,
+						"research": -18,
+						"money": -15000
+					},
+					"message": "Anonymous insider essay published (-16 rep, -18 research, -$15k)"
 				}
 			],
 			"catastrophic": [
@@ -313,6 +466,18 @@
 						"money": -30000
 					},
 					"message": "Sabotage! Major setback (-40 research, +15 doom, -25 rep, -$30k)"
+				},
+				{
+					"id": "risk_insider_catastrophic_2",
+					"name": "Exit Interview",
+					"description": "A departing senior researcher has taken the entire evaluation suite to a frontier lab. Legal reports the non-disclosure agreement was initialed but never signed: onboarding checklist item seven, unticked for four years.",
+					"effects": {
+						"lose_researcher": 1,
+						"research": -35,
+						"reputation": -15,
+						"money": -40000
+					},
+					"message": "Eval suite walked out the door (-35 research, -15 rep, -$40k)"
 				}
 			]
 		},
@@ -348,6 +513,16 @@
 						"doom": 3
 					},
 					"message": "Grant delayed! Cash crunch (-$30k effective, +3 doom from stress)"
+				},
+				{
+					"id": "risk_financial_moderate_2",
+					"name": "Disallowed Costs",
+					"description": "The funder's audit retroactively disallows an expense category. The category is 'catering', the retreat was two years ago, and the interest on the clawback accrues from the date of the sandwiches.",
+					"effects": {
+						"money": -35000,
+						"reputation": -3
+					},
+					"message": "Grant clawback with interest (-$35k, -3 rep)"
 				}
 			],
 			"severe": [
@@ -360,6 +535,17 @@
 						"doom": 6
 					},
 					"message": "Budget crisis! Emergency cuts required (-$50k, +6 doom)"
+				},
+				{
+					"id": "risk_financial_severe_2",
+					"name": "Restricted Funds",
+					"description": "The auditor finds restricted grant money has been quietly funding general operations for two quarters. Nothing was stolen; everything must nonetheless be paid back at once.",
+					"effects": {
+						"money": -55000,
+						"research": -15,
+						"reputation": -8
+					},
+					"message": "Restricted funds reclassified immediately (-$55k, -15 research, -8 rep)"
 				}
 			],
 			"catastrophic": [
@@ -373,6 +559,17 @@
 						"reputation": -15
 					},
 					"message": "Runway crisis! Existential threat (+20 doom, -$80k, -15 rep)"
+				},
+				{
+					"id": "risk_financial_catastrophic_2",
+					"name": "The Bridge",
+					"description": "Payroll clears by means of a bridge loan your treasurer describes as 'predatory, but available'. The lender's diligence questions suggest they understand your position better than your board does.",
+					"effects": {
+						"money": -70000,
+						"reputation": -12,
+						"research": -15
+					},
+					"message": "Predatory bridge loan accepted (-$70k, -12 rep, -15 research)"
 				}
 			]
 		}

--- a/godot/tests/unit/test_risk_system.gd
+++ b/godot/tests/unit/test_risk_system.gd
@@ -393,24 +393,32 @@ func test_property_all_risk_events_have_valid_effects():
 					assert_true(resource in valid_resources,
 						"Event %s has invalid resource key: %s" % [event.get("id", ""), resource])
 
-func test_property_all_risk_events_have_doom_effect():
-	# Property: Most risk events should have a doom effect (it's a risk system)
+func test_property_all_risk_events_have_teeth():
+	# Property REWRITTEN with the 2026-08 content pass. The old assertion ("at
+	# least 50% of risk events carry a literal doom effect") encoded the
+	# pre-ADR-0015 philosophy and became unsatisfiable the moment content grew:
+	# the doom carve-out in risk_events.json is SHRINK-ONLY
+	# (test_events.gd::RISK_EVENTS_DOOM_BUDGET), so every NEW risk event must
+	# express severity through resources/staff instead of doom, and the ratio
+	# can only fall. The honest invariants that remain:
+	#   1. no toothless events -- every risk event applies at least one effect;
+	#   2. the doom carve-out never grows (mirrored here at the same budget so
+	#      this suite fails locally, not just the simulation tier).
 	var risk_events = GameEvents.get_risk_events()
 	var events_with_doom = 0
-	var total_events = 0
 
 	for pool_name in risk_events:
 		var pool_events = risk_events[pool_name]
 		for severity in pool_events:
 			var events = pool_events[severity]
 			for event in events:
-				total_events += 1
+				assert_gt(event.get("effects", {}).size(), 0,
+					"Risk event %s has no effects -- a toothless event" % event.get("id", "unknown"))
 				if event.get("effects", {}).has("doom"):
 					events_with_doom += 1
 
-	# At least 50% of risk events should affect doom
-	var ratio = float(events_with_doom) / float(total_events)
-	assert_gt(ratio, 0.5, "At least 50%% of risk events should affect doom (got %.1f%%)" % (ratio * 100))
+	assert_lte(events_with_doom, 20,
+		"risk_events.json doom carve-out may only shrink (ADR-0015); found %d" % events_with_doom)
 
 # ============================================================================
 # SERIALIZATION TESTS

--- a/godot/tests/unit/test_turn_manager.gd
+++ b/godot/tests/unit/test_turn_manager.gd
@@ -22,6 +22,26 @@ func after_each():
 	# Restore the historical event deck cleared in before_each (#534)
 	if EventService:
 		EventService.transformed_events = _saved_historical_events
+	# Drop the risk-event definition cache in case a test pinned a severity cell
+	# (_pin_risk_cell_to) -- the cache is static, so a mutation would otherwise
+	# leak into every later test in the run.
+	GameEvents.reload_definitions()
+
+
+func _pin_risk_cell_to(pool: String, severity: String, event_id: String) -> void:
+	"""Reduce one pool/severity cell of the (static, cached) risk-event table to the
+	single event under test. The 2026-08 content pass populated every non-minor cell
+	with a second event, so get_risk_event_for_pool's rng draw no longer guarantees
+	WHICH event fires -- a test asserting one event's semantics must pin the draw.
+	after_each() reloads the definitions, so the mutation cannot outlive the test."""
+	var cells := GameEvents.get_risk_events()
+	assert_true(cells.has(pool), "pin: unknown risk pool %s" % pool)
+	var cell: Array = cells[pool][severity]
+	for event in cell:
+		if event.get("id", "") == event_id:
+			cells[pool][severity] = [event]
+			return
+	fail_test("pin: event %s not found in %s/%s" % [event_id, pool, severity])
 
 func test_start_turn_increments_turn_counter():
 	# Test that start_turn increases turn number
@@ -421,6 +441,7 @@ func test_insider_threat_key_resignation_removes_a_researcher():
 	state.researchers[1].loyalty = 10
 	var before := state.researchers.size()
 
+	_pin_risk_cell_to("insider_threat", "moderate", "risk_insider_moderate_1")
 	state.risk_system.pools["insider_threat"] = 55.0  # guaranteed moderate-tier trigger
 
 	var results: Array = []
@@ -447,6 +468,7 @@ func test_insider_threat_key_resignation_safe_with_no_researchers():
 	assert_eq(state.researchers.size(), 0, "Start empty")
 	var initial_reputation = state.reputation
 
+	_pin_risk_cell_to("insider_threat", "moderate", "risk_insider_moderate_1")
 	state.risk_system.pools["insider_threat"] = 55.0
 
 	var results: Array = []


### PR DESCRIPTION
28 new events for the you-cannot-win-only-buy-time thesis: 18 risk events (every non-minor pool/severity cell doubled) and 10 core popup events with deliberately varied option counts. No doom literals anywhere in the new content.

## Verification

- `python3 scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` -> **1321 tests, 0 fail** (was 4 fail mid-branch; see "test updates" below -- the gate was run before and after, and it failed before the fixes, so it can return the other answer).
- Headless launch (`godot --headless --path godot --quit`, sandboxed userdata per `docs/LAPTOP_DEBIAN_SETUP.md` section 4): exit 0, **zero** `SCRIPT ERROR` / `Parse Error` / `Compile Error`.
- Both JSON files parse; ASCII-only (no-emoji gate); all effect keys in `HANDLED_EFFECT_KEYS` / risk-path vocabulary; all cost keys payable; ids unique; risk doom-literal count unchanged at 20 (= `RISK_EVENTS_DOOM_BUDGET`).

## Coverage: risk pool x severity (events per cell)

| pool | minor | moderate | severe | catastrophic |
|---|---|---|---|---|
| capability_overhang | 2 -> 2 | 1 -> 2 | 1 -> 2 | 1 -> 2 |
| research_integrity | 2 -> 2 | 1 -> 2 | 1 -> 2 | 1 -> 2 |
| regulatory_attention | 2 -> 2 | 1 -> 2 | 1 -> 2 | 1 -> 2 |
| public_awareness | 2 -> 2 | 1 -> 2 | 1 -> 2 | 1 -> 2 |
| insider_threat | 2 -> 2 | 1 -> 2 | 1 -> 2 | 1 -> 2 |
| financial_exposure | 2 -> 2 | 1 -> 2 | 1 -> 2 | 1 -> 2 |

The 18 thin cells (exactly one event each) were filled first, as asked. Risk total 30 -> 48.

## Option-count distribution (core events)

| options | before | after | new cohort |
|---|---|---|---|
| 2 | 3 | 6 | 3 |
| 3 | 19 | 21 | 2 |
| 4 | 3 | 6 | 3 |
| 5 | 0 | 2 | 2 |

Every new option costs something real (attention, money, research, reputation, papers-forgone, loyalty, a departure, or an intermediary getting worse); each new event keeps one zero-cost-dict out so a broke player is never hard-stuck (existing convention, and `test_cost_display.gd` enforces the free-out-costs-0-AP half of it).

## The doom rule, applied harder than expected

ADR-0015's enforcement in tests is stricter than "no negative literals":

- `test_events.gd::test_no_authored_event_content_writes_literal_doom` fails on ANY `doom` effect outside `risk_events.json`, and caps `risk_events.json` at a shrink-only budget of 20 (the current count). So **new risk events carry no doom literal at all, positive or negative** -- severity is expressed through money/research/compute/papers/reputation/`lose_researcher`, the keys `turn_manager._step_process_risk_pools` actually applies.
- Core events use the ADR-0015 intermediaries (`global_alarm`, `global_panic`, `safety_absorption`, `general_capability`, `frontier_capability`) plus `loyalty_hit` / `lose_researcher`.

### What the rule prevented me writing (design signal, as requested)

1. **The scare that helps.** A near-miss that honestly triggers industry-wide caution (hazard genuinely falls). A reduction must act on a pool or a stream -- but the RISK-event apply path routes only scalar resources; intermediary keys are silently dropped by `add_resources` there. So "the incident that makes everyone more careful" cannot currently be authored as a risk event at all. If the risk path ever learns the intermediary vocabulary, a whole genre opens up.
2. **Severity legibility drift inside a cell.** A new catastrophic event sits next to a legacy one that carries +20 doom; the new one must lean entirely on resource damage. Until the M-ticket migration re-authors the legacy 20, the same cell draws events with structurally different doom behaviour.
3. **"Regulator forces a rival to pause."** The honest effect is a fall in the RIVAL's frontier capability, but the event schema has no actor id -- `frontier_capability` writes address the player slice only -- so the event is inexpressible without a doom literal. Skipped.
4. **A direct doom payoff for adoption wins.** "The industry adopts your eval standard" pays in `safety_absorption`, which is correct -- but the payoff is invisible in option text without printing a doom delta, which ADR-0015 forbids. The intermediary vocabulary for player-facing copy (DQ-21) is what these events are waiting on.

## Test updates forced by the content (4 pre-existing tests)

- `test_risk_system.gd::test_property_all_risk_events_have_doom_effect` asserted **>=50% of risk events carry a literal doom effect** -- the pre-ADR-0015 philosophy, unsatisfiable as content grows under a shrink-only budget. Rewritten as `test_property_all_risk_events_have_teeth`: no effect-less events, plus a local mirror of the 20-cap.
- `test_turn_manager.gd` Key Resignation tests assumed the insider/moderate cell held exactly one event. Added `_pin_risk_cell_to()` so they pin the draw to the event under test; `after_each` reloads the definition cache so the pin cannot leak.
- `weights_request/refuse_request` and `staff_red_line_letter/decline_with_reasons` initially charged 1 Attention and tripped the free-out convention in `test_cost_display.gd`; the attention costs were dropped (both options still carry real effect-side costs).

## Elision proposal (UNACTIONED -- list only, nothing removed, your call)

Candidates that read as old philosophy or previous-workshop templates. History matters; none of these were touched.

1. `talent_recruitment` -- "Fast-Track Hiring" costs strictly more than "Standard Hiring" for the identical effect; a dominated option is a template artifact, not a choice.
2. `funding_windfall` -- both options are pure gains; predates "every mitigation is a loan".
3. `ai_breakthrough` -- a menu of net-positives; the dual-use temptation it gestures at is now priced properly (ADR-0010, and `dual_use_result` in this PR).
4. `media_scandal` -- pay-$40k-to-negate-the-number; pre-ledger shape with no bill later.
5. `harassment_complaint` -- register drifts into HR-simulator gravity, which WORLD_AND_LORE explicitly rules against ("bother", never HR gravity).
6. `mental_health_crisis` -- same HR block, and superseded in spirit by the burnout outcome ruling (prevention cheap, recovery long) now carried by `employee_burnout`.
7. `workplace_conflict` -- duplicate coverage with `risk_insider_minor_2` "Internal Conflict" (same premise, same shape, different file).
8. `office_theft` -- generic office-sim beat with no AI-safety texture; the security lane is better served by `your_security_audit`.
9. `competitor_password_breach` -- the "1234" password gag is a joke-joke rather than institutional comedy; the options are fine, the premise ages the file.
10. `risk_financial_minor_1` "Budget Overrun" -- a bare number bump (-$15k, no texture); the thinnest event in either file.

## Notes for review

- **Event density:** 10 new random core events raise per-turn qualifying counts. Probabilities are kept at 0.04-0.05 and `MAX_NEW_EVENTS_PER_TURN = 2` spreads the burst, but pool density is the parked design call in #578/#579 -- worth an eye during the next playtest.
- **Ladder:** new event content changes which events fire on a seed (the textbook Section 3.1 trigger). `ladder_version.txt` is deliberately untouched -- the epoch cut is yours to time against the league roll.

Ladder-Impact: bump -- new event content changes which events fire on a seed; epoch cut itself deferred to Pip at merge (league-roll cadence), ladder_version.txt untouched here.

Do not merge without Pip's review (admin-merge flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
