### PR TITLE
feat(ui): the month review as a clipboard -- 3x the area, typeset, no longer covering the feed

### DIFF
--- a/godot/UI_STYLE_GUIDE.md
+++ b/godot/UI_STYLE_GUIDE.md
@@ -229,6 +229,57 @@ have split two adjacent headers. Sizes there are likewise NOT read from
 panel height is hand-authored and test-guarded against its contents -- a theme
 swap would push the content past a box no test run could have seen.
 
+### The diegetic register: the month review clipboard
+
+`MonthReviewPanel` (`scripts/ui/month_review_panel.gd`) is the first surface
+that is an OBJECT rather than a panel -- Pip, 2026-08-14: "the month review
+screen could come in, like, clipboard form or some other diegetic form", the
+same instinct as the 2026-08-12 "semi-diegetic" calendar ruling. Expect more of
+these; this is the register they should share.
+
+Diegetic here does NOT mean photorealistic. The rules that made it work:
+
+- **It is still the terminal register.** Every word on the sheet is set in
+  `TerminalTheme.mono_font()`, the same family as the WATCH feed and the plan
+  screen. A paper object typeset in a proportional face would have left the
+  world the rest of the UI implies.
+- **Paper stays DIM.** `PAPER_TINT` takes the sheet art down to office-light
+  manila. A scanned-document white next to this palette reads as a browser
+  window, not as a thing on a desk. Same for the board: `BOARD_TINT` takes
+  stained plywood down to furniture.
+- **A drop shadow is what makes it an object,** not the colour. The board
+  carries `shadow_size 26` at `Color(0,0,0,0.60)`; without it the panel reads
+  as a rectangle again whatever is painted on it. Corollary: never set
+  `clip_contents` on the panel itself to crop its surface art -- that clips the
+  panel's own stylebox and takes the shadow with it. Put the texture in a
+  clipping child (see `_add_surface`).
+- **Surface art goes in as a `TextureRect` ground, `KEEP_ASPECT_COVERED`, not
+  tiled.** Both surface textures carry a distinctive coffee ring; tiling a
+  512px square across a 1100px sheet prints the ring twice and announces the
+  texture as wallpaper.
+- **Ink is a separate palette from the dark-panel palette.** `INK_GOOD` /
+  `INK_BAD` are the printed renderings of main_ui's `_DELTA_GOOD` /
+  `_DELTA_BAD` -- same MEANING (favourable green, adverse red, doom
+  sign-inverted), remixed because colours tuned to survive a near-black panel
+  go washy on manila. If you build another paper surface, take the inks from
+  `MonthReviewPanel`, not from the HUD.
+- **Overlays on textured art must be translucent.** `PAPER_SHADE` (the
+  attention callout's wash) is `alpha 0.10`; an opaque box punched into the
+  sheet reads as a widget stuck on the paper rather than a rule printed on it.
+- **Keep the controls off the paper.** The forward-door button sits on the
+  BOARD below the sheet, which preserves its B2/B3 teal-on-dark primary chrome
+  -- teal ink on manila is unreadable.
+
+Type on this panel is +2..+4pt over the generic event dialog (body 16 -> 19,
+small 14 -> 17, button 16 -> 20) per Pip's 2026-08-14 note; the masthead is the
+declared exception at 18 -> 24. This is a per-panel bump, NOT a global sweep.
+
+Surface art currently used, both pre-existing and previously unreferenced:
+`res://assets/textures/surfaces/tex_plywood_stained_512.png` (board) and
+`res://assets/textures/surfaces/tex_grid_graphpaper_aged_512.png` (sheet).
+Both are single-const slots so a purpose-drawn clipboard swaps in without
+touching the layout.
+
 ---
 
 ## 4. Spacing & Layout

--- a/godot/scripts/game_manager.gd
+++ b/godot/scripts/game_manager.gd
@@ -804,10 +804,22 @@ func _finish_month_playback() -> void:
 	# INFORMATION." The Funds/Doom/Staff LEVEL line is gone -- the top bar owns funds, the doom
 	# meter owns doom, the roster owns staff. What the HUD cannot show is what MOVED over the
 	# month, so that is all this block prints, and only for stats that actually moved.
-	var body := "%s begins.\n\nAttention: %d fresh decisions this month (last month's unspent reserve evaporated -- no banking).%s%s" % [
-		label, attention_now,
-		_build_month_movement_section(_month_stat_snapshot, end_stats),
-		_build_rivals_review_section()]
+	#
+	# The two blocks are COLLECTED as rows and then formatted, rather than built straight to
+	# text, because the review now has two consumers: the feed record (text, below) and the
+	# clipboard presenter (MonthReviewPanel, which needs the parts separately so a delta can be
+	# coloured and right-aligned instead of living inside a sentence). Collect-then-format keeps
+	# one source for both -- the strings below are assembled from the SAME rows the panel draws,
+	# so the two can never drift. Collection also runs exactly ONCE per boundary: the rivals
+	# collector advances _rival_cap_snapshot, so calling it twice would report every rival flat.
+	var attention_line := "Attention: %d fresh decisions this month (last month's unspent reserve evaporated -- no banking)." % attention_now
+	var movement_rows := _collect_month_movement_rows(_month_stat_snapshot, end_stats)
+	var rival_rows := _collect_rivals_review_rows()
+	var closing_line := "Queue this month's actions, then press COMMIT THE MONTH to play the month out."
+	var body := "%s begins.\n\n%s%s%s" % [
+		label, attention_line,
+		_format_month_movement_section(movement_rows),
+		_format_rivals_review_section(rival_rows)]
 
 	var review := {
 		"id": MONTH_REVIEW_EVENT_ID,
@@ -816,11 +828,27 @@ func _finish_month_playback() -> void:
 		# commit (end_month() below, the EndTurnButton node); the BUTTON is labelled
 		# "COMMIT THE MONTH >". This popup is the most-repeated instruction in the game -- once a
 		# month, every month -- so it was also the most-repeated wrong one.
-		"description": "%s\n\nQueue this month's actions, then press COMMIT THE MONTH to play the month out." % body,
+		"description": "%s\n\n%s" % [body, closing_line],
 		"type": "popup",
 		"options": [
 			{"id": "begin_planning", "text": "Begin planning %s" % label, "costs": {}, "effects": {}}
 		],
+		# PRESENTATION PAYLOAD -- the same content as "description", handed over pre-split so the
+		# clipboard presenter can typeset it (MonthReviewPanel.build). Every string in here is
+		# already in "description"; nothing is computed for the panel that the text does not also
+		# say. A presenter that ignores this key still renders the full review from "description",
+		# which is what every non-review event dialog does.
+		"review": {
+			"heading": "Month Review",
+			"period": label,
+			"lede": "%s begins." % label,
+			"attention": attention_line,
+			"movement_title": "Last month's movement",
+			"movement": movement_rows,
+			"rivals_title": "Rivals this month",
+			"rivals": rival_rows,
+			"closing": closing_line,
+		},
 	}
 	# A10: the review is also the WATCH feed's permanent record, so dismissing the popup costs
 	# the player nothing and months can be compared by scrolling back. Emitted BEFORE the popup
@@ -853,30 +881,78 @@ func _build_month_movement_section(start_stats: Dictionary, end_stats: Dictionar
 	about how doom works; per-cause attribution stays behind the paid doom-breakdown instrument
 	(ADR-0001, spending-buys-sight). A start/end band comparison is world-state display, using
 	ThemeManager's canonical band labels -- the same non-color channel the HUD already uses."""
+	return _format_month_movement_section(_collect_month_movement_rows(start_stats, end_stats))
+
+
+func _collect_month_movement_rows(start_stats: Dictionary, end_stats: Dictionary) -> Array:
+	"""The movement block as ROWS rather than text -- see _finish_month_playback for why the
+	collect/format split exists. Each row carries the pieces the clipboard panel aligns into
+	columns (`stat` / `from` / `to` / `delta`) AND the exact `line` the feed record prints, so
+	the two renderings are the same content by construction.
+
+	`sign` is the DISPLAY sign only: -1 reads as an adverse move, +1 as a favourable one, 0 as
+	neither. It is what colours a delta; nothing downstream may treat it as a magnitude.
+	Doom follows the HUD's inversion (main_ui._render_delta_chip: doom rising is bad)."""
+	var rows: Array = []
 	if start_stats.is_empty() or end_stats.is_empty():
-		return ""
-	var lines: Array[String] = []
+		return rows
 
 	var money_start := float(start_stats.get("money", 0.0))
 	var money_end := float(end_stats.get("money", 0.0))
 	if not is_equal_approx(money_start, money_end):
 		var money_delta := money_end - money_start
-		lines.append("  Funds   %s -> %s   (%s%s)" % [
-			GameConfig.format_money(money_start), GameConfig.format_money(money_end),
-			"+" if money_delta > 0.0 else "-", GameConfig.format_money(abs(money_delta))])
+		var money_text := "%s%s" % [
+			"+" if money_delta > 0.0 else "-", GameConfig.format_money(abs(money_delta))]
+		rows.append({
+			"stat": "Funds",
+			"from": GameConfig.format_money(money_start),
+			"to": GameConfig.format_money(money_end),
+			"delta": money_text,
+			"sign": 1 if money_delta > 0.0 else -1,
+			"line": "  Funds   %s -> %s   (%s)" % [
+				GameConfig.format_money(money_start), GameConfig.format_money(money_end), money_text],
+		})
 
 	var staff_start := int(start_stats.get("staff", 0))
 	var staff_end := int(end_stats.get("staff", 0))
 	if staff_start != staff_end:
-		lines.append("  Staff   %d -> %d   (%s%d)" % [
-			staff_start, staff_end, "+" if staff_end > staff_start else "-", abs(staff_end - staff_start)])
+		var staff_text := "%s%d" % [
+			"+" if staff_end > staff_start else "-", abs(staff_end - staff_start)]
+		rows.append({
+			"stat": "Staff",
+			"from": str(staff_start),
+			"to": str(staff_end),
+			"delta": staff_text,
+			"sign": 1 if staff_end > staff_start else -1,
+			"line": "  Staff   %d -> %d   (%s)" % [staff_start, staff_end, staff_text],
+		})
 
-	var doom_move := _doom_band_movement(float(start_stats.get("doom", 0.0)), float(end_stats.get("doom", 0.0)))
+	var doom_start := float(start_stats.get("doom", 0.0))
+	var doom_end := float(end_stats.get("doom", 0.0))
+	var doom_move := _doom_band_movement(doom_start, doom_end)
 	if doom_move != "":
-		lines.append("  Doom    %s" % doom_move)
+		# ADR-0015: bands, never numbers. The panel gets the two BAND LABELS, which is exactly
+		# what the sentence already contains -- no percentage is added to the payload.
+		var crossed_up := ThemeManager.get_doom_band_index(doom_end) > ThemeManager.get_doom_band_index(doom_start)
+		rows.append({
+			"stat": "Doom",
+			"from": ThemeManager.get_doom_status_label(doom_start),
+			"to": ThemeManager.get_doom_status_label(doom_end),
+			"delta": "crossed up" if crossed_up else "eased down",
+			"sign": -1 if crossed_up else 1,
+			"line": "  Doom    %s" % doom_move,
+		})
 
-	if lines.is_empty():
+	return rows
+
+
+func _format_month_movement_section(rows: Array) -> String:
+	"""Rows -> the feed/description text. Byte-identical to what this block has always printed."""
+	if rows.is_empty():
 		return ""
+	var lines: Array[String] = []
+	for row in rows:
+		lines.append(String(row.get("line", "")))
 	return "\n\nLast month's movement:\n" + "\n".join(lines)
 
 
@@ -916,19 +992,55 @@ func _build_rivals_review_section() -> String:
 	rival, its focus, and a qualitative capability-drift read since last review. Returns ""
 	when nothing is visible so the review stays clean. Deadpan register, display-only (no
 	RNG, no sim reads that could move determinism)."""
+	return _format_rivals_review_section(_collect_rivals_review_rows())
+
+
+func _collect_rivals_review_rows() -> Array:
+	"""The rivals block as ROWS. NOT idempotent -- it advances _rival_cap_snapshot, so the next
+	call reports every rival flat. Call it once per month boundary and pass the rows around
+	(_finish_month_playback does); _build_rivals_review_section is the single-call text wrapper.
+
+	`heat` is a DISPLAY band for the qualitative drift label, not a number the player ever sees:
+	0 flat, 1 slipping, 2 rising, 3 climbing fast. It exists so the panel can weight a rival that
+	is running away from you differently from one standing still, without printing a magnitude
+	the review has never printed."""
+	var rows: Array = []
 	if state == null:
-		return ""
-	var lines: Array[String] = []
+		return rows
 	for rival in state.rival_labs:
 		if not rival.is_visible_to_player():
 			continue
 		var rid: String = rival.id
 		var prev: float = float(_rival_cap_snapshot.get(rid, rival.capability_progress))
-		var drift: String = RivalLabs.capability_drift_label(rival.capability_progress - prev)
+		var delta: float = rival.capability_progress - prev
+		var drift: String = RivalLabs.capability_drift_label(delta)
 		_rival_cap_snapshot[rid] = rival.capability_progress
-		lines.append("  %s (%s) -- %s" % [rival.get_visible_name(), rival.focus, drift])
-	if lines.is_empty():
+		# Thresholds mirror RivalLabs.capability_drift_label -- same cuts, so the band and the
+		# words can never disagree about which rival is moving.
+		var heat := 0
+		if delta > 8.0:
+			heat = 3
+		elif delta > 0.5:
+			heat = 2
+		elif delta < -0.5:
+			heat = 1
+		rows.append({
+			"name": rival.get_visible_name(),
+			"focus": String(rival.focus),
+			"drift": drift,
+			"heat": heat,
+			"line": "  %s (%s) -- %s" % [rival.get_visible_name(), rival.focus, drift],
+		})
+	return rows
+
+
+func _format_rivals_review_section(rows: Array) -> String:
+	"""Rows -> the feed/description text. Byte-identical to what this block has always printed."""
+	if rows.is_empty():
 		return ""
+	var lines: Array[String] = []
+	for row in rows:
+		lines.append(String(row.get("line", "")))
 	return "\n\nRivals this month:\n" + "\n".join(lines)
 
 

--- a/godot/scripts/ui/event_dialog.gd
+++ b/godot/scripts/ui/event_dialog.gd
@@ -175,10 +175,20 @@ func _show_next_event() -> void:
 
 	message_logged.emit("[color=gold]EVENT: %s[/color]" % event.get("name", "Unknown"))
 
+	# The month review gets its own presentation: a diegetic clipboard, roughly triple the
+	# generic panel's area, drawn by MonthReviewPanel. Everything else about the presenter --
+	# the queue, the blocker lifetime, the button wiring, the keyboard metas -- is shared, so
+	# the review keeps every behaviour B1/B2/B3 and #877 pinned to this path.
+	var is_review := MonthReviewPanel.is_month_review(event)
+
 	# Blurred blocker behind event dialog panel (Fix Issue #458 + #485)
 	# Add to root (get_tree().root) to ensure it blocks ALL UI interactions
 	var click_blocker := ColorRect.new()
-	click_blocker.color = Color(0.0, 0.0, 0.0, 0.6)
+	# Playtest 2026-08-14: at 0.6 the WATCH feed behind the review still read at close to full
+	# strength, so the review looked like it was COVERING the month it summarises rather than
+	# replacing it. The review darkens the office further (BACKDROP_ALPHA) so the clipboard is
+	# the only lit surface; every other event keeps the long-standing 0.6.
+	click_blocker.color = Color(0.0, 0.0, 0.0, MonthReviewPanel.BACKDROP_ALPHA if is_review else 0.6)
 	click_blocker.mouse_filter = Control.MOUSE_FILTER_STOP  # Block all mouse events
 	click_blocker.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	click_blocker.z_index = 999  # Just below dialog but above all other UI
@@ -188,69 +198,78 @@ func _show_next_event() -> void:
 
 	# Create event dialog - use Panel for consistent input handling
 	var dialog = Panel.new()
-	dialog.custom_minimum_size = Vector2(600, 450)
-	dialog.size = Vector2(600, 450)
-	# Center it manually
-	dialog.position = Vector2(
-		(get_viewport().get_visible_rect().size.x - 600) / 2,
-		(get_viewport().get_visible_rect().size.y - 450) / 2
-	)
+	# `main_vbox` is whatever container the option buttons and the rejection-reason label go
+	# into. The generic path builds the forest-green panel below; the review path hands back a
+	# slot on the clipboard's board.
+	var main_vbox: VBoxContainer
 
-	# Add forest green background for better visibility
-	var panel_style = StyleBoxFlat.new()
-	panel_style.bg_color = Color(0.15, 0.25, 0.15, 1.0)  # Dark forest green
-	panel_style.border_width_left = 3
-	panel_style.border_width_top = 3
-	panel_style.border_width_right = 3
-	panel_style.border_width_bottom = 3
-	panel_style.border_color = Color(0.3, 0.5, 0.3, 1.0)  # Lighter green border
-	panel_style.corner_radius_top_left = 8
-	panel_style.corner_radius_top_right = 8
-	panel_style.corner_radius_bottom_right = 8
-	panel_style.corner_radius_bottom_left = 8
-	dialog.add_theme_stylebox_override("panel", panel_style)
+	if is_review:
+		MonthReviewPanel.apply_geometry(dialog, get_viewport().get_visible_rect().size)
+		main_vbox = MonthReviewPanel.build(dialog, event)
+	else:
+		dialog.custom_minimum_size = Vector2(600, 450)
+		dialog.size = Vector2(600, 450)
+		# Center it manually
+		dialog.position = Vector2(
+			(get_viewport().get_visible_rect().size.x - 600) / 2,
+			(get_viewport().get_visible_rect().size.y - 450) / 2
+		)
+
+		# Add forest green background for better visibility
+		var panel_style = StyleBoxFlat.new()
+		panel_style.bg_color = Color(0.15, 0.25, 0.15, 1.0)  # Dark forest green
+		panel_style.border_width_left = 3
+		panel_style.border_width_top = 3
+		panel_style.border_width_right = 3
+		panel_style.border_width_bottom = 3
+		panel_style.border_color = Color(0.3, 0.5, 0.3, 1.0)  # Lighter green border
+		panel_style.corner_radius_top_left = 8
+		panel_style.corner_radius_top_right = 8
+		panel_style.corner_radius_bottom_right = 8
+		panel_style.corner_radius_bottom_left = 8
+		dialog.add_theme_stylebox_override("panel", panel_style)
+
+		# Create main container. #630: anchor it to fill the fixed-size Panel (a Panel is
+		# NOT a container, so children default to their content-driven minimum size at
+		# (0,0)). Without this, a long title_label forces the VBox min-width past the
+		# 600px panel and the wrapped body text spills over the right border. Anchoring
+		# clamps the content width to the panel, giving the autowrap labels a real width
+		# to wrap within (inner area = 600 - 2*15 = 570px).
+		var margin = MarginContainer.new()
+		margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+		margin.add_theme_constant_override("margin_left", 15)
+		margin.add_theme_constant_override("margin_right", 15)
+		margin.add_theme_constant_override("margin_top", 15)
+		margin.add_theme_constant_override("margin_bottom", 15)
+		dialog.add_child(margin)
+
+		main_vbox = VBoxContainer.new()
+		margin.add_child(main_vbox)
+
+		# Add title (#630: autowrap so a long event name wraps instead of forcing the
+		# content wider than the panel).
+		var title_label = Label.new()
+		title_label.text = event.get("name", "Event")
+		title_label.add_theme_font_size_override("font_size", 18)
+		title_label.add_theme_color_override("font_color", Color.GOLD)
+		title_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		title_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		main_vbox.add_child(title_label)
+
+		# Add description label. #630: smart word-wrap + fill the container width so long
+		# body text wraps to the panel's inner width instead of clipping past the margins.
+		var desc_label = Label.new()
+		desc_label.text = event.get("description", "An event has occurred!")
+		desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		desc_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		main_vbox.add_child(desc_label)
+
+		# Add spacing
+		var spacer = Control.new()
+		spacer.custom_minimum_size = Vector2(0, 20)
+		main_vbox.add_child(spacer)
 
 	print("[EventDialog] Created Panel for event, size: %s, position: %s" % [dialog.size, dialog.position])
-
-	# Create main container. #630: anchor it to fill the fixed-size Panel (a Panel is
-	# NOT a container, so children default to their content-driven minimum size at
-	# (0,0)). Without this, a long title_label forces the VBox min-width past the
-	# 600px panel and the wrapped body text spills over the right border. Anchoring
-	# clamps the content width to the panel, giving the autowrap labels a real width
-	# to wrap within (inner area = 600 - 2*15 = 570px).
-	var margin = MarginContainer.new()
-	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	margin.add_theme_constant_override("margin_left", 15)
-	margin.add_theme_constant_override("margin_right", 15)
-	margin.add_theme_constant_override("margin_top", 15)
-	margin.add_theme_constant_override("margin_bottom", 15)
-	dialog.add_child(margin)
-
-	var main_vbox = VBoxContainer.new()
-	margin.add_child(main_vbox)
-
-	# Add title (#630: autowrap so a long event name wraps instead of forcing the
-	# content wider than the panel).
-	var title_label = Label.new()
-	title_label.text = event.get("name", "Event")
-	title_label.add_theme_font_size_override("font_size", 18)
-	title_label.add_theme_color_override("font_color", Color.GOLD)
-	title_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	title_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	main_vbox.add_child(title_label)
-
-	# Add description label. #630: smart word-wrap + fill the container width so long
-	# body text wraps to the panel's inner width instead of clipping past the margins.
-	var desc_label = Label.new()
-	desc_label.text = event.get("description", "An event has occurred!")
-	desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	desc_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	main_vbox.add_child(desc_label)
-
-	# Add spacing
-	var spacer = Control.new()
-	spacer.custom_minimum_size = Vector2(0, 20)
-	main_vbox.add_child(spacer)
 
 	# Create container for option buttons
 	var vbox = VBoxContainer.new()
@@ -301,8 +320,15 @@ func _show_next_event() -> void:
 		# Add keyboard hint (LETTERS not numbers) + inline cost summary (#510)
 		if is_navigation:
 			btn.text = "%s   [SPACE]" % choice_text
-			btn.custom_minimum_size = Vector2(520, 54)
-			btn.add_theme_font_size_override("font_size", 16)
+			# The review's door sits on the clipboard's BOARD, not on the sheet, so it keeps the
+			# B2/B3 teal-on-dark primary chrome (teal ink on manila would be unreadable) and only
+			# grows: a wider footprint under a tripled panel, and +4pt like everything else here.
+			btn.custom_minimum_size = MonthReviewPanel.BUTTON_SIZE if is_review else Vector2(520, 54)
+			btn.add_theme_font_size_override("font_size",
+				MonthReviewPanel.SIZE_BUTTON if is_review else 16)
+			if is_review:
+				# The board is up to 1120px wide; a full-width door would out-shout the sheet.
+				btn.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
 			btn.add_theme_color_override("font_color", PRIMARY_TEAL)
 			btn.add_theme_color_override("font_hover_color", Color(1, 1, 1, 1))
 		else:

--- a/godot/scripts/ui/month_review_panel.gd
+++ b/godot/scripts/ui/month_review_panel.gd
@@ -1,0 +1,567 @@
+class_name MonthReviewPanel
+extends RefCounted
+## The month review as an OBJECT, not an overlay (Pip, 2026-08-14: "the month review screen
+## could come in, like, clipboard form or some other diegetic form").
+##
+## Why a clipboard. The thesis of this game is that the bureaucracy IS the game. A month
+## summary drawn as a HUD panel says "here is your data"; a month summary drawn as a sheet
+## somebody clipped to a board and left on your desk says "here is what your month amounted
+## to, and a person typed it up". The second one is the game's own argument, and it is the
+## same instinct as the 2026-08-12 calendar ruling ("semi-diegetic ... shrink or grow rather
+## than disappear and reappear entirely"). It also earns the modal: an object with physical
+## presence has an obvious reason to sit on top of the feed.
+##
+## Diegetic here does NOT mean photorealistic. The register is still the terminal/CRT one the
+## rest of the UI implies (TerminalTheme) and the dark office the isometric floor view shows:
+## a hardboard clip, a manila sheet at the luminance paper actually has in a dark room, and
+## everything on it TYPED -- the same monospace the feed and the plan screen use. The board is
+## drawn with styleboxes, not art, so it costs nothing and cannot go stale; see BOARD ART SLOT
+## below for the single swap that would finish it.
+##
+## PRESENTATION ONLY. Every string on the sheet arrives pre-built in the event's "review"
+## payload (game_manager._finish_month_playback), which is assembled from the SAME rows as the
+## plain-text "description" the WATCH feed records. This file computes no numbers, reads no
+## game state, and rewrites no wording -- it decides where the words sit and what colour the
+## ink is. A presenter that ignores the payload still renders the whole review from
+## "description", which is what every other event dialog does.
+
+# --- SURFACE ART SLOTS ------------------------------------------------------
+# Two surfaces make the object, and both are ALREADY-PACKED art -- no promotion was needed and
+# none was done. They were sitting in the pack unreferenced:
+#
+#   BOARD  res://assets/textures/surfaces/tex_plywood_stained_512.png
+#          Stained plywood with grain, spotting and coffee rings. It is the desk-furniture
+#          register the isometric office floor implies, and dark enough (mid-olive, further
+#          dimmed by BOARD_TINT) to sit inside the CRT palette rather than beside it.
+#   PAPER  res://assets/textures/surfaces/tex_grid_graphpaper_aged_512.png
+#          Aged graph paper, foxed, with two coffee rings printed into it. This is the whole
+#          argument in one asset: the month summary is a form somebody typed on the paper that
+#          was to hand.
+#
+# Set either to "" and that surface falls back to the flat fill below -- the layout is
+# identical either way, so an art lane can swap in a purpose-drawn clipboard by editing one
+# string. What a purpose-drawn replacement would need:
+#   BOARD  a hardboard plate, any size, no baked lighting (the shadow is drawn), top edge
+#          plain because the metal clip is drawn over it.
+#   PAPER  a sheet with visible tooth that stays DIM. A scanned-document white will blow a
+#          hole in this palette; the graph paper works because it is foxed, not bright.
+# Still MISSING from the pack, and worth requesting as art rather than faking: a real clip
+# (the metal jaw here is two styleboxes), and monochrome line-art stamp glyphs at ~24px for
+# the Funds / Staff / Doom rows. The existing 64px resource icons are NOT usable for that --
+# they are glossy vignetted RPG icons with baked dark backgrounds, and on a lit manila sheet
+# they read as stickers, not as print.
+const BOARD_TEXTURE_PATH := "res://assets/textures/surfaces/tex_plywood_stained_512.png"
+const PAPER_TEXTURE_PATH := "res://assets/textures/surfaces/tex_grid_graphpaper_aged_512.png"
+## Multiplied over the surface art. Both source textures are lit for a bright screen; these
+## take the board down to furniture and the paper to office-light manila.
+const BOARD_TINT := Color(0.60, 0.56, 0.50)
+const PAPER_TINT := Color(0.88, 0.86, 0.84)
+
+# --- The object -------------------------------------------------------------
+# Hardboard: warm near-black, one step off TerminalTheme.BG_DARK's green-tinted black so the
+# board reads as a physical thing sitting IN FRONT of the terminal rather than part of it.
+const BOARD := Color(0.145, 0.125, 0.105)
+const BOARD_EDGE := Color(0.33, 0.28, 0.21)
+const CLIP_METAL := Color(0.56, 0.575, 0.585)
+const CLIP_METAL_DARK := Color(0.26, 0.275, 0.285)
+
+# Manila under office light. Deliberately ~0.79 and warm, not paper-white: a full-luminance
+# sheet next to this game's palette reads as a browser window, not an object on a desk.
+const PAPER := Color(0.795, 0.775, 0.705)
+# The attention box's wash. TRANSLUCENT, not a solid fill: the sheet is textured art, and an
+# opaque box punched into it would read as a UI widget stuck on the paper rather than a rule
+# printed on it.
+const PAPER_SHADE := Color(0.20, 0.16, 0.08, 0.10)
+const PAPER_EDGE := Color(0.60, 0.585, 0.525)
+const PAPER_RULE := Color(0.545, 0.53, 0.475)     # hairlines printed on the form
+
+const INK := Color(0.125, 0.125, 0.115)
+const INK_DIM := Color(0.355, 0.35, 0.32)
+const STAMP := Color(0.58, 0.185, 0.145)          # faded red rubber stamp
+
+# Delta inks. Same MEANING as main_ui's _DELTA_GOOD / _DELTA_BAD chips (favourable green,
+# adverse red) re-mixed for paper: those two are tuned to survive a near-black panel and go
+# washy on manila, so these are the printed renderings of the same hues. Sign, not judgement --
+# game_manager supplies the sign, this file only picks the pigment.
+const INK_GOOD := Color(0.09, 0.40, 0.15)
+const INK_BAD := Color(0.62, 0.13, 0.10)
+const INK_WARN := Color(0.60, 0.38, 0.05)         # amber ink, the middle heat band
+
+# Rival heat bands (game_manager._collect_rivals_review_rows): 0 flat, 1 slipping, 2 rising,
+# 3 climbing fast. Colour is HEAT, not verdict -- how fast the rival is moving, which is the
+# one thing three indented sentences could not show at a glance.
+const HEAT_INKS := [INK_DIM, INK_GOOD, INK_WARN, INK_BAD]
+
+# --- Type sizes -------------------------------------------------------------
+# Pip, 2026-08-14: "the text can just all universally go up 2 to 4 points." Applied here only
+# (a global sweep is a separate change). Baselines are the generic event dialog's: body 16,
+# small 14, title 18, navigation button 16.
+const SIZE_BODY := 19        # 16 + 3
+const SIZE_SMALL := 17       # 14 + 3
+const SIZE_CLOSING := 18     # 16 + 2
+const SIZE_PERIOD := 20      # 18 + 2
+# The masthead is the one line that breaks the +2..+4 rule: 18 -> 24. It is now the title of a
+# sheet with three times the area under it, and at 22 it did not read as a masthead beside
+# 19pt body. Flagged rather than smuggled -- easy to pull back to 22.
+const SIZE_HEADING := 24
+## Font size for the single navigation button, applied by EventDialog. 16 + 4.
+const SIZE_BUTTON := 20
+## Button footprint on the board, applied by EventDialog (generic navigation is 520x54).
+const BUTTON_SIZE := Vector2(560, 62)
+
+# --- Geometry ---------------------------------------------------------------
+# The ask was "double or triple the area". The generic event dialog is a fixed 600x450
+# (270,000 px^2) at every resolution; this scales with the viewport and caps out at 1120x760.
+#   1920x1080 -> 1120 x 760  = 851,200 px^2  = 3.15x
+#   1600x900  -> 1120 x 720  = 806,400 px^2  = 2.99x
+#   1280x720  ->  921 x 576  = 530,700 px^2  = 1.97x
+# i.e. triple where Pip plays, still double on the smallest supported window.
+const WIDTH_RATIO := 0.72
+const HEIGHT_RATIO := 0.80
+const MAX_SIZE := Vector2(1120.0, 760.0)
+const MIN_SIZE := Vector2(640.0, 470.0)
+
+## Backdrop opacity behind the clipboard. The generic dialog uses 0.6, which left the WATCH
+## feed reading at nearly full strength around the panel -- the review was covering the thing
+## it summarises rather than replacing it. At 0.85 the office goes dark and the object is the
+## only lit surface, which is also what makes it read as an object.
+const BACKDROP_ALPHA := 0.85
+
+
+static func is_month_review(event: Dictionary) -> bool:
+	"""True when this event carries a month-review presentation payload. Keyed on the payload,
+	not on the event id, so the presenter never needs to know game_manager's constants -- and
+	so a review built without a payload degrades to the generic dialog instead of crashing."""
+	var payload = event.get("review", null)
+	return payload is Dictionary and not (payload as Dictionary).is_empty()
+
+
+static func apply_geometry(dialog: Panel, viewport_size: Vector2) -> void:
+	"""Size and centre the board. Kept separate from build() so the caller sets geometry before
+	the layout is filled, exactly as the generic path does."""
+	var w := clampf(viewport_size.x * WIDTH_RATIO, MIN_SIZE.x, MAX_SIZE.x)
+	var h := clampf(viewport_size.y * HEIGHT_RATIO, MIN_SIZE.y, MAX_SIZE.y)
+	dialog.custom_minimum_size = Vector2(w, h)
+	dialog.size = Vector2(w, h)
+	dialog.position = Vector2(
+		roundf((viewport_size.x - w) / 2.0),
+		roundf((viewport_size.y - h) / 2.0))
+
+
+static func build(dialog: Panel, event: Dictionary) -> VBoxContainer:
+	"""Draw the clipboard into `dialog` and return the container the caller must put the option
+	button (and the rejection-reason label) into. That slot is on the BOARD, below the sheet:
+	the paper is the report, the board is where the action lives, and keeping the button off
+	the paper preserves the teal 'forward door' chrome that B2/B3 gave it -- teal ink on manila
+	would have been unreadable."""
+	var review: Dictionary = event.get("review", {})
+	var font := TerminalTheme.mono_font()
+
+	_skin_board(dialog)
+
+	var outer := MarginContainer.new()
+	outer.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	outer.add_theme_constant_override("margin_left", 16)
+	outer.add_theme_constant_override("margin_right", 16)
+	outer.add_theme_constant_override("margin_top", 10)
+	outer.add_theme_constant_override("margin_bottom", 14)
+	dialog.add_child(outer)
+
+	var board_v := VBoxContainer.new()
+	board_v.add_theme_constant_override("separation", 8)
+	outer.add_child(board_v)
+
+	board_v.add_child(_build_clip())
+	board_v.add_child(_build_sheet(review, font))
+
+	# The action slot, on the board under the sheet.
+	var footer := VBoxContainer.new()
+	footer.add_theme_constant_override("separation", 6)
+	footer.alignment = BoxContainer.ALIGNMENT_CENTER
+	board_v.add_child(footer)
+	return footer
+
+
+# --- the board and its clip -------------------------------------------------
+
+static func _skin_board(dialog: Panel) -> void:
+	"""Hardboard fill, plywood grain over it, and a drop shadow. The shadow is what lifts the
+	object off the darkened office behind it; without it the panel reads as a flat rectangle
+	again no matter what is painted on it."""
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = BOARD
+	sb.border_color = BOARD_EDGE
+	sb.set_border_width_all(2)
+	sb.set_corner_radius_all(4)
+	sb.shadow_color = Color(0.0, 0.0, 0.0, 0.60)
+	sb.shadow_size = 26
+	sb.shadow_offset = Vector2(0, 10)
+	dialog.add_theme_stylebox_override("panel", sb)
+	_add_surface(dialog, BOARD_TEXTURE_PATH, BOARD_TINT, 2)
+
+
+static func _build_clip() -> Control:
+	"""The metal clip. Two stacked bars: a dark jaw and a lit plate over it. Cheap, and it is
+	the single detail that makes the rectangle read as a clipboard rather than a card."""
+	var centre := CenterContainer.new()
+	var jaw := Panel.new()
+	jaw.custom_minimum_size = Vector2(196, 20)
+	var jaw_sb := StyleBoxFlat.new()
+	jaw_sb.bg_color = CLIP_METAL_DARK
+	jaw_sb.set_corner_radius_all(4)
+	jaw_sb.border_color = Color(0.14, 0.15, 0.155)
+	jaw_sb.set_border_width_all(1)
+	jaw.add_theme_stylebox_override("panel", jaw_sb)
+	centre.add_child(jaw)
+
+	var plate := Panel.new()
+	plate.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	plate.offset_left = 26
+	plate.offset_right = -26
+	plate.offset_top = 4
+	plate.offset_bottom = -7
+	var plate_sb := StyleBoxFlat.new()
+	plate_sb.bg_color = CLIP_METAL
+	plate_sb.set_corner_radius_all(2)
+	plate.add_theme_stylebox_override("panel", plate_sb)
+	plate.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	jaw.add_child(plate)
+	return centre
+
+
+# --- the sheet --------------------------------------------------------------
+
+static func _build_sheet(review: Dictionary, font: Font) -> Control:
+	var paper := PanelContainer.new()
+	paper.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = PAPER
+	sb.border_color = PAPER_EDGE
+	sb.set_border_width_all(1)
+	sb.set_corner_radius_all(1)
+	sb.shadow_color = Color(0.0, 0.0, 0.0, 0.35)
+	sb.shadow_size = 8
+	sb.shadow_offset = Vector2(0, 3)
+	paper.add_theme_stylebox_override("panel", sb)
+	# The sheet's ground. A PanelContainer lays every child out over its whole content rect, so
+	# this goes in FIRST and everything added after it is printed on top.
+	_add_surface(paper, PAPER_TEXTURE_PATH, PAPER_TINT, 1)
+
+	var pad := MarginContainer.new()
+	pad.add_theme_constant_override("margin_left", 26)
+	pad.add_theme_constant_override("margin_right", 26)
+	pad.add_theme_constant_override("margin_top", 20)
+	pad.add_theme_constant_override("margin_bottom", 18)
+	paper.add_child(pad)
+
+	var sheet := VBoxContainer.new()
+	sheet.add_theme_constant_override("separation", 12)
+	pad.add_child(sheet)
+
+	sheet.add_child(_build_masthead(review, font))
+	sheet.add_child(_rule(2))
+
+	var lede := String(review.get("lede", ""))
+	if lede != "":
+		sheet.add_child(_ink_label(lede, SIZE_BODY, INK, font))
+
+	var attention := String(review.get("attention", ""))
+	if attention != "":
+		sheet.add_child(_build_attention_box(attention, font))
+
+	var columns := _build_columns(review, font)
+	if columns != null:
+		sheet.add_child(columns)
+	else:
+		# Nothing moved and no rival is visible (month 1, or a freshly loaded save). Let the
+		# sheet breathe rather than jamming the closing line under the attention box.
+		var filler := Control.new()
+		filler.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		sheet.add_child(filler)
+
+	var closing := String(review.get("closing", ""))
+	if closing != "":
+		sheet.add_child(_rule(1))
+		sheet.add_child(_build_closing(closing, font))
+	return paper
+
+
+static func _build_masthead(review: Dictionary, font: Font) -> Control:
+	"""Typed heading on the left, the period it covers on the right -- the two halves of the
+	event name ("Month Review -- October 2017") set as a form header instead of one string."""
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 12)
+
+	var heading := _ink_label(String(review.get("heading", "")), SIZE_HEADING, INK, font)
+	heading.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(heading)
+
+	var period := _ink_label(String(review.get("period", "")), SIZE_PERIOD, INK_DIM, font)
+	period.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	period.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	row.add_child(period)
+	return row
+
+
+static func _build_attention_box(text: String, font: Font) -> Control:
+	"""The attention line is a RULE OF THE GAME, not a status line, so it is set as one: a
+	stamped left rule, a tinted panel, and the house-style `[!]` gutter glyph. Not one word of
+	Pip's sentence is changed -- it is the frame around it that says 'this is the standing
+	rule', which three blank lines of the old wall of text could not."""
+	var box := PanelContainer.new()
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = PAPER_SHADE
+	sb.set_corner_radius_all(0)
+	sb.border_color = STAMP
+	sb.border_width_left = 4
+	sb.content_margin_left = 12
+	sb.content_margin_right = 12
+	sb.content_margin_top = 8
+	sb.content_margin_bottom = 8
+	box.add_theme_stylebox_override("panel", sb)
+
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 10)
+	box.add_child(row)
+
+	var marker := _ink_label("[!]", SIZE_BODY, STAMP, font)
+	marker.vertical_alignment = VERTICAL_ALIGNMENT_TOP
+	row.add_child(marker)
+
+	var body := _ink_label(text, SIZE_BODY, INK, font)
+	body.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(body)
+	return box
+
+
+static func _build_columns(review: Dictionary, font: Font) -> Control:
+	"""Movement and rivals, side by side. Returns null when neither block has content.
+
+	Both blocks used to be indented text under a colon, which is why every line competed: a
+	dollar delta, a headcount and three rival sentences were all the same weight in the same
+	column. Movement is now a table (stat / from -> to / signed delta chip) and each rival is
+	its own carded row, so the two read as two different kinds of thing."""
+	var movement: Array = review.get("movement", [])
+	var rivals: Array = review.get("rivals", [])
+	if movement.is_empty() and rivals.is_empty():
+		return null
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	scroll.follow_focus = false
+
+	var row := HBoxContainer.new()
+	row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	row.add_theme_constant_override("separation", 24)
+	scroll.add_child(row)
+
+	if not movement.is_empty():
+		var left := _build_column(String(review.get("movement_title", "")), font)
+		for entry in movement:
+			if entry is Dictionary:
+				left.add_child(_build_movement_row(entry, font))
+		left.size_flags_stretch_ratio = 1.15
+		row.add_child(left)
+
+	if not movement.is_empty() and not rivals.is_empty():
+		var sep := VSeparator.new()
+		var sep_sb := StyleBoxFlat.new()
+		sep_sb.bg_color = PAPER_RULE
+		sep_sb.content_margin_left = 0
+		sep.add_theme_stylebox_override("separator", sep_sb)
+		sep.add_theme_constant_override("separation", 1)
+		row.add_child(sep)
+
+	if not rivals.is_empty():
+		var right := _build_column(String(review.get("rivals_title", "")), font)
+		for entry in rivals:
+			if entry is Dictionary:
+				right.add_child(_build_rival_card(entry, font))
+		row.add_child(right)
+	return scroll
+
+
+static func _build_column(title: String, font: Font) -> VBoxContainer:
+	var col := VBoxContainer.new()
+	col.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	col.add_theme_constant_override("separation", 7)
+	if title != "":
+		col.add_child(_ink_label(title, SIZE_BODY, INK_DIM, font))
+		col.add_child(_rule(1))
+	return col
+
+
+static func _build_movement_row(entry: Dictionary, font: Font) -> Control:
+	"""stat | from -> to | signed delta chip. The delta gets its own bordered chip at the right
+	margin so a column of them stacks into a readable edge -- the point of the change: a delta
+	should read as a delta, not as the tail of a sentence."""
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+
+	var stat := _ink_label(String(entry.get("stat", "")), SIZE_BODY, INK_DIM, font)
+	stat.custom_minimum_size = Vector2(72, 0)
+	row.add_child(stat)
+
+	var from_to := _ink_label("%s -> %s" % [
+		String(entry.get("from", "")), String(entry.get("to", ""))], SIZE_BODY, INK, font)
+	from_to.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	from_to.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	row.add_child(from_to)
+
+	row.add_child(_delta_chip(String(entry.get("delta", "")), int(entry.get("sign", 0)), font))
+	return row
+
+
+static func _delta_chip(text: String, sign_hint: int, font: Font) -> Control:
+	"""A signed, coloured, boxed delta. `sign_hint` is game_manager's DISPLAY sign (+1
+	favourable, -1 adverse, 0 neither) -- the same inversion the HUD's per-turn chips use, so a
+	falling doom band and a rising balance agree about which way is up."""
+	var ink := INK_DIM
+	if sign_hint > 0:
+		ink = INK_GOOD
+	elif sign_hint < 0:
+		ink = INK_BAD
+
+	var chip := PanelContainer.new()
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = Color(ink.r, ink.g, ink.b, 0.10)
+	sb.border_color = Color(ink.r, ink.g, ink.b, 0.45)
+	sb.set_border_width_all(1)
+	sb.set_corner_radius_all(2)
+	sb.content_margin_left = 8
+	sb.content_margin_right = 8
+	sb.content_margin_top = 1
+	sb.content_margin_bottom = 1
+	chip.add_theme_stylebox_override("panel", sb)
+
+	var label := _ink_label(text, SIZE_BODY, ink, font)
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	chip.add_child(label)
+	return chip
+
+
+static func _build_rival_card(entry: Dictionary, font: Font) -> Control:
+	"""One rival, one card: name and focus on the top line, the drift read underneath in the
+	heat ink. Three indented sentences all said 'capabilities ...' in the same colour; a
+	stack of cards says at a glance which one is running."""
+	var heat: int = clampi(int(entry.get("heat", 0)), 0, HEAT_INKS.size() - 1)
+	var ink: Color = HEAT_INKS[heat]
+
+	var card := PanelContainer.new()
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = Color(0.0, 0.0, 0.0, 0.035)
+	sb.set_corner_radius_all(0)
+	sb.border_color = ink
+	sb.border_width_left = 3
+	sb.content_margin_left = 10
+	sb.content_margin_right = 8
+	sb.content_margin_top = 5
+	sb.content_margin_bottom = 5
+	card.add_theme_stylebox_override("panel", sb)
+
+	var col := VBoxContainer.new()
+	col.add_theme_constant_override("separation", 1)
+	card.add_child(col)
+
+	var top := HBoxContainer.new()
+	top.add_theme_constant_override("separation", 8)
+	var name_label := _ink_label(String(entry.get("name", "")), SIZE_BODY, INK, font)
+	name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	top.add_child(name_label)
+	var focus := String(entry.get("focus", ""))
+	if focus != "":
+		var focus_label := _ink_label(focus, SIZE_SMALL, INK_DIM, font)
+		focus_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+		top.add_child(focus_label)
+	col.add_child(top)
+
+	var drift := _ink_label(String(entry.get("drift", "")), SIZE_SMALL, ink, font)
+	drift.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	col.add_child(drift)
+	return card
+
+
+static func _build_closing(text: String, font: Font) -> Control:
+	"""The standing instruction, set as a footer with the house `>>` gutter rather than as the
+	last paragraph of the same block of prose."""
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 10)
+	row.add_child(_ink_label(">>", SIZE_CLOSING, INK_DIM, font))
+	var body := _ink_label(text, SIZE_CLOSING, INK, font)
+	body.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(body)
+	return row
+
+
+# --- small helpers ----------------------------------------------------------
+
+static func _ink_label(text: String, size: int, color: Color, font: Font) -> Label:
+	"""Every word on the sheet is typed: same monospace family as the feed and plan screen
+	(TerminalTheme.mono_font), which is what keeps a paper object inside the terminal register."""
+	var label := Label.new()
+	label.text = text
+	label.add_theme_font_size_override("font_size", size)
+	label.add_theme_color_override("font_color", color)
+	if font != null:
+		label.add_theme_font_override("font", font)
+	return label
+
+
+static func _rule(thickness: int) -> HSeparator:
+	"""A printed hairline. HSeparator draws its 'separator' stylebox, so a flat fill of
+	PAPER_RULE at a fixed height is the rule itself."""
+	var sep := HSeparator.new()
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = PAPER_RULE
+	sb.content_margin_top = 0
+	sb.content_margin_bottom = 0
+	sep.add_theme_stylebox_override("separator", sb)
+	sep.add_theme_constant_override("separation", thickness)
+	return sep
+
+
+static func _add_surface(node: Control, path: String, tint: Color, inset: int) -> void:
+	"""SURFACE ART SLOT. Paints `path` across `node` as a background TextureRect, inset by
+	`inset` px so the stylebox's own border still reads as the edge of the object.
+
+	KEEP_ASPECT_COVERED, not tiling: both textures carry a distinctive coffee ring, and tiling a
+	512px square across a 1100px sheet would print that ring twice, which announces the texture
+	as wallpaper. Covering scales the square up and crops -- one ring, no seam, no distortion.
+
+	Silent no-op when the slot is empty or the resource is missing: a missing asset must degrade
+	to the flat fill underneath, never to a pink checkerboard or a broken modal the player
+	cannot dismiss.
+
+	The texture goes inside a clipping WRAPPER rather than clipping the panel itself, because
+	`clip_contents` on the panel would also clip the panel's own stylebox -- taking the drop
+	shadow with it, and the shadow is what makes the board read as an object sitting in front
+	of the terminal rather than a rectangle drawn on it."""
+	if path == "" or not ResourceLoader.exists(path):
+		return
+	var tex = load(path)
+	if not (tex is Texture2D):
+		push_warning("[MonthReviewPanel] art slot '%s' is not a Texture2D -- using the flat fill" % path)
+		return
+
+	var clip := Control.new()
+	clip.clip_contents = true
+	clip.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	clip.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	clip.offset_left = inset
+	clip.offset_top = inset
+	clip.offset_right = -inset
+	clip.offset_bottom = -inset
+	node.add_child(clip)
+
+	var ground := TextureRect.new()
+	ground.texture = tex
+	ground.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	ground.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_COVERED
+	ground.modulate = tint
+	ground.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	ground.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	clip.add_child(ground)

