### PR TITLE
fix(doom): route runtime pdoom-data event options through the doom streams (ADR-0015) -- closes a -6 doom/turn sink

### DIFF
--- a/godot/autoload/event_service.gd
+++ b/godot/autoload/event_service.gd
@@ -504,6 +504,39 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 	var doom_effect = int(3 * effect_multiplier)
 	var money_effect = int(10000 * effect_multiplier)
 
+	# --- ADR-0015: these options are built IN CODE, so they never went through the content
+	# migration that stripped literal doom deltas from res://data. They must write a named
+	# world-state INTERMEDIARY; DoomSystem alone owns the doom LEVEL (S1 + single-authority).
+	#
+	# A literal here was NOT inert. execute_event_choice's trap (events.gd:303) caught it and
+	# posted it to the `panic` stream, so it landed as REAL doom under a WRONG name -- and
+	# unbounded: measured at exactly -6.00 doom/turn at the shipped 2-events/turn cap
+	# (-7.78 once momentum compounds it), against a natural +0.06 baseline. Doom hit the 0.0
+	# floor in ~8 turns and stayed there. See test_adr_0015_runtime_doom_literals.gd.
+	#
+	# Magnitudes are Balance-priced and ANCHORED to the prices actions.gd already pays for the
+	# analogous founder move, so this adds no new tuning vocabulary:
+	#   safety_absorption <- action_safety_absorb (4.0)   adopted scrutiny; absorbs frontier
+	#   frontier_capability <- action_acquire_frontier (60.0)  capability actually advanced
+	#   global_panic      <- (1.5)  a shock the world reacts to; see the conversion note below
+	#
+	# WHY EVERY RELIEF GOES TO safety_absorption AND NONE TO global_alarm.
+	# A one-shot input of X integrates to a different total doom depending on the stream:
+	#   alarm:  -W_alarm/(1-alarm_decay) * X = -1.333 * X   (decaying, ~46-turn half-life)
+	#   panic:  +W_panic/(1-panic_decay) * X = +0.667 * X   (decaying)
+	#   absorption/frontier: -/+ W_frontier * X per turn = 0.000039 * X per turn, PERSISTENT
+	# alarm is the engine's designed relief channel and actions.gd uses it freely (lobby,
+	# warning, conference) -- but those are actions, competing for Attention against the whole
+	# board. THESE options recur on up to 2 events EVERY turn, and a repeated input I into a
+	# decaying stock settles at I/(1-decay), so alarm routing reproduces the very exploit
+	# being closed: an early draft of this fix routed safety_analysis to alarm as well and
+	# measured a sustained -0.84 doom/turn, flipping the natural trend negative all over
+	# again. safety_absorption cannot do that: the overhang stream is
+	# max(0, frontier_max - safety_absorption), so absorption past the frontier buys exactly
+	# nothing and the other eight streams are untouched. The bound is STRUCTURAL, not a price.
+	var absorb_effect: float = doom_effect * Balance.num("doom.streams.event_safety_absorb", 4.0)
+	var frontier_effect: float = doom_effect * Balance.num("doom.streams.event_frontier_gain", 60.0)
+
 	# Get reactions for flavor text
 	var safety_reaction = raw.get("safety_researcher_reaction", "")
 	var media_reaction = raw.get("media_reaction", "")
@@ -517,7 +550,8 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 				"id": "collaborate",
 				"text": "Seek collaboration",
 				"costs": {"attention": 1},
