### PR TITLE
docs: define founder hour kinds, league seed and board key for players (#1208, #1209)

### DIFF
--- a/docs/PLAYERGUIDE.md
+++ b/docs/PLAYERGUIDE.md
@@ -396,13 +396,38 @@ Attention is the founder's month, and it is the ONLY currency you spend as the f
   back presence. This is why an action can be greyed out while the Attention counter
   still shows a number.
 
+### The four kinds of founder hour
+When the game refuses an action, the message names the kind of time it needed --
+for example "Not enough Attention: need 2 doors hours, have 0". Every founder
+hour is one of four kinds:
+
+- **Doors** (operating) -- face-time: pitching funders, talking to press, being
+  in the room. If it only works because you are physically there, it is doors.
+- **Approvals** (planning) -- decisions: signing off hires, setting direction,
+  queueing next month's strategic work. The work you can still do from an
+  airport.
+- **Audits** (operating) -- checking: going and looking at what your team
+  actually did, rather than reading what they reported. Audit actions such as
+  Audit Self-Directed Work are exactly the actions that spend these.
+- **Reserve** (operating) -- the emergency hours. Attention you set aside with
+  **Reserve Attention** and later spend reacting to events is booked as reserve.
+  The button and the hour kind are the same idea: the verb and its noun.
+
+The kinds are labels on the two budgets above, not four separate budgets. Doors,
+audits and reserve all draw on your operating hours; approvals draw on planning.
+So "need 2 doors hours" means the action is face-time and your operating budget
+ran out -- the kind names the sort of work, the planning/operating split is what
+actually ran dry. In the current alpha the game never limits one kind separately
+from its family.
+
 ### What staff actually buy you
 - **Researchers** work their own lanes on the workstream backlog. Unassigned staff do
   not idle -- they self-direct, and they report their progress optimistically.
 - **Ops/admin staff** reduce the founder-price of routine actions rather than adding
   to your pool.
-- **Audits** spend founder hours to ground-truth what your team reported. The
-  simulation never lies to you; characters sometimes do.
+- **Audits** spend founder hours -- the audits kind, above -- to ground-truth
+  what your team reported. The simulation never lies to you; characters
+  sometimes do.
 
 ### Visual indicators
 - **Attention readout**: top bar, e.g. `Attention: 20 (14 free, 3 reserved)`; hover it
@@ -414,7 +439,8 @@ Attention is the founder's month, and it is the ONLY currency you spend as the f
 
 ### Strategic tips
 - **Reserve deliberately.** Committing a plan with nothing queued holds all Attention
-  for reacting to events. That is a real strategy, not a wasted month.
+  for reacting to events. That is a real strategy, not a wasted month. Reserved
+  hours you then spend on events are the reserve hour kind described above.
 - **Watch the hour type, not just the total.** Running out of operating hours is the
   usual cause of "I have Attention but the button is dead".
 - **Hire for lanes, not for capacity.** More staff does not mean more founder decisions.
@@ -799,14 +825,46 @@ Your score is how many turns you survived. Try to beat your previous best!
 
 
 ---
-=======
-
 
 ## Seeds & High Scores
 
-**Weekly Seed**: Everyone gets the same challenge each week - compete with friends!
-**Custom Seed**: Use any text as a seed for repeatable games
-**High Scores**: Tracked separately for each seed in `local_highscore.json`
+### What a seed is
+A seed is a short piece of text that fixes which game you get. Every roll of the
+dice in a run is drawn from it -- the events that fire, the candidates who turn
+up, all of it. Two players on the same seed are playing the same world, so their
+scores are comparable. Two players on different seeds are playing different
+games -- neither is harder or easier by design, they are just not the same test.
+
+- **League seed**: the featured seed everyone is playing right now. Leave the
+  seed box empty on the setup screen and this is what you get (the setup screen
+  calls it the "weekly challenge seed" -- same thing). It is named for the year
+  and week it was cut, e.g. `weekly-2026-w33`. In the current alpha the rotation
+  is done by hand, so a league can run a little longer than a calendar week.
+- **Custom seed**: any text you type. Use it for repeatable runs, or as a
+  private challenge -- you and a friend on the same custom seed are on the same
+  board.
+
+### How boards are keyed
+A leaderboard board is one seed played on one ladder epoch. That pair is the
+board's whole identity, and both halves are chosen for fairness:
+
+- The **ladder epoch** is the rules version, shown as `Epoch L4` on the
+  Leaderboard screen. It moves only when the gameplay rules change -- scoring,
+  costs, events, anything that changes what a turn is worth. When it moves, a
+  fresh board opens and the old scores are retired with the rules they were
+  earned under, never mixed with new ones.
+- The **build version** (v0.13.1 and so on) is deliberately not part of the
+  key. A patch that fixes a typo or restyles a screen cannot fork a board:
+  your scores, and your rivals', stay together across updates. Only a real
+  rules change can separate them.
+
+That is the guarantee behind every board: any two rows on it were earned on the
+same world under the same rules. It is also why difficulty is locked to
+Standard for the first leagues, and why scenario starts like Sandbox or Crisis
+are playable but unranked -- the game warns you before an unranked run starts.
+
+Your score is turns survived. Boards are stored on your machine per seed and
+epoch, and shown on the Leaderboard screen.
 
 ---
 


### PR DESCRIPTION
Closes #1208. Closes #1209 (guide half; the in-UI wording items in #1209 -- pregame hint, board-label hover -- are not touched here).

Player-facing copy only: one file, `docs/PLAYERGUIDE.md`. **Do not merge without Pip's read** -- both issues flag the vocabulary calls as Pip's, and this PR is the concrete proposal for those calls, not a pre-approved answer.

## What this adds

**1. The four founder hour kinds** -- new subsection "The four kinds of founder hour" inside Attention Strategy, directly under the existing two-way (planning/operating) material it extends. It names doors / approvals / audits / reserve, gives each one sentence and its family, decodes the real refusal message a player sees ("need 2 doors hours, have 0"), and states plainly that kinds are labels on the two budgets, not four budgets -- in the current build nothing ever limits one kind separately from its family (verified: `MonthPlan.hours_available` gates by family only).

**2. League seed** -- "Seeds & High Scores" rewritten. Defines a seed (the text every dice roll is drawn from; same seed = same world = comparable scores), defines the league seed and explicitly equates it with the setup screen's "weekly challenge seed" (the two names for one thing that #1209 flagged), and is honest that league rotation is currently manual, so a league can outlast its calendar week (`FEATURED_SEED_OVERRIDE` in `game_config.gd` is hand-set to `weekly-2026-w33`).

**3. Board key** -- same section: a board is one seed on one ladder epoch, the epoch moves only on rules changes, and the build version is deliberately excluded so a cosmetic patch can never fork a board. Written to make the care in that design legible: "any two rows on the same board were earned on the same world under the same rules." The register deliberately matches the good `LadderExplainer` copy already on the leaderboard screen.

## Verdict on the audits/reserve collision: disambiguate by unification, no rename needed

#1208 frames the collision as two words carrying incompatible meanings. On reading the code, the meanings are not incompatible -- they were never connected in writing:

- **audits**: the guide's ":404" bullet ("Audits spend founder hours to ground-truth what your team reported") describes precisely the actions that bill the `audits` kind -- `audit_self_directed` and `audit_safety` are the only `audits`-typed actions in the data. The kind is named after the activity the guide already teaches.
- **reserve**: `kind_spent[reserve] == reserve_used` (invariant pinned in `month_plan.gd` / `test_founder_hours.gd`). The hour kind labels exactly the hours the **Reserve Attention** button set aside, when they are later drawn down. Verb, state and kind are one mechanic at three moments: reserve -> reserved -> reserve hours.

So renaming would trade a coherent (if unstated) vocabulary for a fresh migration, and the last migration's debris is still open (#1037). Instead this PR states the identities explicitly: the `:404` audits bullet and the `:416` reserve tip now each connect to the hour kind by name, and the new subsection says "the button and the hour kind are the same idea." **If Pip disagrees, the rename option stays open** -- nothing here entrenches the names further than the engine already does (the refusal message already prints them).

## Further false claims found in the guide (listed, not fixed -- out of scope for this PR)

Verified against `godot/` on this branch; each is checkable with a grep:

1. **Manager cost "$90 (1.5x normal cost)"** (Milestone Events) -- `hire_manager` actually costs **$80,000 + 1 attention** (`godot/data/actions/hiring.json`).
2. **Accounting Software "$500" / Cash Flow UI / prevents the board milestone** (four separate sections) -- in the Godot build `accounting_software` costs **$0 and is flavor-only, no mechanical effect** (#970, `godot/scripts/core/upgrades.gd`).
3. **Comfy Chairs "staff less likely to quit when unpaid"** -- flavor-only, $0, no mechanic (#970, same file).
4. **Espionage "$30k" and also "minimal $500 operational cost"** -- self-contradictory within the guide, and no espionage action with either cost exists in `godot/data/actions/`.
5. **Scout Opponent "$50k, unlocked after Turn 5" and also "free"** -- self-contradictory; the real scouting actions cost 1 attention and $0-$300 (`scouting.json`).
6. **"Event Log System" and "Compact Activity Display" upgrades** (Upgrade Strategy plus a whole dedicated subsection) -- neither exists anywhere in `godot/` (`grep -rn "Event Log System\|Compact Activity" godot/` is empty).
7. **"Zabinga!" sound on paper completion** (two places) -- no hit for `zabinga` anywhere in `godot/`.
8. The already-known **export/import config packages / Community Features** claims are still present in the settings section; left alone here since this PR is scoped to the three definitions.

Items 1-7 look like pygame-era text that survived the port. They probably warrant a dedicated guide-audit issue; happy to file it.

Also fixed in passing: a stray merge-conflict marker (`=======`) sitting above the Seeds section, and the false `local_highscore.json` claim (#1209 item 1) is gone with the rewrite.

## Why the guide, and length

Both issues argue these belong in `PLAYERGUIDE.md` (same channel, sits with the material it extends), and I agree -- a separate glossary doc would be a second thing to keep in sync through the same pipeline. Cost acknowledged: **#1224 (up to five nested scrollbars) makes every added line expensive**, so this stays at +66/-8 -- one subsection and one rewritten section, no worked-example month (the refusal-message decode carries that weight in three lines). If #1224 lands a fix, a worked month example is the natural follow-up.

Ladder-Impact: none -- docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