--- a/godot/scripts/ui/month_review_panel.gd.uid
+++ b/godot/scripts/ui/month_review_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://cmm47oucnqeo1

--- a/godot/tests/unit/test_month_review_panel.gd
+++ b/godot/tests/unit/test_month_review_panel.gd
@@ -1,0 +1,343 @@
+extends GutTest
+## The month review as a diegetic clipboard (Pip, 2026-08-14: "can take up a lot more of the
+## screen space ... the month review screen could come in, like, clipboard form or some other
+## diegetic form").
+##
+## Nothing here proves the screen LOOKS right -- only Pip's eyes can do that, same caveat as
+## test_month_review_navigation. What these tests CAN hold is the three things a restyle
+## silently breaks:
+##
+##   1. Not one word of Pip's copy is dropped by the re-typesetting. The panel now splits the
+##      review across a masthead, a callout, two columns and a footer instead of printing one
+##      string, and the failure mode of that kind of change is a line quietly going missing.
+##   2. The presentation payload and the plain-text description never disagree. The WATCH feed
+##      records the text (A10); if the panel and the record drifted, two "copies" of the same
+##      month would say different things.
+##   3. The panel is actually bigger, and the ADR-0015 doom rule survives the new payload.
+
+const GameManagerScript := preload("res://scripts/game_manager.gd")
+
+## The generic event dialog's fixed footprint (event_dialog.gd), the thing "double or triple
+## the area" is measured against.
+const GENERIC_DIALOG_AREA := 600.0 * 450.0
+
+
+func _gm() -> Node:
+	var gm: Node = GameManagerScript.new()
+	autofree(gm)
+	return gm
+
+
+func _stats(money: float, doom: float, staff: int) -> Dictionary:
+	return {"money": money, "doom": doom, "staff": staff}
+
+
+func _payload() -> Dictionary:
+	"""A review payload in the shape game_manager._finish_month_playback emits."""
+	return {
+		"heading": "Month Review",
+		"period": "October 2017",
+		"lede": "October 2017 begins.",
+		"attention": "Attention: 20 fresh decisions this month (last month's unspent reserve evaporated -- no banking).",
+		"movement_title": "Last month's movement",
+		"movement": _gm()._collect_month_movement_rows(
+			_stats(1119896.0, 25.3, 3), _stats(1083712.0, 25.3, 2)),
+		"rivals_title": "Rivals this month",
+		"rivals": [
+			{"name": "DeepSafety", "focus": "safety", "drift": "capabilities flat", "heat": 0,
+				"line": "  DeepSafety (safety) -- capabilities flat"},
+			{"name": "CapabiliCorp", "focus": "capabilities", "drift": "capabilities climbing fast",
+				"heat": 3, "line": "  CapabiliCorp (capabilities) -- capabilities climbing fast"},
+		],
+		"closing": "Queue this month's actions, then press COMMIT THE MONTH to play the month out.",
+	}
+
+
+func _texts(node: Node, out: Array[String] = []) -> Array[String]:
+	"""Every Label string in a built subtree, so a test can ask what the sheet actually says."""
+	if node is Label:
+		out.append((node as Label).text)
+	for child in node.get_children():
+		_texts(child, out)
+	return out
+
+
+func _build_sheet(payload: Dictionary) -> Panel:
+	var dialog := Panel.new()
+	autofree(dialog)
+	MonthReviewPanel.apply_geometry(dialog, Vector2(1920, 1080))
+	MonthReviewPanel.build(dialog, {"review": payload})
+	return dialog
+
+
+# --- routing: which events get the clipboard ------------------------------------------------
+
+func test_a_review_payload_selects_the_clipboard() -> void:
+	assert_true(MonthReviewPanel.is_month_review({"review": _payload()}))
+
+
+func test_an_ordinary_event_does_not() -> void:
+	# Every crisis window and flavour popup must keep the generic forest-green dialog.
+	assert_false(MonthReviewPanel.is_month_review(
+		{"id": "some_crisis", "name": "X", "description": "y", "options": []}))
+
+
+func test_an_empty_or_malformed_payload_falls_back_to_the_generic_dialog() -> void:
+	# Keyed on the payload rather than on MONTH_REVIEW_EVENT_ID precisely so a review built
+	# without one degrades to a dialog that still renders "description" in full, instead of
+	# handing the player an empty clipboard they cannot dismiss.
+	assert_false(MonthReviewPanel.is_month_review({"review": {}}))
+	assert_false(MonthReviewPanel.is_month_review({"review": "not a dictionary"}))
+	assert_false(MonthReviewPanel.is_month_review({}))
+
+
+# --- the ask: double to triple the area ------------------------------------------------------
+
+func test_the_clipboard_is_between_two_and_three_and_a_half_times_the_generic_panel() -> void:
+	# "can take up a lot more of the screen space, like, double or triple the area". The upper
+	# bound is here so a later tweak cannot quietly grow it into a full-screen takeover.
+	for viewport in [Vector2(1920, 1080), Vector2(1600, 900), Vector2(1280, 720)]:
+		var dialog := Panel.new()
+		autofree(dialog)
+		MonthReviewPanel.apply_geometry(dialog, viewport)
+		var ratio: float = (dialog.size.x * dialog.size.y) / GENERIC_DIALOG_AREA
+		assert_between(ratio, 1.9, 3.5,
+			"at %s the clipboard is %.2fx the generic dialog" % [viewport, ratio])
+
+
+func test_the_clipboard_always_fits_on_screen() -> void:
+	# A modal the player cannot fully see is worse than a small one -- and this one carries the
+	# only button that closes it.
+	for viewport in [Vector2(1920, 1080), Vector2(1366, 768), Vector2(1280, 720), Vector2(1024, 600)]:
+		var dialog := Panel.new()
+		autofree(dialog)
+		MonthReviewPanel.apply_geometry(dialog, viewport)
+		assert_true(dialog.position.x >= 0.0 and dialog.position.y >= 0.0,
+			"at %s the clipboard starts off-screen at %s" % [viewport, dialog.position])
+		assert_true(dialog.position.x + dialog.size.x <= viewport.x + 1.0,
+			"at %s the clipboard runs off the right edge" % viewport)
+		assert_true(dialog.position.y + dialog.size.y <= viewport.y + 1.0,
+			"at %s the clipboard runs off the bottom edge" % viewport)
+
+
+func test_the_review_darkens_the_screen_more_than_a_generic_event() -> void:
+	# The occlusion complaint: at the generic 0.6 the WATCH feed behind the review still read at
+	# close to full strength, so the review covered the month it was summarising. If this ever
+	# drops back to 0.6 the panel is occluding the feed again.
+	assert_gt(MonthReviewPanel.BACKDROP_ALPHA, 0.6,
+		"the review must darken the office further than an ordinary popup does")
+	assert_lte(MonthReviewPanel.BACKDROP_ALPHA, 1.0)
+
+
+func test_the_type_went_up_two_to_four_points() -> void:
+	# Pip, 2026-08-14: "the text can just all universally go up 2 to 4 points." Applied to this
+	# panel only. Baselines are the generic dialog's: body 16, small 14, button 16.
+	assert_between(MonthReviewPanel.SIZE_BODY, 18, 20)
+	assert_between(MonthReviewPanel.SIZE_SMALL, 16, 18)
+	assert_between(MonthReviewPanel.SIZE_BUTTON, 18, 20)
+
+
+# --- Pip's words all survive the re-typesetting ----------------------------------------------
+
+func test_every_line_of_the_review_reaches_the_sheet() -> void:
+	# The whole risk of splitting one description string across a masthead, a callout box, two
+	# columns and a footer is that a piece stops being rendered and nobody notices for months.
+	var payload := _payload()
+	var said := _texts(_build_sheet(payload))
+	for key in ["heading", "period", "lede", "attention", "movement_title", "rivals_title", "closing"]:
+		assert_has(said, String(payload[key]), "the sheet dropped the '%s' line" % key)
+
+
+func test_every_movement_row_reaches_the_sheet_with_its_delta() -> void:
+	var payload := _payload()
+	assert_false(payload["movement"].is_empty(), "test precondition: this month moved")
+	var said := _texts(_build_sheet(payload))
+	for row in payload["movement"]:
+		assert_has(said, "%s -> %s" % [row["from"], row["to"]])
+		assert_has(said, String(row["delta"]), "a delta must still be printed, not just implied")
+		assert_has(said, String(row["stat"]))
+
+
+func test_every_rival_reaches_the_sheet_with_its_focus_and_drift() -> void:
+	var said := _texts(_build_sheet(_payload()))
+	for row in _payload()["rivals"]:
+		assert_has(said, String(row["name"]))
+		assert_has(said, String(row["focus"]))
+		assert_has(said, String(row["drift"]))
+
+
+func test_a_first_month_with_no_movement_and_no_rivals_still_renders() -> void:
+	# Month 1 of a run, and any run resumed from a save: both blocks are empty by design
+	# (A4). The sheet must still show the standing rule and the way out.
+	var payload := _payload()
+	payload["movement"] = []
+	payload["rivals"] = []
+	var said := _texts(_build_sheet(payload))
+	assert_has(said, String(payload["attention"]))
+	assert_has(said, String(payload["closing"]))
+
+
+func test_the_sheet_prints_no_doom_percentage() -> void:
+	# ADR-0015 guard, carried onto the new surface. The old one (test_month_review_movement)
+	# only sees the string; this one sees what is actually drawn.
+	var payload := _payload()
+	payload["movement"] = _gm()._collect_month_movement_rows(
+		_stats(102000.0, 5.0, 3), _stats(84200.0, 95.0, 4))
+	for text in _texts(_build_sheet(payload)):
+		assert_false(text.contains("%"), "no doom percentage may reach the sheet: got '%s'" % text)
+
+
+# --- payload and plain text cannot drift ------------------------------------------------------
+
+func test_the_payload_rows_and_the_feed_text_are_the_same_content() -> void:
+	# The review is recorded into the WATCH feed as text (A10) and drawn from rows. Both are
+	# built from ONE collection, and this is the assertion that keeps it that way: every row's
+	# parts must appear in the line the feed records for that row.
+	var gm := _gm()
+	var rows: Array = gm._collect_month_movement_rows(
+		_stats(1119896.0, 25.3, 3), _stats(1083712.0, 25.3, 2))
+	assert_false(rows.is_empty())
+	var text: String = gm._format_month_movement_section(rows)
+	for row in rows:
+		assert_string_contains(text, String(row["stat"]))
+		assert_string_contains(text, String(row["from"]))
+		assert_string_contains(text, String(row["to"]))
+		assert_string_contains(text, String(row["delta"]))
+
+
+func test_movement_rows_carry_the_display_sign_the_hud_uses() -> void:
+	# main_ui._render_delta_chip: doom rising is bad, everything else rising is good. The sheet
+	# colours its deltas off this sign, so an inverted one would print a loss in green.
+	var gm := _gm()
+	var lost: Array = gm._collect_month_movement_rows(_stats(100.0, 10.0, 3), _stats(50.0, 10.0, 3))
+	assert_eq(int(lost[0]["sign"]), -1, "a month that lost money must read as adverse")
+	var gained: Array = gm._collect_month_movement_rows(_stats(50.0, 10.0, 3), _stats(100.0, 10.0, 3))
+	assert_eq(int(gained[0]["sign"]), 1)
+
+	assert_true(ThemeManager.get_doom_band_index(5.0) < ThemeManager.get_doom_band_index(95.0),
+		"test precondition: 5%% and 95%% doom must be different bands")
+	var doom_up: Array = _gm()._collect_month_movement_rows(_stats(1.0, 5.0, 3), _stats(1.0, 95.0, 3))
+	assert_eq(int(doom_up[0]["sign"]), -1, "doom crossing UP is the adverse direction")
+	var doom_down: Array = _gm()._collect_month_movement_rows(_stats(1.0, 95.0, 3), _stats(1.0, 5.0, 3))
+	assert_eq(int(doom_down[0]["sign"]), 1)
+
+
+func test_rival_heat_bands_agree_with_the_words_beside_them() -> void:
+	# heat is what colours a rival card. If the bands and RivalLabs.capability_drift_label ever
+	# used different cuts, a card could say "flat" in the running-away colour.
+	var expected := {
+		0: "capabilities flat",
+		1: "capabilities slipping",
+		2: "capabilities rising",
+		3: "capabilities climbing fast",
+	}
+	var deltas := {0: 0.0, 1: -5.0, 2: 2.0, 3: 10.0}
+	for heat in expected.keys():
+		assert_eq(RivalLabs.capability_drift_label(deltas[heat]), expected[heat],
+			"heat band %d and its label must describe the same movement" % heat)
+	assert_eq(MonthReviewPanel.HEAT_INKS.size(), expected.size(),
+		"every heat band needs an ink, and no ink may be unreachable")
+
+
+# --- through the real presenter ---------------------------------------------------------------
+
+func _present(event: Dictionary) -> Array:
+	"""Drive EventDialog for real -- the branch added to _show_next_event is the part a unit test
+	of the builder alone would miss. Returns [dialog, buttons] as the presenter handed them to
+	its host. The caller frees the dialog; its tree_exited hook takes the blocker with it."""
+	var presenter := EventDialog.new()
+	add_child_autofree(presenter)
+	presenter.state_provider = func(): return {}
+	var opened: Array = []
+	presenter.dialog_opened.connect(func(dialog, buttons): opened.append([dialog, buttons]))
+	presenter.present(event)
+	await wait_frames(2)
+	assert_eq(opened.size(), 1, "the presenter opened exactly one dialog")
+	return opened[0] if opened.size() == 1 else [null, []]
+
+
+func _review_event() -> Dictionary:
+	var payload := _payload()
+	return {
+		"id": "__month_review__",
+		"name": "Month Review -- October 2017",
+		"description": "%s\n\n%s\n\n%s" % [payload["lede"], payload["attention"], payload["closing"]],
+		"type": "popup",
+		"options": [{"id": "begin_planning", "text": "Begin planning October 2017", "costs": {}, "effects": {}}],
+		"review": payload,
+	}
+
+
+func test_the_presenter_puts_the_review_on_the_clipboard() -> void:
+	var opened: Array = await _present(_review_event())
+	var dialog: Control = opened[0]
+	assert_not_null(dialog)
+	var area: float = dialog.size.x * dialog.size.y
+	assert_gt(area / GENERIC_DIALOG_AREA, 1.9,
+		"the review must not come back as the 600x450 generic panel")
+	assert_has(_texts(dialog), "Month Review")
+	dialog.queue_free()
+
+
+func test_the_review_keeps_every_behaviour_the_playtests_pinned() -> void:
+	# B1/B2/B3 and the one-button contract. The restyle shares the presenter's button loop
+	# precisely so none of this had to be re-implemented -- this asserts it did not have to.
+	var opened: Array = await _present(_review_event())
+	var dialog: Control = opened[0]
+	var buttons: Array = opened[1]
+	assert_eq(buttons.size(), 1, "the review is a door: exactly one option")
+	assert_true(dialog.get_meta("space_advances", false), "B1: SPACE still opens the door")
+	assert_true(dialog.get_meta("is_event_dialog", false), "#452: ESC still must not close it")
+	var face: String = buttons[0].text
+	assert_string_contains(face, "[SPACE]")
+	assert_false(face.contains("(Free)"), "B2: no price tag on a door that was never for sale")
+	assert_false(face.contains("[Q]"), "B2: no letter-menu prefix on a one-option popup")
+	assert_false(buttons[0].disabled, "a costless door can never be unaffordable")
+	dialog.queue_free()
+
+
+func test_an_ordinary_event_still_gets_the_generic_dialog() -> void:
+	# The other half of the branch: every crisis window must be untouched by this change, at the
+	# original 600x450, still printing its whole description as one label.
+	var opened: Array = await _present({
+		"id": "some_crisis",
+		"name": "A Crisis",
+		"description": "Something happened and you must choose.",
+		"type": "popup",
+		"options": [
+			{"id": "handle", "text": "Handle it", "costs": {"money": 20000}},
+			{"id": "ignore", "text": "Ignore it", "costs": {}},
+		],
+	})
+	var dialog: Control = opened[0]
+	assert_eq(dialog.size, Vector2(600, 450), "ordinary events keep the generic footprint")
+	var said := _texts(dialog)
+	assert_has(said, "A Crisis")
+	assert_has(said, "Something happened and you must choose.")
+	assert_eq(opened[1].size(), 2)
+	dialog.queue_free()
+
+
+# --- the art slot ------------------------------------------------------------------------------
+
+func test_the_declared_surface_art_is_actually_packed() -> void:
+	# Both surfaces are pre-existing assets under godot/assets/ -- nothing was promoted for this
+	# panel. If either is ever moved or retired, the panel silently degrades to a flat fill, so
+	# this is the only place that would notice.
+	for path in [MonthReviewPanel.BOARD_TEXTURE_PATH, MonthReviewPanel.PAPER_TEXTURE_PATH]:
+		if path == "":
+			continue  # an emptied slot is a legitimate configuration, not a failure
+		assert_true(ResourceLoader.exists(path), "declared surface art is missing: %s" % path)
+
+
+func test_a_missing_surface_texture_does_not_break_the_sheet() -> void:
+	# The degradation path, exercised for real: a sheet built while the art slot points nowhere
+	# must still carry every word. This is what stops a retired asset turning the month boundary
+	# into an undismissable modal.
+	var dialog := Panel.new()
+	autofree(dialog)
+	MonthReviewPanel.apply_geometry(dialog, Vector2(1920, 1080))
+	MonthReviewPanel._add_surface(dialog, "res://assets/textures/surfaces/__no_such_file__.png",
+		Color.WHITE, 2)
+	MonthReviewPanel.build(dialog, {"review": _payload()})
+	assert_has(_texts(dialog), "Month Review")