-				"effects": {"reputation": rep_effect, "doom": -doom_effect},
+				# Shared safety norms with another lab: adopted scrutiny -> absorption.
+				"effects": {"reputation": rep_effect, "safety_absorption": absorb_effect},
 				"message": "Established collaborative relationship." + (_format_reaction(safety_reaction))
 			},
 			{
@@ -542,14 +576,23 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 				"id": "build_upon",
 				"text": "Build upon this research",
 				"costs": {"attention": 1, "money": money_effect},
-				"effects": {"research": rep_effect * 3, "doom": doom_effect / 2},
+				# The flavour text says it outright -- this ADVANCES THE FRONTIER. The honest
+				# intermediary for that is frontier_capability, which the overhang stream reads.
+				"effects": {"research": rep_effect * 3, "frontier_capability": frontier_effect / 2.0},
 				"message": "Advancing the research frontier." + (_format_reaction(safety_reaction))
 			},
 			{
 				"id": "safety_analysis",
 				"text": "Conduct safety analysis",
 				"costs": {"attention": 1},
-				"effects": {"research": rep_effect, "doom": -doom_effect, "reputation": rep_effect / 2},
+				# The load-bearing one: 1174 of the 1194 shipped pdoom-data events are
+				# `technical_research_breakthrough`, so this single option was ~99% of the
+				# exploit surface. Published safety work -> absorption (+ a little public alarm).
+				"effects": {
+					"research": rep_effect,
+					"safety_absorption": absorb_effect,
+					"reputation": rep_effect / 2,
+				},
 				"message": "Published safety analysis of the work."
 			},
 			{
@@ -567,7 +610,9 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 				"id": "support",
 				"text": "Publicly support",
 				"costs": {"attention": 1},
-				"effects": {"reputation": rep_effect, "doom": -doom_effect},
+				# Governance that actually lands is civilisational absorption. (alarm would be
+				# the prettier fiction, but see the note above -- it is not bounded per-turn.)
+				"effects": {"reputation": rep_effect, "safety_absorption": absorb_effect},
 				"message": "Your support strengthens the policy effort." + (_format_reaction(media_reaction))
 			},
 			{
@@ -592,14 +637,16 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 				"id": "respond_publicly",
 				"text": "Issue public response",
 				"costs": {"attention": 1},
-				"effects": {"reputation": rep_effect, "doom": -doom_effect / 2},
+				# Public understanding of an incident -> scrutiny the field absorbs. Half strength.
+				"effects": {"reputation": rep_effect, "safety_absorption": absorb_effect / 2.0},
 				"message": "Your response shapes public understanding." + (_format_reaction(media_reaction))
 			},
 			{
 				"id": "internal_review",
 				"text": "Conduct internal review",
 				"costs": {"attention": 1},
-				"effects": {"research": rep_effect, "doom": -doom_effect},
+				# "Lessons learned improve your safety practices" IS safety_absorption.
+				"effects": {"research": rep_effect, "safety_absorption": absorb_effect},
 				"message": "Lessons learned improve your safety practices."
 			},
 			{
@@ -626,7 +673,10 @@ func _generate_options(raw: Dictionary, category: String, significance: int) -> 
 				"id": "diversify_funding",
 				"text": "Diversify Funding Sources",
 				"costs": {"attention": 1},
-				"effects": {"doom": -doom_effect / 2, "reputation": rep_effect / 2},
+				# Weakest doom link of the seven, so the most conservative routing: a
+				# funder-diversified lab keeps its safety staff through a downturn instead of
+				# firing them, which is absorption retained. Half strength, as before.
+				"effects": {"safety_absorption": absorb_effect / 2.0, "reputation": rep_effect / 2},
 				"message": "Reduced dependency on any single funder."
 			},
 			{
@@ -692,6 +742,20 @@ func _calculate_base_effects(raw: Dictionary, significance: int) -> Dictionary:
 			effects[game_var] += scaled_change
 		else:
 			effects[game_var] = scaled_change
+
+	# ADR-0015: the pdoom-data variable map launders several source variables into the game
+	# var "doom" (`vibey_doom` alone appears on 1193 of the 1194 shipped events, plus `stress`,
+	# `burnout_risk`, `safety`). The content-scan guard in test_events.gd compares the RAW
+	# variable name against "doom" literally, so every aliased impact walked straight past it
+	# and became a literal doom delta at runtime -- ADR-0015 satisfied on paper by renaming the
+	# key. Convert here, at the single point where the alias resolves, so no caller downstream
+	# ever sees a "doom" effect: these are unmodelled world shocks, which is what the `panic`
+	# stream is for (and is where execute_event_choice's trap was already sending them).
+	# Scaled by 1/(W_panic/(1-panic_decay)) = 1.5 so the INTEGRATED doom is unchanged.
+	if effects.has("doom"):
+		var shock: float = float(effects["doom"]) * Balance.num("doom.streams.event_shock_panic", 1.5)
+		effects.erase("doom")
+		effects["global_panic"] = float(effects.get("global_panic", 0.0)) + shock
 
 	return effects
 
@@ -808,7 +872,11 @@ func _set_default_variable_mapping() -> void:
 	_default_effects = {
 		"common": {"research": 5},
 		"rare": {"research": 10, "reputation": 5},
-		"legendary": {"research": 20, "reputation": 10, "doom": 5}
+		# ADR-0015: no literal doom. The shipped variable_mapping.json already dropped this
+		# key; this in-code fallback (used only when that file is missing) had drifted out of
+		# sync and kept it -- in the content-scan guard's blind spot, since the guard walks
+		# res://data only. 5 doom -> 7.5 panic preserves the integrated magnitude (x1.5).
+		"legendary": {"research": 20, "reputation": 10, "global_panic": 7.5}
 	}
 
 

--- a/godot/data/balance/defaults.json
+++ b/godot/data/balance/defaults.json
@@ -106,7 +106,11 @@
 			"action_sabotage_panic": 5.0,
 			"action_opensource_alarm": 0.6,
 			"action_opensource_diffusion": 0.0,
-			"action_conference_alarm": 0.6
+			"action_conference_alarm": 0.6,
+			"_event_description": "event_* price the RUNTIME-GENERATED pdoom-data event options (event_service.gd _generate_options), which built their effects in code and so never went through the content migration that stripped literal doom deltas from res://data. Each is anchored to the action_* price for the analogous founder move rather than being a new dial. Relief is routed ONLY to safety_absorption, never global_alarm: these options recur on up to 2 events every turn, and a repeated input into a decaying stock settles at input/(1-decay), which reproduces the -6 doom/turn exploit this replaced. The overhang clamp max(0, frontier-absorption) bounds absorption structurally. event_shock_panic is the doom->panic conversion for impacts the pdoom-data variable map launders into 'doom' (vibey_doom/stress/burnout_risk/safety): 1/(W_panic/(1-panic_decay)) = 1.5, which keeps the INTEGRATED doom identical.",
+			"event_safety_absorb": 4.0,
+			"event_frontier_gain": 60.0,
+			"event_shock_panic": 1.5
 		}
 	},
 	"salaries": {

--- a/godot/tests/unit/simulation/test_events.gd
+++ b/godot/tests/unit/simulation/test_events.gd
@@ -42,12 +42,39 @@ func test_all_events_have_required_fields():
 ## CARVE-OUTS (deliberate, both documented in ADR-0015):
 ##  1. START CONFIG -- `starting_resources.doom` sets the initial LEVEL. That is a legitimate
 ##     scenario dial, not an event effect, and is not scanned.
-##  2. risk_events.json -- its 20 pool `effects.doom` fields are LIVE (turn_manager routes
-##     them through doom_system.add_event_doom), so re-authoring them is a BALANCE change
-##     deferred to the ADR-0015 M-ticket. Budgeted below so the count can only shrink.
+##  2. risk_events.json -- its pool `effects.doom` fields are LIVE: turn_manager routes them
+##     through doom_system.add_event_doom(), which is add_stream_input() under a back-compat
+##     name, so they DO arrive as a named stream. See the ratchet note below.
+##
 ## --------------------------------------------------------------------------------------
-
-const RISK_EVENTS_DOOM_BUDGET := 20  # M-ticket backlog; MUST only ever go down
+## THE RATCHET WAS DELIBERATELY LOOSENED -- 2026-08-14, ruled by Pip, for content velocity.
+##
+## This guard used to cap risk_events.json at RISK_EVENTS_DOOM_BUDGET := 20, "may only ever
+## shrink" -- and 20 was exactly the count on the day it was written. That made the real rule
+## "no NEW risk event may carry doom at all, even positive", which is not what ADR-0015 says.
+## It blocked 28 events of good content (#1230) whose positive pool effects were legitimate
+## and established, while the two actual violations -- negative doom literals in
+## event_service.gd -- sat in .gd files this scan never looked at. A count budget cannot tell
+## a legitimate positive pool effect from an illegitimate direct write; it is a proxy that
+## happened to correlate, and it failed in both directions at once.
+##
+## Pip, 2026-08-14: "I want new content to come in, so am willing to ratify a deliberate
+## loosening of that ratchet, as long as this kind of thing is documented and, ideally, we
+## uplift mechanisms in this and the surrounding patterns to improve mechanistic and fail-loud
+## enforcement."
+##
+## So the count cap is GONE and the MECHANISM is enforced instead:
+##   * risk-pool doom must be POSITIVE. A pool is a hazard; positive doom routes through
+##     add_event_doom -> a named stream and is honest. A NEGATIVE literal is the exploit
+##     class this whole lane exists to kill and stays illegal, everywhere, in data and code.
+##   * everything else in res://data stays at zero literals, unchanged.
+##   * and the scan no longer stops at the data tree -- test_adr_0015_runtime_doom_literals.gd
+##     now scans the .gd tree for the same defect, which is where it was actually hiding.
+##
+## If you are reading this in six months wondering whether the looser rule was an erosion:
+## it was a decision, made on 2026-08-14, by Pip, buying content velocity and paying for it
+## with a tighter and wider mechanism. It is not licence to add a negative doom literal.
+## --------------------------------------------------------------------------------------
 
 func _all_data_json_paths(dir_path: String, out: Array) -> void:
 	var dir := DirAccess.open(dir_path)
@@ -82,9 +109,10 @@ func _scan_for_doom_effects(node, path: String, trail: String, hits: Array) -> v
 	for key in node.keys():
 		var child = node[key]
 		var child_trail := "%s.%s" % [trail, key]
-		# (a) the event-choice / event effect schema
+		# (a) the event-choice / event effect schema. Carries the VALUE so the caller can
+		# enforce the sign rule (positive risk-pool doom is legal; negative never is).
 		if key == "effects" and child is Dictionary and child.has("doom"):
-			hits.append("%s%s.doom" % [path, child_trail])
+			hits.append("%s%s.doom=%s" % [path, child_trail, str(child["doom"])])
 		# (b) the pdoom-data override schema (impacts[].variable == "doom")
 		if key == "impacts" and child is Array:
 			for i in range(child.size()):
@@ -123,9 +151,20 @@ func test_no_authored_event_content_writes_literal_doom():
 	assert_eq(hits.size(), 0,
 		"authored content must write an intermediary, never a literal doom effect. Offenders: "
 		+ ", ".join(PackedStringArray(hits)))
-	assert_lte(risk_hits.size(), RISK_EVENTS_DOOM_BUDGET,
-		"the risk_events.json carve-out may only shrink (ADR-0015 M-ticket); found %d"
-		% risk_hits.size())
+
+	# The loosened ratchet: no count cap on risk_events.json (content velocity, ruled
+	# 2026-08-14), but the MECHANISM is enforced -- a risk pool is a hazard, so its doom must
+	# be positive. A negative literal here would be the exploit class in a legal costume.
+	var negative_risk_doom: Array[String] = []
+	for hit in risk_hits:
+		var value_text: String = str(hit).split("=")[-1]
+		if value_text.is_valid_float() and value_text.to_float() < 0.0:
+			negative_risk_doom.append(hit)
+	assert_eq(negative_risk_doom.size(), 0,
+		("risk-pool doom must be POSITIVE -- a pool is a hazard, and a negative literal is a "
+		+ "direct doom write wearing a pool's clothes. Reduce hazard by writing an "
+		+ "intermediary (safety_absorption / global_alarm), never by printing negative doom. "
+		+ "Offenders: ") + ", ".join(PackedStringArray(negative_risk_doom)))
 
 func test_event_count():
 	# Test that we have a substantial number of events

--- a/godot/tests/unit/test_adr_0015_runtime_doom_literals.gd
+++ b/godot/tests/unit/test_adr_0015_runtime_doom_literals.gd
@@ -30,6 +30,154 @@ extends GutTest
 ## untouched. Alarm/panic routing would NOT have closed it -- a repeated input to a decaying
 ## stock reaches a steady state of input/(1-decay), which reproduces the same -6/turn.
 
+## --------------------------------------------------------------------------------------
+## CODE-SIDE SCAN (added 2026-08-14 with the ratchet loosening -- see test_events.gd).
+##
+## The data-side guard capped risk_events.json at a shrink-only count of 20 doom literals.
+## That proxy failed in both directions on the same day: it blocked 28 events of legitimate
+## content (#1230) whose POSITIVE pool doom is honest, while the two real violations -- and
+## in the end seven -- sat in .gd files it never opened. Pip ratified dropping the count cap
+## for content velocity on condition that the mechanism get tighter and louder. This is that
+## half: the same rule, "doom moves through named streams", enforced where the defect
+## actually lived.
+##
+## Everything currently writing doom outside doom_system.gd is enumerated below WITH ITS
+## REASON. A new write fails this test and prints its own source line, so the author has to
+## classify it rather than discover later that a guard quietly did not cover their file.
+## --------------------------------------------------------------------------------------
+
+const DOOM_AUTHORITY := "res://scripts/core/doom_system.gd"
+const CODE_SCAN_DIRS := ["res://scripts", "res://autoload"]
+
+## Legitimate doom writes, keyed by file, matched on the exact trimmed source line.
+const DOOM_WRITE_ALLOWLIST := {
+	# The single authoritative sync: DoomSystem's level -> the mirror on GameState.
+	"res://scripts/core/turn_manager.gd": [
+		"state.doom = state.doom_system.current_doom",
+		# Legacy fallbacks, reached only when no doom_system exists (lightweight test doubles).
+		'state.add_resources({"doom": total_doom_increase})',
+		'state.add_resources({"doom": doom_impact})',
+		'state.add_resources({"doom": amount})',
+	],
+	# execute_event_choice's ADR-0015 trap: routes a literal to add_stream_input("panic"),
+	# falling back to the direct sink only where there is no doom engine to route into.
+	"res://scripts/core/events.gd": [
+		'state.add_resources({"doom": value})',
+	],
+	# Ledger bills route to the `ledger` stream; the direct write is the test-double fallback
+	# (test_liability_ledger.gd deliberately frees doom_system to exercise it). The _note()
+	# payloads are ATTRIBUTION records, not effects.
+	"res://scripts/core/ledger.gd": [
+		"state.doom += amount",
+		'"money_shortfall": shortfall, "doom": doom_hit, "reputation": -rep_hit})',
+		'{"governance_deficit": deficit, "doom": doom_hit})',
+		'_note(state, "ledger_doom_bill", e.source, {"doom": applied})',
+	],
+	# Documented inert sinks (ADR-0015 Legacy #15): clobbered at resolve in the real loop,
+	# retained for direct-state unit tests.
+	"res://scripts/core/game_state.gd": ['doom += gains["doom"]'],
+	"res://scripts/core/resource_accessor.gd": ["state.doom += value"],
+	# Terminal jam on resign + the scenario START-LEVEL dial (an ADR-0015 carve-out).
+	"res://scripts/game_manager.gd": [
+		"state.doom = 100.0",
+		'state.doom = float(resources["doom"])',
+	],
+	# Debug-gated nudges (OS.is_debug_build / alpha-tool gated).
+	"res://scripts/debug/dev_mode_overlay.gd": ["s.doom = clampf(s.doom + delta, 0.0, 100.0)"],
+	"res://scripts/ui/main_ui.gd": [
+		"st.doom = st.doom_system.current_doom",
+		"st.doom = clampf(st.doom + delta, 0.0, 100.0)",
+	],
+	# pdoom-data variable map: a NAME->NAME entry and a scale factor, not effects.
+	"res://autoload/event_service.gd": ['"doom": "doom",', '"doom": 1,'],
+}
+
+## Known-unrouted writes: real ADR-0015 violations that are DELIBERATELY still here, each
+## with an owner-visible reason. Listed separately from the allowlist so they read as debt,
+## not as blessing, and so the count can be asserted downward over time.
+const DOOM_WRITE_KNOWN_DEBT := {
+	# desperation_payroll advertises "-10 doom now" and delivers nothing: add_resources' doom
+	# sink is clobbered at resolve, so this is an inert lie rather than an exploit. Migrating
+	# it would turn a no-op into a real -10 doom -- a BALANCE change, not a routing fix, so it
+	# is out of scope for this lane. Its own comment fences it: "unchanged pre-L5 path".
+	"res://scripts/core/finance_engine.gd": ['state.add_resources({"doom": -suppress})'],
+}
+
+
+func _all_gd_paths(dir_path: String, out: Array) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while entry != "":
+		var full := dir_path.path_join(entry)
+		if dir.current_is_dir():
+			if entry != "addons":
+				_all_gd_paths(full, out)
+		elif entry.ends_with(".gd"):
+			out.append(full)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+
+func test_no_code_outside_the_doom_system_writes_doom_directly() -> void:
+	var paths: Array = []
+	for d in CODE_SCAN_DIRS:
+		_all_gd_paths(d, paths)
+	assert_gt(paths.size(), 50, "the .gd tree was found and walked")
+
+	# A `doom` key given a VALUE (an effect), or a direct write to the doom level.
+	var effect_re := RegEx.new()
+	effect_re.compile('"doom"\\s*:\\s*\\S')
+	var write_re := RegEx.new()
+	write_re.compile('(?:^|[^\\w.])(?:\\w+\\.)?doom\\s*(?:\\+=|-=)|(?:\\w+)\\.doom\\s*=(?!=)')
+	# Readouts/serialisation, where the doom LEVEL is the value being reported.
+	var readout_re := RegEx.new()
+	readout_re.compile('"doom"\\s*:\\s*(?:float\\()?(?:[\\w.]*\\.)?doom\\b|"doom"\\s*:\\s*DoomSystem\\._snap')
+
+	var offenders: Array[String] = []
+	var debt_seen := 0
+
+	for path in paths:
+		if path == DOOM_AUTHORITY:
+			continue
+		var text: String = FileAccess.get_file_as_string(path)
+		var line_no := 0
+		for raw_line in text.split("\n"):
+			line_no += 1
+			var line: String = str(raw_line).strip_edges()
+			if line.begins_with("#") or line.contains("`"):
+				continue
+			if line.contains('== "doom"') or line.contains('!= "doom"'):
+				continue
+			if line.contains('state.get("doom"'):
+				continue
+			if readout_re.search(line) != null:
+				continue
+			if effect_re.search(line) == null and write_re.search(line) == null:
+				continue
+
+			if DOOM_WRITE_KNOWN_DEBT.get(path, []).has(line):
+				debt_seen += 1
+				continue
+			if DOOM_WRITE_ALLOWLIST.get(path, []).has(line):
+				continue
+			offenders.append("%s:%d: %s" % [path, line_no, line])
+
+	assert_eq(offenders.size(), 0,
+		("doom must move through a NAMED STREAM, in code as well as in data (ADR-0015 S1). "
+		+ "These writes are neither on the reviewed allowlist nor on the known-debt list at "
+		+ "the top of this file. If the write is legitimate plumbing, add it there WITH ITS "
+		+ "REASON; if it is an effect, write an intermediary (safety_absorption / "
+		+ "global_alarm / global_panic / frontier_capability) instead:\n  ")
+		+ "\n  ".join(PackedStringArray(offenders)))
+
+	assert_eq(debt_seen, 1,
+		("the known-unrouted doom write list should hold exactly the one fenced "
+		+ "finance_engine case; got %d. If you migrated it, shrink the list.") % debt_seen)
+
+
 const DOOM_REDUCING_CATEGORIES := [
 	"organization", "organization_founding",
 	"research", "paper", "technical_research_breakthrough", "alignment_research",

--- a/godot/tests/unit/test_adr_0015_runtime_doom_literals.gd
+++ b/godot/tests/unit/test_adr_0015_runtime_doom_literals.gd
@@ -1,0 +1,181 @@
+extends GutTest
+## ADR-0015 guard for RUNTIME-GENERATED event options (event_service.gd `_generate_options`).
+##
+## Sibling of test_events.gd::test_no_authored_event_content_writes_literal_doom, which scans
+## authored CONTENT in res://data. That scan cannot see this class of defect: the pdoom-data
+## historical events build their options IN CODE at load time, so seven inline `"doom": -N`
+## literals lived past the content migration (test_events.gd's HANDLED_EFFECT_KEYS comment
+## even records the gap -- "the runtime pdoom-data path in event_service.gd still emits it").
+##
+## Two things are asserted here:
+##
+##  1. STRUCTURE (ADR-0015 S1) -- no runtime-generated option may carry a literal `doom`
+##     effect. Effects address a named world-state INTERMEDIARY; DoomSystem alone writes the
+##     doom LEVEL. A literal here is not inert: execute_event_choice's trap (events.gd:303)
+##     catches it and posts it to the `panic` stream, so it lands as REAL doom that is
+##     MIS-ATTRIBUTED -- "Conduct internal review" shows up in the L6 death chain as panic.
+##
+##  2. BOUNDEDNESS (the exploit) -- the pdoom-data pool ships 1181 events (of 1194) whose
+##     best option carried a negative doom literal, 1174 of them the strictly-dominant
+##     `safety_analysis` on `technical_research_breakthrough`: 1 attention, +research,
+##     +reputation, and -3 doom with no downside. At the shipped cap of 2 new events/turn
+##     that is -6 doom/turn against a natural accumulation of ~+3.6 doom/turn (the
+##     do_nothing calibration: 50 -> 100 over 14 months). Net -2.4/turn == doom-immortality,
+##     bounded only by the 0.0 display clamp. The trend invariant LOGS this but never clamps
+##     it, by design, so nothing in the engine stops it.
+##
+## Routing the reducers through `safety_absorption` closes it STRUCTURALLY rather than by
+## tuning: the overhang stream is `W_frontier * max(0.0, frontier_max - safety_absorption)`,
+## so absorption past the frontier buys literally nothing, and the other eight streams are
+## untouched. Alarm/panic routing would NOT have closed it -- a repeated input to a decaying
+## stock reaches a steady state of input/(1-decay), which reproduces the same -6/turn.
+
+const DOOM_REDUCING_CATEGORIES := [
+	"organization", "organization_founding",
+	"research", "paper", "technical_research_breakthrough", "alignment_research",
+	"policy", "regulation", "policy_event",
+	"incident", "capability", "capability_advance",
+	"funding_catastrophe", "funding",
+	"general",
+]
+
+## The dominant real shape: 1174 of the 1194 shipped pdoom-data events land here.
+func _raw_event(category: String, significance: int = 6) -> Dictionary:
+	return {
+		"id": "adr15_%s" % category,
+		"title": "ADR-0015 probe (%s)" % category,
+		"description": "synthetic probe event",
+		"category": category,
+		"year": 2017,
+		"rarity": "common",
+		"significance": significance,
+		"impacts": [{"variable": "vibey_doom", "change": 10}],
+	}
+
+
+func _options_for(category: String, significance: int = 6) -> Array:
+	var event: Dictionary = EventService._transform_event(_raw_event(category, significance))
+	assert_false(event.is_empty(), "transform should build an event for category '%s'" % category)
+	return event.get("options", [])
+
+
+# ---------------------------------------------------------------------------
+# 1. STRUCTURE -- no literal doom in any runtime-generated option
+# ---------------------------------------------------------------------------
+
+func test_no_runtime_generated_option_carries_a_literal_doom_effect() -> void:
+	var offenders: Array[String] = []
+	var options_seen := 0
+
+	for category in DOOM_REDUCING_CATEGORIES:
+		for option in _options_for(category):
+			options_seen += 1
+			if option.get("effects", {}).has("doom"):
+				offenders.append("%s/%s" % [category, option.get("id", "?")])
+
+	assert_gt(options_seen, 20, "the probe should have exercised every _generate_options branch")
+	assert_eq(offenders.size(), 0,
+		"runtime-generated options must write a world-state intermediary, never a literal "
+		+ "doom effect (ADR-0015 S1). Offenders: " + ", ".join(PackedStringArray(offenders)))
+
+
+func test_runtime_generated_options_still_address_the_doom_system() -> void:
+	## The intent is legitimate -- an internal review SHOULD reduce risk. Guard against a
+	## "fix" that simply deletes the effect: each doom-flavoured option must still write a
+	## named intermediary that DoomSystem._compute_streams actually reads.
+	var intermediaries := ["safety_absorption", "global_alarm", "global_panic",
+		"frontier_capability", "general_capability"]
+
+	var expectations := {
+		"organization": "collaborate",
+		"technical_research_breakthrough": "safety_analysis",
+		"policy": "support",
+		"incident": "internal_review",
+		"funding_catastrophe": "diversify_funding",
+	}
+
+	for category in expectations.keys():
+		var want_id: String = expectations[category]
+		var found := false
+		for option in _options_for(category):
+			if option.get("id", "") != want_id:
+				continue
+			found = true
+			var keys = option.get("effects", {}).keys()
+			var hits := 0
+			for k in keys:
+				if k in intermediaries:
+					hits += 1
+			assert_gt(hits, 0,
+				"%s/%s must still reach the doom system through a named intermediary; got %s"
+				% [category, want_id, str(keys)])
+		assert_true(found, "expected option '%s' in category '%s'" % [want_id, category])
+
+
+# ---------------------------------------------------------------------------
+# 2. BOUNDEDNESS -- the exploit itself
+# ---------------------------------------------------------------------------
+
+const EXPLOIT_TURNS := 20
+const EVENTS_PER_TURN := 2  # the shipped events.max_new_events_per_turn
+
+
+func _run(turns: int, picks_per_turn: int) -> float:
+	"""Play `turns` turns taking the doom-reducing option `picks_per_turn` times each turn,
+	resolving the doom system between turns exactly as the real loop does. Returns the final
+	doom LEVEL. A clean world (no seeded rivals) so the measurement isolates the option."""
+	var state := GameState.new("adr15_exploit_seed")
+	state.doom = 50.0
+	state.doom_system.current_doom = 50.0
+
+	var event: Dictionary = EventService._transform_event(
+		_raw_event("technical_research_breakthrough"))
+
+	for t in range(turns):
+		state.turn = t + 1
+		# A fresh Attention grant each turn. At 20/month against a 1-Attention choice the
+		# founder budget is never the binding constraint -- event SUPPLY is what caps this.
+		state.month_plan.begin_month(Balance.inum("attention.per_month", 20), t)
+		for _p in range(picks_per_turn):
+			var res: Dictionary = GameEvents.execute_event_choice(event, "safety_analysis", state)
+			assert_true(res.get("success", false),
+				"the harness must actually execute the choice (got: %s)"
+				% res.get("message", "?"))
+		state.doom_system.calculate_doom_change(state)
+		state.doom = state.doom_system.current_doom
+
+	return state.doom
+
+
+func test_repeated_risk_reduction_cannot_drive_doom_to_the_floor() -> void:
+	## RED before the fix: the panic stream read exactly -6.00/turn (-7.78 with momentum) and
+	## doom pinned at the 0.0 clamp inside ~8 turns.
+	var exploited := _run(EXPLOIT_TURNS, EVENTS_PER_TURN)
+
+	assert_gt(exploited, 5.0,
+		("repeatedly taking the doom-reducing event option must not drive doom to the floor "
+		+ "-- an unbounded doom sink makes runs non-comparable on the league board "
+		+ "(got %.2f after %d turns x %d picks, started at 50.0)")
+		% [exploited, EXPLOIT_TURNS, EVENTS_PER_TURN])
+
+
+func test_risk_reduction_cannot_reverse_the_natural_doom_trend() -> void:
+	## The load-bearing invariant, measured as a DIFFERENTIAL so it does not depend on how
+	## hostile the surrounding world is: playing the option must not flip a rising doom
+	## trajectory into a falling one. Pre-fix the control rose to 51.57 while the exploited
+	## run sat on the 0.0 floor -- a 51.6-point swing (and only that small because the clamp
+	## ate the rest of the -120).
+	var control := _run(EXPLOIT_TURNS, 0)
+	var exploited := _run(EXPLOIT_TURNS, EVENTS_PER_TURN)
+
+	assert_gt(control, 50.0, "sanity: doom should rise on its own over %d turns" % EXPLOIT_TURNS)
+	assert_gt(exploited, 50.0,
+		("doom must still RISE over %d turns even while spending every event on risk "
+		+ "reduction -- one relief channel must not out-run the other eight streams "
+		+ "(control %.2f, exploited %.2f)") % [EXPLOIT_TURNS, control, exploited])
+
+	var swing := control - exploited
+	assert_lt(swing, 25.0,
+		("the total doom a player can buy with %d risk-reducing choices must stay well "
+		+ "inside the 0-100 scale; got a %.2f-point swing (control %.2f vs exploited %.2f)")
+		% [EXPLOIT_TURNS * EVENTS_PER_TURN, swing, control, exploited])

--- a/godot/tests/unit/test_adr_0015_runtime_doom_literals.gd.uid
+++ b/godot/tests/unit/test_adr_0015_runtime_doom_literals.gd.uid
@@ -1,0 +1,1 @@
+uid://df4sh6igs2een

--- a/godot/tests/unit/test_balance_key_coverage.gd
+++ b/godot/tests/unit/test_balance_key_coverage.gd
@@ -10,15 +10,28 @@ extends GutTest
 const ACTIONS_SRC_PATH := "res://scripts/core/actions.gd"
 const DEFAULTS_PATH := "res://data/balance/defaults.json"
 
+## event_service.gd joined the list when the ADR-0015 runtime-option migration moved the
+## pdoom-data event effects onto `doom.streams.event_*` keys. Same failure mode as actions.gd:
+## a missing key degrades silently to the in-code fallback instead of failing CI.
+const BALANCE_KEY_SOURCES := [
+	ACTIONS_SRC_PATH,
+	"res://autoload/event_service.gd",
+]
+
 
 func test_every_balance_num_key_in_actions_exists_in_defaults() -> void:
-	var src: String = FileAccess.get_file_as_string(ACTIONS_SRC_PATH)
-	assert_false(src.is_empty(), "expected to read %s" % ACTIONS_SRC_PATH)
+	for src_path in BALANCE_KEY_SOURCES:
+		_assert_balance_keys_resolve(src_path)
+
+
+func _assert_balance_keys_resolve(src_path: String) -> void:
+	var src: String = FileAccess.get_file_as_string(src_path)
+	assert_false(src.is_empty(), "expected to read %s" % src_path)
 
 	var regex := RegEx.new()
 	regex.compile("Balance\\.num\\(\\s*\"([^\"]+)\"")
 	var matches := regex.search_all(src)
-	assert_gt(matches.size(), 0, "expected at least one Balance.num() call site in actions.gd")
+	assert_gt(matches.size(), 0, "expected at least one Balance.num() call site in %s" % src_path)
 
 	var defaults_text: String = FileAccess.get_file_as_string(DEFAULTS_PATH)
 	var json := JSON.new()
@@ -46,4 +59,4 @@ func test_every_balance_num_key_in_actions_exists_in_defaults() -> void:
 			missing.append(key)
 
 	assert_eq(missing.size(), 0,
-		"Balance.num() keys referenced in actions.gd but missing from defaults.json (silent 0.0/code-fallback): %s" % [missing])
+		"Balance.num() keys referenced in %s but missing from defaults.json (silent 0.0/code-fallback): %s" % [src_path, missing])


### PR DESCRIPTION
Closes #1232.

Pip found this in a live playtest and named two options. There were **nine**, and the exploit
is real: **-6.00 doom/turn**, measured.

## 1. The exploit, quantified

The pdoom-data events build their options **in code** (`event_service.gd::_generate_options`),
so they never went through the migration that stripped literal doom deltas from `res://data`.

The literals were **not inert**. `execute_event_choice`'s ADR-0015 trap (`events.gd:303`)
catches a literal `doom` key and posts it to the **`panic`** stream -- so it landed as real
doom under the **wrong name** ("Conduct internal review" reads as panic in the L6 death
chain), and unbounded: buffered stream inputs are folded in *after* `_compute_streams`, so
they miss the `maxf(0.0, ...)` hazard clamp.

Measured in `test_adr_0015_runtime_doom_literals.gd`:

| quantity | value |
|---|---|
| `panic` stream while exploiting | **-6.00 doom/turn** at the shipped 2-events/turn cap |
| with momentum | **-7.78 doom/turn** by turn 20 |
| natural accumulation | +0.06/turn baseline; ~+3.6/turn in the do_nothing calibration |
| result | doom **50 -> 0.0 floor in ~8 turns**, pinned |
| control, same world, no picks | doom 50 -> **51.57** |

Supply never binds: **1181 of 1194** shipped events carry a doom-reducing option, 1174 of
them the **strictly dominant** `safety_analysis` (1 Attention, +research, +reputation,
-3 doom, no downside). **-3561** total available against a 0-100 scale; **-339 reachable from
turn 1**. Attention (20/month) is not the constraint; the 2-events/turn cap is.

## 2. How they are routed

| option | now writes |
|---|---|
| `collaborate`, `safety_analysis`, `internal_review`, `support`, `respond_publicly`, `diversify_funding` | `safety_absorption` |
| `build_upon` | `frontier_capability` (its own text says "advancing the research frontier") |
| `_calculate_base_effects` doom, `_default_effects` legendary | `global_panic` |

**Relief goes only to `safety_absorption`, never `global_alarm` -- and that is the whole fix.**
alarm is the engine's designed relief channel and `actions.gd` uses it freely, but those are
*actions*, competing for Attention against the whole board. These options recur on up to 2
events **every turn**, and a repeated input `I` into a decaying stock settles at
`I/(1-decay)`. An early draft of this fix routed `safety_analysis` to alarm and measured a
sustained **-0.84 doom/turn** -- the same exploit in a new costume. `safety_absorption`
cannot do that: overhang is `max(0, frontier_max - safety_absorption)`, so absorption past
the frontier buys **exactly nothing**. The bound is **structural, not a price**.

Two more vectors in the same file, both in the content guard's blind spot (it walks
`res://data` only): the `_default_variable_mapping` legendary bucket still carried
`"doom": 5` after the shipped JSON dropped it; and the variable map launders
`vibey_doom`/`stress`/`burnout_risk`/`safety` into `"doom"` (`vibey_doom` alone is on 1193 of
1194 events) while the guard compares the **raw** name literally.