--- a/godot/tests/unit/test_month_review_panel.gd.uid
+++ b/godot/tests/unit/test_month_review_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://bxf2qhv4a2xe5


### PR DESCRIPTION
## What Pip asked for

> "Month review -- can take up a lot more of the screen space, like, double or triple the area so we have something to work with. In fact, why don't we take this from green to having its own little UI elements - we're starting to promote some of them."

and then, mid-design:

> "the month review screen could come in, like, clipboard form or some other diegetic form"

## What it is now

**An object, not an overlay.** A hardboard clipboard with a metal clip holding a sheet of aged graph paper, and the month typed onto the sheet as a form.

The reasoning, so it can be argued with: the thesis of this game is that the bureaucracy **is** the game. A HUD panel says "here is your data". A sheet somebody clipped to a board and left on your desk says "here is what your month amounted to, and a person typed it up". The second one is the game's own argument. It is the same instinct as the 2026-08-12 calendar ruling ("semi-diegetic ... shrink or grow rather than disappear and reappear entirely"), so this is treated as a house register rather than a one-off -- see the new section in `godot/UI_STYLE_GUIDE.md`.

It also earns the modal. An object with physical presence has an obvious reason to sit on top of the feed, which is the cheapest honest fix for the occlusion complaint.

**Diegetic does not mean photorealistic here.** Every word on the sheet is set in `TerminalTheme.mono_font()` -- the same family as the WATCH feed and the plan screen. The paper is tinted down to office-light manila, not scanned-document white. It belongs to the dark office the isometric floor view implies.

### Layout

```
   +==============================================================================+
   |                            [====== clip ======]                              |
   | +--------------------------------------------------------------------------+ |
   | | Month Review                                              October 2017   | |   masthead, then a 2px rule
   | | ======================================================================== | |
   | | October 2017 begins.                                                     | |
   | |                                                                          | |
   | | | [!]  Attention: 20 fresh decisions this month (last month's unspent    | |   stamped left rule,
   | | |      reserve evaporated -- no banking).                                | |   translucent wash
   | |                                                                          | |
   | | Last month's movement           |  Rivals this month                     | |
   | | -------------------------       |  ------------------------------       | |
   | | Funds $1,119,896 -> $1,083,712  |  | DeepSafety            safety       | |
   | |                      [-$36,185] |  |   capabilities flat                | |
   | | Staff  3 -> 2              [-1] |  | CapabiliCorp    capabilities       | |
   | |                                 |  |   capabilities climbing fast       | |
   | |                                 |  | StealthAI (rumored)   balanced     | |
   | |                                 |  |   capabilities climbing fast       | |
   | | ------------------------------------------------------------------------ | |
   | | >>  Queue this month's actions, then press COMMIT THE MONTH to play the  | |
   | |     month out.                                                           | |
   | +--------------------------------------------------------------------------+ |
   |                                                                              |
   |                 [   Begin planning October 2017   [SPACE]   ]                |   on the BOARD, not the paper
   +==============================================================================+
```