## 3. MAGNITUDE CHANGED -- your ruling wanted

I did not retune, but I cannot preserve magnitude either, and you should see why:
**the printed literal was ~50x a turn's baseline doom.** Preserving it *is* the exploit --
any routing that reproduces -3 doom per click reproduces -6/turn.

Priced at `doom.streams.event_safety_absorb = 4.0`, reusing the existing
`action_safety_absorb` price rather than inventing a dial. For the dominant case
(`doom_effect = 3`): absorption +12, reducing overhang by `0.000039 * 12` per turn while
frontier exceeds absorption -- about **-0.0066 doom over a 14-month run, versus -3.0 before**.
That is roughly a **450x nerf**, and it is the honest consequence of moving from a printed
number to a modelled stock.

If you want it to bite harder, it is a one-line JSON edit --
`godot/data/balance/defaults.json` -> `doom.streams.event_safety_absorb`. Magnitude-preserving
over a 14-turn run would be **~1832**. I would not go there without a sweep; somewhere in the
tens is my guess for "feels like it did something". **Your call.**

## 4. Sweep -- every doom write outside `doom_system.gd`

**Violating**
- `event_service.gd` x9 -- fixed here.
- `finance_engine.gd:361` `state.add_resources({"doom": -suppress})` -- `desperation_payroll`
  advertises "-10 doom now" and delivers **nothing** (the sink is clobbered at resolve). A
  real violation and a **player-visible lie**, but inert, and its own comment fences it
  ("unchanged pre-L5 path"). **Not fixed here on purpose**: migrating it turns a no-op into a
  real -10 doom, which is a balance change, not a routing fix. Recorded as named debt in the
  new guard so it cannot fade.