- **The masthead** is the event name split into heading + period. No new words.
- **The attention line is a rule of the game, so it is set as one**: a stamped left rule, a translucent wash, and the house `[!]` gutter glyph. Not one word of the sentence changed -- it is the frame around it that now says "this is the standing rule".
- **Deltas read as deltas.** `-$36,185` and `-1` are right-aligned in bordered chips, coloured by sign, so a column of them stacks into a readable edge instead of trailing off the end of a sentence. Green/red carry the same meaning as main_ui's per-turn HUD chips (`_DELTA_GOOD` / `_DELTA_BAD`, doom sign-inverted) -- remixed for paper, because colours tuned to survive a near-black panel go washy on manila.
- **Rivals are cards, not three indented lines.** Name and focus on the top line, the drift read underneath in a *heat* ink -- flat is dim, slipping is green, rising is amber, climbing fast is red. Heat, not verdict: it shows which rival is running, which is the one thing three identical sentences could not.
- **The button stays on the board, below the sheet.** The paper is the report, the board is where the action lives. This is also what preserves its B2/B3 teal-on-dark primary chrome -- teal ink on manila would have been unreadable.

### Area

The generic event dialog is a fixed `600x450` (270,000 px^2) at every resolution. The clipboard scales with the viewport, capped at `1120x760`:

| viewport | clipboard | vs. the old panel |
|---|---|---|
| 1920x1080 | 1120 x 760 | **3.15x** |
| 1600x900 | 1120 x 720 | **2.99x** |
| 1280x720 | 921 x 576 | **1.97x** |

Triple where Pip plays, still double on the smallest supported window. Both bounds are pinned by test, the upper one so it cannot creep into a full-screen takeover, and there is a separate test that it never runs off any edge -- it carries the only button that closes it.

### The occlusion

Backdrop `0.6 -> 0.85` **for the review only**; every other event keeps 0.6. At 0.6 the WATCH feed behind the panel still read at close to full strength, so the review looked like it was covering the month it summarises rather than replacing it. At 0.85 the office goes dark and the clipboard is the only lit surface -- which is also what makes it read as an object.

The board carries a real drop shadow (`shadow_size 26`), and that turned out to be load-bearing: without it the panel reads as a flat rectangle again whatever is painted on it.

## Art: what I found and what I used

**Used -- two textures that were already in the pack and referenced by nothing:**

- `res://assets/textures/surfaces/tex_plywood_stained_512.png` -- the board. Stained plywood with grain, spotting and coffee rings.
- `res://assets/textures/surfaces/tex_grid_graphpaper_aged_512.png` -- the sheet. Aged, foxed graph paper with two coffee rings printed into it. This is the whole argument in one asset.

**Nothing was promoted.** Both are pre-existing files under `godot/assets/`, so they were already in the `.pck`; this PR just points at them. A test asserts they are still packed, so retiring either would be caught here rather than silently degrading the panel to a flat fill.

**Surveyed and rejected:** there is **no month/calendar art and no rival-lab art anywhere in the repo**, packed or unpacked. The 64px resource icons (`resource_money_64`, `ui_staff_management_64`, `doom.png`) exist and I looked at them -- they are glossy vignetted RPG icons with baked dark backgrounds, and on a lit manila sheet they read as stickers, not as print. Not used.

**The share/promote route (#1166) is outbound, not inbound.** `tools/assets/build_share_set.py` builds a public candidate manifest from `art_generated/` paths; nothing in it lands in `godot/assets/`. The inbound route is ADR-0019's pull-from-demand pipeline, whose selection file `tools/assets/demand/slot_picks.json` is still empty and whose pull step, by its own README, does not exist yet. Exactly one art file has entered the pack in the last three weeks and it went in by hand. So: nothing to wait for, and I did not promote anything myself.

**What art would finish this**, as a well-specified request rather than a vague one -- both are single-const slots (`BOARD_TEXTURE_PATH` / `PAPER_TEXTURE_PATH`), so a replacement swaps in without touching the layout:

1. **A real clip.** The metal jaw is currently two styleboxes. A drawn clip -- jaw, plate, and a little specular -- is the single detail that would take this from "reads as a clipboard" to "is a clipboard".
2. **Monochrome line-art stamp glyphs, ~24px**, for the Funds / Staff / Doom rows. Flat ink, no baked background, no gloss -- they need to look printed on the form, not pasted onto it.
3. Optional: a purpose-drawn hardboard plate and a sheet with visible tooth. The graph paper works because it is *foxed*; a bright replacement will blow a hole in the palette.

## Scope

**Presentation only.** No numbers, no economy, no phase logic touched. I found no wrong numbers to report.

`game_manager`'s two review blocks are refactored **collect-then-format**: the rows the clipboard draws and the plain text the WATCH feed records (A10) are now built from **one** collection, so the two cannot drift into saying different things about the same month. The emitted text is byte-identical -- the existing `test_month_review_movement` suite passes unchanged against it. Collection runs exactly once per boundary, because the rivals collector advances `_rival_cap_snapshot`.

**ADR-0015 survives the new surface.** The payload carries doom *band labels*, never a percentage, and there is a test that walks the built node tree asserting no `%` reaches the sheet -- a stronger guard than the existing string-level one.

**Every other event dialog is untouched** -- still 600x450, still forest green, still one label of description. The branch turns on one condition (the event carries a `review` payload) and shares everything else: the queue, the blocker lifetime, the button wiring, the `#452` / `#877` / B1 / B2 / B3 metas. There is a test asserting an ordinary crisis window still gets the generic dialog at the original size.

Text is **+2..+4pt on this panel only** per Pip's separate note -- body 16->19, small 14->17, button 16->20. **The masthead is the one exception, 18->24**, flagged in the source rather than smuggled: at 22 it did not read as a masthead beside 19pt body on a sheet with three times the area under it. Easy to pull back if you disagree. No global sweep.

## Verification

| check | result |
|---|---|
| `python3 scripts/run_godot_tests.py --quick --ci-mode --min-tests 300` | **1352 tests, 0 failures, 131/131 files collected**, exit 0, on the rebased branch |
| tests added by this PR | **20** (measured 1313 -> 1333 before the rebase; main brought the rest) |
| `godot --headless --path godot`, 30s | **zero** `SCRIPT ERROR`, `Parse Error`, `Compile Error`; **zero** `ERROR` lines |
| `python3 tools/check_class_cache.py` | `class cache OK -- 97 class_name declaration(s) all resolve` |
| rebased | onto `origin/main` after #1216 / #1217 / #1220 landed; #1217 also touched `event_dialog.gd` and the merge is clean |

The 20 new tests in `godot/tests/unit/test_month_review_panel.gd` hold the three things a restyle silently breaks -- that **no line of Pip's copy is dropped** by the re-typesetting (it walks the built tree and checks every string is actually rendered), that payload and feed text say the same thing, and that the generic dialog is untouched -- plus the area bounds, the on-screen clamp, the sign convention, the heat/label agreement, and the degradation path when an art slot points nowhere.

Three of them drive the **real presenter** (`EventDialog.present`), not just the builder, so the branch added to `_show_next_event` is exercised end-to-end in a live tree.

## What is NOT verified

**Nobody has looked at this on a screen.** This laptop has no `Xvfb` and no virtual display, and the only real display is the one Pip is playtesting on, so I did not launch a window. Everything above is derived from the source and from tests that inspect the built node tree; **only Pip's eyes can say whether it looks right**, which is the same caveat `test_month_review_navigation.gd` already carries.

To see it:

```
cd /home/pip/Repos/pdoom1-monthreview && make run
```

(worktree at `/home/pip/Repos/pdoom1-monthreview`, branch `feat/month-review-panel` -- Pip's shared checkout at `/home/pip/Repos/pdoom1` was not touched)

**Do not merge** -- Pip reviews first.

`Ladder-Impact: none -- presentation only.` The `game_manager` change is a collect-then-format refactor of two DISPLAY string builders; the emitted text is byte-identical, no RNG is drawn, no state is read that was not read before, and the only new state written is a presentation payload on the review event dictionary. Everything else is under `godot/scripts/ui/`, `godot/tests/` and docs.

---

Generated with [Claude Code](https://claude.com/claude-code)