**Legitimate** (confirmed, unchanged): the `events.gd` trap; `ledger.gd` -> `ledger` stream
with a test-double fallback; `turn_manager.gd` risk pools -> `add_event_doom`;
`turn_manager.gd:737` the single authoritative sync; `game_state.gd:648` /
`resource_accessor.gd:79` documented inert sinks; `game_manager.gd` resign jam + scenario
start dial; debug-gated nudges in `main_ui.gd` / `dev_mode_overlay.gd`; all `actions.gd`
(fully migrated). Cosmetic only: `conferences.gd` still declares a field named
`doom_reduction` though it correctly feeds `global_alarm`.

## 5. The ratchet loosening (your 18:00 ruling)

`RISK_EVENTS_DOOM_BUDGET := 20` was a proxy, and 20 was exactly the count the day it was
written -- so the real rule became *"no new risk event may carry doom at all, even positive"*.
It failed in **both directions on the same day**: it blocked 28 events of legitimate content
(#1230) while nine literals sat in a `.gd` file it never opens.

Replaced with the rule it stood in for:
- **Data:** no count cap. Risk-pool doom must be **positive** (a pool is a hazard, and it
  routes through `add_event_doom` -> a named stream). **Negative stays illegal everywhere.**
- **Code (new):** the `.gd` tree is scanned for the same defect. Every doom write outside
  `doom_system.gd` is enumerated **with its reason** -- allowlisted as plumbing, or listed as
  known debt. A new write fails and prints its own source line.
- Documented at the head of `test_events.gd`, attributed and dated, so someone finding the
  looser rule in six months can tell a decision from an erosion.

**Both guards proven capable of the other answer:**

| probe | result |
|---|---|
| reintroduce `"doom": -doom_effect` in `event_service.gd` | code scan **RED**, names file + line |
| negative doom in a risk pool | data scan **RED**, names the JSON path |
| **new positive-doom risk event, count 21 (over the old budget of 20)** | **PASSES** |

### What #1230 needs

Its positive-doom risk events now pass as-is -- that last row is the unblock, measured. The
three things it could not express need mechanism it should not invent locally:
"the scare that helps" wants the risk-event apply path to stop dropping intermediary keys
(it silently ignores them today); "regulator pauses a rival" wants an actor id in the event
schema before rival `frontier_capability` is reachable; the invisible `safety_absorption`
payoffs want DQ-21 vocabulary. All three are follow-ups, not blockers. The one hard rule:
**no negative doom literal**, reduce hazard by writing an intermediary.

## 6. Ladder verdict -- EPOCH-SHAPED, your call

`tools/check_ladder_bump.py` goes **RED** without a declaration. This changes the doom
trajectory for identical seed + choices, so it is genuinely ladder-affecting.

I declared `Ladder-Impact: bump` and left `ladder_version.txt` at **4** -- same pattern as
#1230. **I did not cut the epoch**: the `(weekly-2026-w33, L4)` board is being blessed this
afternoon and forking the board key mid-week is yours to decide. Gate is green on the
declaration.

## 7. Could an existing board entry be affected?

**Possibly, and it is worth your attention.** `(weekly-2026-w33, L4)` holds one entry:
**109 turns**, `doom_integral` 7931 -- mean doom **~27.2**, *below* the 50.0 start --
recorded 16:51 today on v0.14.1. The calibration's mortality check records **max 26 months
across all policies, 0 immortal runs**. 109 is **4.2x** that maximum with mean doom under the
starting value, which is the exploit's signature.

Not proof, and it is your own playtest run -- the one where you found this. **Your ruling
whether it stands.** `(weekly-2026-w32, L4)` predates the board and I did not inspect it.

## 8. Verification

- quick: **1346 pass / 0 fail**, 131/131 files (`--quick --ci-mode --min-tests 300`)
- simulation: **107 pass / 0 fail**, 8/8 files
- headless launch: **zero** `SCRIPT ERROR` / `Parse Error` / `Compile Error`; class cache OK
- RED first: the new test fails before the fix on both the structure arm (23 offending
  option/category pairs) and the boundedness arm
- rebased onto `origin/main` after #1216/#1217/#1220/#1222

## Note on process

Two of my early Godot invocations ran **unisolated** -- `CLAUDE.md`'s `APPDATA` rule is
Windows-specific and does nothing here. They wrote logs and touched `keybinds.cfg`/`theme.cfg`
in your real profile. **The league boards were not touched** (`w33` mtime 16:51 predates every
run of mine; contents verified intact, one entry, `pending_scores.json` empty). Switched to
`XDG_DATA_HOME`+`HOME` per `docs/LAPTOP_DEBIAN_SETUP.md` section 4 for everything after.

Not merging -- yours to review.

Ladder-Impact: bump -- doom routing changes the trajectory for identical seed+choices.

Generated with [Claude Code](https://claude.com/claude-code)
